### PR TITLE
Publish sdist Python packages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,15 @@
   version = "v0.18.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/Azure/go-ansiterm"
+  packages = [
+    ".",
+    "winterm"
+  ]
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -29,6 +38,12 @@
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  name = "github.com/Sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/agext/levenshtein"
@@ -151,6 +166,25 @@
   ]
   revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
   version = "v2.6.2"
+
+[[projects]]
+  name = "github.com/docker/docker"
+  packages = [
+    "pkg/jsonlog",
+    "pkg/jsonmessage",
+    "pkg/progress",
+    "pkg/streamformatter",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
+  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
+  version = "v1.13.1"
+
+[[projects]]
+  name = "github.com/docker/go-units"
+  packages = ["."]
+  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
+  version = "v0.3.3"
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
@@ -551,6 +585,7 @@
     "pkg/util/cmdutil",
     "pkg/util/contract",
     "pkg/util/fsutil",
+    "pkg/util/httputil",
     "pkg/util/mapper",
     "pkg/util/retry",
     "pkg/util/rpcutil",
@@ -559,7 +594,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "085e8fb41220e3f66415c0f3ae83d52156828bfc"
+  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -567,7 +602,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "15c4be53659e613f7a85b967f3c5614da79ec4d1"
+  revision = "28cef72de7316f1f42aa79d11c76c0cea9123bf8"
 
 [[projects]]
   branch = "master"
@@ -741,6 +776,12 @@
     "width"
   ]
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  revision = "26559e0f760e39c24d730d3224364aef164ee23f"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -952,6 +993,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9240f0837341aa5c401dc17bdb8a01de1c2a09a8e6d5c63d48e2f7d94f622957"
+  inputs-digest = "e80c7477d9297caed7f7bbaa7dc1ff19c852694dbc2601c1c528aafb3ee68a6b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,11 +4,11 @@
 
 [[override]]
   name = "github.com/pulumi/pulumi"
-  revision = "085e8fb41220e3f66415c0f3ae83d52156828bfc"
+  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "15c4be53659e613f7a85b967f3c5614da79ec4d1"
+  revision = "28cef72de7316f1f42aa79d11c76c0cea9123bf8"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-kubernetes"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build::
 		python setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./bin/setup.py && rm ./bin/setup.py.bak && \
-		cd ./bin && python setup.py build bdist_wheel --universal
+		cd ./bin && python setup.py build sdist
 
 lint::
 	$(GOMETALINTER) ./cmd/... resources.go | sort ; exit "$${PIPESTATUS[0]}"


### PR DESCRIPTION
This changes over to sdists, rather than bdist_wheels, to ensure that
our custom installation script actually takes effect during installation.

Fixes pulumi/pulumi#1086 for the Kubernetes provider package only.