### PR TITLE
Use slightly modified local copy of latest upstream memcache client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.20.2 (Unreleased)
 
+### Bug fixes
+
+-   Use modified copy of memcache client (https://github.com/pulumi/pulumi-kubernetes/pull/414)
+
 ## 0.20.1 (Released February 6, 2019)
 
 ### Bug fixes

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1206,11 +1206,11 @@
   revision = "5702a69c455d3a129efbc2e86f8de61eb1af25a5"
 
 [[projects]]
-  digest = "1:091ada87ef938eb5bcbfa6e7894c7410e101132ed08db292d05193f96b99ee50"
+  digest = "1:b9f7bd5e364748dbab4889ca541cb8b68db4bb42034dfc80adcb4e8ef09bf686"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
-    "discovery/cached",
+    "discovery/fake",
     "dynamic",
     "kubernetes",
     "kubernetes/scheme",
@@ -1267,6 +1267,7 @@
     "scale/scheme/autoscalingv1",
     "scale/scheme/extensionsint",
     "scale/scheme/extensionsv1beta1",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/clientcmd",
@@ -1353,6 +1354,7 @@
     "github.com/golang/glog",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/struct",
+    "github.com/googleapis/gnostic/OpenAPIv2",
     "github.com/jinzhu/copier",
     "github.com/mitchellh/go-wordwrap",
     "github.com/pkg/errors",
@@ -1387,7 +1389,7 @@
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
-    "k8s.io/client-go/discovery/cached",
+    "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/rest",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1206,10 +1206,11 @@
   revision = "5702a69c455d3a129efbc2e86f8de61eb1af25a5"
 
 [[projects]]
-  digest = "1:b9f7bd5e364748dbab4889ca541cb8b68db4bb42034dfc80adcb4e8ef09bf686"
+  digest = "1:4b463ac43d1ae25d891fec3e9f9383e0b635230b53d51ecca01fbe9e0b064ebc"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/cached",
     "discovery/fake",
     "dynamic",
     "kubernetes",
@@ -1389,6 +1390,7 @@
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/cached",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/plugin/pkg/client/auth",

--- a/pkg/clients/memcache.go
+++ b/pkg/clients/memcache.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// Note: this code is taken nearly verbatim from the upstream memcache client [1].
+// The `refreshLocked` method does not return errors, but instead logs them using
+// the `HandleError` method, which dispatches to klog. This bypasses Pulumi's logging
+// mechanism, and causes unactionable error messages to appear in the CLI.
+// This error logging was disabled.
+//
+// [1] https://github.com/kubernetes/client-go/blob/2dda7ceeec102b5a60e2abf37758642118501910/discovery/cached/memcache.go
+
+package clients
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/googleapis/gnostic/OpenAPIv2"
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+type cacheEntry struct {
+	resourceList *metav1.APIResourceList
+	err          error
+}
+
+// memCacheClient can Invalidate() to stay up-to-date with discovery
+// information.
+//
+// TODO: Switch to a watch interface. Right now it will poll after each
+// Invalidate() call.
+type memCacheClient struct {
+	delegate discovery.DiscoveryInterface
+
+	lock                   sync.RWMutex
+	groupToServerResources map[string]*cacheEntry
+	groupList              *metav1.APIGroupList
+	cacheValid             bool
+}
+
+// Error Constants
+var (
+	ErrCacheNotFound = errors.New("not found")
+)
+
+var _ discovery.CachedDiscoveryInterface = &memCacheClient{}
+
+// isTransientConnectionError checks whether given error is "Connection refused" or
+// "Connection reset" error which usually means that apiserver is temporarily
+// unavailable.
+func isTransientConnectionError(err error) bool {
+	urlError, ok := err.(*url.Error)
+	if !ok {
+		return false
+	}
+	opError, ok := urlError.Err.(*net.OpError)
+	if !ok {
+		return false
+	}
+	errno, ok := opError.Err.(syscall.Errno)
+	if !ok {
+		return false
+	}
+	return errno == syscall.ECONNREFUSED || errno == syscall.ECONNRESET
+}
+
+func isTransientError(err error) bool {
+	if isTransientConnectionError(err) {
+		return true
+	}
+
+	if t, ok := err.(errorsutil.APIStatus); ok && t.Status().Code >= 500 {
+		return true
+	}
+
+	return errorsutil.IsTooManyRequests(err)
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if !d.cacheValid {
+		if err := d.refreshLocked(); err != nil {
+			return nil, err
+		}
+	}
+	cachedVal, ok := d.groupToServerResources[groupVersion]
+	if !ok {
+		return nil, ErrCacheNotFound
+	}
+
+	if cachedVal.err != nil && isTransientError(cachedVal.err) {
+		r, err := d.serverResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			glog.V(9).Infof("couldn't get resource list for %v: %v", groupVersion, err)
+		}
+		cachedVal = &cacheEntry{r, err}
+		d.groupToServerResources[groupVersion] = cachedVal
+	}
+
+	return cachedVal.resourceList, cachedVal.err
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerResources(d)
+}
+
+func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if !d.cacheValid {
+		if err := d.refreshLocked(); err != nil {
+			return nil, err
+		}
+	}
+	return d.groupList, nil
+}
+
+func (d *memCacheClient) RESTClient() restclient.Interface {
+	return d.delegate.RESTClient()
+}
+
+func (d *memCacheClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredResources(d)
+}
+
+func (d *memCacheClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredNamespacedResources(d)
+}
+
+func (d *memCacheClient) ServerVersion() (*version.Info, error) {
+	return d.delegate.ServerVersion()
+}
+
+func (d *memCacheClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	return d.delegate.OpenAPISchema()
+}
+
+func (d *memCacheClient) Fresh() bool {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	// Return whether the cache is populated at all. It is still possible that
+	// a single entry is missing due to transient errors and the attempt to read
+	// that entry will trigger retry.
+	return d.cacheValid
+}
+
+// Invalidate enforces that no cached data that is older than the current time
+// is used.
+func (d *memCacheClient) Invalidate() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.cacheValid = false
+	d.groupToServerResources = nil
+	d.groupList = nil
+}
+
+// refreshLocked refreshes the state of cache. The caller must hold d.lock for
+// writing.
+func (d *memCacheClient) refreshLocked() error {
+	// TODO: Could this multiplicative set of calls be replaced by a single call
+	// to ServerResources? If it's possible for more than one resulting
+	// APIResourceList to have the same GroupVersion, the lists would need merged.
+	gl, err := d.delegate.ServerGroups()
+	if err != nil || len(gl.Groups) == 0 {
+		glog.V(9).Infof("couldn't get current server API group list: %v", err)
+		return err
+	}
+
+	rl := map[string]*cacheEntry{}
+	for _, g := range gl.Groups {
+		for _, v := range g.Versions {
+			r, err := d.serverResourcesForGroupVersion(v.GroupVersion)
+			rl[v.GroupVersion] = &cacheEntry{r, err}
+			if err != nil {
+				glog.V(9).Infof("couldn't get resource list for %v: %v", v.GroupVersion, err)
+			}
+		}
+	}
+
+	d.groupToServerResources, d.groupList = rl, gl
+	d.cacheValid = true
+	return nil
+}
+
+func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	r, err := d.delegate.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return r, err
+	}
+	if len(r.APIResources) == 0 {
+		return r, fmt.Errorf("Got empty response for: %v", groupVersion)
+	}
+	return r, nil
+}
+
+// NewMemCacheClient creates a new CachedDiscoveryInterface which caches
+// discovery information in memory and will stay up-to-date if Invalidate is
+// called with regularity.
+//
+// NOTE: The client will NOT resort to live lookups on cache misses.
+func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
+	return &memCacheClient{
+		delegate:               delegate,
+		groupToServerResources: map[string]*cacheEntry{},
+	}
+}

--- a/pkg/clients/memcache.go
+++ b/pkg/clients/memcache.go
@@ -26,7 +26,6 @@ limitations under the License.
 package clients
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -39,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -60,11 +60,6 @@ type memCacheClient struct {
 	groupList              *metav1.APIGroupList
 	cacheValid             bool
 }
-
-// Error Constants
-var (
-	ErrCacheNotFound = errors.New("not found")
-)
 
 var _ discovery.CachedDiscoveryInterface = &memCacheClient{}
 
@@ -110,7 +105,7 @@ func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*m
 	}
 	cachedVal, ok := d.groupToServerResources[groupVersion]
 	if !ok {
-		return nil, ErrCacheNotFound
+		return nil, cached.ErrCacheNotFound
 	}
 
 	if cachedVal.err != nil && isTransientError(cachedVal.err) {

--- a/pkg/clients/memcache_test.go
+++ b/pkg/clients/memcache_test.go
@@ -91,7 +91,7 @@ func TestClient(t *testing.T) {
 	if c.Fresh() {
 		t.Errorf("Expected not fresh.")
 	}
-	g, err := c.ServerGroups()
+	_, err := c.ServerGroups()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Expected not fresh.")
 	}
 
-	g, err = c.ServerGroups()
+	g, err := c.ServerGroups()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/clients/memcache_test.go
+++ b/pkg/clients/memcache_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery/fake"
+)
+
+type resourceMapEntry struct {
+	list *metav1.APIResourceList
+	err  error
+}
+
+type fakeDiscovery struct {
+	*fake.FakeDiscovery
+
+	lock         sync.Mutex
+	groupList    *metav1.APIGroupList
+	groupListErr error
+	resourceMap  map[string]*resourceMapEntry
+}
+
+func (c *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if rl, ok := c.resourceMap[groupVersion]; ok {
+		return rl.list, rl.err
+	}
+	return nil, errors.New("doesn't exist")
+}
+
+func (c *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.groupList == nil {
+		return nil, errors.New("doesn't exist")
+	}
+	return c.groupList, c.groupListErr
+}
+
+func TestClient(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	g, err := c.ServerGroups()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected fresh.")
+	}
+	c.Invalidate()
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+
+	g, err = c.ServerGroups()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap = map[string]*resourceMapEntry{
+		"astronomy/v8beta1": {
+			list: &metav1.APIResourceList{
+				GroupVersion: "astronomy/v8beta1",
+				APIResources: []metav1.APIResource{{
+					Name:         "stars",
+					SingularName: "star",
+					Namespaced:   true,
+					Kind:         "Star",
+					ShortNames:   []string{"s"},
+				}},
+			},
+		},
+	}
+	fake.lock.Unlock()
+
+	c.Invalidate()
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestServerGroupsFails(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		groupListErr: errors.New("some error"),
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	_, err := c.ServerGroups()
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	fake.lock.Lock()
+	fake.groupListErr = nil
+	fake.lock.Unlock()
+	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+}
+
+func TestPartialPermanentFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}, {
+					GroupVersion: "astronomy2/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: errors.New("some permanent error"),
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We don't retry permanent errors, so it should fail.
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	c.Invalidate()
+
+	// After Invalidate, we should retry.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestPartialRetryableFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}, {
+					GroupVersion: "astronomy2/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: &errorsutil.StatusError{
+					ErrStatus: metav1.Status{
+						Message: "Some retryable error",
+						Code:    int32(http.StatusServiceUnavailable),
+						Reason:  metav1.StatusReasonServiceUnavailable,
+					},
+				},
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We should retry retryable error even without Invalidate() being called,
+	// so no error is expected.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	// Check that the last result was cached and we don't retry further.
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"].err = errors.New("some permanent error")
+	fake.lock.Unlock()
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}


### PR DESCRIPTION
The latest upstream memcache client includes retry logic. Use this code,
but remove the klog logging statements for failed cache operations, and
switch to a --v9 glog info message.

Fixes #398 