### PR TITLE
Replace usages of `watcher` package in favor of the client-go `watch` API in await.go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1073,7 +1073,7 @@
     "third_party/forked/golang/reflect"
   ]
   revision = "302974c03f7e50f16561ba237db776ab93594ef6"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.10.2"
 
 [[projects]]
   name = "k8s.io/apiserver"

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -17,6 +17,7 @@ package await
 import (
 	"context"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/pulumi/pulumi-kubernetes/pkg/client"
 	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
@@ -318,10 +319,7 @@ func Deletion(
 
 	timeoutSeconds := int64(300)
 	listOpts := metav1.ListOptions{
-		FieldSelector: fields.AndSelectors(
-			fields.OneTermEqualSelector("metadata.namespace", namespace),
-			fields.OneTermEqualSelector("metadata.name", name),
-		).String(),
+		FieldSelector:  fields.OneTermEqualSelector("metadata.name", name).String(),
 		TimeoutSeconds: &timeoutSeconds,
 	}
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -360,12 +360,19 @@ func Deletion(
 				case watch.Deleted:
 					return nil
 				case watch.Error:
-					return &initializationError{} // TODO: not sure what object to put here
+					resource, _ := clientForResource.Get(name, metav1.GetOptions{})
+					return &initializationError{
+						object:    resource,
+						subErrors: []string{errors.FromObject(event.Object).Error()},
+					}
 				}
 			case <-ctx.Done(): // Handle user cancellation during watch for deletion.
 				watcher.Stop()
 				glog.V(3).Infof("Received error deleting object '%s': %#v", id, err)
-				return &cancellationError{} // TODO: not sure what object to put here
+				resource, _ := clientForResource.Get(name, metav1.GetOptions{})
+				return &cancellationError{
+					object: resource,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Refactor await logic to use the Kubernetes Watch API rather than the `watcher` package.

Partial fix for #222 