### PR TITLE
Accept a `kubeconfig` config option.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1378,6 +1378,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0b565c5bfab567d99e5729a9790dac6087444adb99418ccd9b0c424e0e61beef"
+  inputs-digest = "cc43a37fc57695ea63a4a49b841702f1450bd03c7cd53420e559564724fb39d3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pack/nodejs/package.json
+++ b/pack/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "v0.14.1-dev-1533852470-g73af71a",
+    "version": "v0.14.1-dev-1530572194-g218d72d-dirty",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
     "license": "Apache 2.0",
     "keywords": [

--- a/pack/nodejs/package.json
+++ b/pack/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "v0.14.1-dev-1530572194-g218d72d-dirty",
+    "version": "v0.14.1-dev-1533852470-g73af71a",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
     "license": "Apache 2.0",
     "keywords": [

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -86,14 +86,35 @@ var _ pulumirpc.ResourceProviderServer = (*kubeProvider)(nil)
 func makeKubeProvider(
 	host *provider.HostClient, name, version string,
 ) (pulumirpc.ResourceProviderServer, error) {
-	// Use client-go to resolve the final configuration values for the client. Typically these
-	// values would would reside in the $KUBECONFIG file, but can also be altered in several
-	// places, including in env variables, client-go default values, and (if we allowed it) CLI
-	// flags.
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	kubeconfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(
-		loadingRules, &clientcmd.ConfigOverrides{}, os.Stdin)
+	return &kubeProvider{
+		canceler:       makeCancellationContext(),
+		name:           name,
+		version:        version,
+		providerPrefix: name + gvkDelimiter,
+	}, nil
+}
+
+// Configure configures the resource provider with "globals" that control its behavior.
+func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequest) (*pbempty.Empty, error) {
+	vars := req.GetVariables()
+
+	var kubeconfig clientcmd.ClientConfig
+	if configJSON, ok := vars["kubernetes:config:kubeconfig"]; ok {
+		config, err := clientcmd.Load([]byte(configJSON))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kubeconfig: %v", err)
+		}
+		kubeconfig = clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
+	} else {
+		// Use client-go to resolve the final configuration values for the client. Typically these
+		// values would would reside in the $KUBECONFIG file, but can also be altered in several
+		// places, including in env variables, client-go default values, and (if we allowed it) CLI
+		// flags.
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+		kubeconfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(
+			loadingRules, &clientcmd.ConfigOverrides{}, os.Stdin)
+	}
 
 	// Configure the discovery client.
 	conf, err := kubeconfig.ClientConfig()
@@ -116,19 +137,7 @@ func makeKubeProvider(
 	// apps, etc.)
 	pool := dynamic.NewClientPool(conf, mapper, pathresolver)
 
-	return &kubeProvider{
-		host:           host,
-		canceler:       makeCancellationContext(),
-		client:         discoCache,
-		pool:           pool,
-		name:           name,
-		version:        version,
-		providerPrefix: name + gvkDelimiter,
-	}, nil
-}
-
-// Configure configures the resource provider with "globals" that control its behavior.
-func (k *kubeProvider) Configure(context.Context, *pulumirpc.ConfigureRequest) (*pbempty.Empty, error) {
+	k.client, k.pool = discoCache, pool
 	return &pbempty.Empty{}, nil
 }
 


### PR DESCRIPTION
This option is the literal text of a serialized `kubeconfig` value. If
this options is set, the config specified within is used in place of the
ambient config.

In addition to adding this option, these changes move the timing of
client creation, etc. to `Configure` rather than plugin creation.

Both of these changes are in service of instantiating a first-class
k8s provider that is configured based on the output of other resources
(e.g. an EKS cluster).

Fixes #100, #101.