### PR TITLE
Improve error handling for "no match found" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Improvements
 
--   None
+-   Improve error handling for "no match found" errors (https://github.com/pulumi/pulumi-kubernetes/pull/530)
 
 ### Bug fixes
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -118,7 +118,8 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				return err
 			}
 
-			return nil
+			// TODO(levi): return nil here to be more explicit (early returns on any error)
+			return err
 
 		}).
 		WithMaxRetries(5).

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -105,6 +105,8 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 			if client == nil {
 				client, err = c.ClientSet.ResourceClient(c.Inputs.GroupVersionKind(), c.Inputs.GetNamespace())
 				if err != nil {
+					_ = c.Host.LogStatus(c.Context, diag.Info, c.URN, fmt.Sprintf(
+						"Retry #%d; creation failed: %v", i, err))
 					return err
 				}
 			}
@@ -116,7 +118,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				return err
 			}
 
-			return err
+			return nil
 
 		}).
 		WithMaxRetries(5).

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -553,13 +553,13 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 			// If it's a "no match" error, this is probably a CustomResource with no corresponding
 			// CustomResourceDefinition. This usually happens if the CRD was deleted, and it's safe
 			// to consider the CR to be deleted as well in this case.
-			return &pulumirpc.ReadResponse{Id: "", Properties: nil}, nil
+			return deleteResponse, nil
 		}
 
 		statusErr, ok := readErr.(*errors.StatusError)
 		if ok && statusErr.ErrStatus.Code == 404 {
 			// If it's a 404 error, this resource was probably deleted.
-			return &pulumirpc.ReadResponse{Id: "", Properties: nil}, nil
+			return deleteResponse, nil
 		}
 
 		if partialErr, ok := readErr.(await.PartialError); ok {
@@ -921,3 +921,6 @@ func canonicalNamespace(ns string) string {
 	}
 	return ns
 }
+
+// deleteResponse causes the resource to be deleted from the state.
+var deleteResponse = &pulumirpc.ReadResponse{Id: "", Properties: nil}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -703,6 +703,15 @@ func (k *kubeProvider) Update(
 	// Apply update.
 	initialized, awaitErr := await.Update(config)
 	if awaitErr != nil {
+		if meta.IsNoMatchError(awaitErr) {
+			// If it's a "no match" error, this is probably a CustomResource with no corresponding
+			// CustomResourceDefinition. This usually happens if the CRD was not created, and we
+			// print a more useful error message in this case.
+			return nil, fmt.Errorf(
+				"the apiVersion for this resource is not registered with the Kubernetes API server. "+
+					"Verify that any required CRDs have been created: %s", awaitErr)
+		}
+
 		var getErr error
 		initialized, getErr = k.readLiveObject(newInputs)
 		if getErr != nil {

--- a/tests/integration/crds/crd_test.go
+++ b/tests/integration/crds/crd_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/tests"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCRDs(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                  "step1",
+		Dependencies:         []string{"@pulumi/kubernetes"},
+		Quick:                false,
+		ExpectRefreshChanges: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Deployment)
+			assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
+
+			tests.SortResourcesByURN(stackInfo)
+
+			crd := stackInfo.Deployment.Resources[0]
+			namespace := stackInfo.Deployment.Resources[1]
+			ct1 := stackInfo.Deployment.Resources[2]
+			provRes := stackInfo.Deployment.Resources[3]
+			stackRes := stackInfo.Deployment.Resources[4]
+
+			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+			assert.True(t, providers.IsProviderType(provRes.URN.Type()))
+
+			assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), namespace.URN.Type())
+
+			//
+			// Assert that CRD and CR exist
+			//
+
+			assert.Equal(t, "crontab", string(crd.URN.Name()))
+			assert.Equal(t, "my-new-cron-object", string(ct1.URN.Name()))
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      "step2",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					namespace := stackInfo.Deployment.Resources[0]
+					provRes := stackInfo.Deployment.Resources[2]
+					stackRes := stackInfo.Deployment.Resources[3]
+
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+					assert.True(t, providers.IsProviderType(provRes.URN.Type()))
+
+					assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), namespace.URN.Type())
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/crds/step1/Pulumi.yaml
+++ b/tests/integration/crds/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: crd-tests
+description: A program that tests CRD/CR error handling.
+runtime: nodejs

--- a/tests/integration/crds/step1/index.ts
+++ b/tests/integration/crds/step1/index.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+//
+// Create a CustomResourceDefinition and a CustomResource.
+//
+
+new k8s.apiextensions.v1beta1.CustomResourceDefinition("crontab", {
+    metadata: { name: "crontabs.stable.example.com" },
+    spec: {
+        group: "stable.example.com",
+        version: "v1",
+        scope: "Namespaced",
+        names: {
+            plural: "crontabs",
+            singular: "crontab",
+            kind: "CronTab",
+            shortNames: ["ct"]
+        }
+    }
+});
+
+new k8s.apiextensions.CustomResource(
+    "my-new-cron-object",
+    {
+        apiVersion: "stable.example.com/v1",
+        kind: "CronTab",
+      metadata: {
+        namespace: namespace.metadata.name,
+        name: "my-new-cron-object",
+      },
+        spec: { cronSpec: "* * * * */5", image: "my-awesome-cron-image" }
+    },
+);

--- a/tests/integration/crds/step1/package.json
+++ b/tests/integration/crds/step1/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/crds/step1/tsconfig.json
+++ b/tests/integration/crds/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/crds/step2/Pulumi.yaml
+++ b/tests/integration/crds/step2/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: crd-tests
+description: A program that tests CRD/CR error handling.
+runtime: nodejs

--- a/tests/integration/crds/step2/index.ts
+++ b/tests/integration/crds/step2/index.ts
@@ -1,0 +1,35 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+//
+// Delete the CustomResourceDefinition. On the next refresh, the CustomResource will be
+// automatically deleted from the state rather than returning a "kind not found" error.
+//
+
+new k8s.apiextensions.CustomResource(
+    "my-new-cron-object",
+    {
+        apiVersion: "stable.example.com/v1",
+        kind: "CronTab",
+      metadata: {
+        namespace: namespace.metadata.name,
+        name: "my-new-cron-object",
+      },
+        spec: { cronSpec: "* * * * */6", image: "my-awesome-cron-image" }
+    },
+);

--- a/tests/integration/crds/step2/index.ts
+++ b/tests/integration/crds/step2/index.ts
@@ -19,6 +19,8 @@ const namespace = new k8s.core.v1.Namespace("test-namespace");
 //
 // Delete the CustomResourceDefinition. On the next refresh, the CustomResource will be
 // automatically deleted from the state rather than returning a "kind not found" error.
+// This is a contrived example for testing, and it doesn't make any sense to delete a
+// CRD while leaving related CRs.
 //
 
 new k8s.apiextensions.CustomResource(

--- a/tests/integration/crds/step2/package.json
+++ b/tests/integration/crds/step2/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/crds/step2/tsconfig.json
+++ b/tests/integration/crds/step2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/deployment-rollout/deployment_rollout_test.go
+++ b/tests/integration/deployment-rollout/deployment_rollout_test.go
@@ -19,13 +19,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/tokens"
-
 	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
 	"github.com/pulumi/pulumi-kubernetes/tests"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
For k8s to work with CustomResources, the corresponding CustomResourceDefinition
must be registered with the API server. In cases where the CRD does not exist, add
special handling rather than failing with an error. The relevant cases are:

1. Create/Update - Fail with a descriptive error after retrying
2. Read/Delete - Consider the CR to be deleted if the CRD is missing

Fixes #526 