### PR TITLE
BREAKING: Change resource naming scheme, fix a small set of bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build:: $(OPENAPI_FILE)
 		yarn install && \
 		yarn run tsc
 	cp README.md LICENSE ${PACKDIR}/nodejs/package.json ${PACKDIR}/nodejs/yarn.lock ${PACKDIR}/nodejs/bin/
-	sed -i 's/$${VERSION}/$(VERSION)/g' ${PACKDIR}/nodejs/bin/package.json
+	sed -i.bak 's/$${VERSION}/$(VERSION)/g' ${PACKDIR}/nodejs/bin/package.json
 
 lint::
 	$(GOMETALINTER) ./cmd/... ./pkg/... | sort ; exit "$${PIPESTATUS[0]}"

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,16 @@ install::
 	mkdir -p "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	cp -r pack/nodejs/bin/. "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/node_modules"
+	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/tests"
 	cd "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)" && \
 		yarn install --offline --production && \
 		(yarn unlink > /dev/null 2>&1 || true) && \
 		yarn link
 
-test_all::
+test_fast::
+	./pack/nodejs/node_modules/mocha/bin/mocha ./pack/nodejs/bin/tests
+
+test_all:: test_fast
 	PATH=$(PULUMI_BIN):$(PATH) $(GO) test -v -cover -timeout 1h -parallel ${TESTPARALLELISM} $(TESTABLE_PKGS)
 
 .PHONY: publish_tgz

--- a/pack/nodejs/helm.ts
+++ b/pack/nodejs/helm.ts
@@ -5,6 +5,7 @@ import * as k8s from "./index";
 import * as pulumi from "@pulumi/pulumi";
 import * as shell from "shell-quote";
 import * as tmp from "tmp";
+import * as path from "./path";
 
 export namespace v2 {
     export interface ChartOpts {
@@ -142,16 +143,16 @@ export function fetch(chart: string, opts?: FetchOpts) {
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         if (opts.version !== undefined)     { flags.push(`--version ${shell.quote([opts.version])}`);         }
-        if (opts.caFile !== undefined)      { flags.push(`--ca-file ${shell.quote([opts.caFile])}`);          }
-        if (opts.certFile !== undefined)    { flags.push(`--cert-file ${shell.quote([opts.certFile])}`);      }
-        if (opts.keyFile !== undefined)     { flags.push(`--key-file ${shell.quote([opts.keyFile])}`);        }
-        if (opts.destination !== undefined) { flags.push(`--destination ${shell.quote([opts.destination])}`); }
-        if (opts.keyring !== undefined)     { flags.push(`--keyring ${shell.quote([opts.keyring])}`);         }
+        if (opts.caFile !== undefined)      { flags.push(`--ca-file ${path.quotePath(opts.caFile)}`);          }
+        if (opts.certFile !== undefined)    { flags.push(`--cert-file ${path.quotePath(opts.certFile)}`);      }
+        if (opts.keyFile !== undefined)     { flags.push(`--key-file ${path.quotePath(opts.keyFile)}`);        }
+        if (opts.destination !== undefined) { flags.push(`--destination ${path.quotePath(opts.destination)}`); }
+        if (opts.keyring !== undefined)     { flags.push(`--keyring ${path.quotePath(opts.keyring)}`);         }
         if (opts.password !== undefined)    { flags.push(`--password ${shell.quote([opts.password])}`);       }
         if (opts.repo !== undefined)        { flags.push(`--repo ${shell.quote([opts.repo])}`);               }
-        if (opts.untardir !== undefined)    { flags.push(`--untardir ${shell.quote([opts.untardir])}`);       }
+        if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);       }
-        if (opts.home !== undefined)        { flags.push(`--home ${shell.quote([opts.home])}`);               }
+        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                          }
         if (opts.prov === true)             { flags.push(`--prov`);                                           }
         if (opts.verify === true)           { flags.push(`--verify`);                                         }

--- a/pack/nodejs/helm.ts
+++ b/pack/nodejs/helm.ts
@@ -66,6 +66,9 @@ export namespace v2 {
                     yaml: [yamlStream],
                     transformations: config.transformations || [],
                 }, { parent: this });
+            } catch (e) {
+                // Shed stack trace, only emit the error.
+                throw new pulumi.RunError(e.toString());
             } finally {
                 // Clean up temporary files and directories.
                 chartDir.removeCallback()

--- a/pack/nodejs/package.json
+++ b/pack/nodejs/package.json
@@ -20,7 +20,9 @@
         "tmp": "^0.0.33",
         "@types/tmp": "^0.0.33",
         "glob": "^7.1.2",
-        "@types/glob": "^5.0.35"
+        "@types/glob": "^5.0.35",
+        "mocha": "^5.2.0",
+        "@types/mocha": "^5.2.5"
     },
     "devDependencies": {
         "typescript": "^2.6.2",

--- a/pack/nodejs/path.ts
+++ b/pack/nodejs/path.ts
@@ -1,0 +1,19 @@
+import * as shell from "shell-quote";
+
+export function quotePath(path: string): string {
+    if (process.platform === "win32") {
+        return quoteWindowsPath(path);
+    } else {
+        return shell.quote([path]);
+    }
+}
+
+export function quoteWindowsPath(path: string): string {
+    // Unescape paths for Windows. Taken directly from[1], an unmerged, but LGTM'd PR to the
+    // official library.
+    //
+    // [1]: https://github.com/substack/node-shell-quote/pull/34
+
+    path = String(path).replace(/([A-z]:)?([#!"$&'()*,:;<=>?@\[\\\]^`{|}])/g, "$1\\$2");
+    return path.replace(/\\\\/g, "\\");
+}

--- a/pack/nodejs/tests/path.ts
+++ b/pack/nodejs/tests/path.ts
@@ -1,0 +1,17 @@
+import * as assert from "assert";
+import * as path from "../path";
+
+describe("path.quoteWindowsPath", () => {
+    it("escapes Windows path with drive prefix correctly", () => {
+        const p = path.quoteWindowsPath("C:\\Users\\grace hopper\\AppData\\Local\\Temp");
+        assert.equal(p, "C:\\Users\\grace hopper\\AppData\\Local\\Temp");
+    });
+    it("escapes Windows path with no drive prefix correctly", () => {
+        const p = path.quoteWindowsPath("\\Users\\grace hopper\\AppData\\Local\\Temp");
+        assert.equal(p, "\\Users\\grace hopper\\AppData\\Local\\Temp");
+    });
+    it("escapes relative Windows path correctly", () => {
+        const p = path.quoteWindowsPath("Users\\grace hopper\\AppData\\Local\\Temp");
+        assert.equal(p, "Users\\grace hopper\\AppData\\Local\\Temp");
+    });
+});

--- a/pack/nodejs/yarn.lock
+++ b/pack/nodejs/yarn.lock
@@ -83,6 +83,10 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
+"@types/mocha@^5.2.5":
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
+
 "@types/node@*":
   version "10.5.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.8.tgz#6f14ccecad1d19332f063a6a764f8907801fece0"
@@ -166,6 +170,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -204,6 +212,10 @@ colour@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
 
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -215,6 +227,12 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.1.2:
   version "2.6.9"
@@ -249,9 +267,13 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^3.1.0:
+diff@3.5.0, diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+escape-string-regexp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -280,7 +302,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@7.1.2, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -299,6 +321,10 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 grpc@^1.12.2:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.14.0.tgz#5aea131ef078285eff543301b99ba994e4db2c73"
@@ -308,9 +334,17 @@ grpc@^1.12.2:
     node-pre-gyp "^0.10.0"
     protobufjs "^5.0.3"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -404,7 +438,7 @@ make-error@^1.1.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -431,11 +465,27 @@ minizlib@^1.1.0:
   dependencies:
     minipass "^2.2.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -759,6 +809,12 @@ strip-ansi@^4.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 tar@^4:
   version "4.4.6"

--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -595,18 +595,21 @@ func canonicalizeDeploymentAPIVersion(ver string) string {
 }
 
 func isOwnedBy(obj, possibleOwner *unstructured.Unstructured) bool {
+	var possibleOwnerAPIVersion string
+
 	// Canonicalize apiVersion for Deployments.
 	if possibleOwner.GetKind() == "Deployment" {
-		possibleOwner.SetAPIVersion(canonicalizeDeploymentAPIVersion(possibleOwner.GetAPIVersion()))
+		possibleOwnerAPIVersion = canonicalizeDeploymentAPIVersion(possibleOwner.GetAPIVersion())
 	}
 
 	owners := obj.GetOwnerReferences()
 	for _, owner := range owners {
+		var ownerAPIVersion string
 		if owner.Kind == "Deployment" {
-			owner.APIVersion = canonicalizeDeploymentAPIVersion(owner.APIVersion)
+			ownerAPIVersion = canonicalizeDeploymentAPIVersion(owner.APIVersion)
 		}
 
-		if owner.APIVersion == possibleOwner.GetAPIVersion() &&
+		if ownerAPIVersion == possibleOwnerAPIVersion &&
 			possibleOwner.GetKind() == owner.Kind && possibleOwner.GetName() == owner.Name {
 			return true
 		}

--- a/pkg/await/core_pod.go
+++ b/pkg/await/core_pod.go
@@ -271,6 +271,10 @@ func (pc *podChecker) errorMessages() []string {
 	}
 
 	for reason, errors := range pc.containerErrors {
+		// Ignore non-useful status messages.
+		if reason == "ContainersNotReady" {
+			continue
+		}
 		for _, message := range errors {
 			messages = append(messages, fmt.Sprintf("[%s] %s", reason, message))
 		}

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -39,7 +39,7 @@ func FqObjName(o metav1.Object) string {
 
 // ParseFqName will parse a fully-qualified Kubernetes object name.
 func ParseFqName(id string) (namespace, name string) {
-	split := strings.Split(id, ".")
+	split := strings.Split(id, "/")
 	if len(split) == 1 {
 		return "", split[0]
 	}
@@ -47,12 +47,12 @@ func ParseFqName(id string) (namespace, name string) {
 	return
 }
 
-// FqName returns "namespace.name"
+// FqName returns "namespace/name"
 func FqName(namespace, name string) string {
 	if namespace == "" {
 		return name
 	}
-	return fmt.Sprintf("%s.%s", namespace, name)
+	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 // NamespaceOrDefault returns `ns` or the the default namespace `"default"` if `ns` is empty.

--- a/pkg/client/version_test.go
+++ b/pkg/client/version_test.go
@@ -123,7 +123,7 @@ func TestFqName(t *testing.T) {
 	}
 
 	obj.SetNamespace("mynamespace")
-	if n := FqName(obj.GetNamespace(), obj.GetName()); n != "mynamespace.myname" {
+	if n := FqName(obj.GetNamespace(), obj.GetName()); n != "mynamespace/myname" {
 		t.Errorf("Got %q for %v", n, obj)
 	}
 }

--- a/pkg/gen/node-templates/helm.ts.mustache
+++ b/pkg/gen/node-templates/helm.ts.mustache
@@ -5,6 +5,7 @@ import * as k8s from "./index";
 import * as pulumi from "@pulumi/pulumi";
 import * as shell from "shell-quote";
 import * as tmp from "tmp";
+import * as path from "./path";
 
 export namespace v2 {
     export interface ChartOpts {
@@ -142,16 +143,16 @@ export function fetch(chart: string, opts?: FetchOpts) {
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         if (opts.version !== undefined)     { flags.push(`--version ${shell.quote([opts.version])}`);         }
-        if (opts.caFile !== undefined)      { flags.push(`--ca-file ${shell.quote([opts.caFile])}`);          }
-        if (opts.certFile !== undefined)    { flags.push(`--cert-file ${shell.quote([opts.certFile])}`);      }
-        if (opts.keyFile !== undefined)     { flags.push(`--key-file ${shell.quote([opts.keyFile])}`);        }
-        if (opts.destination !== undefined) { flags.push(`--destination ${shell.quote([opts.destination])}`); }
-        if (opts.keyring !== undefined)     { flags.push(`--keyring ${shell.quote([opts.keyring])}`);         }
+        if (opts.caFile !== undefined)      { flags.push(`--ca-file ${path.quotePath(opts.caFile)}`);          }
+        if (opts.certFile !== undefined)    { flags.push(`--cert-file ${path.quotePath(opts.certFile)}`);      }
+        if (opts.keyFile !== undefined)     { flags.push(`--key-file ${path.quotePath(opts.keyFile)}`);        }
+        if (opts.destination !== undefined) { flags.push(`--destination ${path.quotePath(opts.destination)}`); }
+        if (opts.keyring !== undefined)     { flags.push(`--keyring ${path.quotePath(opts.keyring)}`);         }
         if (opts.password !== undefined)    { flags.push(`--password ${shell.quote([opts.password])}`);       }
         if (opts.repo !== undefined)        { flags.push(`--repo ${shell.quote([opts.repo])}`);               }
-        if (opts.untardir !== undefined)    { flags.push(`--untardir ${shell.quote([opts.untardir])}`);       }
+        if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);       }
-        if (opts.home !== undefined)        { flags.push(`--home ${shell.quote([opts.home])}`);               }
+        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                          }
         if (opts.prov === true)             { flags.push(`--prov`);                                           }
         if (opts.verify === true)           { flags.push(`--verify`);                                         }

--- a/pkg/gen/node-templates/helm.ts.mustache
+++ b/pkg/gen/node-templates/helm.ts.mustache
@@ -66,6 +66,9 @@ export namespace v2 {
                     yaml: [yamlStream],
                     transformations: config.transformations || [],
                 }, { parent: this });
+            } catch (e) {
+                // Shed stack trace, only emit the error.
+                throw new pulumi.RunError(e.toString());
             } finally {
                 // Clean up temporary files and directories.
                 chartDir.removeCallback()

--- a/pkg/gen/node-templates/package.json.mustache
+++ b/pkg/gen/node-templates/package.json.mustache
@@ -20,7 +20,9 @@
         "tmp": "^0.0.33",
         "@types/tmp": "^0.0.33",
         "glob": "^7.1.2",
-        "@types/glob": "^5.0.35"
+        "@types/glob": "^5.0.35",
+        "mocha": "^5.2.0",
+        "@types/mocha": "^5.2.5"
     },
     "devDependencies": {
         "typescript": "^2.6.2",

--- a/pkg/openapi/match.go
+++ b/pkg/openapi/match.go
@@ -1,0 +1,72 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// PropertiesChanged compares two versions of an object to see if any path specified in `paths` has
+// been changed. Paths are specified as JSONPaths, e.g., `.spec.accessModes` refers to `{spec:
+// {accessModes: {}}}`.
+func PropertiesChanged(oldObj, newObj map[string]interface{}, paths []string) ([]string, error) {
+	patch, err := mergePatchObj(oldObj, newObj)
+	if err != nil {
+		return nil, err
+	}
+
+	j := jsonpath.New("")
+	matches := []string{}
+	for _, path := range paths {
+		j.AllowMissingKeys(true)
+		err := j.Parse(fmt.Sprintf("{%s}", path))
+		if err != nil {
+			return nil, err
+		}
+		buf := new(bytes.Buffer)
+		err = j.Execute(buf, patch)
+		if err != nil {
+			continue
+		}
+
+		if len(buf.String()) > 0 {
+			matches = append(matches, path)
+		}
+	}
+
+	return matches, nil
+}
+
+// mergePatchObj takes a two objects and returns an object that is the union of all
+// fields that were changed (e.g., were deleted, were added, and so on) between the two.
+//
+// For example, say we have {a: 1, c:3} and {a:1, b:2}. This function would then return {b:2, c:3}.
+//
+// This is useful so that we can (e.g.) use jsonpath to see which fields were altered.
+func mergePatchObj(oldObj, newObj map[string]interface{}) (map[string]interface{}, error) {
+	oldJSON, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, err
+	}
+
+	newJSON, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, err
+	}
+
+	patchBytes, err := jsonpatch.CreateMergePatch(oldJSON, newJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	patch := map[string]interface{}{}
+	err = json.Unmarshal(patchBytes, &patch)
+	if err != nil {
+		return nil, err
+	}
+
+	return patch, nil
+}

--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -15,13 +15,8 @@
 package provider
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/util/jsonpath"
 )
 
 func forceNewProperties(
@@ -36,66 +31,7 @@ func forceNewProperties(
 		}
 	}
 
-	return matchingProperties(oldObj, newObj, props)
-}
-
-func matchingProperties(oldObj, newObj map[string]interface{}, ps properties) ([]string, error) {
-	patch, err := mergePatchObj(oldObj, newObj)
-	if err != nil {
-		return nil, err
-	}
-
-	j := jsonpath.New("")
-	matches := []string{}
-	for _, path := range ps {
-		j.AllowMissingKeys(true)
-		err := j.Parse(fmt.Sprintf("{%s}", path))
-		if err != nil {
-			return nil, err
-		}
-		buf := new(bytes.Buffer)
-		err = j.Execute(buf, patch)
-		if err != nil {
-			continue
-		}
-
-		if len(buf.String()) > 0 {
-			matches = append(matches, path)
-		}
-	}
-
-	return matches, nil
-}
-
-// mergePatchObj takes a two objects and returns an object that is the union of all
-// fields that were changed (e.g., were deleted, were added, and so on) between the two.
-//
-// For example, say we have {a: 1, c:3} and {a:1, b:2}. This function would then return {b:2, c:3}.
-//
-// This is useful so that we can (e.g.) use jsonpath to see which fields were altered.
-func mergePatchObj(oldObj, newObj map[string]interface{}) (map[string]interface{}, error) {
-	oldJSON, err := json.Marshal(oldObj)
-	if err != nil {
-		return nil, err
-	}
-
-	newJSON, err := json.Marshal(newObj)
-	if err != nil {
-		return nil, err
-	}
-
-	patchBytes, err := jsonpatch.CreateMergePatch(oldJSON, newJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	patch := map[string]interface{}{}
-	err = json.Unmarshal(patchBytes, &patch)
-	if err != nil {
-		return nil, err
-	}
-
-	return patch, nil
+	return openapi.PropertiesChanged(oldObj, newObj, props)
 }
 
 type groups map[string]versions

--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -40,6 +40,11 @@ type kinds map[string]properties
 type properties []string
 
 var forceNew = groups{
+	"apps": versions{
+		// NOTE: These fields do NOT trigger a replace in extensions/v1beta1 or apps/v1beta1.
+		"v1beta2": kinds{"Deployment": deployment},
+		"v1":      kinds{"Deployment": deployment},
+	},
 	// List `core` under its canonical name and under it's legacy name (i.e., "", the empty string)
 	// for compatibility purposes.
 	"core": core,
@@ -81,6 +86,10 @@ var core = versions{
 			".spec.type",
 		},
 	},
+}
+
+var deployment = properties{
+	".spec.selector",
 }
 
 func metadataForceNewProperties(prefix string) properties {

--- a/pkg/provider/diff_test.go
+++ b/pkg/provider/diff_test.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"reflect"
 	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
 )
 
 type object map[string]interface{}
@@ -40,7 +42,7 @@ func TestFieldsChanged(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		diff, err := matchingProperties(test.old, test.new,
+		diff, err := openapi.PropertiesChanged(test.old, test.new,
 			forceNew[test.group][test.version][test.kind])
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
BREAKING CHANGE: This PR fixes a small set of bugs and changes the way resources are named in the Pulumi Kubernetes provider. Quoting from the relevant commit:

> Use `/` in fully-qualified resource names
>
> Fixes #146.
> 
> Currently we're creating canonical IDs for resources using the `.`
> character. These IDs take the form of `${namespace}.${name}`, or simply
> `${name}` if namespace does not exist.
> 
> We copied this strategy from ksonnet, which in turn copied it from some
> part of kubectl, but this turns out to be a critical flaw, because `.`
> is an allowed character in DNS-1123-compliant names. This means it's
> possible to name your resource `foo.bar`, and if it does not contain a
> namespace, then we'd decide the namespace was `foo`.
> 
> The solution is to move canonical IDs for resources to use `/` to
> delimit namespace, which is much better because `/` is not DNS-1123
> compliant, and therefore no Kubernetes resource can have the slash in
> it.

This change is absolutely necessary, but it will be painful for anyone who (1) has a stack with explicitly-namespaced resources, or (2) uses `.` in the name or namespace of a resource.

Our plan is to:

- Include this in v0.15.2
- Find all users who are affected by the change (we have the appropriate SQL query written)
- Email all of them to let them know what will happen when they upgrade
- In my personal time, I will write a migration tool so they can do something like `pulumi stack export | migrate.sh | pulumi stack import`