### PR TITLE
Implement `ResourceProviderServer#Cancel`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -597,7 +597,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "fe7c8d554a1f64dd4ff54e6f60ec0f7e0aab46e5"
+  revision = "2e9a2e8a91db1cd73ae5961041c247755a330eaf"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
This commit will implement `Cancel`, the new function exposed on the
gRPC resource provider server interface introduced in
pulumi/pulumi #1633.

The semantics of `Cancel` are to issue a non-blocking, advisory
cancellation signal to all resource operations in progress.

In practice, since the Kubernetes Go client does not take a cancellation
context to cancel resource operations that are currently in flight, in
the case of the Kubernetes resource provider, we will typically cancel
as we are waiting for the resource operation (e.g., initialization) to
complete. In other words, the HTTP request we use to signal resource
creation to the Kubernetes API server will never be cancelled in flight;
if the resource is complex enough to require initialization, we'll
cancel at the nearest opportunity.