### PR TITLE
Add resource autonaming, fix various replacement issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOMETALINTER    :=${GOMETALINTERBIN} --config=Gometalinter.json
 CURL            ?= curl
 
 TESTPARALLELISM := 10
-TESTABLE_PKGS   := ./pkg/... ./examples
+TESTABLE_PKGS   := ./pkg/... ./examples ./tests/...
 
 $(OPENAPI_FILE)::
 	@mkdir -p $(OPENAPI_DIR)

--- a/pkg/await/awaiters.go
+++ b/pkg/await/awaiters.go
@@ -141,6 +141,8 @@ var awaiters = map[string]awaitSpec{
 		awaitCreation: untilCoreV1PersistentVolumeClaimBound,
 	},
 	coreV1Pod: {
+		// NOTE: Because we replace the Pod in most situations, we do not require special logic for the
+		// update path.
 		awaitCreation: untilCoreV1PodInitialized,
 		awaitDeletion: untilCoreV1PodDeleted,
 	},

--- a/pkg/provider/diff_test.go
+++ b/pkg/provider/diff_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+type object map[string]interface{}
+type list []interface{}
+
+func TestFieldsChanged(t *testing.T) {
+	tests := []struct {
+		group    string
+		version  string
+		kind     string
+		old      object
+		new      object
+		expected []string
+	}{
+		{
+			group: "core", version: "v1", kind: "PersistentVolumeClaim",
+			old:      object{"spec": object{}},
+			new:      object{"spec": object{"accessModes": object{}}},
+			expected: []string{".spec", ".spec.accessModes"},
+		},
+		{
+			group: "core", version: "v1", kind: "Pod",
+			old:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			new:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx:1.15-alpine"}}}},
+			expected: []string{".spec.containers[*].image"},
+		},
+		{
+			group: "", version: "v1", kind: "Pod",
+			old:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			new:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx:1.15-alpine"}}}},
+			expected: []string{".spec.containers[*].image"},
+		},
+	}
+
+	for _, test := range tests {
+		diff, err := matchingProperties(test.old, test.new,
+			forceNew[test.group][test.version][test.kind])
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(diff, test.expected) {
+			t.Errorf("Got '%v' expected '%v'", diff, test.expected)
+		}
+	}
+}

--- a/pkg/provider/naming.go
+++ b/pkg/provider/naming.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const annotationInternalPrefix = "pulumi.com/"
+const annotationInternalAutonamed = "pulumi.com/autonamed"
+
+var dns1123Alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+// assignName generates a name for an object. Uses DNS-1123-compliant characters. All auto-named
+// resources get the annotation `pulumi.com/autonamed` for tooling purposes.
+func assignNameIfAutonamable(obj *unstructured.Unstructured, base tokens.QName) {
+	contract.Assert(base != "")
+	if obj.GetName() == "" {
+		obj.SetName(fmt.Sprintf("%s-%s", base, randString(8)))
+		setAutonameAnnotation(obj)
+	}
+}
+
+// adoptOldNameIfUnnamed checks if `newObj` has a name, and if not, "adopts" the name of `oldObj`
+// instead. If `oldObj` was autonamed, then we mark `newObj` as autonamed, too.
+func adoptOldNameIfUnnamed(newObj, oldObj *unstructured.Unstructured) {
+	contract.Assert(oldObj.GetName() != "")
+	if newObj.GetName() == "" {
+		newObj.SetName(oldObj.GetName())
+		if isAutonamed(oldObj) {
+			setAutonameAnnotation(newObj)
+		}
+	}
+}
+
+func setAutonameAnnotation(obj *unstructured.Unstructured) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[annotationInternalAutonamed] = "true"
+	obj.SetAnnotations(annotations)
+}
+
+func isAutonamed(obj *unstructured.Unstructured) bool {
+	annotations := obj.GetAnnotations()
+	autonamed := annotations[annotationInternalAutonamed]
+	return autonamed == "true"
+}
+
+func randString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = dns1123Alphabet[rand.Intn(len(dns1123Alphabet))]
+	}
+	return string(b)
+}
+
+// Seed RNG to get different random names at each suffix.
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}

--- a/pkg/provider/naming_test.go
+++ b/pkg/provider/naming_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestAssignNameIfAutonamable(t *testing.T) {
+	// o1 has no name, so autonaming succeeds.
+	o1 := &unstructured.Unstructured{}
+	assignNameIfAutonamable(o1, "foo")
+	assert.True(t, isAutonamed(o1))
+	assert.True(t, strings.HasPrefix(o1.GetName(), "foo-"))
+
+	// o2 has a name, so autonaming fails.
+	o2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "bar"}},
+	}
+	assignNameIfAutonamable(o2, "foo")
+	assert.False(t, isAutonamed(o2))
+	assert.Equal(t, "bar", o2.GetName())
+}
+
+func TestAdoptName(t *testing.T) {
+	// new1 is named and therefore DOES NOT adopt old1's name.
+	old1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "old1",
+				// NOTE: annotations needs to be a `map[string]interface{}` rather than `map[string]string`
+				// or the k8s utility functions fail.
+				"annotations": map[string]interface{}{annotationInternalAutonamed: "true"},
+			}},
+	}
+	new1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "new1"}},
+	}
+	adoptOldNameIfUnnamed(new1, old1)
+	assert.Equal(t, "old1", old1.GetName())
+	assert.True(t, isAutonamed(old1))
+	assert.Equal(t, "new1", new1.GetName())
+	assert.False(t, isAutonamed(new1))
+
+	// new2 is unnamed and therefore DOES adopt old1's name.
+	new2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+	adoptOldNameIfUnnamed(new2, old1)
+	assert.Equal(t, "old1", new2.GetName())
+	assert.True(t, isAutonamed(new2))
+}

--- a/tests/integration/autonaming/autonaming_test.go
+++ b/tests/integration/autonaming/autonaming_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi-kubernetes/tests"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+var step1Name interface{}
+var step2Name interface{}
+var step3Name interface{}
+
+func TestAutonaming(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "step1",
+		Dependencies: []string{"@pulumi/kubernetes"},
+		Quick:        true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Deployment)
+			assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+			tests.SortResourcesByURN(stackInfo)
+
+			stackRes := stackInfo.Deployment.Resources[1]
+			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+			//
+			// Assert Pod is successfully given a unique name by Pulumi.
+			//
+
+			pod := stackInfo.Deployment.Resources[0]
+			assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
+			step1Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+			assert.True(t, strings.HasPrefix(step1Name.(string), "autonaming-test-"))
+
+			autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+				"pulumi.com/autonamed")
+			assert.Equal(t, "true", autonamed)
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      "step2",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					//
+					// Assert Pod was replaced, i.e., destroyed and re-created, with allocating a new name.
+					//
+
+					pod := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
+					step2Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					assert.True(t, strings.HasPrefix(step2Name.(string), "autonaming-test-"))
+
+					autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+						"pulumi.com/autonamed")
+					assert.Equal(t, "true", autonamed)
+
+					assert.NotEqual(t, step1Name, step2Name)
+
+				},
+			},
+			{
+				Dir:      "step3",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					//
+					// Assert Pod was NOT replaced, and has the same name, previously allocated by Pulumi.
+					//
+
+					pod := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
+					step3Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					assert.True(t, strings.HasPrefix(step3Name.(string), "autonaming-test-"))
+
+					autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+						"pulumi.com/autonamed")
+					assert.Equal(t, "true", autonamed)
+
+					assert.Equal(t, step2Name, step3Name)
+				},
+			},
+			{
+				Dir:      "step4",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					//
+					// User has specified their own name for the Pod, so we replace it, and Pulumi does NOT
+					// allocate a name on its own.
+					//
+
+					pod := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
+					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					assert.Equal(t, "autonaming-test", name.(string))
+
+					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+						"pulumi.com/autonamed")
+					assert.False(t, autonamed)
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/autonaming/step1/Pulumi.yaml
+++ b/tests/integration/autonaming/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: autonaming-test
+description: A program that tests partial provider failure.
+runtime: nodejs

--- a/tests/integration/autonaming/step1/index.ts
+++ b/tests/integration/autonaming/step1/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// A simple Pod definition. `.metadata.name` is not provided, so Pulumi will allocate a unique name
+// to the resource upon creation.
+//
+
+const pod = new k8s.core.v1.Pod("autonaming-test", {
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx"},
+    ],
+  },
+});

--- a/tests/integration/autonaming/step1/package.json
+++ b/tests/integration/autonaming/step1/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "steps",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^0.14.0-rc1"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/autonaming/step1/tsconfig.json
+++ b/tests/integration/autonaming/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/autonaming/step2/index.ts
+++ b/tests/integration/autonaming/step2/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// The image in the Pod's container has changed, triggering a replace. Because `.metadata.name` is
+// not specified, Pulumi again will provide a name upon creation of the new Pod resource.
+//
+
+const pod = new k8s.core.v1.Pod("autonaming-test", {
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.15-alpine"},
+    ],
+  },
+});

--- a/tests/integration/autonaming/step3/index.ts
+++ b/tests/integration/autonaming/step3/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Only the labels have changed, so no replace is triggered. Pulumi should update the object
+// in-place, and the name should not be changed.
+//
+
+const pod = new k8s.core.v1.Pod("autonaming-test", {
+  metadata: {
+    labels: {app: "autonaming-test"},
+  },
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.15-alpine"},
+    ],
+  },
+});

--- a/tests/integration/autonaming/step4/index.ts
+++ b/tests/integration/autonaming/step4/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// User has now specified `.metadata.name`, so Pulumi should replace the resource, and NOT allocate
+// a name to it.
+//
+
+const pod = new k8s.core.v1.Pod("autonaming-test", {
+  metadata: {
+    name: "autonaming-test",
+    labels: {app: "autonaming-test"},
+  },
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.15-alpine"},
+    ],
+  },
+});

--- a/tests/integration/delete-before-replace/delete_before_replace_test.go
+++ b/tests/integration/delete-before-replace/delete_before_replace_test.go
@@ -1,0 +1,172 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi-kubernetes/tests"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPod(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "step1",
+		Dependencies: []string{"@pulumi/kubernetes"},
+		Quick:        true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Deployment)
+			assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+			tests.SortResourcesByURN(stackInfo)
+
+			stackRes := stackInfo.Deployment.Resources[1]
+			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+			//
+			// Assert pod is successfully created.
+			//
+
+			pod := stackInfo.Deployment.Resources[0]
+			name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+			assert.Equal(t, name.(string), "pod-test")
+
+			// Not autonamed.
+			_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+				"pulumi.com/autonamed")
+			assert.False(t, autonamed)
+
+			// Status is "Running"
+			phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+			assert.Equal(t, "Running", phase)
+
+			// Status "Ready" is "True".
+			conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+			ready := conditions.([]interface{})[1].(map[string]interface{})
+			readyType, _ := ready["type"]
+			assert.Equal(t, "Ready", readyType)
+			readyStatus, _ := ready["status"]
+			assert.Equal(t, "True", readyStatus)
+
+			// Container is called "nginx" and uses image "nginx:1.13-alpine".
+			containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+			containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
+			containerName, _ := containerStatus["name"]
+			assert.Equal(t, "nginx", containerName)
+			image, _ := containerStatus["image"]
+			assert.Equal(t, "nginx:1.13-alpine", image)
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      "step2",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					//
+					// Assert Pod is deleted before being replaced with the new Pod, running
+					// nginx:1.15-alpine.
+					//
+					// Because the Pod name is supplied in the resource definition, we are forced to delete it
+					// before replacing it, as otherwise Kubernetes would complain that it can't have two Pods
+					// with the same name.
+					//
+
+					pod := stackInfo.Deployment.Resources[0]
+					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					assert.Equal(t, name.(string), "pod-test")
+
+					// Not autonamed.
+					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+						"pulumi.com/autonamed")
+					assert.False(t, autonamed)
+
+					// Status is "Running"
+					phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+					assert.Equal(t, "Running", phase)
+
+					// Status "Ready" is "True".
+					conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+					ready := conditions.([]interface{})[1].(map[string]interface{})
+					readyType, _ := ready["type"]
+					assert.Equal(t, "Ready", readyType)
+					readyStatus, _ := ready["status"]
+					assert.Equal(t, "True", readyStatus)
+
+					// Container is called "nginx" and uses image "nginx:1.13-alpine".
+					containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+					containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
+					containerName, _ := containerStatus["name"]
+					assert.Equal(t, "nginx", containerName)
+					image, _ := containerStatus["image"]
+					assert.Equal(t, "nginx:1.15-alpine", image)
+				},
+			},
+			{
+				Dir:      "step3",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 2, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					//
+					// Assert new Pod is deleted before being replaced with the new Pod, running
+					// nginx:1.13-alpine, EVEN WHEN we change the namespace from "" -> "default". This
+					// captures the case that we need to delete-before-replace if we're deploying to the same
+					// namespace, as measured by canonical name, rather than literal string equality.
+					//
+
+					pod := stackInfo.Deployment.Resources[0]
+					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					assert.Equal(t, name.(string), "pod-test")
+
+					// Not autonamed.
+					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
+						"pulumi.com/autonamed")
+					assert.False(t, autonamed)
+
+					// Status is "Running"
+					phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+					assert.Equal(t, "Running", phase)
+
+					// Status "Ready" is "True".
+					conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+					ready := conditions.([]interface{})[1].(map[string]interface{})
+					readyType, _ := ready["type"]
+					assert.Equal(t, "Ready", readyType)
+					readyStatus, _ := ready["status"]
+					assert.Equal(t, "True", readyStatus)
+
+					// Container is called "nginx" and uses image "nginx:1.13-alpine".
+					containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+					containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
+					containerName, _ := containerStatus["name"]
+					assert.Equal(t, "nginx", containerName)
+					image, _ := containerStatus["image"]
+					assert.Equal(t, "nginx:1.13-alpine", image)
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/delete-before-replace/step1/Pulumi.yaml
+++ b/tests/integration/delete-before-replace/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: delete-before-replace
+description: A program that tests partial provider failure.
+runtime: nodejs

--- a/tests/integration/delete-before-replace/step1/index.ts
+++ b/tests/integration/delete-before-replace/step1/index.ts
@@ -1,0 +1,18 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Create a simple Pod.
+//
+
+const pod = new k8s.core.v1.Pod("pod-test", {
+  metadata: {
+    name: "pod-test",
+  },
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.13-alpine"},
+    ],
+  },
+})

--- a/tests/integration/delete-before-replace/step1/package.json
+++ b/tests/integration/delete-before-replace/step1/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "steps",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^0.14.0-rc1"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/delete-before-replace/step1/tsconfig.json
+++ b/tests/integration/delete-before-replace/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/delete-before-replace/step2/index.ts
+++ b/tests/integration/delete-before-replace/step2/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Cause hard delete-before-replace. Changing the Pod's container image tag, causes it to be
+// replaced, and since we've manually specified a name, the engine has no choice but to delete it
+// first, since names are unique, and it can't generate the name by itself.
+//
+
+const pod = new k8s.core.v1.Pod("pod-test", {
+  metadata: {
+    name: "pod-test",
+  },
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.15-alpine"},
+    ],
+  },
+})

--- a/tests/integration/delete-before-replace/step3/index.ts
+++ b/tests/integration/delete-before-replace/step3/index.ts
@@ -1,0 +1,23 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Cause hard delete-before-replace, when specifying a new namespace ("delete") that is equivalent
+// to the old namespace ("", the blanks string). We trigger the hard-replace by again changing the
+// Pod's container image tag. If the new pod has succeeded in being created, and the name is
+// `pod-test`, then we know that it was deleted before being replaced, because Kubernetes would have
+// otherwise complained you can't add two pods with that name.
+//
+
+const pod = new k8s.core.v1.Pod("pod-test", {
+  metadata: {
+    name: "pod-test",
+    namespace: "default",
+  },
+  spec: {
+    containers: [
+      {name: "nginx", image: "nginx:1.13-alpine"},
+    ],
+  },
+})

--- a/tests/util.go
+++ b/tests/util.go
@@ -1,0 +1,13 @@
+package tests
+
+import (
+	"sort"
+
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+)
+
+func SortResourcesByURN(stackInfo integration.RuntimeValidationStackInfo) {
+	sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
+		return stackInfo.Deployment.Resources[i].URN < stackInfo.Deployment.Resources[j].URN
+	})
+}


### PR DESCRIPTION
Add autonaming (_cf_., #10). The design of this feature (which is fairly simple) is specified in that issue.

Fix #68, #99, and #81 (correctness and replacement issues).

Add end-to-end tests for delete-before-replace semantics (partial for #90).

NOTE: We would add end to end tests for service and PVs, but they won't work until we write up the test ci cluster.

[![asciicast](https://asciinema.org/a/slOPaYVTX6pZu49m1FIyHYCci.png)](https://asciinema.org/a/slOPaYVTX6pZu49m1FIyHYCci?autoplay=1)