### PR TITLE
Move to latest versions

### DIFF
--- a/examples/apache/package.json
+++ b/examples/apache/package.json
@@ -2,7 +2,7 @@
   "name": "apache",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1"
+    "@pulumi/pulumi": "dev"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",

--- a/examples/guestbook/package.json
+++ b/examples/guestbook/package.json
@@ -2,7 +2,7 @@
   "name": "guestbook",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1"
+    "@pulumi/pulumi": "dev"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",

--- a/examples/helm-local/package.json
+++ b/examples/helm-local/package.json
@@ -2,7 +2,7 @@
   "name": "nodeserver",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1",
+    "@pulumi/pulumi": "dev",
     "@types/js-yaml": "^3.11.2",
     "js-yaml": "^3.12.0"
   },

--- a/examples/helm/package.json
+++ b/examples/helm/package.json
@@ -2,7 +2,7 @@
   "name": "nodeserver",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1",
+    "@pulumi/pulumi": "dev",
     "@types/js-yaml": "^3.11.2",
     "js-yaml": "^3.12.0"
   },

--- a/examples/mariadb/package.json
+++ b/examples/mariadb/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@pulumi/pulumi": "dev",
-    "@pulumi/random": "^0.3.0"
+    "@pulumi/random": "dev"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",

--- a/examples/mariadb/package.json
+++ b/examples/mariadb/package.json
@@ -2,7 +2,7 @@
   "name": "mariadb",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.16.6",
+    "@pulumi/pulumi": "dev",
     "@pulumi/random": "^0.3.0"
   },
   "devDependencies": {

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -2,7 +2,7 @@
     "name": "minimal",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/examples/provider/package.json
+++ b/examples/provider/package.json
@@ -2,7 +2,7 @@
     "name": "provider",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/examples/yaml-guestbook/package.json
+++ b/examples/yaml-guestbook/package.json
@@ -2,7 +2,7 @@
   "name": "guestbook",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1"
+    "@pulumi/pulumi": "dev"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",

--- a/pkg/gen/nodejs-templates/package.json.mustache
+++ b/pkg/gen/nodejs-templates/package.json.mustache
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.9",
+        "@pulumi/pulumi": "^0.16.14",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.9",
+        "@pulumi/pulumi": "^0.16.14",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/tests/integration/autonaming/step1/package.json
+++ b/tests/integration/autonaming/step1/package.json
@@ -2,7 +2,7 @@
     "name": "steps",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.12"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/delete-before-replace/step1/package.json
+++ b/tests/integration/delete-before-replace/step1/package.json
@@ -2,7 +2,7 @@
     "name": "steps",
 	"version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.2"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/get/step1/package.json
+++ b/tests/integration/get/step1/package.json
@@ -2,7 +2,7 @@
     "name": "steps",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/get/step2/package.json
+++ b/tests/integration/get/step2/package.json
@@ -2,7 +2,7 @@
     "name": "steps",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/istio/step1/package.json
+++ b/tests/integration/istio/step1/package.json
@@ -5,9 +5,11 @@
         "typescript": "^2.5.3"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/random": "^0.3.0",
-        "@pulumi/gcp": "latest",
-        "@pulumi/kubernetes": "^0.17.4"
+        "@pulumi/pulumi": "dev",
+        "@pulumi/random": "dev",
+        "@pulumi/gcp": "dev"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/integration/retry/step1/package.json
+++ b/tests/integration/retry/step1/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/pulumi": "dev",
-        "@pulumi/random": "^0.3.0"
+        "@pulumi/random": "dev"
     },
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/yaml-url/step1/package.json
+++ b/tests/integration/yaml-url/step1/package.json
@@ -2,7 +2,7 @@
   "name": "guestbook",
   "version": "0.1.0",
   "dependencies": {
-    "@pulumi/pulumi": "^0.15.1"
+    "@pulumi/pulumi": "dev"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",


### PR DESCRIPTION
1. in tests, reference "dev" versions.  that way tests catch issues from downstream changes.
2. refefence latest *released* versions in the actual sdk.