### PR TITLE
Fix buggy ownership logic for Pods in Deployment awaiter

### DIFF
--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -3,7 +3,6 @@ package await
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -459,7 +458,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 	// we would now have fewer replicas than we had requested in the `Deployment` we last submitted
 	// when we last ran `pulumi up`.
 	rawSpecReplicas, specReplicasExists := openapi.Pluck(rs.Object, "spec", "replicas")
-	specReplicas, _ := rawSpecReplicas.(float64)
+	specReplicas, _ := rawSpecReplicas.(int64)
 	if !specReplicasExists {
 		specReplicas = 1
 	}
@@ -505,8 +504,6 @@ func (dia *deploymentInitAwaiter) changeTriggeredRollout() bool {
 }
 
 func (dia *deploymentInitAwaiter) processPodEvent(event watch.Event) {
-	inputDeploymentName := dia.config.currentInputs.GetName()
-
 	pod, isUnstructured := event.Object.(*unstructured.Unstructured)
 	if !isUnstructured {
 		glog.V(3).Infof("Pod watch received unknown object type '%s'",
@@ -515,10 +512,11 @@ func (dia *deploymentInitAwaiter) processPodEvent(event watch.Event) {
 	}
 
 	// Check whether this Pod was created by our Deployment.
-	podName := pod.GetName()
-	if !strings.HasPrefix(podName+"-", inputDeploymentName) {
+	currentReplicaSet := dia.replicaSets[dia.currentGeneration]
+	if !isOwnedBy(pod, currentReplicaSet) {
 		return
 	}
+	podName := pod.GetName()
 
 	// If Pod was deleted, remove it from our aggregated checkers.
 	if event.Type == watch.Deleted {

--- a/pkg/await/apps_deployment_test.go
+++ b/pkg/await/apps_deployment_test.go
@@ -486,7 +486,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Failed Pod should show up in the errors.
 				pods <- watchAddedEvent(deployedFailedPod(inputNamespace, readyPodName, replicaSetGeneratedName))
 
-				// // Unrelated successful Pod should generate no errors.
+				// Unrelated successful Pod should generate no errors.
 				pods <- watchAddedEvent(deployedReadyPod(inputNamespace, readyPodName, "bar"))
 
 				// Timeout. Failure.
@@ -496,6 +496,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				object: deploymentProgressing(inputNamespace, deploymentInputName, revision1),
 				subErrors: []string{
 					"Minimum number of live Pods was not attained",
+					`1 Pods failed to run because: [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
 				}},
 		},
 		{
@@ -511,7 +512,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				// Failed Pod should show up in the errors.
 				pods <- watchAddedEvent(deployedFailedPod(inputNamespace, readyPodName, replicaSetGeneratedName))
 
-				// // Unrelated successful Pod should generate no errors.
+				// Unrelated successful Pod should generate no errors.
 				pods <- watchAddedEvent(deployedReadyPod(inputNamespace, readyPodName, "bar"))
 
 				// Timeout. Failure.
@@ -521,6 +522,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				object: deploymentProgressing(inputNamespace, deploymentInputName, revision2),
 				subErrors: []string{
 					"Minimum number of live Pods was not attained",
+					`1 Pods failed to run because: [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
 				}},
 		},
 		{


### PR DESCRIPTION
The Deployment awaiter was erroneously overwriting aggregated
Pod errors if they had the same name due to buggy ownership checking.
Fixed the ownership logic and the relevant tests.