### PR TITLE
Update to latest pulumi, pulumi-terraform

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -87,11 +87,14 @@
     "aws/signer/v4",
     "internal/shareddefaults",
     "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/cloudwatchlogs",
     "service/s3",
     "service/sts"
   ]
@@ -527,11 +530,14 @@
 [[projects]]
   name = "github.com/pulumi/pulumi"
   packages = [
-    "pkg/compiler/errors",
+    "pkg/apitype",
+    "pkg/backend",
+    "pkg/backend/local",
     "pkg/diag",
     "pkg/diag/colors",
     "pkg/encoding",
     "pkg/engine",
+    "pkg/operations",
     "pkg/resource",
     "pkg/resource/config",
     "pkg/resource/deploy",
@@ -552,7 +558,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "7aedf80fa2ea10ada802cfb77acb42b148e7429b"
+  revision = "7e14a09b3b63bfab1aaeac47fdad944ac466b241"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -560,7 +566,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "b1672250664d402e48a1a0592d6256b4d8cf414b"
+  revision = "fe4b00ca832323f3c9461bf64118c523e8792812"
 
 [[projects]]
   branch = "master"
@@ -945,6 +951,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "76aee803b060f7e1a746daee1cb132f51b58c8f6a86773b0d5b4cfd79bb90ab8"
+  inputs-digest = "0e9e48f03736e98046021ba585f89b1035b7ea0fce8380fe6871a7de260c093e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,11 +4,11 @@
 
 [[override]]
   name = "github.com/pulumi/pulumi"
-  revision = "7aedf80fa2ea10ada802cfb77acb42b148e7429b"
+  revision = "7e14a09b3b63bfab1aaeac47fdad944ac466b241"
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "b1672250664d402e48a1a0592d6256b4d8cf414b"
+  revision = "fe4b00ca832323f3c9461bf64118c523e8792812"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-kubernetes"

--- a/resources.go
+++ b/resources.go
@@ -77,7 +77,7 @@ func Provider() tfbridge.ProviderInfo {
 			Modules:      map[string]*tfbridge.OverlayInfo{},
 			Dependencies: map[string]string{},
 			PeerDependencies: map[string]string{
-				"@pulumi/pulumi": "^0.11.0-dev-65-g7aedf80f",
+				"@pulumi/pulumi": "^0.11.0-dev-168-g7e14a09b",
 			},
 		},
 	}


### PR DESCRIPTION
To prepare for cutting 0.11.0-rc1 of this package, let's make sure it is on the newest versions of things and CI is green.