### PR TITLE
`cancellationError` should implement `InitializationError`

### DIFF
--- a/pkg/await/error.go
+++ b/pkg/await/error.go
@@ -25,6 +25,7 @@ type cancellationError struct {
 
 var _ error = (*cancellationError)(nil)
 var _ AggregatedError = (*cancellationError)(nil)
+var _ InitializationError = (*cancellationError)(nil)
 
 func (ce *cancellationError) Error() string {
 	return fmt.Sprintf("Resource operation was cancelled for '%s'", ce.object.GetName())
@@ -33,6 +34,10 @@ func (ce *cancellationError) Error() string {
 // SubErrors returns the errors that were present when cancellation occurred.
 func (ce *cancellationError) SubErrors() []string {
 	return ce.subErrors
+}
+
+func (ce *cancellationError) Object() *unstructured.Unstructured {
+	return ce.object
 }
 
 // timeoutError represents an operation that failed because it timed out.


### PR DESCRIPTION
`InitializationError` is used to signal to the provider that a resource
has successfully been created, but not initialized. Currently
`cancellationError` does not implement this interface, so if
`Deployment` or `Service` are cancelled, this is not registered as a
partial failure with the engine or service.

This did not used to be the case, but was a regression with #236.

We already have good tests to make sure that `Deployment` and `Service` return the appropriate cancellation and timeout errors under various circumstances -- it's not clear that additional tests would help here, as the problem is that the error implementations didn't technically implement the correct interface. As a safeguard against this in the future I've added a sentinel check `var _ InitializationError = (*cancellationError)(nil)`, which should cause the compiler to error out on regression.