### PR TITLE
Add container and restartPolicy properties to Job diff logic

### DIFF
--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -106,6 +106,8 @@ var deployment = properties{
 
 var job = properties{
 	".spec.selector",
+	".spec.template.spec.containers[*]",
+	".spec.template.spec.restartPolicy",
 }
 
 var statefulSet = properties{


### PR DESCRIPTION
Closes #330. Following [this comment](https://github.com/kubernetes/kubernetes/issues/48388#issuecomment-320975927) and a lot of local tests, both `containers` and `restartPolicy` cannot be changed after it's creation. Instead, Pulumi should replace them.

This PR fixes this by adding two new rules:
* `.spec.template.spec.containers[*]`
* `.spec.template.spec.restartPolicy`