### PR TITLE
Fix buggy behavior with annotations/labels on preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug fixes
 
--   None
+-   Properly handle computed values in labels and annotations (https://github.com/pulumi/pulumi-kubernetes/pull/461)
 
 ## 0.20.3 (February 20, 2019)
 

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -44,12 +44,19 @@ func IsInternalAnnotation(key string) bool {
 }
 
 func SetAnnotation(obj *unstructured.Unstructured, key, value string) {
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
+	// Note: Cannot use obj.GetAnnotations() here because it doesn't properly handle computed values from preview.
+	metadataRaw := obj.Object["metadata"]
+	metadata := metadataRaw.(map[string]interface{})
+	annotationsRaw, ok := metadata["annotations"]
+	var annotations map[string]interface{}
+	if !ok {
+		annotations = make(map[string]interface{})
+	} else {
+		annotations = annotationsRaw.(map[string]interface{})
 	}
 	annotations[key] = value
-	obj.SetAnnotations(annotations)
+
+	metadata["annotations"] = annotations
 }
 
 func SetAnnotationTrue(obj *unstructured.Unstructured, key string) {

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -18,15 +18,24 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// SetLabel sets the specified key/value pair as a label on the provided Unstructured object.
 func SetLabel(obj *unstructured.Unstructured, key, value string) {
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
+	// Note: Cannot use obj.GetLabels() here because it doesn't properly handle computed values from preview.
+	metadataRaw := obj.Object["metadata"]
+	metadata := metadataRaw.(map[string]interface{})
+	labelsRaw, ok := metadata["labels"]
+	var labels map[string]interface{}
+	if !ok {
+		labels = make(map[string]interface{})
+	} else {
+		labels = labelsRaw.(map[string]interface{})
 	}
 	labels[key] = value
-	obj.SetLabels(labels)
+
+	metadata["labels"] = labels
 }
 
+// SetManagedByLabel sets the `app.kubernetes.io/managed-by` label to `pulumi`.
 func SetManagedByLabel(obj *unstructured.Unstructured) {
 	SetLabel(obj, "app.kubernetes.io/managed-by", "pulumi")
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -24,9 +24,9 @@ import (
 	"github.com/golang/glog"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/struct"
-	"github.com/pulumi/pulumi-kubernetes/pkg/metadata"
 	"github.com/pulumi/pulumi-kubernetes/pkg/await"
 	"github.com/pulumi/pulumi-kubernetes/pkg/clients"
+	"github.com/pulumi/pulumi-kubernetes/pkg/metadata"
 	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
@@ -338,7 +338,7 @@ func (k *kubeProvider) Diff(
 	}
 	oldInputs, _ := parseCheckpointObject(oldState)
 
-	// Get new resouce inputs. The user is submitting these as an update.
+	// Get new resource inputs. The user is submitting these as an update.
 	newResInputs, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
 		Label: fmt.Sprintf("%s.news", label), KeepUnknowns: true, SkipNulls: true,
 	})


### PR DESCRIPTION
The unstructured GetLabels and GetAnnotations methods expect
that all of the annotations have string values, and error silently
if this is not the case. During previews that included computed
values in either the labels or annotations, the provider was
erroneously clearing these fields due to this error. This fix
manually updates those fields to avoid resetting them.

Fixes #438 