### PR TITLE
`timeoutError` should implement `InitializationError`

### DIFF
--- a/pkg/await/error.go
+++ b/pkg/await/error.go
@@ -48,6 +48,7 @@ type timeoutError struct {
 
 var _ error = (*timeoutError)(nil)
 var _ AggregatedError = (*timeoutError)(nil)
+var _ InitializationError = (*timeoutError)(nil)
 
 func (te *timeoutError) Error() string {
 	return fmt.Sprintf("Timeout occurred for '%s'", te.object.GetName())
@@ -56,6 +57,10 @@ func (te *timeoutError) Error() string {
 // SubErrors returns the errors that were present when timeout occurred.
 func (te *timeoutError) SubErrors() []string {
 	return te.subErrors
+}
+
+func (te *timeoutError) Object() *unstructured.Unstructured {
+	return te.object
 }
 
 // readError occurs when we attempt to read a resource that failed to fully initialize.


### PR DESCRIPTION
`InitializationError` is used to signal to the provider that a resource
has successfully been created, but not initialized. Currently
`timeoutError` does not implement this interface, so if
`Deployment` or `Service` are cancelled, this is not registered as a
partial failure with the engine or service.

This did not used to be the case, but was a regression with #236.