### PR TITLE
Pin to dev builds of pulumi/pulumi

### DIFF
--- a/pkg/gen/nodejs-templates/package.json.mustache
+++ b/pkg/gen/nodejs-templates/package.json.mustache
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1",
+        "@pulumi/pulumi": "dev",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1",
+        "@pulumi/pulumi": "dev",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",


### PR DESCRIPTION
As part of the release process, we'll need to change the constraint to a non-developer build like we do for all of our other package repos.