### PR TITLE
 Move live object properties to the root of resource state. 

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -56,10 +56,10 @@ func TestExamples(t *testing.T) {
 					sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
 						ri := stackInfo.Deployment.Resources[i]
 						rj := stackInfo.Deployment.Resources[j]
-						riname, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "name")
-						rinamespace, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "namespace")
-						rjname, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "name")
-						rjnamespace, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "namespace")
+						riname, _ := openapi.Pluck(ri.Outputs, "metadata", "name")
+						rinamespace, _ := openapi.Pluck(ri.Outputs, "metadata", "namespace")
+						rjname, _ := openapi.Pluck(rj.Outputs, "metadata", "name")
+						rjnamespace, _ := openapi.Pluck(rj.Outputs, "metadata", "namespace")
 						return fmt.Sprintf("%s/%s/%s", ri.URN.Type(), rinamespace, riname) <
 							fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
 					})
@@ -67,19 +67,19 @@ func TestExamples(t *testing.T) {
 					// Verify redis pod.
 					redisPV := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:PersistentVolume"), redisPV.URN.Type())
-					status, _ := openapi.Pluck(redisPV.Outputs, "live", "status", "phase")
+					status, _ := openapi.Pluck(redisPV.Outputs, "status", "phase")
 					assert.Equal(t, "Available", status)
 
 					// Verify nginx pod.
 					nginxPod := stackInfo.Deployment.Resources[1]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Pod"), nginxPod.URN.Type())
-					status, _ = openapi.Pluck(nginxPod.Outputs, "live", "status", "phase")
+					status, _ = openapi.Pluck(nginxPod.Outputs, "status", "phase")
 					assert.Equal(t, "Running", status)
 
 					// Verify redis pod.
 					redisPod := stackInfo.Deployment.Resources[2]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Pod"), redisPod.URN.Type())
-					status, _ = openapi.Pluck(redisPod.Outputs, "live", "status", "phase")
+					status, _ = openapi.Pluck(redisPod.Outputs, "status", "phase")
 					assert.Equal(t, "Running", status)
 
 					// Verify the provider resource.
@@ -102,10 +102,10 @@ func TestExamples(t *testing.T) {
 					sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
 						ri := stackInfo.Deployment.Resources[i]
 						rj := stackInfo.Deployment.Resources[j]
-						riname, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "name")
-						rinamespace, _ := openapi.Pluck(ri.Outputs, "live", "metadata", "namespace")
-						rjname, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "name")
-						rjnamespace, _ := openapi.Pluck(rj.Outputs, "live", "metadata", "namespace")
+						riname, _ := openapi.Pluck(ri.Outputs, "metadata", "name")
+						rinamespace, _ := openapi.Pluck(ri.Outputs, "metadata", "namespace")
+						rjname, _ := openapi.Pluck(rj.Outputs, "metadata", "name")
+						rjnamespace, _ := openapi.Pluck(rj.Outputs, "metadata", "namespace")
 						return fmt.Sprintf("%s/%s/%s", ri.URN.Type(), rinamespace, riname) <
 							fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
 					})
@@ -116,49 +116,49 @@ func TestExamples(t *testing.T) {
 					// Verify frontend deployment.
 					frontendDepl := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), frontendDepl.URN.Type())
-					name, _ = openapi.Pluck(frontendDepl.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(frontendDepl.Outputs, "metadata", "name")
 					assert.Equal(t, "frontend", name)
-					status, _ = openapi.Pluck(frontendDepl.Outputs, "live", "status", "readyReplicas")
+					status, _ = openapi.Pluck(frontendDepl.Outputs, "status", "readyReplicas")
 					assert.Equal(t, float64(3), status)
 
 					// Verify redis-master deployment.
 					redisMasterDepl := stackInfo.Deployment.Resources[1]
 					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisMasterDepl.URN.Type())
-					name, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(redisMasterDepl.Outputs, "metadata", "name")
 					assert.Equal(t, "redis-master", name)
-					status, _ = openapi.Pluck(redisMasterDepl.Outputs, "live", "status", "readyReplicas")
+					status, _ = openapi.Pluck(redisMasterDepl.Outputs, "status", "readyReplicas")
 					assert.Equal(t, float64(1), status)
 
 					// Verify redis-slave deployment.
 					redisSlaveDepl := stackInfo.Deployment.Resources[2]
 					assert.Equal(t, tokens.Type("kubernetes:apps/v1:Deployment"), redisSlaveDepl.URN.Type())
-					name, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(redisSlaveDepl.Outputs, "metadata", "name")
 					assert.Equal(t, "redis-slave", name)
-					status, _ = openapi.Pluck(redisSlaveDepl.Outputs, "live", "status", "readyReplicas")
+					status, _ = openapi.Pluck(redisSlaveDepl.Outputs, "status", "readyReplicas")
 					assert.Equal(t, float64(1), status)
 
 					// Verify frontend service.
 					frontentService := stackInfo.Deployment.Resources[3]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), frontentService.URN.Type())
-					name, _ = openapi.Pluck(frontentService.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(frontentService.Outputs, "metadata", "name")
 					assert.Equal(t, "frontend", name)
-					status, _ = openapi.Pluck(frontentService.Outputs, "live", "spec", "clusterIP")
+					status, _ = openapi.Pluck(frontentService.Outputs, "spec", "clusterIP")
 					assert.True(t, len(status.(string)) > 1)
 
 					// Verify redis-master service.
 					redisMasterService := stackInfo.Deployment.Resources[4]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisMasterService.URN.Type())
-					name, _ = openapi.Pluck(redisMasterService.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(redisMasterService.Outputs, "metadata", "name")
 					assert.Equal(t, "redis-master", name)
-					status, _ = openapi.Pluck(redisMasterService.Outputs, "live", "spec", "clusterIP")
+					status, _ = openapi.Pluck(redisMasterService.Outputs, "spec", "clusterIP")
 					assert.True(t, len(status.(string)) > 1)
 
 					// Verify redis-slave service.
 					redisSlaveService := stackInfo.Deployment.Resources[5]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Service"), redisSlaveService.URN.Type())
-					name, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "metadata", "name")
+					name, _ = openapi.Pluck(redisSlaveService.Outputs, "metadata", "name")
 					assert.Equal(t, "redis-slave", name)
-					status, _ = openapi.Pluck(redisSlaveService.Outputs, "live", "spec", "clusterIP")
+					status, _ = openapi.Pluck(redisSlaveService.Outputs, "spec", "clusterIP")
 					assert.True(t, len(status.(string)) > 1)
 
 					// Verify the provider resource.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -720,6 +720,8 @@ func parseCheckpointObject(obj resource.PropertyMap) (oldInputs, live *unstructu
 		inputs, hasInputs = pm["__inputs"]
 		if hasInputs {
 			delete(liveMap.(map[string]interface{}), "__inputs")
+		} else {
+			inputs = map[string]interface{}{}
 		}
 	}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var (
+	objInputs = map[string]interface{}{
+		"foo": "bar",
+		"baz": float64(1234),
+		"qux": map[string]interface{}{
+			"xuq": "oof",
+		},
+	}
+	objLive = map[string]interface{}{
+		"oof": "bar",
+		"zab": float64(4321),
+		"xuq": map[string]interface{}{
+			"qux": "foo",
+		},
+	}
+)
+
+func TestParseOldCheckpointObject(t *testing.T) {
+	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"inputs": objInputs,
+		"live":   objLive,
+	})
+
+	oldInputs, live := parseCheckpointObject(old)
+	assert.Equal(t, objInputs, oldInputs.Object)
+	assert.Equal(t, objLive, live.Object)
+}
+
+func TestParseNewCheckpointObject(t *testing.T) {
+	old := resource.NewPropertyMapFromMap(objLive)
+	old["__inputs"] = resource.NewObjectProperty(resource.NewPropertyMapFromMap(objInputs))
+
+	oldInputs, live := parseCheckpointObject(old)
+	assert.Equal(t, objInputs, oldInputs.Object)
+	assert.Equal(t, objLive, live.Object)
+}
+
+func TestCheckpointObject(t *testing.T) {
+	inputs := &unstructured.Unstructured{Object: objInputs}
+	live := &unstructured.Unstructured{Object: objLive}
+
+	obj := checkpointObject(inputs, live)
+	assert.NotNil(t, obj)
+
+	oldInputs := obj["__inputs"]
+	assert.Equal(t, objInputs, oldInputs.Mappable())
+
+	delete(obj, "__inputs")
+	assert.Equal(t, objLive, obj.Mappable())
+}
+
+func TestRoundtripCheckpointObject(t *testing.T) {
+	old := resource.NewPropertyMapFromMap(objLive)
+	old["__inputs"] = resource.NewObjectProperty(resource.NewPropertyMapFromMap(objInputs))
+
+	oldInputs, oldLive := parseCheckpointObject(old)
+	assert.Equal(t, objInputs, oldInputs.Object)
+	assert.Equal(t, objLive, oldLive.Object)
+
+	obj := checkpointObject(oldInputs, oldLive)
+	assert.Equal(t, old, obj)
+
+	newInputs, newLive := parseCheckpointObject(obj)
+	assert.Equal(t, oldInputs, newInputs)
+	assert.Equal(t, oldLive, newLive)
+}

--- a/tests/integration/autonaming/autonaming_test.go
+++ b/tests/integration/autonaming/autonaming_test.go
@@ -48,11 +48,10 @@ func TestAutonaming(t *testing.T) {
 
 			pod := stackInfo.Deployment.Resources[0]
 			assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
-			step1Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+			step1Name, _ = openapi.Pluck(pod.Outputs, "metadata", "name")
 			assert.True(t, strings.HasPrefix(step1Name.(string), "autonaming-test-"))
 
-			autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-				"pulumi.com/autonamed")
+			autonamed, _ := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 			assert.Equal(t, "true", autonamed)
 		},
 		EditDirs: []integration.EditDir{
@@ -77,11 +76,10 @@ func TestAutonaming(t *testing.T) {
 
 					pod := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
-					step2Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					step2Name, _ = openapi.Pluck(pod.Outputs, "metadata", "name")
 					assert.True(t, strings.HasPrefix(step2Name.(string), "autonaming-test-"))
 
-					autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-						"pulumi.com/autonamed")
+					autonamed, _ := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 					assert.Equal(t, "true", autonamed)
 
 					assert.NotEqual(t, step1Name, step2Name)
@@ -109,11 +107,10 @@ func TestAutonaming(t *testing.T) {
 
 					pod := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
-					step3Name, _ = openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					step3Name, _ = openapi.Pluck(pod.Outputs, "metadata", "name")
 					assert.True(t, strings.HasPrefix(step3Name.(string), "autonaming-test-"))
 
-					autonamed, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-						"pulumi.com/autonamed")
+					autonamed, _ := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 					assert.Equal(t, "true", autonamed)
 
 					assert.Equal(t, step2Name, step3Name)
@@ -141,11 +138,10 @@ func TestAutonaming(t *testing.T) {
 
 					pod := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, "autonaming-test", string(pod.URN.Name()))
-					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					name, _ := openapi.Pluck(pod.Outputs, "metadata", "name")
 					assert.Equal(t, "autonaming-test", name.(string))
 
-					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-						"pulumi.com/autonamed")
+					_, autonamed := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 					assert.False(t, autonamed)
 				},
 			},

--- a/tests/integration/delete-before-replace/delete_before_replace_test.go
+++ b/tests/integration/delete-before-replace/delete_before_replace_test.go
@@ -42,20 +42,19 @@ func TestPod(t *testing.T) {
 			//
 
 			pod := stackInfo.Deployment.Resources[0]
-			name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+			name, _ := openapi.Pluck(pod.Outputs, "metadata", "name")
 			assert.Equal(t, name.(string), "pod-test")
 
 			// Not autonamed.
-			_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-				"pulumi.com/autonamed")
+			_, autonamed := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 			assert.False(t, autonamed)
 
 			// Status is "Running"
-			phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+			phase, _ := openapi.Pluck(pod.Outputs, "status", "phase")
 			assert.Equal(t, "Running", phase)
 
 			// Status "Ready" is "True".
-			conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+			conditions, _ := openapi.Pluck(pod.Outputs, "status", "conditions")
 			ready := conditions.([]interface{})[1].(map[string]interface{})
 			readyType, _ := ready["type"]
 			assert.Equal(t, "Ready", readyType)
@@ -63,7 +62,7 @@ func TestPod(t *testing.T) {
 			assert.Equal(t, "True", readyStatus)
 
 			// Container is called "nginx" and uses image "nginx:1.13-alpine".
-			containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+			containerStatuses, _ := openapi.Pluck(pod.Outputs, "status", "containerStatuses")
 			containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
 			containerName, _ := containerStatus["name"]
 			assert.Equal(t, "nginx", containerName)
@@ -96,20 +95,19 @@ func TestPod(t *testing.T) {
 					//
 
 					pod := stackInfo.Deployment.Resources[0]
-					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					name, _ := openapi.Pluck(pod.Outputs, "metadata", "name")
 					assert.Equal(t, name.(string), "pod-test")
 
 					// Not autonamed.
-					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-						"pulumi.com/autonamed")
+					_, autonamed := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 					assert.False(t, autonamed)
 
 					// Status is "Running"
-					phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+					phase, _ := openapi.Pluck(pod.Outputs, "status", "phase")
 					assert.Equal(t, "Running", phase)
 
 					// Status "Ready" is "True".
-					conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+					conditions, _ := openapi.Pluck(pod.Outputs, "status", "conditions")
 					ready := conditions.([]interface{})[1].(map[string]interface{})
 					readyType, _ := ready["type"]
 					assert.Equal(t, "Ready", readyType)
@@ -117,7 +115,7 @@ func TestPod(t *testing.T) {
 					assert.Equal(t, "True", readyStatus)
 
 					// Container is called "nginx" and uses image "nginx:1.13-alpine".
-					containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+					containerStatuses, _ := openapi.Pluck(pod.Outputs, "status", "containerStatuses")
 					containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
 					containerName, _ := containerStatus["name"]
 					assert.Equal(t, "nginx", containerName)
@@ -148,20 +146,19 @@ func TestPod(t *testing.T) {
 					//
 
 					pod := stackInfo.Deployment.Resources[0]
-					name, _ := openapi.Pluck(pod.Outputs, "live", "metadata", "name")
+					name, _ := openapi.Pluck(pod.Outputs, "metadata", "name")
 					assert.Equal(t, name.(string), "pod-test")
 
 					// Not autonamed.
-					_, autonamed := openapi.Pluck(pod.Outputs, "live", "metadata", "annotations",
-						"pulumi.com/autonamed")
+					_, autonamed := openapi.Pluck(pod.Outputs, "metadata", "annotations", "pulumi.com/autonamed")
 					assert.False(t, autonamed)
 
 					// Status is "Running"
-					phase, _ := openapi.Pluck(pod.Outputs, "live", "status", "phase")
+					phase, _ := openapi.Pluck(pod.Outputs, "status", "phase")
 					assert.Equal(t, "Running", phase)
 
 					// Status "Ready" is "True".
-					conditions, _ := openapi.Pluck(pod.Outputs, "live", "status", "conditions")
+					conditions, _ := openapi.Pluck(pod.Outputs, "status", "conditions")
 					ready := conditions.([]interface{})[1].(map[string]interface{})
 					readyType, _ := ready["type"]
 					assert.Equal(t, "Ready", readyType)
@@ -169,7 +166,7 @@ func TestPod(t *testing.T) {
 					assert.Equal(t, "True", readyStatus)
 
 					// Container is called "nginx" and uses image "nginx:1.13-alpine".
-					containerStatuses, _ := openapi.Pluck(pod.Outputs, "live", "status", "containerStatuses")
+					containerStatuses, _ := openapi.Pluck(pod.Outputs, "status", "containerStatuses")
 					containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
 					containerName, _ := containerStatus["name"]
 					assert.Equal(t, "nginx", containerName)


### PR DESCRIPTION
We currently next the live properties of a Kubernetes resource under
the key "live" when storing the resource's state in the checkpoint file.
This prevents output properties from resolving when using Node.JS (and
most likely Python as well), as the Pulumi JS library only looks for
property values at the root of an object's state.

The simplest, most localized fix we can make for this is to move a
Kubernetes resource's live properties into the root of the resource's
state. This commit implements that approach.

Fixes #137.