### PR TITLE
Allow more flexible chart options

### DIFF
--- a/examples/helm/index.ts
+++ b/examples/helm/index.ts
@@ -31,3 +31,23 @@ const nginx = new k8s.helm.v2.Chart("simple-nginx", {
 // Export the (cluster-private) IP address of the Guestbook frontend.
 export const frontendClusterIp = nginx.getResourceProperty("v1/Service", "simple-nginx-nginx-lego", "spec")
     .apply(spec => spec.clusterIP);
+
+// Test a variety of other inputs on a chart that creates no resources.
+const empty1 = new k8s.helm.v2.Chart("empty1", {
+    chart: "https://kubernetes-charts-incubator.storage.googleapis.com/raw-0.1.0.tgz",
+});
+
+const empty2 = new k8s.helm.v2.Chart("empty2", {
+    chart: "raw",
+    version: "0.1.0",
+    fetchOpts: {
+        repo: "https://kubernetes-charts-incubator.storage.googleapis.com/",
+    },
+});
+
+const empty3 = new k8s.helm.v2.Chart("empty3", {
+    chart: "raw",
+    fetchOpts: {
+        repo: "https://kubernetes-charts-incubator.storage.googleapis.com/",
+    },
+});

--- a/pkg/gen/nodejs-templates/helm.ts.mustache
+++ b/pkg/gen/nodejs-templates/helm.ts.mustache
@@ -19,7 +19,7 @@ export namespace v2 {
     export interface ChartOpts extends BaseChartOpts {
         repo: pulumi.Input<string>;
         chart: pulumi.Input<string>;
-        version: pulumi.Input<string>;
+        version?: pulumi.Input<string>;
 
         fetchOpts?: pulumi.Input<FetchOpts>;
     }

--- a/pkg/gen/nodejs-templates/helm.ts.mustache
+++ b/pkg/gen/nodejs-templates/helm.ts.mustache
@@ -11,15 +11,15 @@ import * as nodepath from "path";
 
 export namespace v2 {
     interface BaseChartOpts {
-        /** 
+        /**
          * The optional namespace to install chart resources into.
          */
         namespace?: pulumi.Input<string>;
-        /** 
-         * Overrides for chart values. 
+        /**
+         * Overrides for chart values.
          */
         values?: pulumi.Inputs;
-        /** 
+        /**
          * Optional array of transformations to apply to resources that will be created by this chart prior to
          * creation. Allows customization of the chart behaviour without directly modifying the chart itself.
          */
@@ -53,7 +53,7 @@ export namespace v2 {
     }
 
     export interface LocalChartOpts extends BaseChartOpts {
-        /** 
+        /**
          * The path to the chart directory which contains the `Chart.yaml` file.
          */
         path: string;

--- a/pkg/gen/nodejs-templates/helm.ts.mustache
+++ b/pkg/gen/nodejs-templates/helm.ts.mustache
@@ -11,25 +11,51 @@ import * as nodepath from "path";
 
 export namespace v2 {
     interface BaseChartOpts {
+        /** 
+         * The optional namespace to install chart resources into.
+         */
         namespace?: pulumi.Input<string>;
+        /** 
+         * Overrides for chart values. 
+         */
         values?: pulumi.Inputs;
+        /** 
+         * Optional array of transformations to apply to resources that will be created by this chart prior to
+         * creation. Allows customization of the chart behaviour without directly modifying the chart itself.
+         */
         transformations?: ((o: any) => void)[];
     }
 
     export interface ChartOpts extends BaseChartOpts {
-        repo: pulumi.Input<string>;
+        /**
+         * The repository containing the desired chart.  If not provided, [chart] must be a fully qualified chart URL
+         * or repo/chartname.
+         */
+        repo?: pulumi.Input<string>;
+        /**
+         * The chart to deploy.  If [repo] is provided, this chart name is looked up in the given repository.  Else
+         * this chart name must be a fully qualified chart URL or `repo/chartname`.
+         */
         chart: pulumi.Input<string>;
+        /**
+         * The version of the chart to deploy. If not provided, the latest version will be deployed.
+         */
         version?: pulumi.Input<string>;
 
+        /**
+         * Additional options to customize the fetching of the Helm chart.
+         */
         fetchOpts?: pulumi.Input<FetchOpts>;
     }
 
     function isChartOpts(o: any): o is ChartOpts {
-        return "repo" in o && "chart" in o && "version" in o;
+        return "chart" in o;
     }
 
     export interface LocalChartOpts extends BaseChartOpts {
-        // path of the Chart directory, which contains the `Chart.yaml` file.
+        /** 
+         * The path to the chart directory which contains the `Chart.yaml` file.
+         */
         path: string;
     }
 
@@ -83,13 +109,16 @@ export namespace v2 {
                     let defaultValues: string;
                     if (isChartOpts(cfg)) {
                         // Fetch chart.
-                        fetch(`${cfg.repo}/${cfg.chart}`, {
+                        const chartToFetch = cfg.repo ? `${cfg.repo}/${cfg.chart}` : cfg.chart;
+                        const fetchOpts = Object.assign({}, cfg.fetchOpts, {
                             destination: chartDir.name,
                             version: cfg.version
                         });
-                        chart = path.quotePath(nodepath.join(chartDir.name, cfg.chart));
+                        fetch(chartToFetch, fetchOpts);
+                        const fetchedChartName = fs.readdirSync(chartDir.name)[0];
+                        chart = path.quotePath(nodepath.join(chartDir.name, fetchedChartName));
                         defaultValues = path.quotePath(
-                            nodepath.join(chartDir.name, cfg.chart, "values.yaml")
+                            nodepath.join(chartDir.name, fetchedChartName, "values.yaml")
                         );
                     } else {
                         chart = path.quotePath(cfg.path);

--- a/sdk/nodejs/helm.ts
+++ b/sdk/nodejs/helm.ts
@@ -19,7 +19,7 @@ export namespace v2 {
     export interface ChartOpts extends BaseChartOpts {
         repo: pulumi.Input<string>;
         chart: pulumi.Input<string>;
-        version: pulumi.Input<string>;
+        version?: pulumi.Input<string>;
 
         fetchOpts?: pulumi.Input<FetchOpts>;
     }

--- a/sdk/nodejs/helm.ts
+++ b/sdk/nodejs/helm.ts
@@ -11,15 +11,15 @@ import * as nodepath from "path";
 
 export namespace v2 {
     interface BaseChartOpts {
-        /** 
+        /**
          * The optional namespace to install chart resources into.
          */
         namespace?: pulumi.Input<string>;
-        /** 
-         * Overrides for chart values. 
+        /**
+         * Overrides for chart values.
          */
         values?: pulumi.Inputs;
-        /** 
+        /**
          * Optional array of transformations to apply to resources that will be created by this chart prior to
          * creation. Allows customization of the chart behaviour without directly modifying the chart itself.
          */
@@ -53,7 +53,7 @@ export namespace v2 {
     }
 
     export interface LocalChartOpts extends BaseChartOpts {
-        /** 
+        /**
          * The path to the chart directory which contains the `Chart.yaml` file.
          */
         path: string;

--- a/sdk/nodejs/helm.ts
+++ b/sdk/nodejs/helm.ts
@@ -11,25 +11,51 @@ import * as nodepath from "path";
 
 export namespace v2 {
     interface BaseChartOpts {
+        /** 
+         * The optional namespace to install chart resources into.
+         */
         namespace?: pulumi.Input<string>;
+        /** 
+         * Overrides for chart values. 
+         */
         values?: pulumi.Inputs;
+        /** 
+         * Optional array of transformations to apply to resources that will be created by this chart prior to
+         * creation. Allows customization of the chart behaviour without directly modifying the chart itself.
+         */
         transformations?: ((o: any) => void)[];
     }
 
     export interface ChartOpts extends BaseChartOpts {
-        repo: pulumi.Input<string>;
+        /**
+         * The repository containing the desired chart.  If not provided, [chart] must be a fully qualified chart URL
+         * or repo/chartname.
+         */
+        repo?: pulumi.Input<string>;
+        /**
+         * The chart to deploy.  If [repo] is provided, this chart name is looked up in the given repository.  Else
+         * this chart name must be a fully qualified chart URL or `repo/chartname`.
+         */
         chart: pulumi.Input<string>;
+        /**
+         * The version of the chart to deploy. If not provided, the latest version will be deployed.
+         */
         version?: pulumi.Input<string>;
 
+        /**
+         * Additional options to customize the fetching of the Helm chart.
+         */
         fetchOpts?: pulumi.Input<FetchOpts>;
     }
 
     function isChartOpts(o: any): o is ChartOpts {
-        return "repo" in o && "chart" in o && "version" in o;
+        return "chart" in o;
     }
 
     export interface LocalChartOpts extends BaseChartOpts {
-        // path of the Chart directory, which contains the `Chart.yaml` file.
+        /** 
+         * The path to the chart directory which contains the `Chart.yaml` file.
+         */
         path: string;
     }
 
@@ -83,13 +109,16 @@ export namespace v2 {
                     let defaultValues: string;
                     if (isChartOpts(cfg)) {
                         // Fetch chart.
-                        fetch(`${cfg.repo}/${cfg.chart}`, {
+                        const chartToFetch = cfg.repo ? `${cfg.repo}/${cfg.chart}` : cfg.chart;
+                        const fetchOpts = Object.assign({}, cfg.fetchOpts, {
                             destination: chartDir.name,
                             version: cfg.version
                         });
-                        chart = path.quotePath(nodepath.join(chartDir.name, cfg.chart));
+                        fetch(chartToFetch, fetchOpts);
+                        const fetchedChartName = fs.readdirSync(chartDir.name)[0];
+                        chart = path.quotePath(nodepath.join(chartDir.name, fetchedChartName));
                         defaultValues = path.quotePath(
-                            nodepath.join(chartDir.name, cfg.chart, "values.yaml")
+                            nodepath.join(chartDir.name, fetchedChartName, "values.yaml")
                         );
                     } else {
                         chart = path.quotePath(cfg.path);


### PR DESCRIPTION
Fixes #255.
Fixes #229.
Fixes #257.

Align more closely with `helm` options for chart references to support all scenarios supported by Helm including (a) getting latest by passing no version (b) using explicitly repo URLs (c) providing fully qualified URLs to charts. 

All of the following now work:

```javascript
// 1. Explicit repo/chart/version - not technically part of `helm` format but needed for back compat
repo: "stable",
chart: "nginx-lego",
version: "0.3.1",

// 2. Reference to "latest"
repo: "stable",
chart: "nginx-lego",

// 3. Helm "chart reference"
chart: "stable/nginx-lego",

// 4. Helm "chart reference" with explicit version
chart: "stable/nginx-lego",
version: "0.3.1"

// 5. Helm "chart reference and repo url" with explicit version
chart: "nginx-lego",
version: "0.3.1",
fetchOpts: {
  repo: "https://kubernetes-charts.storage.googleapis.com"
},

// 6. Helm "chart reference and repo url" 
chart: "nginx-lego",
fetchOpts: {
  repo: "https://kubernetes-charts.storage.googleapis.com"
},

// 7. Helm "absolute URL" 
chart: "https://kubernetes-charts.storage.googleapis.com/nginx-lego-0.3.1.tgz",
```