### PR TITLE
Fix namespaceable check for diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Bug fixes
 
--   None
+-   Fix namespaceable check for diff (https://github.com/pulumi/pulumi-kubernetes/pull/554)
 
 ## 0.23.0 (April 30, 2019)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -392,7 +392,14 @@ func (k *kubeProvider) Diff(
 
 	namespacedKind, err := k.clientSet.IsNamespacedKind(gvk)
 	if err != nil {
-		return nil, err
+		if clients.IsNoNamespaceInfoErr(err) {
+			// This is probably a CustomResource without a registered CustomResourceDefinition.
+			// Since we can't tell for sure at this point, assume it is namespaced, and correct if
+			// required during the Create step.
+			namespacedKind = true
+		} else {
+			return nil, err
+		}
 	}
 
 	if namespacedKind {


### PR DESCRIPTION
For deployments that rely on CRDs created by a controller,
it is not possible to tell if the related CR is namespaceable
during preview or diff. The diff case was overlooked in the
previous fix for preview. Rather than returning an error,
assume that the CR is namespaceable, and correct during
the Create if required.

Fixes #553 