### PR TITLE
Use the newest pulumi/pulumi

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -641,7 +641,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "cea165615e6abd05948491d4618d00b979c94f64"
+  revision = "466f92dfb13e7d7c14be85acc8e7ce954f4edd21"
 
 [[projects]]
   branch = "master"

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -106,8 +106,6 @@ func (vc *VersionConfig) ListKindsAndAliases() []*KindConfig {
 			}
 		}
 
-		fmt.Println(kind.Kind(), strings.HasSuffix(kind.Kind(), "List"), hasItems)
-
 		if strings.HasSuffix(kind.Kind(), "List") && hasItems {
 			listKinds = append(listKinds, kind)
 		}


### PR DESCRIPTION
This fixes scripts/get-py-version, which without the most recent
pulumi/pulumi, will be unable to parse the new version scheme.