### PR TITLE
Implement status-rich updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -597,7 +597,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "2e9a2e8a91db1cd73ae5961041c247755a330eaf"
+  revision = "b0c383e1e841977d3f4abb3978e4e29946e10085"
 
 [[projects]]
   branch = "master"
@@ -1378,6 +1378,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4623d7279f537366e9f25fa7cdc36c1e20aa435ef810160d987c2ec4ef01043"
+  inputs-digest = "0b565c5bfab567d99e5729a9790dac6087444adb99418ccd9b0c424e0e61beef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -86,83 +86,88 @@ func TestExamples(t *testing.T) {
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 				},
 			}),
-			base.With(integration.ProgramTestOptions{
-				Dir: path.Join(cwd, "guestbook"),
-				ExtraRuntimeValidation: func(
-					t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
-				) {
-					assert.NotNil(t, stackInfo.Deployment)
-					assert.Equal(t, 7, len(stackInfo.Deployment.Resources))
+			// TODO[pulumi-kubernetes#117]: Enable this when parallelism is turned on.
+			//
+			// base.With(integration.ProgramTestOptions{
+			// 	Dir: path.Join(cwd, "guestbook"),
+			// 	ExtraRuntimeValidation: func(
+			// 		t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+			// 	) {
+			// 		assert.NotNil(t, stackInfo.Deployment)
+			// 		assert.Equal(t, 7, len(stackInfo.Deployment.Resources))
 
-					sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
-						ri := stackInfo.Deployment.Resources[i]
-						rj := stackInfo.Deployment.Resources[j]
-						riname, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "name")
-						rinamespace, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "namespace")
-						rjname, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "name")
-						rjnamespace, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "namespace")
-						return fmt.Sprintf("%s/%s/%s", ri.URN.Type(), rinamespace, riname) <
-							fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
-					})
+			// 		sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
+			// 			ri := stackInfo.Deployment.Resources[i]
+			// 			rj := stackInfo.Deployment.Resources[j]
+			// 			riname, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "name")
+			// 			rinamespace, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "namespace")
+			// 			rjname, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "name")
+			// 			rjnamespace, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "namespace")
+			// 			return fmt.Sprintf("%s/%s/%s", ri.URN.Type(), rinamespace, riname) <
+			// 				fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
+			// 		})
 
-					var name interface{}
-					var status interface{}
+			// 		var name interface{}
+			// 		var status interface{}
 
-					// Verify frontend deployment.
-					frontendDepl := stackInfo.Deployment.Resources[0]
-					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), frontendDepl.URN.Type())
-					name, _ = openapi.Pluck(frontendDepl.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "frontend", name)
-					status, _ = openapi.Pluck(frontendDepl.Outputs, "live", "status", "readyReplicas")
-					assert.Equal(t, float64(3), status)
+			// 		// Verify frontend deployment.
+			// 		frontendDepl := stackInfo.Deployment.Resources[0]
+			// 		assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), frontendDepl.URN.Type())
+			// 		name, _ = openapi.Pluck(frontendDepl.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "frontend", name)
+			// 		status, _ = openapi.Pluck(frontendDepl.Outputs, "live", "status", "readyReplicas")
+			// 		assert.Equal(t, float64(3), status)
 
-					// Verify redis-master deployment.
-					redisMasterDepl := stackInfo.Deployment.Resources[1]
-					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisMasterDepl.URN.Type())
-					name, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "redis-master", name)
-					status, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "status", "readyReplicas")
-					assert.Equal(t, float64(1), status)
+			// 		// Verify redis-master deployment.
+			// 		redisMasterDepl := stackInfo.Deployment.Resources[1]
+			// 		assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisMasterDepl.URN.Type())
+			// 		name, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "redis-master", name)
+			// 		status, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "status", "readyReplicas")
+			// 		assert.Equal(t, float64(1), status)
 
-					// Verify redis-slave deployment.
-					redisSlaveDepl := stackInfo.Deployment.Resources[2]
-					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisSlaveDepl.URN.Type())
-					name, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "redis-slave", name)
-					status, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "status", "readyReplicas")
-					assert.Equal(t, float64(1), status)
+			// 		// Verify redis-slave deployment.
+			// 		redisSlaveDepl := stackInfo.Deployment.Resources[2]
+			// 		assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisSlaveDepl.URN.Type())
+			// 		name, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "redis-slave", name)
+			// 		status, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "status", "readyReplicas")
+			// 		assert.Equal(t, float64(1), status)
 
-					// Verify frontend service.
-					frontentService := stackInfo.Deployment.Resources[3]
-					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), frontentService.URN.Type())
-					name, _ = openapi.Pluck(frontentService.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "frontend", name)
-					status, _ = openapi.Pluck(frontentService.Outputs, "live", "spec", "clusterIP")
-					assert.True(t, len(status.(string)) > 1)
+			// 		// Verify frontend service.
+			// 		frontentService := stackInfo.Deployment.Resources[3]
+			// 		assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), frontentService.URN.Type())
+			// 		name, _ = openapi.Pluck(frontentService.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "frontend", name)
+			// 		status, _ = openapi.Pluck(frontentService.Outputs, "live", "spec", "clusterIP")
+			// 		assert.True(t, len(status.(string)) > 1)
 
-					// Verify redis-master service.
-					redisMasterService := stackInfo.Deployment.Resources[4]
-					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisMasterService.URN.Type())
-					name, _ = openapi.Pluck(redisMasterService.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "redis-master", name)
-					status, _ = openapi.Pluck(redisMasterService.Outputs, "live", "spec", "clusterIP")
-					assert.True(t, len(status.(string)) > 1)
+			// 		// Verify redis-master service.
+			// 		redisMasterService := stackInfo.Deployment.Resources[4]
+			// 		assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisMasterService.URN.Type())
+			// 		name, _ = openapi.Pluck(redisMasterService.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "redis-master", name)
+			// 		status, _ = openapi.Pluck(redisMasterService.Outputs, "live", "spec", "clusterIP")
+			// 		assert.True(t, len(status.(string)) > 1)
 
-					// Verify redis-slave service.
-					redisSlaveService := stackInfo.Deployment.Resources[5]
-					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisSlaveService.URN.Type())
-					name, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "metadata", "name")
-					assert.Equal(t, "redis-slave", name)
-					status, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "spec", "clusterIP")
-					assert.True(t, len(status.(string)) > 1)
+			// 		// Verify redis-slave service.
+			// 		redisSlaveService := stackInfo.Deployment.Resources[5]
+			// 		assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisSlaveService.URN.Type())
+			// 		name, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "metadata", "name")
+			// 		assert.Equal(t, "redis-slave", name)
+			// 		status, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "spec", "clusterIP")
+			// 		assert.True(t, len(status.(string)) > 1)
 
-					// Verify root resource.
-					stackRes := stackInfo.Deployment.Resources[6]
-					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+			// 		// Verify root resource.
+			// 		stackRes := stackInfo.Deployment.Resources[6]
+			// 		assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+			// 	},
+			// }),
 
-				},
-			}),
-			base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "helm")}),
+			// TODO[pulumi-kubernetes#117]: Enable this when parallelism is turned on.
+			//
+			// base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "helm")}),
+
 			// TODO(hausdorff): Enable this when we transition to a version of minikube which correctly
 			// reports version.
 			//

--- a/pack/nodejs/provider.ts
+++ b/pack/nodejs/provider.ts
@@ -1399,7 +1399,7 @@ export namespace apps {
       /**
        * The annotations to be updated to a deployment
        */
-      public readonly updatedAnnotations: pulumi.Output<object>;
+      public readonly updatedAnnotations: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
 
       public getInputs(): inputApi.apps.v1beta1.DeploymentRollback { return this.__inputs; }
@@ -3869,7 +3869,7 @@ export namespace core {
        * Data contains the configuration data. Each key must consist of alphanumeric characters,
        * '-', '_' or '.'.
        */
-      public readonly data: pulumi.Output<object>;
+      public readonly data: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
       /**
        * Kind is a string value representing the REST resource this object represents. Servers may
@@ -5453,7 +5453,7 @@ export namespace core {
        * write-only convenience method. All keys and values are merged into the data field on write,
        * overwriting any existing values. It is never output when reading from the API.
        */
-      public readonly stringData: pulumi.Output<object>;
+      public readonly stringData: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
       /**
        * Used to facilitate programmatic handling of secret data.
@@ -6240,7 +6240,7 @@ export namespace extensions {
       /**
        * The annotations to be updated to a deployment
        */
-      public readonly updatedAnnotations: pulumi.Output<object>;
+      public readonly updatedAnnotations: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
 
       public getInputs(): inputApi.extensions.v1beta1.DeploymentRollback { return this.__inputs; }
@@ -9195,7 +9195,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      public readonly parameters: pulumi.Output<object>;
+      public readonly parameters: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
       /**
        * Provisioner indicates the type of the provisioner.
@@ -9464,7 +9464,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      public readonly parameters: pulumi.Output<object>;
+      public readonly parameters: pulumi.Output<{[key: string]: pulumi.Output<string>}>;
 
       /**
        * Provisioner indicates the type of the provisioner.

--- a/pack/nodejs/types/input.ts
+++ b/pack/nodejs/types/input.ts
@@ -2380,7 +2380,7 @@ export namespace apps {
       /**
        * The annotations to be updated to a deployment
        */
-      updatedAnnotations?: pulumi.Input<object>
+      updatedAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
     }
 
@@ -2646,7 +2646,7 @@ export namespace apps {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      selector?: pulumi.Input<object>
+      selector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -3820,7 +3820,7 @@ export namespace apps {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      selector?: pulumi.Input<object>
+      selector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -7080,7 +7080,7 @@ export namespace core {
        * Data contains the configuration data. Each key must consist of alphanumeric characters,
        * '-', '_' or '.'.
        */
-      data?: pulumi.Input<object>
+      data?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Kind is a string value representing the REST resource this object represents. Servers may
@@ -8228,7 +8228,7 @@ export namespace core {
       /**
        * Optional: Extra command options if any.
        */
-      options?: pulumi.Input<object>
+      options?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in
@@ -10415,7 +10415,7 @@ export namespace core {
        * must match a node's labels for the pod to be scheduled on that node. More info:
        * https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
        */
-      nodeSelector?: pulumi.Input<object>
+      nodeSelector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * The priority value. Various system components use this field to find the priority of the
@@ -11072,7 +11072,7 @@ export namespace core {
        * defaulted to labels on Pod template. More info:
        * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
        */
-      selector?: pulumi.Input<object>
+      selector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Template is the object that describes the pod that will be created if insufficient replicas
@@ -11476,7 +11476,7 @@ export namespace core {
        * write-only convenience method. All keys and values are merged into the data field on write,
        * overwriting any existing values. It is never output when reading from the API.
        */
-      stringData?: pulumi.Input<object>
+      stringData?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Used to facilitate programmatic handling of secret data.
@@ -12026,7 +12026,7 @@ export namespace core {
        * LoadBalancer. Ignored if type is ExternalName. More info:
        * https://kubernetes.io/docs/concepts/services-networking/service/
        */
-      selector?: pulumi.Input<object>
+      selector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based
@@ -13136,7 +13136,7 @@ export namespace extensions {
       /**
        * The annotations to be updated to a deployment
        */
-      updatedAnnotations?: pulumi.Input<object>
+      updatedAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
     }
 
@@ -14357,7 +14357,7 @@ export namespace extensions {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      selector?: pulumi.Input<object>
+      selector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -14746,7 +14746,7 @@ export namespace meta {
        * equivalent to an element of matchExpressions, whose key field is "key", the operator is
        * "In", and the values array contains only "value". The requirements are ANDed.
        */
-      matchLabels?: pulumi.Input<object>
+      matchLabels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
     }
 
@@ -14819,7 +14819,7 @@ export namespace meta {
        * be preserved when modifying objects. More info:
        * http://kubernetes.io/docs/user-guide/annotations
        */
-      annotations?: pulumi.Input<object>
+      annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * The name of the cluster which the object belongs to. This is used to distinguish resources
@@ -14914,7 +14914,7 @@ export namespace meta {
        * select) objects. May match selectors of replication controllers and services. More info:
        * http://kubernetes.io/docs/user-guide/labels
        */
-      labels?: pulumi.Input<object>
+      labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Name must be unique within a namespace. Is required when creating resources, although some
@@ -17288,7 +17288,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      parameters?: pulumi.Input<object>
+      parameters?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Dynamically provisioned PersistentVolumes of this storage class are created with this
@@ -17491,7 +17491,7 @@ export namespace storage {
        * operation that must be passed into subsequent WaitForAttach or Mount calls. This field must
        * only be set by the entity completing the attach operation, i.e. the external-attacher.
        */
-      attachmentMetadata?: pulumi.Input<object>
+      attachmentMetadata?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * The last error encountered during detach operation, if any. This field must only be set by
@@ -17574,7 +17574,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      parameters?: pulumi.Input<object>
+      parameters?: pulumi.Input<{[key: string]: pulumi.Input<string>}>
 
       /**
        * Dynamically provisioned PersistentVolumes of this storage class are created with this

--- a/pack/nodejs/types/output.ts
+++ b/pack/nodejs/types/output.ts
@@ -2242,7 +2242,7 @@ export namespace apps {
       /**
        * The annotations to be updated to a deployment
        */
-      readonly updatedAnnotations: object
+      readonly updatedAnnotations: {[key: string]: string}
 
     }
 
@@ -2493,7 +2493,7 @@ export namespace apps {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      readonly selector: object
+      readonly selector: {[key: string]: string}
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -3603,7 +3603,7 @@ export namespace apps {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      readonly selector: object
+      readonly selector: {[key: string]: string}
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -6674,7 +6674,7 @@ export namespace core {
        * Data contains the configuration data. Each key must consist of alphanumeric characters,
        * '-', '_' or '.'.
        */
-      readonly data: object
+      readonly data: {[key: string]: string}
 
       /**
        * Kind is a string value representing the REST resource this object represents. Servers may
@@ -7771,7 +7771,7 @@ export namespace core {
       /**
        * Optional: Extra command options if any.
        */
-      readonly options: object
+      readonly options: {[key: string]: string}
 
       /**
        * Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in
@@ -9851,7 +9851,7 @@ export namespace core {
        * must match a node's labels for the pod to be scheduled on that node. More info:
        * https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
        */
-      readonly nodeSelector: object
+      readonly nodeSelector: {[key: string]: string}
 
       /**
        * The priority value. Various system components use this field to find the priority of the
@@ -10481,7 +10481,7 @@ export namespace core {
        * defaulted to labels on Pod template. More info:
        * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
        */
-      readonly selector: object
+      readonly selector: {[key: string]: string}
 
       /**
        * Template is the object that describes the pod that will be created if insufficient replicas
@@ -10868,7 +10868,7 @@ export namespace core {
        * write-only convenience method. All keys and values are merged into the data field on write,
        * overwriting any existing values. It is never output when reading from the API.
        */
-      readonly stringData: object
+      readonly stringData: {[key: string]: string}
 
       /**
        * Used to facilitate programmatic handling of secret data.
@@ -11387,7 +11387,7 @@ export namespace core {
        * LoadBalancer. Ignored if type is ExternalName. More info:
        * https://kubernetes.io/docs/concepts/services-networking/service/
        */
-      readonly selector: object
+      readonly selector: {[key: string]: string}
 
       /**
        * Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based
@@ -12451,7 +12451,7 @@ export namespace extensions {
       /**
        * The annotations to be updated to a deployment
        */
-      readonly updatedAnnotations: object
+      readonly updatedAnnotations: {[key: string]: string}
 
     }
 
@@ -13603,7 +13603,7 @@ export namespace extensions {
        * label query over pods that should match the replicas count. More info:
        * http://kubernetes.io/docs/user-guide/labels#label-selectors
        */
-      readonly selector: object
+      readonly selector: {[key: string]: string}
 
       /**
        * label selector for pods that should match the replicas count. This is a serializated
@@ -13966,7 +13966,7 @@ export namespace meta {
        * equivalent to an element of matchExpressions, whose key field is "key", the operator is
        * "In", and the values array contains only "value". The requirements are ANDed.
        */
-      readonly matchLabels: object
+      readonly matchLabels: {[key: string]: string}
 
     }
 
@@ -14036,7 +14036,7 @@ export namespace meta {
        * be preserved when modifying objects. More info:
        * http://kubernetes.io/docs/user-guide/annotations
        */
-      readonly annotations: object
+      readonly annotations: {[key: string]: string}
 
       /**
        * The name of the cluster which the object belongs to. This is used to distinguish resources
@@ -14131,7 +14131,7 @@ export namespace meta {
        * select) objects. May match selectors of replication controllers and services. More info:
        * http://kubernetes.io/docs/user-guide/labels
        */
-      readonly labels: object
+      readonly labels: {[key: string]: string}
 
       /**
        * Name must be unique within a namespace. Is required when creating resources, although some
@@ -16328,7 +16328,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      readonly parameters: object
+      readonly parameters: {[key: string]: string}
 
       /**
        * Provisioner indicates the type of the provisioner.
@@ -16518,7 +16518,7 @@ export namespace storage {
        * operation that must be passed into subsequent WaitForAttach or Mount calls. This field must
        * only be set by the entity completing the attach operation, i.e. the external-attacher.
        */
-      readonly attachmentMetadata: object
+      readonly attachmentMetadata: {[key: string]: string}
 
       /**
        * The last error encountered during detach operation, if any. This field must only be set by
@@ -16594,7 +16594,7 @@ export namespace storage {
        * Parameters holds the parameters for the provisioner that should create volumes of this
        * storage class.
        */
-      readonly parameters: object
+      readonly parameters: {[key: string]: string}
 
       /**
        * Provisioner indicates the type of the provisioner.

--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -1,0 +1,483 @@
+package await
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-kubernetes/pkg/client"
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi/pkg/diag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ------------------------------------------------------------------------------------------------
+
+// Await logic for extensions/v1beta1/Deployment, apps/v1beta1/Deployment, apps/v1beta2/Deployment,
+// and apps/v1/Deployment.
+//
+// The goal of this code is to provide a fine-grained account of the status of a Kubernetes
+// Deployment as it is being initialized. The idea is that if something goes wrong early, we want to
+// alert the user so they can cancel the operation instead of waiting for timeout (~10 minutes).
+//
+// A Deployment is a construct that allows users to specify how to execute an update to an
+// application that is replicated some number of times in a cluster. When an application is updated,
+// the Deployment will incrementally roll out the new version (according to the policy requested by
+// the user). When the new application Pods becomes "live" (as specified by the liveness and
+// readiness probes), the old Pods are killed and deleted.
+//
+// Because this resource abstracts over so much (it is a way to roll out, essentially, ReplicaSets,
+// which themseves are an abstraction for replicating Pods), the success conditions are fairly
+// complex:
+//
+//   1. `.metadata.annotations["deployment.kubernetes.io/revision"]` in the current Deployment must
+//      have been incremented by the Deployment controller, i.e., it must not be equal to the
+//      revision number in the previous outputs.
+//
+//      This number is used to indicate the the active ReplicaSet. Any time a change is made to the
+//      Deployment's Pod template, this revision is incremented, and a new ReplicaSet is created
+//      with a corresponding revision number in its own annotations. This condition overall is a
+//      test to make sure that the Deployment controller is making progress in rolling forward to
+//      the new generation.
+//   2. `.status.conditions` has a status with `type` equal to `Progressing`, a `status` set to
+//      `True`, and a `reason` set to `NewReplicaSetAvailable`. Though the condition is called
+//      "Progressing", this condition indicates that the new ReplicaSet has become healthy and
+//      available, and the Deployment controller is now free to delete the old ReplicaSet.
+//   3. `.status.conditions` has a status with `type` equal to `Available`, a `status` equal to
+//      `True`. If the Deployment is not available, we should fail the Deployment immediately.
+//
+// The core event loop of this awaiter is actually individually straightforward, except for the
+// fact that it must aggregate statuses for all Pods in the new ReplicaSet. The event loop depends
+// on the following channels:
+//
+//   1. The Deployment channel, to which the Kubernetes API server will proactively push every change
+//      (additions, modifications, deletions) to any Deployment it knows about.
+//   2. The Pod channel, which is the same idea as the Deployment channel, except it gets updates
+//      to Pod objects. These are then aggregated and any errors are bundled together and
+//      periodically reported to the user.
+//   3. A timeout channel, which fires after some minutes.
+//   4. A cancellation channel, with which the user can signal cancellation (e.g., using SIGINT).
+//   5. A period channel, which is used to signal when we should display an aggregated report of
+//      Pod errors we know about.
+//
+// The `deploymentInitAwaiter` will synchronously process events from the union of all these channels.
+// Any time the success conditions described above a reached, we will terminate the awaiter.
+//
+// The opportunity to display intermediate results will typically appear after a container in the
+// Pod fails, (e.g., volume fails to mount, image fails to pull, exited with code 1, etc.).
+//
+//
+// x-refs:
+//   * https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+//   * https://kubernetes-v1-4.github.io/docs/user-guide/pod-states/
+
+// ------------------------------------------------------------------------------------------------
+
+const (
+	revision = "deployment.kubernetes.io/revision"
+)
+
+type deploymentInitAwaiter struct {
+	config                 updateAwaitConfig
+	rolloutComplete        bool
+	updatedReplicaSetReady bool
+	currentGeneration      string
+
+	deploymentErrors map[string]string
+
+	replicaSets map[string]*unstructured.Unstructured
+	pods        map[string]*unstructured.Unstructured
+}
+
+func makeDeploymentInitAwaiter(c updateAwaitConfig) *deploymentInitAwaiter {
+	return &deploymentInitAwaiter{
+		config:                 c,
+		rolloutComplete:        false,
+		updatedReplicaSetReady: false,
+		// NOTE: Generation 0 is invalid, so this is a good sentinel value.
+		currentGeneration: "0",
+
+		deploymentErrors: map[string]string{},
+
+		pods:        map[string]*unstructured.Unstructured{},
+		replicaSets: map[string]*unstructured.Unstructured{},
+	}
+}
+
+func (dia *deploymentInitAwaiter) Await() error {
+	//
+	// We succeed when only when all of the following are true:
+	//
+	//   1. `.metadata.generation` is equal to `.status.observedGeneration`
+	//   2. `.status.conditions` has a status of type `Progressing`, whose `status` member is set
+	//      to `True`, and whose `reason` is `NewReplicaSetAvailable`.
+	//   3. `.status.conditions` has a status of type `Available` whose `status` member is set to
+	//      `True`.
+	//
+
+	// Create Deployment watcher.
+	deploymentWatcher, err := dia.config.clientForResource.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Could set up watch for Deployment object '%s'",
+			dia.config.currentInputs.GetName())
+	}
+	defer deploymentWatcher.Stop()
+
+	// Create ReplicaSet watcher.
+	replicaSetClient, err := client.FromGVK(dia.config.pool, dia.config.disco,
+		schema.GroupVersionKind{
+			Group:   "extensions",
+			Version: "v1beta1",
+			Kind:    "ReplicaSet",
+		}, dia.config.currentInputs.GetNamespace())
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not make client to watch ReplicaSets associated with Deployment '%s'",
+			dia.config.currentInputs.GetName())
+	}
+
+	replicaSetWatcher, err := replicaSetClient.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not create watcher for ReplicaSet objects associated with Deployment '%s'",
+			dia.config.currentInputs.GetName())
+	}
+	defer replicaSetWatcher.Stop()
+
+	// Create Pod watcher.
+	podClient, err := client.FromGVK(dia.config.pool, dia.config.disco,
+		schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Pod",
+		}, dia.config.currentInputs.GetNamespace())
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not make client to watch Pods associated with Deployment '%s'",
+			dia.config.currentInputs.GetName())
+	}
+
+	podWatcher, err := podClient.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not create watcher for Pods objects associated with Deployment '%s'",
+			dia.config.currentInputs.GetName())
+	}
+	defer podWatcher.Stop()
+
+	period := time.NewTicker(10 * time.Second)
+	defer period.Stop()
+
+	return dia.await(deploymentWatcher, replicaSetWatcher, podWatcher, time.After(5*time.Minute), period.C)
+}
+
+// await is a helper companion to `Await` designed to make it easy to test this module.
+func (dia *deploymentInitAwaiter) await(
+	deploymentWatcher, replicaSetWatcher, podWatcher watch.Interface, timeout, period <-chan time.Time,
+) error {
+	inputPodName := dia.config.currentInputs.GetName()
+	for {
+		// Check whether we've succeeded.
+		if dia.rolloutComplete && dia.updatedReplicaSetReady {
+			return nil
+		}
+
+		// Else, wait for updates.
+		select {
+		case <-dia.config.ctx.Done():
+			return &cancellationError{
+				objectName: inputPodName,
+				subErrors:  dia.errorMessages(),
+			}
+		case <-timeout:
+			return &timeoutError{
+				objectName: inputPodName,
+				subErrors:  dia.errorMessages(),
+			}
+		case <-period:
+			scheduleErrors, containerErrors := dia.aggregatePodErrors()
+			for _, message := range scheduleErrors {
+				dia.warn(message)
+			}
+
+			for _, message := range containerErrors {
+				dia.warn(message)
+			}
+		case event := <-deploymentWatcher.ResultChan():
+			dia.processDeploymentEvent(event)
+		case event := <-replicaSetWatcher.ResultChan():
+			dia.processReplicaSetEvent(event)
+		case event := <-podWatcher.ResultChan():
+			dia.processPodEvent(event)
+		}
+	}
+}
+
+func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
+	inputDeploymentName := dia.config.currentInputs.GetName()
+
+	deployment, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("Deployment watch received unknown object type '%s'",
+			reflect.TypeOf(deployment))
+		return
+	}
+
+	// Start over, prove that rollout is complete.
+	dia.rolloutComplete = false
+	dia.deploymentErrors = map[string]string{}
+
+	// Do nothing if this is not the Deployment we're waiting for.
+	if deployment.GetName() != inputDeploymentName {
+		return
+	}
+
+	// Mark the rollout as incomplete if it's deleted.
+	if event.Type == watch.Deleted {
+		return
+	}
+
+	// Get current generation of the Deployment.
+	dia.currentGeneration = deployment.GetAnnotations()[revision]
+	if dia.currentGeneration == "" {
+		// No current generation, Deployment controller has not yet created a ReplicaSet. Do
+		// nothing.
+		return
+	}
+
+	// Check Deployments conditions to see whether new ReplicaSet is available. If it is, we are
+	// successful.
+	rawConditions, hasConditions := openapi.Pluck(deployment.Object, "status", "conditions")
+	conditions, isSlice := rawConditions.([]interface{})
+	if !hasConditions || !isSlice {
+		// Deployment controller has not made progress yet. Do nothing.
+		return
+	}
+
+	// Success occurs when the ReplicaSet of the `currentGeneration` is marked as available, and
+	// when the deployment is available.
+	replicaSetAvailable := false
+	deploymentAvailable := false
+	for _, rawCondition := range conditions {
+		condition, isMap := rawCondition.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+
+		if condition["type"] == "Progressing" {
+			isProgressing := condition["status"] == trueStatus
+			if !isProgressing {
+				rawReason, hasReason := condition["reason"]
+				reason, isString := rawReason.(string)
+				if !hasReason || !isString {
+					continue
+				}
+				rawMessage, hasMessage := condition["message"]
+				message, isString := rawMessage.(string)
+				if !hasMessage || !isString {
+					continue
+				}
+				message = fmt.Sprintf("[%s] %s", reason, message)
+				dia.deploymentErrors[reason] = message
+				dia.warn(message)
+			}
+
+			replicaSetAvailable = condition["reason"] == "NewReplicaSetAvailable" && isProgressing
+		}
+
+		if condition["type"] == "Available" {
+			deploymentAvailable = condition["status"] == trueStatus
+			if !deploymentAvailable {
+				rawReason, hasReason := condition["reason"]
+				reason, isString := rawReason.(string)
+				if !hasReason || !isString {
+					continue
+				}
+				rawMessage, hasMessage := condition["message"]
+				message, isString := rawMessage.(string)
+				if !hasMessage || !isString {
+					continue
+				}
+				message = fmt.Sprintf("[%s] %s", reason, message)
+				dia.deploymentErrors[reason] = message
+			}
+		}
+	}
+
+	dia.rolloutComplete = replicaSetAvailable && deploymentAvailable
+	dia.checkReplicaSetStatus()
+}
+
+func (dia *deploymentInitAwaiter) processReplicaSetEvent(event watch.Event) {
+	rs, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("ReplicaSet watch received unknown object type '%s'",
+			reflect.TypeOf(rs))
+		return
+	}
+
+	// Check whether this ReplicaSet was created by our Deployment.
+	if !isOwnedBy(rs, dia.config.currentInputs) {
+		return
+	}
+
+	// If Pod was deleted, remove it from our aggregated checkers.
+	generation := rs.GetAnnotations()[revision]
+	if event.Type == watch.Deleted {
+		delete(dia.replicaSets, generation)
+		return
+	}
+	dia.replicaSets[generation] = rs
+	dia.checkReplicaSetStatus()
+}
+
+func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
+	inputs := dia.config.currentInputs
+
+	glog.V(3).Infof("Checking ReplicaSet status for Deployment '%s'", inputs.GetName())
+
+	rs, udpatedReplicaSetCreated := dia.replicaSets[dia.currentGeneration]
+	if dia.currentGeneration == "0" || !udpatedReplicaSetCreated {
+		return
+	}
+
+	glog.V(3).Infof("Deployment '%s' has generation '%s', which corresponds to ReplicaSet '%s'",
+		inputs.GetName(), dia.currentGeneration, rs.GetName())
+
+	var lastGeneration string
+	if outputs := dia.config.lastOutputs; outputs != nil {
+		lastGeneration = outputs.GetAnnotations()[revision]
+	}
+
+	glog.V(3).Infof("The last generation of Deployment '%s' was '%s'", inputs.GetName(), lastGeneration)
+
+	rawSpecReplicas, specReplicasExists := openapi.Pluck(inputs.Object, "spec", "replicas")
+	specReplicas, _ := rawSpecReplicas.(float64)
+	rawReadyReplicas, readyReplicasExists := openapi.Pluck(rs.Object, "status", "readyReplicas")
+	readyReplicas, _ := rawReadyReplicas.(int64)
+
+	glog.V(3).Infof("ReplicaSet '%s' requests '%v' replicas, but has '%v' ready",
+		rs.GetName(), specReplicas, lastGeneration)
+
+	dia.updatedReplicaSetReady = lastGeneration != dia.currentGeneration && udpatedReplicaSetCreated &&
+		specReplicasExists && readyReplicasExists && readyReplicas >= int64(specReplicas)
+}
+
+func (dia *deploymentInitAwaiter) processPodEvent(event watch.Event) {
+	inputDeploymentName := dia.config.currentInputs.GetName()
+
+	pod, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("Pod watch received unknown object type '%s'",
+			reflect.TypeOf(pod))
+		return
+	}
+
+	// Check whether this Pod was created by our Deployment.
+	podName := pod.GetName()
+	if !strings.HasPrefix(podName+"-", inputDeploymentName) {
+		return
+	}
+
+	// If Pod was deleted, remove it from our aggregated checkers.
+	if event.Type == watch.Deleted {
+		delete(dia.pods, podName)
+		return
+	}
+
+	dia.pods[podName] = pod
+}
+
+func (dia *deploymentInitAwaiter) warn(message string) {
+	if dia.config.host != nil {
+		_ = dia.config.host.Log(dia.config.ctx, diag.Warning, dia.config.urn, message)
+	}
+}
+
+func (dia *deploymentInitAwaiter) aggregatePodErrors() ([]string, []string) {
+	rs, exists := dia.replicaSets[dia.currentGeneration]
+	if !exists {
+		return []string{}, []string{}
+	}
+
+	scheduleErrorCounts := map[string]int{}
+	containerErrorCounts := map[string]int{}
+	for _, pod := range dia.pods {
+		// Filter down to only Pods owned by the active ReplicaSet.
+		if !isOwnedBy(pod, rs) {
+			continue
+		}
+
+		// Check the pod for errors.
+		checker := makePodChecker()
+		checker.check(pod)
+
+		for reason, message := range checker.podScheduledErrors {
+			message = fmt.Sprintf("[%s] %s", reason, message)
+			scheduleErrorCounts[message] = scheduleErrorCounts[message] + 1
+		}
+
+		for reason, messages := range checker.containerErrors {
+			for _, message := range messages {
+				message = fmt.Sprintf("[%s] %s", reason, message)
+				containerErrorCounts[message] = containerErrorCounts[message] + 1
+			}
+		}
+	}
+
+	scheduleErrors := []string{}
+	for message, count := range scheduleErrorCounts {
+		message = fmt.Sprintf("%d Pods failed to schedule because: %s", count, message)
+		scheduleErrors = append(scheduleErrors, message)
+	}
+
+	containerErrors := []string{}
+	for message, count := range containerErrorCounts {
+		message = fmt.Sprintf("%d Pods failed to run because: %s", count, message)
+		containerErrors = append(containerErrors, message)
+	}
+
+	return scheduleErrors, containerErrors
+}
+
+func (dia *deploymentInitAwaiter) errorMessages() []string {
+	messages := []string{}
+	for _, message := range dia.deploymentErrors {
+		messages = append(messages, message)
+	}
+	if !dia.updatedReplicaSetReady {
+		messages = append(messages, "Updated ReplicaSet was never created")
+	}
+	scheduleErrors, containerErrors := dia.aggregatePodErrors()
+	messages = append(messages, scheduleErrors...)
+	messages = append(messages, containerErrors...)
+
+	return messages
+}
+
+func isOwnedBy(obj, possibleOwner *unstructured.Unstructured) bool {
+	// Canonicalize apiVersion for Deployments.
+	if possibleOwner.GetAPIVersion() == "extensions/v1beta1" && possibleOwner.GetKind() == "Deployment" {
+		possibleOwner.SetAPIVersion("apps/v1beta1")
+	}
+
+	owners := obj.GetOwnerReferences()
+	for _, owner := range owners {
+		if owner.APIVersion == "extensions/v1beta1" && owner.Kind == "Deployment" {
+			owner.APIVersion = "apps/v1beta1"
+		}
+
+		if owner.APIVersion == possibleOwner.GetAPIVersion() &&
+			possibleOwner.GetKind() == owner.Kind && possibleOwner.GetName() == owner.Name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/await/apps_deployment_test.go
+++ b/pkg/await/apps_deployment_test.go
@@ -1,0 +1,1363 @@
+package await
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	inputNamespace          = "default"
+	deploymentInputName     = "foo-4setj4y6"
+	replicaSetGeneratedName = "foo-4setj4y6-7cdf7ddc54"
+	revision1               = "1"
+)
+
+func Test_Apps_Deployment(t *testing.T) {
+	tests := []struct {
+		description   string
+		do            func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time)
+		expectedError error
+	}{
+		{
+			description: "Should succeed after creating first ReplicaSet",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully creates and initializes Deployment and ReplicaSet
+				// objects.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingUnavailable(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should succeed even if ReplicaSet becomes available before Deployment repots it",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully creates and initializes Deployment and ReplicaSet
+				// objects.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingUnavailable(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should succeed if update has rolled out",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// Deployment is updated by the user. The controller creates and successfully
+				// initializes the ReplicaSet.
+				deployments <- watchAddedEvent(
+					deploymentUpdated(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentUpdatedReplicaSetProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentUpdatedReplicaSetProgressed(inputNamespace, deploymentInputName, revision1))
+
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should fail if unrelated Deployment succeeds",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				deployments <- watchAddedEvent(deploymentRolloutComplete(inputNamespace, "bar", revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+		},
+		{
+			description: "Should succeed when unrelated deployment fails",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				deployments <- watchAddedEvent(deploymentAdded(inputNamespace, "bar", revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should report success immediately even if the next event is a failure",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should fail if timeout occurs before Deployment controller progresses",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// User submits a deployment. Controller hasn't created the ReplicaSet when we time
+				// out.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName, subErrors: []string{}},
+		},
+		{
+			description: "Should fail if timeout occurs before ReplicaSet is created",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// User submits a deployment. Controller creates ReplicaSet, but the replication
+				// controller does not start initializing it before it errors out.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+		},
+		{
+			description: "Should fail if timeout occurs before ReplicaSet becomes available",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// User submits a deployment. Controller creates ReplicaSet, but it's still
+				// unavailable when we time out.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingUnavailable(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName,
+				subErrors: []string{
+					"[MinimumReplicasUnavailable] Deployment does not have minimum availability.",
+					"Updated ReplicaSet was never created"}},
+		},
+		{
+			description: "Should fail if new ReplicaSet isn't created after an update",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// Deployment is updated by the user. The controller does not create a new
+				// ReplicaSet before we time out.
+				deployments <- watchAddedEvent(
+					deploymentUpdated(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+		},
+		{
+			description: "Should fail if timeout before new ReplicaSet becomes available",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// Deployment is updated by the user. The controller creates the ReplicaSet, but we
+				// time out before it can complete initializing.
+				deployments <- watchAddedEvent(
+					deploymentUpdated(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentUpdatedReplicaSetProgressing(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+		},
+		{
+			description: "Should fail if Deployment not progressing",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// User submits a deployment. Controller creates ReplicaSet, and it tries to
+				// progress, but it fails.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentNotProgressing(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName,
+				subErrors: []string{
+					`[ProgressDeadlineExceeded] ReplicaSet "foo-13y9rdnu-b94df86d6" has timed ` +
+						`out progressing.`}},
+		},
+		{
+			description: "Should fail if Deployment is progressing but new ReplicaSet not available",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// User submits a deployment. Controller creates ReplicaSet, and it tries to
+				// progress, but it will not, because it is using an invalid container image.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: deploymentInputName, subErrors: []string{}},
+		},
+		{
+			description: "Failure should only report Pods from active ReplicaSet, part 1",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				readyPodName := "foo-4setj4y6-7cdf7ddc54-kvh2w"
+
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Ready Pod should generate no errors.
+				pods <- watchAddedEvent(deployedReadyPod(inputNamespace, readyPodName, replicaSetGeneratedName))
+
+				// Pod belonging to some other ReplicaSet should not show up in the errors.
+				pods <- watchAddedEvent(deployedFailedPod(inputNamespace, readyPodName, "bar"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+		},
+		{
+			description: "Failure should only report Pods from active ReplicaSet, part 2",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				readyPodName := "foo-4setj4y6-7cdf7ddc54-kvh2w"
+
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				// Failed Pod should show up in the errors.
+				pods <- watchAddedEvent(deployedFailedPod(inputNamespace, readyPodName, replicaSetGeneratedName))
+
+				// // Unrelated successful Pod should generate no errors.
+				pods <- watchAddedEvent(deployedReadyPod(inputNamespace, readyPodName, "bar"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+		},
+		{
+			description: "Should fail if ReplicaSet generations do not match",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, "2"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Updated ReplicaSet was never created"}},
+		},
+	}
+
+	for _, test := range tests {
+		awaiter := makeDeploymentInitAwaiter(
+			updateAwaitConfig{
+				createAwaitConfig: mockAwaitConfig(deploymentInput(inputNamespace, deploymentInputName)),
+			})
+		deployments := make(chan watch.Event)
+		replicaSets := make(chan watch.Event)
+		pods := make(chan watch.Event)
+
+		timeout := make(chan time.Time)
+		period := make(chan time.Time)
+		go test.do(deployments, replicaSets, pods, timeout)
+
+		err := awaiter.await(&mockWatcher{results: deployments}, &mockWatcher{results: replicaSets},
+			&mockWatcher{results: pods}, timeout, period)
+		assert.Equal(t, test.expectedError, err, test.description)
+	}
+}
+
+// --------------------------------------------------------------------------
+
+// Deployment objects.
+
+// --------------------------------------------------------------------------
+
+func deploymentInput(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "labels": {
+            "app": "foo"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx"
+                    }
+                ]
+            }
+        }
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentAdded(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 1,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {}
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentProgressing(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 1,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "conditions": [
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T21:49:04Z",
+                "lastTransitionTime": "2018-07-31T21:49:04Z",
+                "reason": "NewReplicaSetCreated",
+                "message": "Created new replica set \"foo-lobqxn87-546cb87d96\""
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentNotProgressing(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "generation": 3,
+        "labels": {
+            "app": "foo"
+        },
+        "namespace": "%s",
+        "name": "%s",
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "sdkjsdjkljklds",
+                        "name": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 1,
+        "conditions": [
+            {
+                "lastTransitionTime": "2018-07-31T23:42:21Z",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastTransitionTime": "2018-08-01T02:46:31Z",
+                "lastUpdateTime": "2018-08-01T02:46:31Z",
+                "message": "ReplicaSet \"foo-13y9rdnu-b94df86d6\" has timed out progressing.",
+                "reason": "ProgressDeadlineExceeded",
+                "status": "False",
+                "type": "Progressing"
+            }
+        ],
+        "observedGeneration": 3,
+        "readyReplicas": 1,
+        "replicas": 2,
+        "unavailableReplicas": 1,
+        "updatedReplicas": 1
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentProgressingInvalidContainer(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "generation": 4,
+        "labels": {
+            "app": "foo"
+        },
+        "namespace": "%s",
+        "name": "%s",
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "sdkjlsdlkj",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 1,
+        "conditions": [
+            {
+                "lastTransitionTime": "2018-07-31T23:42:21Z",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastTransitionTime": "2018-08-01T03:04:50Z",
+                "lastUpdateTime": "2018-08-01T03:04:50Z",
+                "message": "ReplicaSet \"foo-13y9rdnu-58ddf8f46\" is progressing.",
+                "reason": "ReplicaSetUpdated",
+                "status": "True",
+                "type": "Progressing"
+            }
+        ],
+        "observedGeneration": 4,
+        "readyReplicas": 1,
+        "replicas": 2,
+        "unavailableReplicas": 1,
+        "updatedReplicas": 1
+    }
+}
+`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentProgressingUnavailable(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 1,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "unavailableReplicas": 1,
+        "conditions": [
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T21:49:04Z",
+                "lastTransitionTime": "2018-07-31T21:49:04Z",
+                "reason": "NewReplicaSetCreated",
+                "message": "Created new replica set \"foo-lobqxn87-546cb87d96\""
+            },
+            {
+                "type": "Available",
+                "status": "False",
+                "lastUpdateTime": "2018-07-31T21:49:04Z",
+                "lastTransitionTime": "2018-07-31T21:49:04Z",
+                "reason": "MinimumReplicasUnavailable",
+                "message": "Deployment does not have minimum availability."
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentRolloutComplete(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 1,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "readyReplicas": 1,
+        "availableReplicas": 1,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T21:49:11Z",
+                "lastTransitionTime": "2018-07-31T21:49:11Z",
+                "reason": "MinimumReplicasAvailable",
+                "message": "Deployment has minimum availability."
+            },
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T21:49:11Z",
+                "lastTransitionTime": "2018-07-31T21:49:04Z",
+                "reason": "NewReplicaSetAvailable",
+                "message": "ReplicaSet \"foo-lobqxn87-546cb87d96\" has successfully progressed."
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentUpdated(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 2,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx:1.15-alpine"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "readyReplicas": 1,
+        "availableReplicas": 1,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "lastTransitionTime": "2018-07-31T23:42:21Z",
+                "reason": "MinimumReplicasAvailable",
+                "message": "Deployment has minimum availability."
+            },
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "lastTransitionTime": "2018-07-31T23:42:19Z",
+                "reason": "NewReplicaSetAvailable",
+                "message": "ReplicaSet \"foo-13y9rdnu-546cb87d96\" has successfully progressed."
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentUpdatedReplicaSetProgressing(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 2,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx:1.15-alpine"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "observedGeneration": 2,
+        "replicas": 2,
+        "updatedReplicas": 1,
+        "readyReplicas": 2,
+        "availableReplicas": 2,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "lastTransitionTime": "2018-07-31T23:42:21Z",
+                "reason": "MinimumReplicasAvailable",
+                "message": "Deployment has minimum availability."
+            },
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:43:18Z",
+                "lastTransitionTime": "2018-07-31T23:42:19Z",
+                "reason": "ReplicaSetUpdated",
+                "message": "ReplicaSet \"foo-13y9rdnu-5694b49bf5\" is progressing."
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deploymentUpdatedReplicaSetProgressed(namespace, name, revision string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s",
+        "generation": 2,
+        "labels": {
+            "app": "foo"
+        },
+        "annotations": {
+            "deployment.kubernetes.io/revision": "%s",
+            "pulumi.com/autonamed": "true"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "app": "foo"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx:1.15-alpine"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            }
+        }
+    },
+    "status": {
+        "observedGeneration": 2,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "readyReplicas": 1,
+        "availableReplicas": 1,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:42:21Z",
+                "lastTransitionTime": "2018-07-31T23:42:21Z",
+                "reason": "MinimumReplicasAvailable",
+                "message": "Deployment has minimum availability."
+            },
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2018-07-31T23:43:18Z",
+                "lastTransitionTime": "2018-07-31T23:42:19Z",
+                "reason": "NewReplicaSetAvailable",
+                "message": "ReplicaSet \"foo-13y9rdnu-5694b49bf5\" has successfully progressed."
+            }
+        ]
+    }
+}`, namespace, name, revision))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// --------------------------------------------------------------------------
+
+// ReplicaSet objects.
+
+// --------------------------------------------------------------------------
+
+func availableReplicaSet(namespace, name, deploymentName, revision string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "ReplicaSet",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/desired-replicas": "3",
+            "deployment.kubernetes.io/max-replicas": "4",
+            "deployment.kubernetes.io/revision": "%s",
+            "deployment.kubernetes.io/revision-history": "3",
+            "moolumi.com/metricsChecked": "true",
+            "pulumi.com/autonamed": "true"
+        },
+        "creationTimestamp": "2018-08-03T05:03:53Z",
+        "generation": 1,
+        "labels": {
+            "app": "foo",
+            "pod-template-hash": "3789388710"
+        },
+        "namespace": "%s",
+        "name": "%s",
+        "ownerReferences": [
+            {
+                "apiVersion": "extensions/v1beta1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "Deployment",
+                "name": "%s",
+                "uid": "e4a728af-96d9-11e8-9050-080027bd9056"
+            }
+        ]
+    },
+    "spec": {
+        "replicas": 3,
+        "selector": {
+            "matchLabels": {
+                "app": "foo",
+                "pod-template-hash": "3789388710"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "foo",
+                    "pod-template-hash": "3789388710"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "nginx:1.15-alpine",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/config",
+                                "name": "config-volume"
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30,
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "configmap-rollout-mfonkaf3"
+                        },
+                        "name": "config-volume"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "fullyLabeledReplicas": 3,
+        "observedGeneration": 3,
+        "readyReplicas": 3,
+        "replicas": 3
+    }
+}
+`, revision, namespace, name, deploymentName))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// --------------------------------------------------------------------------
+
+// Pod objects.
+
+// --------------------------------------------------------------------------
+
+func deployedReadyPod(namespace, name, replicaSetName string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"%s\",\"uid\":\"9e300c56-96da-11e8-9050-080027bd9056\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"813941\"}}\n"
+        },
+        "creationTimestamp": "2018-08-03T05:04:10Z",
+        "generateName": "%s-",
+        "labels": {
+            "app": "foo",
+            "pod-template-hash": "3789388710"
+        },
+        "namespace": "%s",
+        "name": "%s",
+        "ownerReferences": [
+            {
+                "apiVersion": "extensions/v1beta1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "ReplicaSet",
+                "name": "%s",
+                "uid": "9e300c56-96da-11e8-9050-080027bd9056"
+            }
+        ]
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "nginx:1.15-alpine",
+                "imagePullPolicy": "Always",
+                "name": "nginx",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/etc/config",
+                        "name": "config-volume"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-rkzb2",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "nodeName": "minikube",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "name": "configmap-rollout-mfonkaf3"
+                },
+                "name": "config-volume"
+            },
+            {
+                "name": "default-token-rkzb2",
+                "secret": {
+                    "defaultMode": 420,
+                    "secretName": "default-token-rkzb2"
+                }
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T05:04:10Z",
+                "status": "True",
+                "type": "Initialized"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T05:04:13Z",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T05:04:10Z",
+                "status": "True",
+                "type": "PodScheduled"
+            }
+        ],
+        "containerStatuses": [
+            {
+                "containerID": "docker://a91bc460f583402484ceeef5801a0f6221bb71f184359e79a8e795e7f463ba02",
+                "image": "nginx:1.15-alpine",
+                "imageID": "docker-pullable://nginx@sha256:23e4dacbc60479fa7f23b3b8e18aad41bd8445706d0538b25ba1d575a6e2410b",
+                "lastState": {},
+                "name": "nginx",
+                "ready": true,
+                "restartCount": 0,
+                "state": {
+                    "running": {
+                        "startedAt": "2018-08-03T05:04:13Z"
+                    }
+                }
+            }
+        ],
+        "hostIP": "192.168.99.100",
+        "phase": "Running",
+        "podIP": "172.17.0.5",
+        "qosClass": "BestEffort",
+        "startTime": "2018-08-03T05:04:10Z"
+    }
+}
+
+`, replicaSetName, replicaSetName, namespace, name, replicaSetName))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func deployedFailedPod(namespace, name, replicaSetName string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"%s\",\"uid\":\"c80dda50-96e4-11e8-9050-080027bd9056\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"819008\"}}\n"
+        },
+        "generateName": "%s-",
+        "labels": {
+            "app": "foo",
+            "pod-template-hash": "3789350985"
+        },
+        "namespace": "%s",
+        "name": "%s",
+        "ownerReferences": [
+            {
+                "apiVersion": "extensions/v1beta1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "ReplicaSet",
+                "name": "%s",
+                "uid": "c80dda50-96e4-11e8-9050-080027bd9056"
+            }
+        ]
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "sdkjlsdlkj",
+                "imagePullPolicy": "Always",
+                "name": "nginx",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/etc/config",
+                        "name": "config-volume"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-rkzb2",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "nodeName": "minikube",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "name": "configmap-rollout-mfonkaf3"
+                },
+                "name": "config-volume"
+            },
+            {
+                "name": "default-token-rkzb2",
+                "secret": {
+                    "defaultMode": 420,
+                    "secretName": "default-token-rkzb2"
+                }
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T06:16:38Z",
+                "status": "True",
+                "type": "Initialized"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T06:16:38Z",
+                "message": "containers with unready status: [nginx]",
+                "reason": "ContainersNotReady",
+                "status": "False",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T06:16:38Z",
+                "status": "True",
+                "type": "PodScheduled"
+            }
+        ],
+        "containerStatuses": [
+            {
+                "image": "sdkjlsdlkj",
+                "imageID": "",
+                "lastState": {},
+                "name": "nginx",
+                "ready": false,
+                "restartCount": 0,
+                "state": {
+                    "waiting": {
+                        "message": "Back-off pulling image \"sdkjlsdlkj\"",
+                        "reason": "ImagePullBackOff"
+                    }
+                }
+            }
+        ],
+        "hostIP": "192.168.99.100",
+        "phase": "Pending",
+        "podIP": "172.17.0.7",
+        "qosClass": "BestEffort",
+        "startTime": "2018-08-03T06:16:38Z"
+    }
+}`, replicaSetName, replicaSetName, namespace, name, replicaSetName))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -177,7 +177,11 @@ func Update(
 		if awaiter.awaitUpdate != nil {
 			conf := updateAwaitConfig{
 				createAwaitConfig: createAwaitConfig{
-					pool: pool, disco: disco, clientForResource: clientForResource, currentInputs: currentSubmitted,
+					ctx:               ctx,
+					pool:              pool,
+					disco:             disco,
+					clientForResource: clientForResource,
+					currentInputs:     currentSubmitted,
 				},
 				lastInputs:  lastSubmitted,
 				lastOutputs: liveOldObj,

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -21,6 +21,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/pulumi/pulumi-kubernetes/pkg/client"
 	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/provider"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -45,7 +47,8 @@ import (
 // (1) the Kubernetes resource is reported to be initialized; (2) the initialization timeout has
 // occurred; or (3) an error has occurred while the resource was being initialized.
 func Creation(
-	ctx context.Context, pool dynamic.ClientPool, disco discovery.ServerResourcesInterface, obj *unstructured.Unstructured,
+	ctx context.Context, host *provider.HostClient, pool dynamic.ClientPool,
+	disco discovery.ServerResourcesInterface, urn resource.URN, obj *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {
 	clientForResource, err := client.FromResource(pool, disco, obj)
 	if err != nil {
@@ -65,10 +68,12 @@ func Creation(
 	if awaiter, exists := awaiters[id]; exists {
 		if awaiter.awaitCreation != nil {
 			conf := createAwaitConfig{
+				host:              host,
 				ctx:               ctx,
 				pool:              pool,
 				disco:             disco,
 				clientForResource: clientForResource,
+				urn:               urn,
 				currentInputs:     obj,
 			}
 			waitErr := awaiter.awaitCreation(conf)
@@ -99,7 +104,8 @@ func Creation(
 // [2]:
 // https://kubernetes.io/docs/concepts/overview/object-management-kubectl/declarative-config/#how-apply-calculates-differences-and-merges-changes
 func Update(
-	ctx context.Context, pool dynamic.ClientPool, disco discovery.CachedDiscoveryInterface,
+	ctx context.Context, host *provider.HostClient, pool dynamic.ClientPool,
+	disco discovery.CachedDiscoveryInterface, urn resource.URN,
 	lastSubmitted, currentSubmitted *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {
 	//
@@ -177,10 +183,12 @@ func Update(
 		if awaiter.awaitUpdate != nil {
 			conf := updateAwaitConfig{
 				createAwaitConfig: createAwaitConfig{
+					host:              host,
 					ctx:               ctx,
 					pool:              pool,
 					disco:             disco,
 					clientForResource: clientForResource,
+					urn:               urn,
 					currentInputs:     currentSubmitted,
 				},
 				lastInputs:  lastSubmitted,
@@ -207,8 +215,8 @@ func Update(
 // (1) the Kubernetes resource is reported to be deleted; (2) the initialization timeout has
 // occurred; or (3) an error has occurred while the resource was being deleted.
 func Deletion(
-	ctx context.Context, pool dynamic.ClientPool, disco discovery.DiscoveryInterface,
-	gvk schema.GroupVersionKind, namespace, name string,
+	ctx context.Context, host *provider.HostClient, pool dynamic.ClientPool,
+	disco discovery.DiscoveryInterface, gvk schema.GroupVersionKind, namespace, name string,
 ) error {
 	// Make delete options based on the version of the client.
 	version, err := client.FetchVersion(disco)

--- a/pkg/await/awaiters.go
+++ b/pkg/await/awaiters.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/pkg/client"
 	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
 	"github.com/pulumi/pulumi-kubernetes/pkg/watcher"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/provider"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,10 +38,12 @@ import (
 // live number of Pods reaches the minimum liveness threshold. `pool` and `disco` are provided
 // typically from a client pool so that polling is reasonably efficient.
 type createAwaitConfig struct {
+	host              *provider.HostClient
 	ctx               context.Context
 	pool              dynamic.ClientPool
 	disco             discovery.ServerResourcesInterface
 	clientForResource dynamic.ResourceInterface
+	urn               resource.URN
 	currentInputs     *unstructured.Unstructured
 }
 

--- a/pkg/await/core_pod.go
+++ b/pkg/await/core_pod.go
@@ -1,0 +1,390 @@
+package await
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi/pkg/diag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ------------------------------------------------------------------------------------------------
+
+// Await logic for core/v1/Pod.
+//
+// Unlike the goals for the other "complex" awaiters, the goal of this code is to provide a
+// fine-grained account of the status of a Kubernetes Pod as it is being initialized in the context
+// of some controller (e.g., a Deployment, etc.).
+//
+// In our context (i.e., supporting `apps/v1*/Deployment`) this means our success measurement for
+// Pods essentially boils down to:
+//
+//   * Waiting until `.status.phase` is set to "Running".
+//   * Waiting until `.status.conditions` has a `Ready` condition, with `status` set to "Ready".
+//
+// But there are subtleties to this, and it's important to understand (1) the weaknesses of the Pod
+// API, and (2) what impact they have on our ability to provide a compelling user experience for
+// them.
+//
+// First, it is important to realize that aside from being explicitly designed to be flexible enough
+// to be managed by a variety of controllers (e.g., Deployments, DaemonSets, ReplicaSets, and so
+// on), they are nearly unusable on their own:
+//
+//   1. Pods are extremely difficult to manage: Once scheduled, they are bound to a node forever,
+//      so if a node fails, the Pod is never rescheduled; there is no built-in, reliable way to
+//      upgrade or change them with predictable consequences; and most importantly, there is no
+//      advantage to NOT simply using a controller to manage them.
+//   2. It is impossible to tell from the resource JSON schema alone whether a Pod is meant to run
+//      indefinitely, or to terminate, which makes it hard to tell in general whether a deployment
+//      was successful. These semantics are typically conferred by a controller that manages Pod
+//      objects -- for example, a Deployment expects Pods to run indefinitely, while a Job expects
+//      them to terminate.
+//
+// For each of these different controllers, there are different success conditions. For a
+// Deployment, a Pod becomes successfully initialized when `.status.phase` is set to "Running". For
+// a Job, a Pod becomes successful when it successfully completes. Since at this point we only
+// support Deployment, we'll settle for the former as "the success condition" for Pods.
+//
+// The subtlety of this that "Running" actually just means that the Pod has been bound to a node,
+// all containers have been created, and at least one is still "alive" -- a status is set once the
+// liveness and readiness probes (which usually simply ping some endpoint, and which are
+// customizable by the user) return success. Along the say several things can go wrong (e.g., image
+// pull error, container exits with code 1), but each of these things would prevent the probes from
+// reporting success, or they would be picked up by the Kubelet.
+//
+// The design of this awaiter is relatively simple, since the conditions of success are relatively
+// straightforward. This awaiter relies on three channels:
+//
+//   1. The Pod channel, to which the Kubernetes API server will proactively push every change
+//      (additions, modifications, deletions) to any Pod it knows about.
+//   2. A timeout channel, which fires after some minutes.
+//   3. A cancellation channel, with which the user can signal cancellation (e.g., using SIGINT).
+//
+// The `podInitAwaiter` will synchronously process events from the union of all these channels. Any
+// time the success conditions described above a reached, we will terminate the awaiter.
+//
+// The opportunity to display intermediate results will typically appear after a container in the
+// Pod fails, (e.g., volume fails to mount, image fails to pull, exited with code 1, etc.).
+//
+//
+// x-refs:
+//   * https://kubernetes-v1-4.github.io/docs/user-guide/pod-states/
+
+// ------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------
+
+// POD CHECKING. Routines for checking whether a Pod has been initialized correctly.
+
+// --------------------------------------------------------------------------
+
+// podChecker receives a Pod and will check its validity. Unlike the complex awaiter for v1/Service,
+// we factor this out as a separate piece so that we can aggregate statuses from many pods together
+// for apps/v1/Deployment.
+type podChecker struct {
+	podScheduled       bool
+	podScheduledErrors map[string]string
+	podInitialized     bool
+	podInitErrors      map[string]string
+	podReady           bool
+	podReadyErrors     map[string]string
+	containerErrors    map[string][]string
+}
+
+func makePodChecker() *podChecker {
+	return &podChecker{
+		podScheduled:       false,
+		podScheduledErrors: map[string]string{},
+		podInitialized:     false,
+		podInitErrors:      map[string]string{},
+		podReady:           false,
+		podReadyErrors:     map[string]string{},
+		containerErrors:    map[string][]string{},
+	}
+}
+
+func (pc *podChecker) check(pod *unstructured.Unstructured) {
+	// Attempt to get status to check if pod is ready.
+	rawStatus, hasStatus := openapi.Pluck(pod.Object, "status")
+	if !hasStatus {
+		// No status, kubelet has not yet started to initialize Pod. Do nothing.
+		return
+	}
+	status, isMap := rawStatus.(map[string]interface{})
+	if !isMap {
+		glog.V(3).Infof("Pod watch received unexpected status type '%s'",
+			reflect.TypeOf(rawStatus))
+		return
+
+	}
+
+	// Alway clear all errors so we start fresh.
+	pc.clearErrors()
+
+	// Check if the pod is ready.
+	switch phase := status["phase"]; phase {
+	case "Running", "Pending", "Failed", "Unknown", nil, "":
+		pc.checkPod(pod, status)
+	default:
+		glog.V(3).Infof("Pod '%s' has unknown status phase '%s'",
+			pod.GetName(), phase)
+	}
+}
+
+func (pc *podChecker) checkPod(pod *unstructured.Unstructured, status map[string]interface{}) {
+	rawConditions, exists := status["conditions"]
+	conditions, isSlice := rawConditions.([]interface{})
+	if !exists && !isSlice {
+		// Kubelet has not yet started to initialize Pod. Do nothing.
+		return
+	}
+
+	// Check if Pod was scheduled. If it wasn't, there's no sense in continuing, because there won't
+	// be other errors.
+	for _, rawCondition := range conditions {
+		condition, isMap := rawCondition.(map[string]interface{})
+		if !isMap {
+			glog.V(3).Infof("Pod '%s' has condition of unknown type: '%s'", pod.GetName(),
+				reflect.TypeOf(rawCondition))
+			continue
+		}
+		if condition["type"] == "Initialized" {
+			pc.podInitialized = condition["status"] == trueStatus
+			if !pc.podInitialized {
+				errorFromCondition(pc.podInitErrors, condition)
+			}
+		}
+		if condition["type"] == "PodScheduled" {
+			pc.podScheduled = condition["status"] == trueStatus
+			if !pc.podScheduled {
+				errorFromCondition(pc.podScheduledErrors, condition)
+			}
+		}
+		if condition["type"] == "Ready" {
+			pc.podReady = condition["status"] == trueStatus
+			if !pc.podReady {
+				errorFromCondition(pc.podReadyErrors, condition)
+			}
+		}
+	}
+
+	// Collect the errors from any containers that are failing.
+	rawContainerStatuses, exists := status["containerStatuses"]
+	containerStatuses, isSlice := rawContainerStatuses.([]interface{})
+	if !exists || !isSlice {
+		return
+	}
+	for _, rawContainerStatus := range containerStatuses {
+		containerStatus, isMap := rawContainerStatus.(map[string]interface{})
+		if !isMap || containerStatus["ready"] == true {
+			continue
+		}
+
+		// Best effort attempt to get name of container. (This should always succeed and if it
+		// doesn't, it's not worth crashing the provider over).
+		rawName := containerStatus["name"]
+		var name string
+		name, _ = rawName.(string)
+
+		// Process container that's waiting.
+		rawWaiting, isWaiting := openapi.Pluck(containerStatus, "state", "waiting")
+		waiting, isMap := rawWaiting.(map[string]interface{})
+		if isWaiting && rawWaiting != nil && isMap {
+			pc.checkWaitingContainer(name, waiting)
+		}
+
+		// Process container that's terminated.
+		rawTerminated, isTerminated := openapi.Pluck(containerStatus, "state", "terminated")
+		terminated, isMap := rawTerminated.(map[string]interface{})
+		if isTerminated && rawTerminated != nil && isMap {
+			pc.checkTerminatedContainer(name, terminated)
+		}
+	}
+
+	// Exhausted our knowledge of possible error states for Pods. Return.
+}
+
+func (pc *podChecker) checkWaitingContainer(name string, waiting map[string]interface{}) {
+	rawReason, hasReason := waiting["reason"]
+	reason, isString := rawReason.(string)
+	if !hasReason || !isString || reason == "" || reason == "ContainerCreating" {
+		return
+	}
+
+	rawMessage, hasMessage := waiting["message"]
+	message, isString := rawMessage.(string)
+	if !hasMessage || !isString {
+		return
+	}
+
+	// Image pull error has a bunch of useless junk at the beginning of the error message. Try to
+	// remove it.
+	imagePullJunk := "rpc error: code = Unknown desc = Error response from daemon: "
+	message = strings.TrimPrefix(message, imagePullJunk)
+
+	pc.containerErrors[reason] = append(pc.containerErrors[reason], message)
+}
+
+func (pc *podChecker) checkTerminatedContainer(name string, terminated map[string]interface{}) {
+	rawReason, hasReason := terminated["reason"]
+	reason, isString := rawReason.(string)
+	if !hasReason || !isString || reason == "" {
+		return
+	}
+
+	rawMessage, hasMessage := terminated["message"]
+	message, isString := rawMessage.(string)
+	if !hasMessage || !isString {
+		message = fmt.Sprintf("Container completed with exit code %d", terminated["exitCode"])
+	}
+
+	pc.containerErrors[reason] = append(pc.containerErrors[reason], message)
+}
+
+func (pc *podChecker) clearErrors() {
+	pc.podScheduledErrors = map[string]string{}
+	pc.containerErrors = map[string][]string{}
+}
+
+func (pc *podChecker) errorMessages() []string {
+	messages := []string{}
+	for reason, message := range pc.podScheduledErrors {
+		messages = append(messages, fmt.Sprintf("Pod unscheduled: [%s] %s", reason, message))
+	}
+
+	for reason, message := range pc.podInitErrors {
+		messages = append(messages, fmt.Sprintf("Pod uninitialized: [%s] %s", reason, message))
+	}
+
+	for reason, message := range pc.podReadyErrors {
+		messages = append(messages, fmt.Sprintf("Pod not ready: [%s] %s", reason, message))
+	}
+
+	for reason, errors := range pc.containerErrors {
+		for _, message := range errors {
+			messages = append(messages, fmt.Sprintf("[%s] %s", reason, message))
+		}
+	}
+	return messages
+}
+
+func errorFromCondition(errors map[string]string, condition map[string]interface{}) {
+	rawReason, hasReason := condition["reason"]
+	reason, isString := rawReason.(string)
+	if !hasReason || !isString {
+		return
+	}
+	rawMessage, hasMessage := condition["message"]
+	message, isString := rawMessage.(string)
+	if !hasMessage || !isString {
+		return
+	}
+	errors[reason] = message
+}
+
+// --------------------------------------------------------------------------
+
+// POD AWAITING. Routines for waiting until a Pod has been initialized correctly.
+
+// --------------------------------------------------------------------------
+
+type podInitAwaiter struct {
+	podChecker
+	config createAwaitConfig
+}
+
+func makePodInitAwaiter(c createAwaitConfig) *podInitAwaiter {
+	return &podInitAwaiter{
+		config:     c,
+		podChecker: *makePodChecker(),
+	}
+}
+
+func (pia *podInitAwaiter) Await() error {
+	//
+	// We succeed when `.status.phase` is set to "Running".
+	//
+
+	podWatcher, err := pia.config.clientForResource.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Couldn't set up watch for Pod object '%s'",
+			pia.config.currentInputs.GetName())
+	}
+	defer podWatcher.Stop()
+
+	return pia.await(podWatcher, time.After(5*time.Minute))
+}
+
+// await is a helper companion to `Await` designed to make it easy to test this module.
+func (pia *podInitAwaiter) await(podWatcher watch.Interface, timeout <-chan time.Time) error {
+	inputPodName := pia.config.currentInputs.GetName()
+	for {
+		// Check whether we've succeeded.
+		if pia.podReady {
+			return nil
+		}
+
+		if pia.config.host != nil {
+			for _, message := range pia.errorMessages() {
+				_ = pia.config.host.Log(pia.config.ctx, diag.Warning, pia.config.urn, message)
+			}
+		}
+
+		// Else, wait for updates.
+		select {
+		// TODO: If Pod is added and not making progress on initialization after
+		// ~30 seconds, report that.
+		case <-pia.config.ctx.Done():
+			// On cancel, check one last time if the service is ready.
+			if pia.podReady {
+				return nil
+			}
+			return &cancellationError{
+				objectName: inputPodName,
+				subErrors:  pia.errorMessages(),
+			}
+		case <-timeout:
+			// On timeout, check one last time if the service is ready.
+			if pia.podReady {
+				return nil
+			}
+			return &timeoutError{
+				objectName: inputPodName,
+				subErrors:  pia.errorMessages(),
+			}
+		case event := <-podWatcher.ResultChan():
+			pia.processPodEvent(event)
+		}
+	}
+}
+
+func (pia *podInitAwaiter) processPodEvent(event watch.Event) {
+	pod, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("Pod watch received unknown object type '%s'",
+			reflect.TypeOf(pod))
+		return
+	}
+
+	// Do nothing if this is not the pod we're waiting for.
+	if pod.GetName() != pia.config.currentInputs.GetName() {
+		return
+	}
+
+	// Start over, prove that pod is ready.
+	pia.podReady = false
+
+	// Mark the pod as not ready if it's deleted.
+	if event.Type == watch.Deleted {
+		return
+	}
+
+	pia.check(pod)
+}

--- a/pkg/await/core_pod_test.go
+++ b/pkg/await/core_pod_test.go
@@ -1,0 +1,762 @@
+package await
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func Test_Core_Pod(t *testing.T) {
+	tests := []struct {
+		description   string
+		do            func(deployments chan watch.Event, timeout chan time.Time)
+		expectedError error
+	}{
+		{
+			description: "Should succeed after booting containers",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully initializes Pod.
+				pods <- watchAddedEvent(podRunning("default", "foo-4setj4y6"))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should transition to success state after initial image pull error",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully adds Pod; pod transitions through various error states
+				// until it successfully reaches running state.
+				pods <- watchAddedEvent(podAdded("default", "foo-4setj4y6"))
+				pods <- watchAddedEvent(podScheduled("default", "foo-4setj4y6"))
+				pods <- watchAddedEvent(podContainerCreating("default", "foo-4setj4y6"))
+				pods <- watchAddedEvent(podErrImagePull("default", "foo-4setj4y6"))
+				pods <- watchAddedEvent(podImagePullBackoff("default", "foo-4setj4y6"))
+				pods <- watchAddedEvent(podRunning("default", "foo-4setj4y6"))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should fail if Kubelet doesn't boot containers",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server begins to initialize Pod, but does not succeed in time.
+				pods <- watchAddedEvent(podAdded("default", "foo-4setj4y6"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6", subErrors: []string{}},
+		},
+		{
+			description: "Should fail if Pod is scheduled but containers aren't created",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server passes initialized service and endpoint objects back.
+				pods <- watchAddedEvent(podScheduled("default", "foo-4setj4y6"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6", subErrors: []string{}},
+		},
+		{
+			description: "Should fail if Pod is unschedulable",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server fails to schedule Pod, marks status as such.
+				pods <- watchAddedEvent(podUnschedulable("default", "foo-4setj4y6"))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{
+					"Pod unscheduled: [Unschedulable] No nodes are available that match all " +
+						"of the predicates: Insufficient cpu (3).",
+				},
+			},
+		},
+		{
+			description: "Should fail if timeout when creating containers",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server passes initialized service and endpoint objects back.
+				pods <- watchAddedEvent(podContainerCreating("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6", subErrors: []string{
+					"Pod not ready: [ContainersNotReady] containers with unready status: [nginx]",
+				}},
+		},
+		{
+			description: "Should fail if timeout after image pull failure",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				// API server tries to initialize Pod, but can't pull the image from $WHATEVER registry.
+				pods <- watchAddedEvent(podErrImagePull("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{
+					"Pod not ready: [ContainersNotReady] containers with unready status: [nginx]",
+					"[ErrImagePull] repository dsjkdsjkljks not found: does not exist or no " +
+						"pull access",
+				},
+			},
+		},
+		{
+			description: "Should fail if container terminated with error",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				pods <- watchAddedEvent(podTerminatedError("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{
+					"Pod not ready: [ContainersNotReady] containers with unready status: [completer]",
+					"[RunContainerError] failed to start container " +
+						"\"ce5652ee18060c0f58144968587f5c333cf97dad907c6743e1e95a63541aab72\": Error " +
+						"response from daemon: oci runtime error: container_linux.go:262: starting " +
+						"container process caused \"exec: \\\"echo foo\\\": executable file not " +
+						"found in $PATH\"",
+				},
+			},
+		},
+		{
+			description: "Should fail if container terminated successfully",
+			do: func(pods chan watch.Event, timeout chan time.Time) {
+				pods <- watchAddedEvent(podTerminatedSuccess("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{
+					"Pod not ready: [ContainersNotReady] containers with unready status: [completer]",
+					"[Completed] Container completed with exit code 0",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		awaiter := makePodInitAwaiter(mockAwaitConfig(podInput("default", "foo-4setj4y6")))
+		pods := make(chan watch.Event)
+
+		timeout := make(chan time.Time)
+		go test.do(pods, timeout)
+
+		err := awaiter.await(&mockWatcher{results: pods}, timeout)
+		assert.Equal(t, test.expectedError, err, test.description)
+	}
+}
+
+// --------------------------------------------------------------------------
+
+// Utility constructs.
+
+// --------------------------------------------------------------------------
+
+func podInput(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podAdded(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    },
+    "status": {
+        "phase": "Pending",
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podUnschedulable(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T20:37:58Z",
+                "message": "No nodes are available that match all of the predicates: Insufficient cpu (3).",
+                "reason": "Unschedulable",
+                "status": "False",
+                "type": "PodScheduled"
+            }
+        ],
+        "phase": "Pending",
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podScheduled(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    },
+    "status": {
+        "phase": "Pending",
+        "conditions": [
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podContainerCreating(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    },
+    "status": {
+        "phase": "Pending",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [nginx]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            }
+        ],
+        "hostIP": "10.0.0.7",
+        "startTime": "2018-07-30T03:19:45Z",
+        "containerStatuses": [
+            {
+                "name": "nginx",
+                "state": {
+                    "waiting": {
+                        "reason": "ContainerCreating"
+                    }
+                },
+                "lastState": {},
+                "ready": false,
+                "restartCount": 0,
+                "image": "dsjkdsjkljks",
+                "imageID": ""
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podErrImagePull(namespace, name string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "dsjkdsjkljks"}
+        ]
+    },
+    "status": {
+        "phase": "Pending",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [nginx]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            }
+        ],
+        "hostIP": "10.0.0.7",
+        "startTime": "2018-07-30T03:19:45Z",
+        "containerStatuses": [
+            {
+                "name": "nginx",
+                "state": {
+                    "waiting": {
+                        "reason": "ErrImagePull",
+                        "message": "rpc error: code = Unknown desc = Error response from daemon: repository dsjkdsjkljks not found: does not exist or no pull access"
+                    }
+                },
+                "lastState": {},
+                "ready": false,
+                "restartCount": 0,
+                "image": "dsjkdsjkljks",
+                "imageID": ""
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podImagePullBackoff(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "dsjkdsjkljks"}
+        ]
+    },
+    "status": {
+        "phase": "Pending",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [nginx]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            }
+        ],
+        "hostIP": "10.0.0.7",
+        "podIP": "10.32.1.13",
+        "startTime": "2018-07-30T03:19:45Z",
+        "containerStatuses": [
+            {
+                "name": "nginx",
+                "state": {
+                    "waiting": {
+                        "reason": "ImagePullBackOff",
+                        "message": "Back-off pulling image \"dsjkdsjkljks\""
+                    }
+                },
+                "lastState": {},
+                "ready": false,
+                "restartCount": 0,
+                "image": "dsjkdsjkljks",
+                "imageID": ""
+            }
+        ],
+        "qosClass": "Burstable"
+      }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podRunning(namespace, name string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "containers": [
+            {"name": "nginx", "image": "nginx:1.15-alpine"}
+        ]
+    },
+    "status": {
+        "phase": "Running",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            },
+            {
+                "type": "Ready",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:42:08Z"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-07-30T03:19:45Z"
+            }
+        ],
+        "hostIP": "10.0.0.7",
+        "podIP": "10.32.1.13",
+        "startTime": "2018-07-30T03:19:45Z",
+        "containerStatuses": [
+            {
+                "name": "nginx",
+                "state": {
+                    "running": {
+                        "startedAt": "2018-07-30T03:42:07Z"
+                    }
+                },
+                "lastState": {},
+                "ready": true,
+                "restartCount": 0,
+                "image": "nginx:latest",
+                "imageID": "docker-pullable://nginx@sha256:4ffd9758ea9ea360fd87d0cee7a2d1cf9dba630bb57ca36b3108dcd3708dc189",
+                "containerID": "docker://045ad24362a3c834af31b691e099d30bf7e803c6e79d461d6ae540ac0b21b30f"
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podTerminatedError(namespace, name string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "volumes": [
+            {
+                "name": "default-token-rkzb2",
+                "secret": {
+                    "secretName": "default-token-rkzb2",
+                    "defaultMode": 420
+                }
+            }
+        ],
+        "containers": [
+            {
+                "name": "completer",
+                "image": "alpine",
+                "command": [
+                    "echo foo"
+                ],
+                "resources": {},
+                "volumeMounts": [
+                    {
+                        "name": "default-token-rkzb2",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                    }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "Always"
+            }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler"
+    },
+    "status": {
+        "phase": "Running",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:27:03Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:27:03Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [completer]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:27:03Z"
+            }
+        ],
+        "hostIP": "192.168.99.100",
+        "podIP": "172.17.0.4",
+        "startTime": "2018-08-03T00:27:03Z",
+        "containerStatuses": [
+            {
+                "name": "completer",
+                "state": {
+                    "waiting": {
+                        "reason": "RunContainerError",
+                        "message": "failed to start container \"ce5652ee18060c0f58144968587f5c333cf97dad907c6743e1e95a63541aab72\": Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused \"exec: \\\"echo foo\\\": executable file not found in $PATH\""
+                    }
+                },
+                "lastState": {
+                    "terminated": {
+                        "exitCode": 127,
+                        "reason": "ContainerCannotRun",
+                        "message": "oci runtime error: container_linux.go:262: starting container process caused \"exec: \\\"echo foo\\\": executable file not found in $PATH\"\n",
+                        "startedAt": "2018-08-03T00:27:09Z",
+                        "finishedAt": "2018-08-03T00:27:09Z",
+                        "containerID": "docker://ce5652ee18060c0f58144968587f5c333cf97dad907c6743e1e95a63541aab72"
+                    }
+                },
+                "ready": false,
+                "restartCount": 1,
+                "image": "alpine:latest",
+                "imageID": "docker-pullable://alpine@sha256:7043076348bf5040220df6ad703798fd8593a0918d06d3ce30c6c93be117e430",
+                "containerID": "docker://ce5652ee18060c0f58144968587f5c333cf97dad907c6743e1e95a63541aab72"
+            }
+        ],
+        "qosClass": "BestEffort"
+    }
+}
+`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func podTerminatedSuccess(namespace, name string) *unstructured.Unstructured {
+	// nolint
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+        "namespace": "%s",
+        "name": "%s"
+    },
+    "spec": {
+        "volumes": [
+            {
+                "name": "default-token-rkzb2",
+                "secret": {
+                    "secretName": "default-token-rkzb2",
+                    "defaultMode": 420
+                }
+            }
+        ],
+        "containers": [
+            {
+                "name": "completer",
+                "image": "alpine",
+                "command": [
+                    "/bin/sh"
+                ],
+                "resources": {},
+                "volumeMounts": [
+                    {
+                        "name": "default-token-rkzb2",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                    }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "Always"
+            }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler"
+    },
+    "status": {
+        "phase": "Running",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:53:09Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:53:09Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [completer]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2018-08-03T00:53:09Z"
+            }
+        ],
+        "hostIP": "192.168.99.100",
+        "podIP": "172.17.0.4",
+        "startTime": "2018-08-03T00:53:09Z",
+        "containerStatuses": [
+            {
+                "name": "completer",
+                "state": {
+                    "terminated": {
+                        "exitCode": 0,
+                        "reason": "Completed",
+                        "startedAt": "2018-08-03T00:53:16Z",
+                        "finishedAt": "2018-08-03T00:53:16Z",
+                        "containerID": "docker://7dd9e12bb149cd60eada7d5008ca1c694dd4dcf6b642aa4cdc9c1b2ca607f27b"
+                    }
+                },
+                "lastState": {
+                    "terminated": {
+                        "exitCode": 0,
+                        "reason": "Completed",
+                        "startedAt": "2018-08-03T00:53:13Z",
+                        "finishedAt": "2018-08-03T00:53:13Z",
+                        "containerID": "docker://f56da68168029d2b8d0e7f7915d6aa0a5446879cc0c01924c9464bdca0167d79"
+                    }
+                },
+                "ready": false,
+                "restartCount": 1,
+                "image": "alpine:latest",
+                "imageID": "docker-pullable://alpine@sha256:7043076348bf5040220df6ad703798fd8593a0918d06d3ce30c6c93be117e430",
+                "containerID": "docker://7dd9e12bb149cd60eada7d5008ca1c694dd4dcf6b642aa4cdc9c1b2ca607f27b"
+            }
+        ],
+        "qosClass": "BestEffort"
+    }
+}`, namespace, name))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}

--- a/pkg/await/core_service.go
+++ b/pkg/await/core_service.go
@@ -1,0 +1,296 @@
+package await
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-kubernetes/pkg/client"
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi/pkg/diag"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ------------------------------------------------------------------------------------------------
+
+// Await logic for core/v1/Service.
+//
+// The goal of this code is to provide a fine-grained account of the status of a Kubernetes Service
+// as it is being initialized. The idea is that if something goes wrong early, we want to alert the
+// user so they can cancel the operation instead of waiting for timeout (~10 minutes).
+//
+// A Service can be one of several types, and the initialization behavior differs for each:
+//
+//   - If the type is `LoadBalancer`, the Service will be allocated a public IP address, and an
+//     Endpoint object will be created, which specifies to which Pods traffic on different ports is
+//     should be directed.
+//   - If the type is `ClusterIP`, the Service is directly addressable only from inside the
+//     cluster, so no public IP address will be allocated. An Endpoint object will still be created
+//     to specify to which Pods traffic on different ports should be directed.
+//
+// The design of this awaiter is fundamentally an event loop on five channels:
+//
+//   1. The Service channel, to which the Kubernetes API server will proactively push every change
+//      (additions, modifications, deletions) to any Service it knows about.
+//   2. The Endpoint channel, which is the same idea as the Service channel, except it gets updates
+//      to Endpoint objects.
+//   3. A timeout channel, which fires after some minutes.
+//   4. A cancellation channel, with which the user can signal cancellation (e.g., using SIGINT).
+//   5. A "settled" channel, which is meant to fire a few seconds after any update to an Endpoint
+//      object, so that we're sure they have time to "settle".
+//
+// The `serviceInitAwaiter` will synchronously process events from the union of all these channels.
+// Any time the success conditions described above a reached, we will terminate the awaiter.
+//
+// The intermediate status we report tends to be related to whether endpoints are targeting > 0
+// Pods. Because an external IP can take a long time to execute, we simply have to wait.
+//
+//
+// x-refs:
+//   * https://kubernetes.io/docs/tutorials/services/
+
+// ------------------------------------------------------------------------------------------------
+
+type serviceInitAwaiter struct {
+	config           createAwaitConfig
+	serviceReady     bool
+	endpointsReady   bool
+	endpointsSettled bool
+}
+
+func makeServiceInitAwaiter(c createAwaitConfig) *serviceInitAwaiter {
+	return &serviceInitAwaiter{
+		config:           c,
+		serviceReady:     false,
+		endpointsReady:   false,
+		endpointsSettled: false,
+	}
+}
+
+func awaitServiceInit(c createAwaitConfig) error {
+	return makeServiceInitAwaiter(c).Await()
+}
+
+func (sia *serviceInitAwaiter) Await() error {
+	//
+	// We succeed only when all of the following are true:
+	//
+	//   1. Service object exists.
+	//   2. Endpoint objects created. Each time we get an update, wait ~5-10 seconds
+	//      after update to wait for any stragglers.
+	//   3. The endpoints objects target some number of living objects.
+	//   4. External IP address is allocated (if we're type `LoadBalancer`).
+	//
+
+	// Create service watcher.
+	serviceWatcher, err := sia.config.clientForResource.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Could set up watch for Service object '%s'",
+			sia.config.currentInputs.GetName())
+	}
+	defer serviceWatcher.Stop()
+
+	// Create endpoint watcher.
+	endpointClient, err := client.FromGVK(sia.config.pool, sia.config.disco, schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Endpoints",
+	}, sia.config.currentInputs.GetNamespace())
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not make client to watch Endpoint object associated with Service '%s'",
+			sia.config.currentInputs.GetName())
+	}
+
+	endpointWatcher, err := endpointClient.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not create watcher for Endpoint objects associated with Service '%s'",
+			sia.config.currentInputs.GetName())
+	}
+	defer endpointWatcher.Stop()
+
+	return sia.await(serviceWatcher, endpointWatcher, time.After(10*time.Minute), make(chan struct{}))
+}
+
+// await is a helper companion to `Await` designed to make it easy to test this module.
+func (sia *serviceInitAwaiter) await(
+	serviceWatcher, endpointWatcher watch.Interface, timeout <-chan time.Time,
+	settled chan struct{},
+) error {
+	inputServiceName := sia.config.currentInputs.GetName()
+	for {
+		// Check whether we've succeeded.
+		if sia.serviceReady && sia.endpointsSettled && sia.endpointsReady {
+			return nil
+		}
+
+		// Else, wait for updates.
+		select {
+		case <-sia.config.ctx.Done():
+			// On cancel, check one last time if the service is ready.
+			if sia.serviceReady && sia.endpointsReady {
+				return nil
+			}
+			return &cancellationError{
+				objectName: inputServiceName,
+				subErrors:  sia.errorMessages(),
+			}
+		case <-timeout:
+			// On timeout, check one last time if the service is ready.
+			if sia.serviceReady && sia.endpointsReady {
+				return nil
+			}
+			return &timeoutError{
+				objectName: inputServiceName,
+				subErrors:  sia.errorMessages(),
+			}
+		case <-settled:
+			var message string
+			sev := diag.Warning
+			if sia.endpointsReady {
+				message = fmt.Sprintf("✅ Service '%s' successfully created endpoint objects\n",
+					inputServiceName)
+				sev = diag.Info
+			} else {
+				message = fmt.Sprintf("Service '%s' does not target any Pods\n", inputServiceName)
+			}
+
+			if sia.config.host != nil {
+				_ = sia.config.host.Log(sia.config.ctx, sev, sia.config.urn, message)
+			}
+			sia.endpointsSettled = true
+		case event := <-serviceWatcher.ResultChan():
+			sia.processServiceEvent(event)
+		case event := <-endpointWatcher.ResultChan():
+			sia.processEndpointEvent(event, settled)
+		}
+	}
+}
+
+func (sia *serviceInitAwaiter) processServiceEvent(event watch.Event) {
+	inputServiceName := sia.config.currentInputs.GetName()
+
+	service, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("Service watch received unknown object type '%s'",
+			reflect.TypeOf(service))
+		return
+	}
+
+	// Do nothing if this is not the service we're waiting for.
+	if service.GetName() != inputServiceName {
+		return
+	}
+
+	// Start with a blank slate.
+	sia.serviceReady = false
+
+	// Mark the service as not ready if it's deleted.
+	if event.Type == watch.Deleted {
+		return
+	}
+
+	specType, _ := openapi.Pluck(sia.config.currentInputs.Object, "spec", "type")
+	if fmt.Sprintf("%v", specType) == string(v1.ServiceTypeLoadBalancer) {
+		// If it's type `LoadBalancer`, check whether an IP was allocated.
+		lbIngress, _ := openapi.Pluck(service.Object, "status", "loadBalancer", "ingress")
+		status, _ := openapi.Pluck(service.Object, "status")
+
+		glog.V(3).Infof("Received status for service '%s': %#v", inputServiceName, status)
+		ing, isSlice := lbIngress.([]interface{})
+
+		// Update status of service object so that we can check success.
+		sia.serviceReady = isSlice && len(ing) > 0
+
+		if sia.serviceReady {
+			if sia.config.host != nil {
+				_ = sia.config.host.Log(sia.config.ctx, diag.Info, sia.config.urn,
+					"✅ Service has been allocated an IP")
+			}
+		}
+		glog.V(3).Infof("Waiting for service '%q' to assign IP/hostname for a load balancer",
+			inputServiceName)
+	} else {
+		// If it's not type `LoadBalancer`, report success.
+		sia.serviceReady = true
+	}
+}
+
+func (sia *serviceInitAwaiter) processEndpointEvent(event watch.Event, settledCh chan<- struct{}) {
+	inputServiceName := sia.config.currentInputs.GetName()
+
+	// Get endpoint object.
+	endpoint, isUnstructured := event.Object.(*unstructured.Unstructured)
+	if !isUnstructured {
+		glog.V(3).Infof("Endpoint watch received unknown object type '%s'",
+			reflect.TypeOf(endpoint))
+		return
+	}
+
+	// Ignore if it's not one of the endpoint objects created by the service.
+	//
+	// NOTE: Because the client pool is per-namespace, the endpointName can be used as an
+	// ID, as it's guaranteed by the API server to be unique.
+	if endpoint.GetName() != inputServiceName {
+		return
+	}
+
+	// Start over, prove that service is ready.
+	sia.endpointsReady = false
+
+	// Update status of endpoint objects so we can check success.
+	if event.Type == watch.Added || event.Type == watch.Modified {
+		subsets, hasTargets := openapi.Pluck(endpoint.Object, "subsets")
+		targets, targetsIsSlice := subsets.([]interface{})
+		endpointTargetsPod := hasTargets && targetsIsSlice && len(targets) > 0
+
+		sia.endpointsReady = endpointTargetsPod
+	} else if event.Type == watch.Deleted {
+		sia.endpointsReady = false
+	}
+
+	// Every time we get an update to one of our endpoints objects, give it a few seconds
+	// for them to settle.
+	sia.endpointsSettled = false
+	go func() {
+		time.Sleep(10 * time.Second)
+		settledCh <- struct{}{}
+	}()
+}
+
+func (sia *serviceInitAwaiter) errorMessages() []string {
+	messages := []string{}
+	if !sia.endpointsReady {
+		messages = append(messages, "Service does not target any Pods")
+	}
+
+	specType, _ := openapi.Pluck(sia.config.currentInputs.Object, "spec", "type")
+	if fmt.Sprintf("%v", specType) == string(v1.ServiceTypeLoadBalancer) && !sia.serviceReady {
+		messages = append(messages, "Service was not allocated an IP address")
+	}
+
+	return messages
+}
+
+func (sia *serviceInitAwaiter) collectWarningEvents() error {
+	clientForEvents, err := sia.config.eventClient()
+	if err != nil {
+		glog.V(3).Infof("Could not retrieve warning events for service '%s': %v",
+			sia.config.currentInputs.GetName(), err)
+	}
+	lastWarnings, wErr := getLastWarningsForObject(clientForEvents,
+		sia.config.currentInputs.GetNamespace(),
+		sia.config.currentInputs.GetName(), "Service", 3)
+	if wErr != nil {
+		glog.V(3).Infof("Could not retrieve warning events for service '%s': %v",
+			sia.config.currentInputs.GetName(), wErr)
+	}
+	return fmt.Errorf("%s%s", err, stringifyEvents(lastWarnings))
+}

--- a/pkg/await/core_service_test.go
+++ b/pkg/await/core_service_test.go
@@ -1,0 +1,290 @@
+package await
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func Test_Core_Service(t *testing.T) {
+	tests := []struct {
+		description   string
+		do            func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time)
+		expectedError error
+	}{
+		{
+			description: "Should succeed when Service is allocated an IP address and Endpoints target a Pod",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes initialized service and endpoint objects back.
+				services <- watchAddedEvent(initializedService("default", "foo-4setj4y6"))
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				settled <- struct{}{}
+			},
+		},
+		{
+			description: "Should succeed if Endpoints have settled when timeout occurs",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes initialized service back.
+				services <- watchAddedEvent(initializedService("default", "foo-4setj4y6"))
+
+				// Pass initialized endpoint objects.
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "foo-4setj4y6"))
+
+				// Time out. NOTE: the endpoint objects are not marked as settled.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should fail if unrelated Service succeeds",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				services <- watchAddedEvent(initializedService("default", "bar"))
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "bar"))
+
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{"Service does not target any Pods",
+					"Service was not allocated an IP address"}},
+		},
+		{
+			description: "Should succeed when unrelated Service fails",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				services <- watchAddedEvent(initializedService("default", "foo-4setj4y6"))
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "foo-4setj4y6"))
+
+				// Unrelated Service should fail because it does not have an Endpoint.
+				services <- watchAddedEvent(initializedService("default", "bar"))
+
+				settled <- struct{}{}
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "Should report success immediately even if the next event is a failure",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes initialized service and endpoint objects back.
+				services <- watchAddedEvent(initializedService("default", "foo-4setj4y6"))
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				settled <- struct{}{}
+
+				endpoints <- watchAddedEvent(
+					uninitializedEndpoint("default", "foo-4setj4y6"))
+			},
+		},
+		{
+			description: "Should fail if neither the Service nor the Endpoints have initialized",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// Trigger timeout.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors: []string{
+					"Service does not target any Pods",
+					"Service was not allocated an IP address"}},
+		},
+		{
+			description: "Should fail if Endpoints have not initialized",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes initialized service back.
+				services <- watchAddedEvent(initializedService("default", "foo-4setj4y6"))
+
+				// Pass uninitialized endpoint objects. Mark them as settled.
+				endpoints <- watchAddedEvent(
+					uninitializedEndpoint("default", "foo-4setj4y6"))
+				settled <- struct{}{}
+
+				// Finally, time out.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors:  []string{"Service does not target any Pods"}},
+		},
+		{
+			description: "Should fail if Service is not allocated an IP address",
+			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes uninitialized service back.
+				services <- watchAddedEvent(serviceInput("default", "foo-4setj4y6"))
+
+				// Pass initialized endpoint objects. Mark them as settled.
+				endpoints <- watchAddedEvent(
+					initializedEndpoint("default", "foo-4setj4y6"))
+				settled <- struct{}{}
+
+				// Finally, time out.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				objectName: "foo-4setj4y6",
+				subErrors:  []string{"Service was not allocated an IP address"}},
+		},
+	}
+
+	for _, test := range tests {
+		awaiter := makeServiceInitAwaiter(
+			mockAwaitConfig(serviceInput("default", "foo-4setj4y6")))
+
+		services := make(chan watch.Event)
+		endpoints := make(chan watch.Event)
+		settled := make(chan struct{})
+		timeout := make(chan time.Time)
+		go test.do(services, endpoints, settled, timeout)
+
+		err := awaiter.await(&mockWatcher{results: services}, &mockWatcher{results: endpoints},
+			timeout, settled)
+		assert.Equal(t, test.expectedError, err, test.description)
+	}
+}
+
+// --------------------------------------------------------------------------
+
+// Utility constructs.
+
+// --------------------------------------------------------------------------
+
+func serviceInput(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+        "labels": {
+            "app": "%s"
+        },
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "spec": {
+        "clusterIP": "10.35.241.240",
+        "externalTrafficPolicy": "Cluster",
+        "ports": [
+            {
+                "nodePort": 32277,
+                "port": 6379,
+                "protocol": "TCP",
+                "targetPort": 6379
+            }
+        ],
+        "selector": {
+            "app": "foo"
+        },
+        "sessionAffinity": "None",
+        "type": "LoadBalancer"
+    },
+    "status": {
+        "loadBalancer": {}
+    }
+}`, name, name, namespace))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func initializedService(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+        "labels": {
+            "app": "%s"
+        },
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "spec": {
+        "clusterIP": "10.35.241.240",
+        "externalTrafficPolicy": "Cluster",
+        "ports": [
+            {
+                "nodePort": 32277,
+                "port": 6379,
+                "protocol": "TCP",
+                "targetPort": 6379
+            }
+        ],
+        "selector": {
+            "app": "foo"
+        },
+        "sessionAffinity": "None",
+        "type": "LoadBalancer"
+    },
+    "status": {
+        "loadBalancer": {
+            "ingress": [
+                {
+                    "ip": "35.184.65.22"
+                }
+            ]
+        }
+    }
+}`, name, name, namespace))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func uninitializedEndpoint(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(
+		fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Endpoints",
+    "metadata": {
+        "labels": {
+            "app": "%s"
+        },
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "subsets": null
+}`, name, name, namespace))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func initializedEndpoint(namespace, name string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(
+		fmt.Sprintf(`{
+    "apiVersion": "v1",
+    "kind": "Endpoints",
+    "metadata": {
+        "labels": {
+            "app": "%s"
+        },
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "subsets": [
+        {
+            "addresses": [
+                {
+                    "ip": "35.192.99.34"
+                }
+            ],
+            "ports": [
+                {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "TCP"
+                }
+            ]
+        }
+    ]
+}`, name, name, namespace))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}

--- a/pkg/await/util.go
+++ b/pkg/await/util.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+const trueStatus = "True"
+
 // --------------------------------------------------------------------------
 
 // Event helpers.

--- a/pkg/await/util_test.go
+++ b/pkg/await/util_test.go
@@ -1,0 +1,51 @@
+package await
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type mockWatcher struct {
+	results chan watch.Event
+}
+
+var _ watch.Interface = (*mockWatcher)(nil)
+
+func (mw *mockWatcher) Stop() {}
+
+func (mw *mockWatcher) ResultChan() <-chan watch.Event {
+	return mw.results
+}
+
+func mockAwaitConfig(obj *unstructured.Unstructured) createAwaitConfig {
+	return createAwaitConfig{
+		ctx:               context.Background(),
+		pool:              nil,
+		disco:             nil,
+		clientForResource: nil,
+		currentInputs:     obj,
+	}
+}
+
+func decodeUnstructured(text string) (*unstructured.Unstructured, error) {
+	obj, _, err := unstructured.UnstructuredJSONScheme.Decode([]byte(text), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	unst, isUnstructured := obj.(*unstructured.Unstructured)
+	if !isUnstructured {
+		return nil, fmt.Errorf("Could not decode object as *unstructured.Unstructured: %v", unst)
+	}
+	return unst, nil
+}
+
+func watchAddedEvent(obj runtime.Object) watch.Event {
+	return watch.Event{
+		Type:   watch.Added,
+		Object: obj,
+	}
+}

--- a/pkg/gen/node-templates/provider.ts.mustache
+++ b/pkg/gen/node-templates/provider.ts.mustache
@@ -14,7 +14,7 @@ export namespace {{Group}} {
     export class {{Kind}} extends pulumi.CustomResource {
       {{#Properties}}
       {{{Comment}}}
-      public readonly {{Name}}: pulumi.Output<{{PropType}}>;
+      public readonly {{Name}}: pulumi.Output<{{{PropType}}}>;
 
       {{/Properties}}
 

--- a/pkg/gen/node-templates/typesInput.ts.mustache
+++ b/pkg/gen/node-templates/typesInput.ts.mustache
@@ -12,12 +12,12 @@ export namespace {{Group}} {
     export interface {{Kind}} {
       {{#RequiredProperties}}
       {{{Comment}}}
-      {{Name}}: pulumi.Input<{{PropType}}>
+      {{Name}}: pulumi.Input<{{{PropType}}}>
 
       {{/RequiredProperties}}
       {{#OptionalProperties}}
       {{{Comment}}}
-      {{Name}}?: pulumi.Input<{{PropType}}>
+      {{Name}}?: pulumi.Input<{{{PropType}}}>
 
       {{/OptionalProperties}}
     }

--- a/pkg/gen/node-templates/typesOutput.ts.mustache
+++ b/pkg/gen/node-templates/typesOutput.ts.mustache
@@ -10,7 +10,7 @@ export namespace {{Group}} {
     export interface {{Kind}} {
       {{#Properties}}
       {{{Comment}}}
-      readonly {{Name}}: {{PropType}}
+      readonly {{Name}}: {{{PropType}}}
 
       {{/Properties}}
     }

--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -120,6 +120,7 @@ var forceNew = groups{
 
 var core = versions{
 	"v1": kinds{
+		"ConfigMap": properties{".binaryData", ".data"},
 		"PersistentVolumeClaim": append(
 			properties{
 				".spec",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -694,10 +694,14 @@ func parseCheckpointObject(obj resource.PropertyMap) (oldInputs, live *unstructu
 }
 
 func initializationError(id string, err error, inputsAndComputed *structpb.Struct) error {
+	reasons := []string{err.Error()}
+	if aggregate, isAggregate := err.(await.AggregatedError); isAggregate {
+		reasons = append(reasons, aggregate.SubErrors()...)
+	}
 	detail := pulumirpc.ErrorResourceInitFailed{
 		Id:         id,
 		Properties: inputsAndComputed,
-		Reasons:    []string{err.Error()},
+		Reasons:    reasons,
 	}
 	return rpcerror.WithDetails(rpcerror.New(codes.Unknown, err.Error()), &detail)
 }

--- a/pkg/provider/serve.go
+++ b/pkg/provider/serve.go
@@ -28,7 +28,7 @@ func Serve(providerName, version string) {
 	// Start gRPC service.
 	err := provider.Main(
 		providerName, func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
-			return makeKubeProvider(providerName, version)
+			return makeKubeProvider(host, providerName, version)
 		})
 
 	if err != nil {


### PR DESCRIPTION
This PR principally contains the logic for status-rich updates of the key "complex" Kubernetes resources (_i.e._, `Pod`, `Service`, and `Deployment`), as well as fixes for a set of bugs that affect this change.

The changes related to the status-rich updates themselves essentially have two parts:

* **A series of playback tests.** We used CarbonQL to observe changes to these key resources under various circumstances, and then encoded those as tests "playing back" those events. This was designed to (1) give a transparent view of what these "complex" awaiters do, and (2) give us a rigorous backbone on top of which to ensure the correctness of this code.
* **A set of three "complex awaiter" objects.** These objects are essentially structs that are each wrapped around an event loop that is continuously observing events from several streams (_i.e._, updates to one or more resources from the API server, plus channels each for timeout and cancellation). As events are received, these objects update the known state of the resources so that helpful intermediate errors can be displayed.

The rest of the changes are ancillary fixes to make this experience good. Most of these are small bugs.