### PR TITLE
Don't dirty the working tree when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ build:: $(OPENAPI_FILE)
 		yarn install && \
 		yarn run tsc
 	cp README.md LICENSE ${PACKDIR}/nodejs/package.json ${PACKDIR}/nodejs/yarn.lock ${PACKDIR}/nodejs/bin/
+	sed -i 's/$${VERSION}/$(VERSION)/g' ${PACKDIR}/nodejs/bin/package.json
 
 lint::
 	$(GOMETALINTER) ./cmd/... ./pkg/... | sort ; exit "$${PIPESTATUS[0]}"
@@ -66,9 +67,13 @@ publish_packages:
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
 
+.PHONY: check_clean_worktree
+check_clean_worktree:
+	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
+
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: only_build publish_tgz only_test publish_packages
-travis_pull_request: all
+travis_push: only_build check_clean_worktree publish_tgz only_test publish_packages
+travis_pull_request: all check_clean_worktree
 travis_api: all

--- a/pack/nodejs/package.json
+++ b/pack/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "v0.15.1-dev-1534375259-gef6d913-dirty",
+    "version": "${VERSION}",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
     "license": "Apache 2.0",
     "keywords": [

--- a/pack/nodejs/provider.ts
+++ b/pack/nodejs/provider.ts
@@ -804,7 +804,7 @@ export namespace yaml {
         let id: string = obj["metadata"]["name"];
         const namespace = obj["metadata"]["namespace"] || undefined;
         if (namespace !== undefined) {
-            id = `${namespace}/${name}`;
+            id = `${namespace}/${id}`;
         }
         switch (`${apiVersion}/${kind}`) {
             case "admissionregistration.k8s.io/v1alpha1/InitializerConfiguration":

--- a/pkg/gen/node-templates/package.json.mustache
+++ b/pkg/gen/node-templates/package.json.mustache
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "{{ProviderVersion}}",
+    "version": "${VERSION}",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
     "license": "Apache 2.0",
     "keywords": [


### PR DESCRIPTION
For the package.json we generate, don't embed the version string right
away. Instead, just wack the version in the one we place in the bin
folder. This is in line with how we handle our other projects.

To lock in these fixes, add similar logic to CI to ensure the worktree
is clean after a PR runs and for a push job, before we publish.