### PR TITLE
Allow `apiextensions.CustomResource` to take CRD as arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Improvements
 
--   None
+-   Allow `apiextensions.CustomResource` to take a `CustomResourceDefinition` as
+    an argument, instead of only the strings `apiVersion` and `kind`.
 
 ### Bug fixes
 

--- a/tests/integration/get/step1/index.ts
+++ b/tests/integration/get/step1/index.ts
@@ -36,9 +36,9 @@ const ct = new k8s.apiextensions.v1beta1.CustomResourceDefinition("crontab", {
             plural: "crontabs",
             singular: "crontab",
             kind: "CronTab",
-            shortNames: ["ct"]
-        }
-    }
+            shortNames: ["ct"],
+        },
+    },
 });
 
 new k8s.apiextensions.CustomResource(
@@ -46,11 +46,24 @@ new k8s.apiextensions.CustomResource(
     {
         apiVersion: "stable.example.com/v1",
         kind: "CronTab",
-      metadata: {
-        namespace: namespace.metadata.name,
-        name: "my-new-cron-object",
-      },
-        spec: { cronSpec: "* * * * */5", image: "my-awesome-cron-image" }
+        metadata: {
+            namespace: namespace.metadata.name,
+            name: "my-new-cron-object",
+        },
+        spec: { cronSpec: "* * * * */5", image: "my-awesome-cron-image" },
     },
-    { dependsOn: ct }
+    { dependsOn: ct },
+);
+
+new k8s.apiextensions.CustomResource(
+    "my-new-cron-object-2",
+    {
+        definition: ct,
+        metadata: {
+            namespace: namespace.metadata.name,
+            name: "my-new-cron-object",
+        },
+        spec: { cronSpec: "* * * * */5", image: "my-awesome-cron-image" },
+    },
+    { dependsOn: ct },
 );


### PR DESCRIPTION
This patch is designed to make #531 vastly less likely in native Pulumi
applications.

We currently expose a `CustomResource` class which is a low-level,
mostly-untyped API for instantiating a Kubernetes CRD. Suppose a Pulumi
application declares a CRD, and also a bunch of CRs that are instances
of that CRD. Suppose then the user removes the CRD from the program, but
not the CRs. In this case, the the CRs will be "invisibly" deleted, and
subsequent `pulumi up` calls will not notice, unless they touch those
CRs, or the user runs `refresh`.

This commit allows users to pass the `CustomResourceDefinition` object
into the CR constructor, which implicitly parents the CR to the CRD.
This makes this "invisble deletion" scenario vastly less likely.