### PR TITLE
Don't require names for built-in Kubernetes list types

### DIFF
--- a/pkg/gen/nodejs-templates/provider.ts.mustache
+++ b/pkg/gen/nodejs-templates/provider.ts.mustache
@@ -217,9 +217,28 @@ export namespace yaml {
         const kind = obj["kind"];
         const apiVersion = obj["apiVersion"];
 
-        // Flatten `v1.List`. `v1.List` is an undocumented Kubernetes resource, and does not appear
-        // in the Kubernetes OpenAPI spec. `kubectl`, ksonnet, and Helm all flatten it.
-        if (apiVersion == "v1" && kind == "List") {
+        // Recursively traverse built-in Kubernetes list types into a single set of "naked" resource
+        // definitions that we can register with the Pulumi engine.
+        //
+        // Kubernetes does not instantiate list types like `v1.List`. When the API server receives
+        // a list, it will recursively traverse it and perform the necessary operations on the
+        // each "instantiable" resource it finds. For example, `kubectl apply` on a
+        // `v1.ConfigMapList` will cause the API server to traverse the list, and `apply` each
+        // `v1.ConfigMap` it finds.
+        //
+        // Since Kubernetes does not instantiate list types directly, Pulumi also traverses lists
+        // for resource definitions that can be managed by Kubernetes, and registers those with the
+        // engine instead.
+        if (
+               (apiVersion == "v1" && kind == "List")
+            {{#Groups}}
+            {{#Versions}}
+            {{#ListKindsAndAliases}}
+            || (apiVersion == "{{RawAPIVersion}}" && kind == "{{Kind}}")
+            {{/ListKindsAndAliases}}
+            {{/Versions}}
+            {{/Groups}}
+        ) {
             const objs = [];
             const items = obj["items"] || [];
             for (const item of items) {
@@ -229,7 +248,7 @@ export namespace yaml {
         }
 
         if (!("metadata" in obj) || !("name" in obj["metadata"])) {
-            throw new Error(`YAML object does not have a .metadata.name: ${JSON.stringify(obj)}`)
+            throw new Error(`YAML object does not have a .metadata.name: ${obj.apiVersion}/${obj.kind} ${JSON.stringify(obj.metadata)}`)
         }
 
         const meta = obj["metadata"];

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -92,6 +92,30 @@ func (vc *VersionConfig) KindsAndAliases() []*KindConfig {
 	return kindsAndAliases
 }
 
+// ListKindsAndAliases will return all known `Kind`s that are lists, or aliases of lists. These
+// `Kind`s are not instantiated by the API server, and we must "flatten" them client-side to get an
+// accurate view of what resource operations we need to perform.
+func (vc *VersionConfig) ListKindsAndAliases() []*KindConfig {
+	listKinds := []*KindConfig{}
+	for _, kind := range vc.KindsAndAliases() {
+		hasItems := false
+		for _, prop := range kind.properties {
+			if prop.name == "items" {
+				hasItems = true
+				break
+			}
+		}
+
+		fmt.Println(kind.Kind(), strings.HasSuffix(kind.Kind(), "List"), hasItems)
+
+		if strings.HasSuffix(kind.Kind(), "List") && hasItems {
+			listKinds = append(listKinds, kind)
+		}
+	}
+
+	return listKinds
+}
+
 // APIVersion returns the fully-qualified apiVersion (e.g., `storage.k8s.io/v1` for storage, etc.)
 func (vc *VersionConfig) APIVersion() string { return vc.apiVersion }
 


### PR DESCRIPTION
`.metadata.name` is not required for built-in list types. Our provider
expects this property, which means it will crash if it's not given. This
commit changes ouur provider to not expect such.

The specifics are slightly more complex. Here is the background:
Kubernetes does not instantiate or manage the lifecycle of list types
like `v1.List`. If it receives a list type, it will recursively traverse
it for resource definitions that it is supposed to manage, and then
perform the relevant operation on each. (e.g., `apply`'ing each
`v1.ConfigMap` in a `v1.ConfigMapList`.)

Because of this property, lists are not required to have names.
Unfortunately, while our code handles `v1.List` correctly, it does not
handle all these other built-in lists. A resource is not specified as a
list in the OpenAPI spec, either, so we will simply generate a set of
checks for things that "look like" lists, and trust that when we update
the OpenAPI spec, we will catch any weirdness in the diffs.
