### PR TITLE
Include managed-by label in diff preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug fixes
 
--   None
+-   Include managed-by label in diff preview (https://github.com/pulumi/pulumi-kubernetes/pull/431)
 
 ## 0.20.2 (Released February 13, 2019)
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -109,9 +109,6 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				}
 			}
 
-			// Set a "managed-by: pulumi" label on all created k8s resources.
-			metadata.SetManagedByLabel(c.Inputs)
-
 			outputs, err = client.Create(c.Inputs, metav1.CreateOptions{})
 			if err != nil {
 				_ = c.Host.LogStatus(c.Context, diag.Info, c.URN, fmt.Sprintf(

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -252,6 +252,9 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 		metadata.AssignNameIfAutonamable(newInputs, urn.Name())
 	}
 
+	// Set a "managed-by: pulumi" label on all created k8s resources.
+	metadata.SetManagedByLabel(newInputs)
+
 	gvk, err := k.gvkFromURN(urn)
 	if err != nil {
 		return nil, err

--- a/tests/integration/namespace/namespace_test.go
+++ b/tests/integration/namespace/namespace_test.go
@@ -96,8 +96,7 @@ func TestNamespace(t *testing.T) {
 					namespace := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), namespace.URN.Type())
 					namespaceLabels, _ := openapi.Pluck(namespace.Outputs, "metadata", "labels")
-					assert.Equal(t, map[string]interface{}{"hello": "world"},
-						namespaceLabels.(map[string]interface{}))
+					assert.True(t, namespaceLabels.(map[string]interface{})["hello"] == "world")
 				},
 			},
 			{


### PR DESCRIPTION
The `app.kubernetes.io/managed-by: "pulumi"` label
was being set in the await logic rather than the provider,
so it was not appearing in the resource diff. Move this
label application to the provider so it shows up as expected.