### PR TITLE
Put all resources in specified provider namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   Move helm module into a directory (https://github.com/pulumi/pulumi-kubernetes/pull/512)
 -   Move yaml module into a directory (https://github.com/pulumi/pulumi-kubernetes/pull/513)
+-   Put all resources in specified provider namespace (https://github.com/pulumi/pulumi-kubernetes/pull/506)
 
 ### Bug fixes
 

--- a/tests/integration/provider/provider_test.go
+++ b/tests/integration/provider/provider_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/tokens"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi-kubernetes/tests"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "step1",
+		Dependencies: []string{"@pulumi/kubernetes"},
+		Quick:        true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Deployment)
+			assert.Equal(t, 7, len(stackInfo.Deployment.Resources))
+
+			tests.SortResourcesByURN(stackInfo)
+
+			stackRes := stackInfo.Deployment.Resources[6]
+			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+			k8sProvider := stackInfo.Deployment.Resources[5]
+			assert.True(t, providers.IsProviderType(k8sProvider.URN.Type()))
+
+			defaultProvider := stackInfo.Deployment.Resources[4]
+			assert.True(t, providers.IsProviderType(defaultProvider.URN.Type()))
+
+			// Assert the provider Namespace was created
+			providerNamespace := stackInfo.Deployment.Resources[0]
+			assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), providerNamespace.URN.Type())
+			providerNsName, _ := openapi.Pluck(providerNamespace.Outputs, "metadata", "name")
+
+			// Assert the other Namespace was created despite the provider override.
+			otherNamespace := stackInfo.Deployment.Resources[1]
+			assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), otherNamespace.URN.Type())
+			nsName, _ := openapi.Pluck(otherNamespace.Outputs, "metadata", "name")
+			assert.NotEqual(t, nsName, providerNsName)
+
+			// Assert the Pod was created in the provider namespace.
+			pod := stackInfo.Deployment.Resources[3]
+			assert.Equal(t, "nginx", string(pod.URN.Name()))
+			podNamespace, _ := openapi.Pluck(pod.Outputs, "metadata", "namespace")
+			assert.Equal(t, providerNamespace.ID.String(), podNamespace.(string))
+
+			// Assert the Pod was created in the provider namespace rather than the specified namespace.
+			namespacedPod := stackInfo.Deployment.Resources[2]
+			assert.Equal(t, "namespaced-nginx", string(namespacedPod.URN.Name()))
+			namespacedPodNamespace, _ := openapi.Pluck(namespacedPod.Outputs, "metadata", "namespace")
+			assert.Equal(t, providerNamespace.ID.String(), namespacedPodNamespace.(string))
+		},
+	})
+}

--- a/tests/integration/provider/step1/Pulumi.yaml
+++ b/tests/integration/provider/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: provider
+description: Tests first-class provider support.
+runtime: nodejs

--- a/tests/integration/provider/step1/index.ts
+++ b/tests/integration/provider/step1/index.ts
@@ -1,0 +1,60 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Use the existing ~/.kube/config kubeconfig
+const kubeconfig = fs.readFileSync(path.join(os.homedir(), ".kube", "config")).toString();
+
+const ns = new k8s.core.v1.Namespace("ns");
+
+// Create a new provider
+const myk8s = new k8s.Provider("myk8s", {
+    kubeconfig: kubeconfig,
+    namespace: ns.metadata.name,
+});
+
+// Create a Pod using the custom provider.
+// The namespace should be automatically set by the provider override.
+new k8s.core.v1.Pod("nginx", {
+    spec: {
+        containers: [{
+            image: "nginx:1.7.9",
+            name: "nginx",
+            ports: [{ containerPort: 80 }],
+        }],
+    },
+}, { provider: myk8s });
+
+// Create a Pod using the custom provider with a specified namespace.
+// The namespace should be overridden by the provider override.
+new k8s.core.v1.Pod("namespaced-nginx", {
+    metadata: { namespace: ns.metadata.name },
+    spec: {
+        containers: [{
+            image: "nginx:1.7.9",
+            name: "nginx",
+            ports: [{ containerPort: 80 }],
+        }],
+    },
+}, { provider: myk8s });
+
+// Create a Namespace using the custom provider
+// The namespace should not be affected by the provider override since it is a non-namespaceable kind.
+new k8s.core.v1.Namespace("other-ns",
+    {},
+    { provider: myk8s });

--- a/tests/integration/provider/step1/package.json
+++ b/tests/integration/provider/step1/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "dev",
+        "@pulumi/random": "dev"
+    },
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/provider/step1/tsconfig.json
+++ b/tests/integration/provider/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
Fixes: #415 

Reviewer notes / points of discussion:

1. This change currently requires the provider namespace to be created explicitly. This is up for discussion.
1. The current behavior is to always override the resource namespace if it is set on the provider, even if a different namespace is specified on the resource.