### PR TITLE
Fix Ingress awaiter for ExternalName Services

### DIFF
--- a/pkg/await/extensions_ingress_test.go
+++ b/pkg/await/extensions_ingress_test.go
@@ -134,7 +134,16 @@ func Test_Extensions_Ingress_Read(t *testing.T) {
 			endpoint:     initializedEndpoint,
 		},
 		{
-			description:  "Read should succeed when Ingress is allocated an IP address and all paths match an existing Endpoint",
+			description:  "Read should fail if not all Ingress paths match existing Endpoints",
+			ingressInput: ingressInput,
+			ingress:      initializedIngress,
+			expectedSubErrors: []string{
+				"Ingress has at least one rule that does not target any Service. " +
+					"Field '.spec.rules[].http.paths[].backend.serviceName' may not match any active Service",
+			},
+		},
+		{
+			description:  "Read should succeed when Ingress is allocated an IP address and Service is type ExternalName",
 			ingressInput: ingressInput,
 			ingress:      initializedIngress,
 			service:      externalNameService,


### PR DESCRIPTION
The await logic was incorrectly waiting for active Pods for all Service
types. However, Services with type: ExternalName do not have
associated Pods and should succeed as long as the Service exists.

Fixes #317 