### PR TITLE
Improve failure handling in the dynamic client

### DIFF
--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -56,19 +56,19 @@ type ProviderConfig struct {
 
 type CreateConfig struct {
 	ProviderConfig
-	Inputs    *unstructured.Unstructured
+	Inputs *unstructured.Unstructured
 }
 
 type ReadConfig struct {
 	ProviderConfig
-	Inputs    *unstructured.Unstructured
-	Name      string
+	Inputs *unstructured.Unstructured
+	Name   string
 }
 
 type UpdateConfig struct {
 	ProviderConfig
-	Previous  *unstructured.Unstructured
-	Inputs    *unstructured.Unstructured
+	Previous *unstructured.Unstructured
+	Inputs   *unstructured.Unstructured
 }
 
 type DeleteConfig struct {

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -152,8 +152,10 @@ func (dcs *DynamicClientSet) gvkForKind(kind Kind) (*schema.GroupVersionKind, er
 	resources, err := dcs.DiscoveryClientCached.ServerPreferredResources()
 	if err != nil {
 		if discovery.IsGroupDiscoveryFailedError(err) {
-			// Ignore Group Discovery Failed errors. This type of error may cause
-			// later resource introspection to fail, but the error will be handled at that point.
+			// The ServerPreferredResources method will return a best-effort list of resources,
+			// and will also return a GroupDiscoveryFailed error with a list of any resources
+			// that failed discovery. We will ignore this type of error and process the partial
+			// list of resources.
 		} else {
 			return nil, err
 		}

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -17,7 +17,6 @@ package clients
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -123,10 +122,7 @@ func (dcs *DynamicClientSet) ResourceClient(gvk schema.GroupVersionKind, namespa
 	if err != nil {
 		// If the REST mapping failed, try refreshing the cache and remapping before giving up.
 		// This can occur if a CRD is being registered from another resource.
-		dcs.DiscoveryClientCached.Invalidate()
 		dcs.RESTMapper.Reset()
-
-		time.Sleep(2 * time.Second)
 
 		m, err = dcs.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
@@ -256,9 +252,7 @@ func (dcs *DynamicClientSet) getServerResourcesForGV(gv schema.GroupVersion,
 	resourceList, err = dcs.DiscoveryClientCached.ServerResourcesForGroupVersion(gv.String())
 
 	if err != nil && isServerCacheError(err) {
-		dcs.DiscoveryClientCached.Invalidate()
 		dcs.RESTMapper.Reset()
-		time.Sleep(2 * time.Second)
 
 		resourceList, err = dcs.DiscoveryClientCached.ServerResourcesForGroupVersion(gv.String())
 	}

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -225,7 +225,7 @@ func (dcs *DynamicClientSet) getServerResources(gvs ...schema.GroupVersion,
 					// later resource introspection to fail, but the error will be handled at that point.
 					err = nil
 				} else {
-					return
+					return nil, err
 				}
 			}
 
@@ -239,7 +239,7 @@ func (dcs *DynamicClientSet) getServerResources(gvs ...schema.GroupVersion,
 				// later resource introspection to fail, but the error will be handled at that point.
 				err = nil
 			} else {
-				return
+				return nil, err
 			}
 		}
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -458,7 +458,6 @@ func (k *kubeProvider) Create(
 	// refresh the cache, at which point the CRD definition will be present, so that it doesn't fail
 	// with an `errors.IsNotFound`.
 	if clients.IsCRD(newInputs) {
-		k.clientSet.DiscoveryClientCached.Invalidate()
 		k.clientSet.RESTMapper.Reset()
 	}
 


### PR DESCRIPTION
- Rather than failing on partial resource discovery, process the partial list and
handle further failures downstream

Fixes #359 