### PR TITLE
Update package metadata

### DIFF
--- a/pkg/gen/node-templates/package.json.mustache
+++ b/pkg/gen/node-templates/package.json.mustache
@@ -2,11 +2,12 @@
     "name": "@pulumi/kubernetes",
     "version": "{{ProviderVersion}}",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
+    "license": "Apache 2.0",
     "keywords": [
         "pulumi",
         "kubernetes"
     ],
-    "homepage": "https://pulumi.io/kubernetes",
+    "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-kubernetes",
     "scripts": {
         "build": "tsc"


### PR DESCRIPTION
Include a license property and update the homepage to the root of
http://pulumi.io (the existing link 404'd).