### PR TITLE
Disable istio integration test

### DIFF
--- a/tests/integration/istio/istio_test.go
+++ b/tests/integration/istio/istio_test.go
@@ -2,46 +2,47 @@
 
 package ints
 
-import (
-	"fmt"
-	"net/http"
-	"os"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/pulumi/pulumi/pkg/testing/integration"
-)
-
-func TestIstio(t *testing.T) {
-	kubectx := os.Getenv("KUBERNETES_CONTEXT")
-
-	if kubectx == "" {
-		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
-	}
-
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:          "step1",
-		Dependencies: []string{"@pulumi/kubernetes"},
-		Quick:        true,
-		SkipRefresh:  true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			frontend := stackInfo.Outputs["frontendIp"].(string)
-
-			// Retry the GET on the Istio gateway repeatedly. Istio doesn't publish `.status` on any
-			// of its CRDs, so this is as reliable as we can be right now.
-			for i := 1; i < 10; i++ {
-				req, err := http.Get(fmt.Sprintf("http://%s", frontend))
-				if err != nil {
-					fmt.Printf("Request to Istio gateway failed: %v\n", err)
-					time.Sleep(time.Second * 10)
-				} else if req.StatusCode == 200 {
-					return
-				}
-			}
-
-			assert.Fail(t, "Maximum Istio gateway request retries exceeded")
-		},
-	})
-}
+// fixme(levi): Fix program to work with istio 1.1 and uncomment this test.
+//import (
+//	"fmt"
+//	"net/http"
+//	"os"
+//	"testing"
+//	"time"
+//
+//	"github.com/stretchr/testify/assert"
+//
+//	"github.com/pulumi/pulumi/pkg/testing/integration"
+//)
+//
+//func TestIstio(t *testing.T) {
+//	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+//
+//	if kubectx == "" {
+//		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+//	}
+//
+//	integration.ProgramTest(t, &integration.ProgramTestOptions{
+//		Dir:          "step1",
+//		Dependencies: []string{"@pulumi/kubernetes"},
+//		Quick:        true,
+//		SkipRefresh:  true,
+//		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+//			frontend := stackInfo.Outputs["frontendIp"].(string)
+//
+//			// Retry the GET on the Istio gateway repeatedly. Istio doesn't publish `.status` on any
+//			// of its CRDs, so this is as reliable as we can be right now.
+//			for i := 1; i < 10; i++ {
+//				req, err := http.Get(fmt.Sprintf("http://%s", frontend))
+//				if err != nil {
+//					fmt.Printf("Request to Istio gateway failed: %v\n", err)
+//					time.Sleep(time.Second * 10)
+//				} else if req.StatusCode == 200 {
+//					return
+//				}
+//			}
+//
+//			assert.Fail(t, "Maximum Istio gateway request retries exceeded")
+//		},
+//	})
+//}


### PR DESCRIPTION
During the istio 1.1 release on 2019-03-19, the helm chart repo we
were using was taken down. I couldn't find one for the 1.0.1 release,
so I'm disabling the test until we can get it working with 1.1.