### PR TITLE
Use ephemeral status messages in status-rich updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     - minikube update-context
 
     # Install Pulumi
-    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.15.1-dev-1534221790-gd83774ca
+    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.15.1-dev-1535756213-gdea68b8b
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -599,7 +599,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "58a75cbbf45d25f1fa7450ac812cfe5d331a44fd"
+  revision = "dea68b8b37f7fb26abf299b6f205a6e7ad6f2f97"
 
 [[projects]]
   branch = "master"

--- a/pkg/await/apps_deployment_test.go
+++ b/pkg/await/apps_deployment_test.go
@@ -140,7 +140,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "[Revision 2] Should fail if unrelated Deployment succeeds",
@@ -157,7 +159,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "[Revision 1] Should succeed when unrelated deployment fails",
@@ -233,7 +237,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Minimum number of live Pods was not attained",
+				}},
 		},
 		{
 			description: "[Revision 2] Should fail if timeout occurs before Deployment controller progresses",
@@ -249,7 +255,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Minimum number of live Pods was not attained",
+				}},
 		},
 		{
 			description: "[Revision 2] Should fail if timeout occurs before ReplicaSet is created",
@@ -265,7 +273,8 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Minimum number of live Pods was not attained"}},
 		},
 		{
 			description: "[Revision 2] Should fail if timeout occurs before ReplicaSet becomes available",
@@ -286,7 +295,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				objectName: deploymentInputName,
 				subErrors: []string{
 					"[MinimumReplicasUnavailable] Deployment does not have minimum availability.",
-					"Updated ReplicaSet was never created"}},
+					"Minimum number of live Pods was not attained"}},
 		},
 		{
 			description: "[Revision 2] Should fail if new ReplicaSet isn't created after an update",
@@ -300,7 +309,8 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Attempted to roll forward to new ReplicaSet, but minimum number of Pods did not become live"}},
 		},
 		{
 			description: "[Revision 2] Should fail if timeout before new ReplicaSet becomes available",
@@ -316,7 +326,8 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{"Updated ReplicaSet was never created"}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Minimum number of Pods to consider the application live was not attained"}},
 		},
 		{
 			description: "[Revision 1] Deployment should succeed and not report 'Progressing' condition",
@@ -353,7 +364,8 @@ func Test_Apps_Deployment(t *testing.T) {
 			},
 			expectedError: &timeoutError{
 				objectName: deploymentInputName,
-				subErrors:  []string{}},
+				subErrors: []string{
+					"Minimum number of Pods to consider the application live was not attained"}},
 		},
 		{
 			description: "[Revision 2] Deployment should fail if Deployment reports 'Progressing' failure",
@@ -376,7 +388,8 @@ func Test_Apps_Deployment(t *testing.T) {
 				objectName: deploymentInputName,
 				subErrors: []string{
 					`[ProgressDeadlineExceeded] ReplicaSet "foo-13y9rdnu-b94df86d6" has timed ` +
-						`out progressing.`}},
+						`out progressing.`,
+					"Minimum number of Pods to consider the application live was not attained"}},
 		},
 		{
 			description: "[Revision 2] Should fail if Deployment is progressing but new ReplicaSet not available",
@@ -396,7 +409,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				objectName: deploymentInputName, subErrors: []string{}},
+				objectName: deploymentInputName, subErrors: []string{
+					"Minimum number of Pods to consider the application live was not attained",
+				}},
 		},
 		{
 			description: "[Revision 1] Failure should only report Pods from active ReplicaSet, part 1",
@@ -417,7 +432,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "[Revision 2] Failure should only report Pods from active ReplicaSet, part 1",
@@ -438,7 +455,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "[Revision 1] Failure should only report Pods from active ReplicaSet, part 2",
@@ -459,7 +478,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "[Revision 2] Failure should only report Pods from active ReplicaSet, part 2",
@@ -480,7 +501,9 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{}},
+			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
+				"Minimum number of live Pods was not attained",
+			}},
 		},
 		{
 			description: "Should fail if ReplicaSet generations do not match",
@@ -494,7 +517,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{objectName: deploymentInputName, subErrors: []string{
-				"Updated ReplicaSet was never created"}},
+				"Minimum number of Pods to consider the application live was not attained"}},
 		},
 	}
 
@@ -603,7 +626,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision1,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision1,
-			expectedSubErrors:  []string{},
+			expectedSubErrors:  []string{"Minimum number of live Pods was not attained"},
 		},
 		{
 			description:        "Read should fail if Deployment status empty",
@@ -611,7 +634,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision1,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision1,
-			expectedSubErrors:  []string{},
+			expectedSubErrors:  []string{"Minimum number of live Pods was not attained"},
 		},
 		{
 			description:        "Read should fail if Deployment is progressing",
@@ -619,7 +642,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision1,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision1,
-			expectedSubErrors:  []string{},
+			expectedSubErrors:  []string{"Minimum number of live Pods was not attained"},
 		},
 		{
 			description:        "[Revision 2] Read should fail if Deployment Progressing status set to False",
@@ -629,6 +652,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			replicaSetRevision: revision2,
 			expectedSubErrors: []string{
 				"[ProgressDeadlineExceeded] ReplicaSet \"foo-13y9rdnu-b94df86d6\" has timed out progressing.",
+				"Minimum number of Pods to consider the application live was not attained",
 			},
 		},
 		{
@@ -637,7 +661,8 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision2,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision2,
-			expectedSubErrors:  []string{},
+			expectedSubErrors: []string{
+				"Minimum number of Pods to consider the application live was not attained"},
 		},
 		{
 			description:        "[Revision 2] Read should fail if Deployment progressing but unavailable",
@@ -647,7 +672,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			replicaSetRevision: revision2,
 			expectedSubErrors: []string{
 				"[MinimumReplicasUnavailable] Deployment does not have minimum availability.",
-			},
+				"Minimum number of live Pods was not attained"},
 		},
 		{
 			description: "[Revision 1] Read should succeed if Deployment reported available",
@@ -664,7 +689,8 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			},
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision2,
-			expectedSubErrors:  []string{},
+			expectedSubErrors: []string{
+				"Minimum number of Pods to consider the application live was not attained"},
 		},
 		{
 			description:        "[Revision 2] Read should succeed if rollout completes",
@@ -679,7 +705,9 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision2,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision1,
-			expectedSubErrors:  []string{"Updated ReplicaSet was never created"},
+			expectedSubErrors: []string{
+				"Attempted to roll forward to new ReplicaSet, but minimum number of Pods did not become live",
+			},
 		},
 		{
 			description:        "[Revision 2] Read should fail Deployment if new ReplicaSet still progressing",
@@ -687,7 +715,8 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			deploymentRevision: revision2,
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision2,
-			expectedSubErrors:  []string{},
+			expectedSubErrors: []string{
+				"Minimum number of Pods to consider the application live was not attained"},
 		},
 		{
 			description:        "[Revision 2] Read should succeed Deployment if new ReplicaSet still rolled out",

--- a/pkg/await/core_service_test.go
+++ b/pkg/await/core_service_test.go
@@ -50,8 +50,10 @@ func Test_Core_Service(t *testing.T) {
 			},
 			expectedError: &timeoutError{
 				objectName: "foo-4setj4y6",
-				subErrors: []string{"Service does not target any Pods",
-					"Service was not allocated an IP address"}},
+				subErrors: []string{
+					"Service does not target any Pods. Application Pods may failed to become alive, or " +
+						"field '.spec.selector' may not match labels on any Pods",
+					"Service was not allocated an IP address; does your cloud provider support this?"}},
 		},
 		{
 			description: "Should succeed when unrelated Service fails",
@@ -89,8 +91,9 @@ func Test_Core_Service(t *testing.T) {
 			expectedError: &timeoutError{
 				objectName: "foo-4setj4y6",
 				subErrors: []string{
-					"Service does not target any Pods",
-					"Service was not allocated an IP address"}},
+					"Service does not target any Pods. Application Pods may failed to become alive, or " +
+						"field '.spec.selector' may not match labels on any Pods",
+					"Service was not allocated an IP address; does your cloud provider support this?"}},
 		},
 		{
 			description: "Should fail if Endpoints have not initialized",
@@ -108,7 +111,9 @@ func Test_Core_Service(t *testing.T) {
 			},
 			expectedError: &timeoutError{
 				objectName: "foo-4setj4y6",
-				subErrors:  []string{"Service does not target any Pods"}},
+				subErrors: []string{
+					"Service does not target any Pods. Application Pods may failed to become alive, or " +
+						"field '.spec.selector' may not match labels on any Pods"}},
 		},
 		{
 			description: "Should fail if Service is not allocated an IP address",
@@ -126,7 +131,9 @@ func Test_Core_Service(t *testing.T) {
 			},
 			expectedError: &timeoutError{
 				objectName: "foo-4setj4y6",
-				subErrors:  []string{"Service was not allocated an IP address"}},
+				subErrors: []string{
+					"Service was not allocated an IP address; does your cloud provider support this?",
+				}},
 		},
 	}
 
@@ -154,10 +161,12 @@ func Test_Core_Service_Read(t *testing.T) {
 		expectedSubErrors []string
 	}{
 		{
-			description:       "Read should fail if Service does not target any Pods",
-			service:           initializedService,
-			endpoint:          uninitializedEndpoint,
-			expectedSubErrors: []string{"Service does not target any Pods"},
+			description: "Read should fail if Service does not target any Pods",
+			service:     initializedService,
+			endpoint:    uninitializedEndpoint,
+			expectedSubErrors: []string{
+				"Service does not target any Pods. Application Pods may failed to become alive, or " +
+					"field '.spec.selector' may not match labels on any Pods"},
 		},
 		{
 			description: "Read should succeed if Service does target Pods",
@@ -165,10 +174,12 @@ func Test_Core_Service_Read(t *testing.T) {
 			endpoint:    initializedEndpoint,
 		},
 		{
-			description:       "Read should fail if Service not allocated an IP address",
-			service:           serviceInput,
-			endpoint:          initializedEndpoint,
-			expectedSubErrors: []string{"Service was not allocated an IP address"},
+			description: "Read should fail if Service not allocated an IP address",
+			service:     serviceInput,
+			endpoint:    initializedEndpoint,
+			expectedSubErrors: []string{
+				"Service was not allocated an IP address; does your cloud provider support this?",
+			},
 		},
 	}
 

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -38,7 +38,7 @@ type ServerVersion struct {
 // DefaultVersion takes a wild guess (v1.9) at the version of a Kubernetes cluster.
 func DefaultVersion() ServerVersion {
 	cmdutil.Diag().Warningf(
-		diag.Message("", "Cluster failed to report its version number; falling back to 1.9"))
+		diag.Message("", "Cluster failed to report its version number; falling back to 1.9"), false)
 
 	//
 	// Fallback behavior to work around [1]. Some versions of minikube erroneously report a blank

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"github.com/pulumi/pulumi/pkg/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func hasComputedValue(obj *unstructured.Unstructured) bool {
+	if obj == nil || obj.Object == nil {
+		return false
+	}
+
+	objects := []map[string]interface{}{obj.Object}
+	var curr map[string]interface{}
+
+	for {
+		if len(objects) == 0 {
+			break
+		}
+		curr, objects = objects[0], objects[1:]
+		for _, v := range curr {
+			if _, isComputed := v.(resource.Computed); isComputed {
+				return true
+			}
+			if field, isMap := v.(map[string]interface{}); isMap {
+				objects = append(objects, field)
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/provider/util_test.go
+++ b/pkg/provider/util_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasComputedValue(t *testing.T) {
+	tests := []struct {
+		name             string
+		obj              *unstructured.Unstructured
+		hasComputedValue bool
+	}{
+		{
+			name:             "nil object does not have a computed value",
+			obj:              nil,
+			hasComputedValue: false,
+		},
+		{
+			name:             "Empty object does not have a computed value",
+			obj:              &unstructured.Unstructured{},
+			hasComputedValue: false,
+		},
+		{
+			name:             "Object with no computed values does not have a computed value",
+			obj:              &unstructured.Unstructured{Object: map[string]interface{}{}},
+			hasComputedValue: false,
+		},
+		{
+			name: "Object with one concrete value does not have a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+			}},
+			hasComputedValue: false,
+		},
+		{
+			name: "Object with one computed value does have a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": resource.Computed{},
+			}},
+			hasComputedValue: true,
+		},
+		{
+			name: "Object with one nested computed value does have a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": map[string]interface{}{
+					"field3": resource.Computed{},
+				},
+			}},
+			hasComputedValue: true,
+		},
+		{
+			name: "Object with nested maps and no computed values",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": map[string]interface{}{
+					"field3": "3",
+				},
+			}},
+			hasComputedValue: false,
+		},
+		{
+			name: "Object with doubly nested maps and 1 computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": map[string]interface{}{
+					"field3": "3",
+					"field4": map[string]interface{}{
+						"field5": resource.Computed{},
+					},
+				},
+			}},
+			hasComputedValue: true,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.hasComputedValue, hasComputedValue(test.obj), test.name)
+	}
+}


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi/pull/1853. Quoting from its first commit:

> Allow log events to be marked "status" events
>
> This commit will introduce a field, `IsStatus` to `LogRequest`. A
"status" logging event will be displayed in the `Info` column of the
main display, but will not be printed out at the end, when resource
operations complete.
> 
> For example, for complex resource initialization, we'd like to display a
series of intermediate results: `[1/4] Service object created`, for
example. We'd like these to appear in the `Info` column, but not at the
end, where they are not helpful to the user.

<hr>

## Success case demo

[![asciicast](https://asciinema.org/a/199008.png)](https://asciinema.org/a/199008?speed=3&autoplay=1)

## Failure case demo

[![asciicast](https://asciinema.org/a/199009.png)](https://asciinema.org/a/199009?speed=3&autoplay=1)