### PR TITLE
Use package.json version when publishing.

### DIFF
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -6,7 +6,7 @@ ROOT=$(dirname $0)/..
 PUBDIR=$(mktemp -du)
 GITVER=$(git rev-parse HEAD)
 PUBFILE=$(dirname ${PUBDIR})/${GITVER}.tgz
-VERSION=$($ROOT/scripts/get-version)
+VERSION=$(jq -r '.version' < "${ROOT}/pack/nodejs/bin/package.json")
 
 # Figure out which branch we're on. Prefer $TRAVIS_BRANCH, if set, since
 # Travis leaves us at detached HEAD and `git rev-parse` just returns "HEAD".

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -5,7 +5,7 @@ set -o nounset -o errexit -o pipefail
 
 ROOT=$(dirname $0)/..
 WORK_PATH=$(mktemp -d)
-VERSION=$($ROOT/scripts/get-version)
+VERSION=$(jq -r '.version' < "${ROOT}/pack/nodejs/bin/package.json")
 PLUGIN_PACKAGE_NAME="pulumi-resource-kubernetes-${VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
 PLUGIN_PACKAGE_DIR="$(mktemp -d)"
 PLUGIN_PACKAGE_PATH="${PLUGIN_PACKAGE_DIR}/${PLUGIN_PACKAGE_NAME}"


### PR DESCRIPTION
Our publish scripts called `scripts/get-version`, which adds a -dirty
tag when the work-tree is dirty.  It happens that due to our source
generation stragegy, during a build in the CI the tree can become
dirty (since the generated package.json in the pack/nodejs folder gets
updated with the version of the package we are building), which means
calling `scripts/get-version` later is going to do the wrong thing.

Now, you can make an argument that simply building should not dirty
the tree, and I expect at some point that will be the case (as we
adopt Luke's versioning plan of not auto-generating version numbers),
but regardless, we really we should just be using whatever version is
in the package.json we are going to publish (since `pulumi` will use
that version when trying to download the plugins anyway).

Fixes #64