### PR TITLE
Fix an issue with variable casing

### DIFF
--- a/pkg/gen/python-templates/kind.py.mustache
+++ b/pkg/gen/python-templates/kind.py.mustache
@@ -18,8 +18,8 @@ class {{Kind}}(pulumi.CustomResource):
         __props__['apiVersion'] = '{{RawAPIVersion}}'
         __props__['kind'] = '{{Kind}}'
         {{#RequiredProperties}}
-        if not {{Name}}:
-            raise TypeError('Missing required property {{Name}}')
+        if {{LanguageName}} is None:
+            raise TypeError('Missing required property {{LanguageName}}')
         __props__['{{Name}}'] = {{LanguageName}}
         {{/RequiredProperties}}
         {{#OptionalProperties}}

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/InitializerConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/InitializerConfigurationList.py
@@ -19,7 +19,7 @@ class InitializerConfigurationList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'admissionregistration.k8s.io/v1alpha1'
         __props__['kind'] = 'InitializerConfigurationList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
@@ -19,7 +19,7 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'admissionregistration.k8s.io/v1beta1'
         __props__['kind'] = 'MutatingWebhookConfigurationList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
@@ -19,7 +19,7 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'admissionregistration.k8s.io/v1beta1'
         __props__['kind'] = 'ValidatingWebhookConfigurationList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
@@ -20,7 +20,7 @@ class CustomResourceDefinition(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apiextensions.k8s.io/v1beta1'
         __props__['kind'] = 'CustomResourceDefinition'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
@@ -19,7 +19,7 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apiextensions.k8s.io/v1beta1'
         __props__['kind'] = 'CustomResourceDefinitionList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
@@ -19,7 +19,7 @@ class APIServiceList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apiregistration.k8s.io/v1'
         __props__['kind'] = 'APIServiceList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
@@ -19,7 +19,7 @@ class APIServiceList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apiregistration.k8s.io/v1beta1'
         __props__['kind'] = 'APIServiceList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
@@ -26,7 +26,7 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'ControllerRevision'
-        if not revision:
+        if revision is None:
             raise TypeError('Missing required property revision')
         __props__['revision'] = revision
         __props__['data'] = data

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
@@ -19,7 +19,7 @@ class ControllerRevisionList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'ControllerRevisionList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
@@ -19,7 +19,7 @@ class DaemonSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'DaemonSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
@@ -19,7 +19,7 @@ class DeploymentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'DeploymentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
@@ -19,7 +19,7 @@ class ReplicaSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'ReplicaSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
@@ -19,7 +19,7 @@ class StatefulSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1'
         __props__['kind'] = 'StatefulSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -28,7 +28,7 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta1'
         __props__['kind'] = 'ControllerRevision'
-        if not revision:
+        if revision is None:
             raise TypeError('Missing required property revision')
         __props__['revision'] = revision
         __props__['data'] = data

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
@@ -19,7 +19,7 @@ class ControllerRevisionList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta1'
         __props__['kind'] = 'ControllerRevisionList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
@@ -19,7 +19,7 @@ class DeploymentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta1'
         __props__['kind'] = 'DeploymentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
@@ -19,7 +19,7 @@ class StatefulSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta1'
         __props__['kind'] = 'StatefulSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -28,7 +28,7 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'ControllerRevision'
-        if not revision:
+        if revision is None:
             raise TypeError('Missing required property revision')
         __props__['revision'] = revision
         __props__['data'] = data

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
@@ -19,7 +19,7 @@ class ControllerRevisionList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'ControllerRevisionList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
@@ -19,7 +19,7 @@ class DaemonSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'DaemonSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
@@ -19,7 +19,7 @@ class DeploymentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'DeploymentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
@@ -19,7 +19,7 @@ class ReplicaSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'ReplicaSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
@@ -19,7 +19,7 @@ class StatefulSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'apps/v1beta2'
         __props__['kind'] = 'StatefulSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
@@ -19,7 +19,7 @@ class AuditSinkList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'auditregistration.k8s.io/v1alpha1'
         __props__['kind'] = 'AuditSinkList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
@@ -20,7 +20,7 @@ class TokenReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authentication.k8s.io/v1'
         __props__['kind'] = 'TokenReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
@@ -20,7 +20,7 @@ class TokenReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authentication.k8s.io/v1beta1'
         __props__['kind'] = 'TokenReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
@@ -21,7 +21,7 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1'
         __props__['kind'] = 'LocalSubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
@@ -21,7 +21,7 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1'
         __props__['kind'] = 'SelfSubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
@@ -26,7 +26,7 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1'
         __props__['kind'] = 'SelfSubjectRulesReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
@@ -19,7 +19,7 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1'
         __props__['kind'] = 'SubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
@@ -21,7 +21,7 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1beta1'
         __props__['kind'] = 'LocalSubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
@@ -21,7 +21,7 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1beta1'
         __props__['kind'] = 'SelfSubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
@@ -26,7 +26,7 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1beta1'
         __props__['kind'] = 'SelfSubjectRulesReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
@@ -19,7 +19,7 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'authorization.k8s.io/v1beta1'
         __props__['kind'] = 'SubjectAccessReview'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
@@ -19,7 +19,7 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'autoscaling/v1'
         __props__['kind'] = 'HorizontalPodAutoscalerList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
@@ -19,7 +19,7 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'autoscaling/v2beta1'
         __props__['kind'] = 'HorizontalPodAutoscalerList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
@@ -19,7 +19,7 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'autoscaling/v2beta2'
         __props__['kind'] = 'HorizontalPodAutoscalerList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
@@ -19,7 +19,7 @@ class JobList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'batch/v1'
         __props__['kind'] = 'JobList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
@@ -19,7 +19,7 @@ class CronJobList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'batch/v1beta1'
         __props__['kind'] = 'CronJobList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
@@ -19,7 +19,7 @@ class CronJobList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'batch/v2alpha1'
         __props__['kind'] = 'CronJobList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
@@ -17,7 +17,7 @@ class CertificateSigningRequestList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'certificates.k8s.io/v1beta1'
         __props__['kind'] = 'CertificateSigningRequestList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
@@ -19,7 +19,7 @@ class LeaseList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'coordination.k8s.io/v1beta1'
         __props__['kind'] = 'LeaseList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/Binding.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Binding.py
@@ -20,7 +20,7 @@ class Binding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'Binding'
-        if not target:
+        if target is None:
             raise TypeError('Missing required property target')
         __props__['target'] = target
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ComponentStatusList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ComponentStatusList.py
@@ -19,7 +19,7 @@ class ComponentStatusList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ComponentStatusList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -19,7 +19,7 @@ class ConfigMapList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ConfigMapList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
@@ -19,7 +19,7 @@ class EndpointsList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'EndpointsList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Event.py
@@ -19,10 +19,10 @@ class Event(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'Event'
-        if not involvedObject:
-            raise TypeError('Missing required property involvedObject')
+        if involved_object is None:
+            raise TypeError('Missing required property involved_object')
         __props__['involvedObject'] = involved_object
-        if not metadata:
+        if metadata is None:
             raise TypeError('Missing required property metadata')
         __props__['metadata'] = metadata
         __props__['action'] = action

--- a/sdk/python/pulumi_kubernetes/core/v1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EventList.py
@@ -19,7 +19,7 @@ class EventList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'EventList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
@@ -19,7 +19,7 @@ class LimitRangeList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'LimitRangeList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
@@ -19,7 +19,7 @@ class NamespaceList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'NamespaceList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
@@ -19,7 +19,7 @@ class NodeList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'NodeList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
@@ -19,7 +19,7 @@ class PersistentVolumeClaimList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'PersistentVolumeClaimList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
@@ -19,7 +19,7 @@ class PersistentVolumeList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'PersistentVolumeList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/PodList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodList.py
@@ -19,7 +19,7 @@ class PodList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'PodList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
@@ -19,7 +19,7 @@ class PodTemplateList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'PodTemplateList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
@@ -19,7 +19,7 @@ class ReplicationControllerList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ReplicationControllerList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
@@ -19,7 +19,7 @@ class ResourceQuotaList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ResourceQuotaList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
@@ -19,7 +19,7 @@ class SecretList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'SecretList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
@@ -19,7 +19,7 @@ class ServiceAccountList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ServiceAccountList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
@@ -19,7 +19,7 @@ class ServiceList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'v1'
         __props__['kind'] = 'ServiceList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
@@ -20,8 +20,8 @@ class Event(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'events.k8s.io/v1beta1'
         __props__['kind'] = 'Event'
-        if not eventTime:
-            raise TypeError('Missing required property eventTime')
+        if event_time is None:
+            raise TypeError('Missing required property event_time')
         __props__['eventTime'] = event_time
         __props__['action'] = action
         __props__['deprecatedCount'] = deprecated_count

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
@@ -19,7 +19,7 @@ class EventList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'events.k8s.io/v1beta1'
         __props__['kind'] = 'EventList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
@@ -19,7 +19,7 @@ class DaemonSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'DaemonSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
@@ -19,7 +19,7 @@ class DeploymentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'DeploymentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
@@ -19,7 +19,7 @@ class IngressList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'IngressList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
@@ -20,7 +20,7 @@ class NetworkPolicyList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'NetworkPolicyList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
@@ -20,7 +20,7 @@ class PodSecurityPolicyList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'PodSecurityPolicyList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
@@ -19,7 +19,7 @@ class ReplicaSetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'extensions/v1beta1'
         __props__['kind'] = 'ReplicaSetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
@@ -19,7 +19,7 @@ class NetworkPolicyList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'networking.k8s.io/v1'
         __props__['kind'] = 'NetworkPolicyList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
@@ -19,7 +19,7 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'policy/v1beta1'
         __props__['kind'] = 'PodDisruptionBudgetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
@@ -19,7 +19,7 @@ class PodSecurityPolicyList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'policy/v1beta1'
         __props__['kind'] = 'PodSecurityPolicyList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -20,7 +20,7 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'ClusterRole'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['aggregationRule'] = aggregation_rule

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -20,8 +20,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'ClusterRoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
@@ -19,7 +19,7 @@ class ClusterRoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'ClusterRoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
@@ -19,7 +19,7 @@ class ClusterRoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'ClusterRoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -20,7 +20,7 @@ class Role(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'Role'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -22,8 +22,8 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'RoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
@@ -19,7 +19,7 @@ class RoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'RoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
@@ -19,7 +19,7 @@ class RoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1'
         __props__['kind'] = 'RoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -20,7 +20,7 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'ClusterRole'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['aggregationRule'] = aggregation_rule

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -20,8 +20,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'ClusterRoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
@@ -19,7 +19,7 @@ class ClusterRoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'ClusterRoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
@@ -19,7 +19,7 @@ class ClusterRoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'ClusterRoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -20,7 +20,7 @@ class Role(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'Role'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -22,8 +22,8 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'RoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
@@ -19,7 +19,7 @@ class RoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'RoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
@@ -19,7 +19,7 @@ class RoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1alpha1'
         __props__['kind'] = 'RoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -20,7 +20,7 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'ClusterRole'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['aggregationRule'] = aggregation_rule

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -20,8 +20,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'ClusterRoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
@@ -19,7 +19,7 @@ class ClusterRoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'ClusterRoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
@@ -19,7 +19,7 @@ class ClusterRoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'ClusterRoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -20,7 +20,7 @@ class Role(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'Role'
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -22,8 +22,8 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'RoleBinding'
-        if not roleRef:
-            raise TypeError('Missing required property roleRef')
+        if role_ref is None:
+            raise TypeError('Missing required property role_ref')
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
@@ -19,7 +19,7 @@ class RoleBindingList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'RoleBindingList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
@@ -19,7 +19,7 @@ class RoleList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'rbac.authorization.k8s.io/v1beta1'
         __props__['kind'] = 'RoleList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -20,7 +20,7 @@ class PriorityClass(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'scheduling.k8s.io/v1alpha1'
         __props__['kind'] = 'PriorityClass'
-        if not value:
+        if value is None:
             raise TypeError('Missing required property value')
         __props__['value'] = value
         __props__['description'] = description

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
@@ -19,7 +19,7 @@ class PriorityClassList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'scheduling.k8s.io/v1alpha1'
         __props__['kind'] = 'PriorityClassList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -20,7 +20,7 @@ class PriorityClass(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'scheduling.k8s.io/v1beta1'
         __props__['kind'] = 'PriorityClass'
-        if not value:
+        if value is None:
             raise TypeError('Missing required property value')
         __props__['value'] = value
         __props__['description'] = description

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
@@ -19,7 +19,7 @@ class PriorityClassList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'scheduling.k8s.io/v1beta1'
         __props__['kind'] = 'PriorityClassList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
@@ -19,7 +19,7 @@ class PodPresetList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'settings.k8s.io/v1alpha1'
         __props__['kind'] = 'PodPresetList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
@@ -23,7 +23,7 @@ class StorageClass(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1'
         __props__['kind'] = 'StorageClass'
-        if not provisioner:
+        if provisioner is None:
             raise TypeError('Missing required property provisioner')
         __props__['provisioner'] = provisioner
         __props__['allowVolumeExpansion'] = allow_volume_expansion

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
@@ -19,7 +19,7 @@ class StorageClassList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1'
         __props__['kind'] = 'StorageClassList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
@@ -22,7 +22,7 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1'
         __props__['kind'] = 'VolumeAttachment'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
@@ -19,7 +19,7 @@ class VolumeAttachmentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1'
         __props__['kind'] = 'VolumeAttachmentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
@@ -22,7 +22,7 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1alpha1'
         __props__['kind'] = 'VolumeAttachment'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
@@ -19,7 +19,7 @@ class VolumeAttachmentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1alpha1'
         __props__['kind'] = 'VolumeAttachmentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
@@ -23,7 +23,7 @@ class StorageClass(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1beta1'
         __props__['kind'] = 'StorageClass'
-        if not provisioner:
+        if provisioner is None:
             raise TypeError('Missing required property provisioner')
         __props__['provisioner'] = provisioner
         __props__['allowVolumeExpansion'] = allow_volume_expansion

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
@@ -19,7 +19,7 @@ class StorageClassList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1beta1'
         __props__['kind'] = 'StorageClassList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
@@ -22,7 +22,7 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1beta1'
         __props__['kind'] = 'VolumeAttachment'
-        if not spec:
+        if spec is None:
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
@@ -19,7 +19,7 @@ class VolumeAttachmentList(pulumi.CustomResource):
 
         __props__['apiVersion'] = 'storage.k8s.io/v1beta1'
         __props__['kind'] = 'VolumeAttachmentList'
-        if not items:
+        if items is None:
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata


### PR DESCRIPTION
We accidentally emitted required variable presence checks against the
property name instead of the property's language name, which resulted in
crashes due to the reference to an unbound variable. In addition, this
commit corrects the presence check to test directly against None instead
of using the bool-ness of the variable.

FIxes https://github.com/pulumi/pulumi-kubernetes/issues/411.