### PR TITLE
Pass package versions to engine when registering resources

### DIFF
--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     {{{Comment}}}
     export class {{Kind}} extends pulumi.CustomResource {
@@ -43,6 +44,14 @@ import * as outputApi from "../../types/output";
           {{#Properties}}
           inputs["{{Name}}"] = {{{DefaultValue}}};
           {{/Properties}}
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:{{URNAPIVersion}}:{{Kind}}", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/pkg/gen/nodejs-templates/package.json.mustache
+++ b/pkg/gen/nodejs-templates/package.json.mustache
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.1",
+        "@pulumi/pulumi": "^0.17.8",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/pkg/gen/python-templates/CustomResource.py
+++ b/pkg/gen/python-templates/CustomResource.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from .. import tables
+from .. import tables, version
 
 
 class CustomResource(pulumi.CustomResource):
@@ -35,6 +35,11 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CustomResource, self).__init__(
             "kubernetes:%s:%s" % (api_version, kind),

--- a/pkg/gen/python-templates/kind.py.mustache
+++ b/pkg/gen/python-templates/kind.py.mustache
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class {{Kind}}(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class {{Kind}}(pulumi.CustomResource):
         {{#OptionalProperties}}
         __props__['{{Name}}'] = {{LanguageName}}
         {{/OptionalProperties}}
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super({{Kind}}, self).__init__(
             "kubernetes:{{URNAPIVersion}}:{{Kind}}",

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * MutatingWebhookConfiguration describes the configuration of and admission webhook that accept
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "MutatingWebhookConfiguration";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["webhooks"] = args && args.webhooks || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "MutatingWebhookConfigurationList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfigurationList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ValidatingWebhookConfiguration describes the configuration of and admission webhook that
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ValidatingWebhookConfiguration";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["webhooks"] = args && args.webhooks || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ValidatingWebhookConfigurationList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfigurationList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiextensions/CustomResource.ts
+++ b/sdk/nodejs/apiextensions/CustomResource.ts
@@ -15,6 +15,7 @@
 import * as pulumi from "@pulumi/pulumi"
 import * as inputApi from "../types/input";
 import * as outputApi from "../types/output";
+import { getVersion } from "../version";
 
 /**
  * CustomResourceArgs represents a resource definition we'd use to create an instance of a
@@ -136,6 +137,13 @@ export class CustomResource extends pulumi.CustomResource {
         let inputs: pulumi.Inputs = {};
         for (const key of Object.keys(args)) {
             inputs[key] = (args as any)[key];
+        }
+
+        if (!opts) {
+            opts = {}
+        }
+        if (!opts.version) {
+            opts.version = getVersion();
         }
         super(`kubernetes:${args.apiVersion}:${args.kind}`, name, inputs, opts);
         this.__inputs = args;

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CustomResourceDefinition represents a resource that should be exposed on the API server.  Its
@@ -72,6 +73,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
@@ -65,6 +66,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CustomResourceDefinitionList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinitionList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * APIService represents a server for a particular GroupVersion. Name must be "version.group".
@@ -71,6 +72,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiregistration/v1:APIService", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiregistration/v1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1/APIServiceList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * APIServiceList is a list of APIService objects.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "APIServiceList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiregistration/v1:APIServiceList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * APIService represents a server for a particular GroupVersion. Name must be "version.group".
@@ -71,6 +72,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiregistration/v1beta1:APIService", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * APIServiceList is a list of APIService objects.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "APIServiceList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apiregistration/v1beta1:APIServiceList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevision.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
@@ -81,6 +82,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ControllerRevision";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["revision"] = args && args.revision || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:ControllerRevision", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevisionList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ControllerRevisionList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:ControllerRevisionList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1/DaemonSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DaemonSet represents the configuration of a daemon set.
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:DaemonSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1/DaemonSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DaemonSetList is a collection of daemon sets.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DaemonSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:DaemonSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Deployment enables declarative updates for Pods and ReplicaSets.
@@ -73,6 +74,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:Deployment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1/DeploymentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DeploymentList is a list of Deployments.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DeploymentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:DeploymentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:ReplicaSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicaSetList is a collection of ReplicaSets.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ReplicaSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:ReplicaSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:StatefulSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1/StatefulSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StatefulSetList is a collection of StatefulSets.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "StatefulSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1:StatefulSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of ControllerRevision is deprecated by
@@ -83,6 +84,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ControllerRevision";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["revision"] = args && args.revision || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:ControllerRevision", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ControllerRevisionList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:ControllerRevisionList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:Deployment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta1/DeploymentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DeploymentList is a list of Deployments.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DeploymentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:DeploymentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:StatefulSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StatefulSetList is a collection of StatefulSets.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "StatefulSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta1:StatefulSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of ControllerRevision is deprecated by
@@ -83,6 +84,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ControllerRevision";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["revision"] = args && args.revision || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:ControllerRevision", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ControllerRevisionList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:ControllerRevisionList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:DaemonSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DaemonSetList is a collection of daemon sets.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DaemonSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:DaemonSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:Deployment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta2/DeploymentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DeploymentList is a list of Deployments.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DeploymentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:DeploymentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the
@@ -80,6 +81,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:ReplicaSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicaSetList is a collection of ReplicaSets.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ReplicaSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:ReplicaSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:StatefulSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StatefulSetList is a collection of StatefulSets.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "StatefulSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:apps/v1beta2:StatefulSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * AuditSink represents a cluster level audit sink
@@ -65,6 +66,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "AuditSink";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSink", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * AuditSinkList is a list of AuditSink items.
@@ -65,6 +66,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "AuditSinkList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSinkList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authentication/v1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1/TokenReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may
@@ -72,6 +73,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authentication.k8s.io/v1:TokenReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authentication/v1beta1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1beta1/TokenReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may
@@ -72,6 +73,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authentication.k8s.io/v1beta1:TokenReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a
@@ -74,6 +75,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not
@@ -73,6 +74,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SubjectAccessReview checks whether or not a user or group can perform an action.
@@ -71,6 +72,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a
@@ -74,6 +75,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not
@@ -73,6 +74,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SubjectAccessReview checks whether or not a user or group can perform an action.
@@ -71,6 +72,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * configuration of a horizontal pod autoscaler.
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * list of horizontal pod autoscaler objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "HorizontalPodAutoscalerList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v1:HorizontalPodAutoscalerList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "HorizontalPodAutoscalerList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscalerList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "HorizontalPodAutoscalerList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscalerList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v1/Job.ts
+++ b/sdk/nodejs/batch/v1/Job.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Job represents the configuration of a single job.
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v1:Job", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v1/JobList.ts
+++ b/sdk/nodejs/batch/v1/JobList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * JobList is a collection of jobs.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "JobList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v1:JobList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v1beta1/CronJob.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJob.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CronJob represents the configuration of a single cron job.
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v1beta1:CronJob", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v1beta1/CronJobList.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJobList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CronJobList is a collection of cron jobs.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CronJobList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v1beta1:CronJobList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v2alpha1/CronJob.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJob.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CronJob represents the configuration of a single cron job.
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v2alpha1:CronJob", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/batch/v2alpha1/CronJobList.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJobList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CronJobList is a collection of cron jobs.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CronJobList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:batch/v2alpha1:CronJobList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Describes a certificate signing request
@@ -71,6 +72,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequest", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     
     export class CertificateSigningRequestList extends pulumi.CustomResource {
@@ -61,6 +62,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CertificateSigningRequestList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequestList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/coordination/v1/Lease.ts
+++ b/sdk/nodejs/coordination/v1/Lease.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Lease defines a lease concept.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Lease";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:coordination.k8s.io/v1:Lease", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/coordination/v1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1/LeaseList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LeaseList is a list of Lease objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "LeaseList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:coordination.k8s.io/v1:LeaseList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/coordination/v1beta1/Lease.ts
+++ b/sdk/nodejs/coordination/v1beta1/Lease.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Lease defines a lease concept.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Lease";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:coordination.k8s.io/v1beta1:Lease", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/coordination/v1beta1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1beta1/LeaseList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LeaseList is a list of Lease objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "LeaseList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:coordination.k8s.io/v1beta1:LeaseList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Binding.ts
+++ b/sdk/nodejs/core/v1/Binding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Binding ties one object to another; for example, a pod is bound to a node by a scheduler.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Binding";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["target"] = args && args.target || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Binding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ComponentStatus.ts
+++ b/sdk/nodejs/core/v1/ComponentStatus.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ComponentStatus (and ComponentStatusList) holds the cluster validation info.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["conditions"] = args && args.conditions || undefined;
           inputs["kind"] = "ComponentStatus";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ComponentStatus", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ComponentStatusList.ts
+++ b/sdk/nodejs/core/v1/ComponentStatusList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Status of all the conditions for the component as a list of ComponentStatus objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ComponentStatusList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ComponentStatusList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ConfigMap.ts
+++ b/sdk/nodejs/core/v1/ConfigMap.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ConfigMap holds configuration data for pods to consume.
@@ -80,6 +81,14 @@ import * as outputApi from "../../types/output";
           inputs["data"] = args && args.data || undefined;
           inputs["kind"] = "ConfigMap";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ConfigMap", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ConfigMapList.ts
+++ b/sdk/nodejs/core/v1/ConfigMapList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ConfigMapList is a resource containing a list of ConfigMap objects.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ConfigMapList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ConfigMapList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Endpoints.ts
+++ b/sdk/nodejs/core/v1/Endpoints.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Endpoints is a collection of endpoints that implement the actual service. Example:
@@ -84,6 +85,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Endpoints";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["subsets"] = args && args.subsets || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Endpoints", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/EndpointsList.ts
+++ b/sdk/nodejs/core/v1/EndpointsList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * EndpointsList is a list of endpoints.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "EndpointsList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:EndpointsList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Event.ts
+++ b/sdk/nodejs/core/v1/Event.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Event is a report of an event somewhere in the cluster.
@@ -147,6 +148,14 @@ import * as outputApi from "../../types/output";
           inputs["series"] = args && args.series || undefined;
           inputs["source"] = args && args.source || undefined;
           inputs["type"] = args && args.type || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Event", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/EventList.ts
+++ b/sdk/nodejs/core/v1/EventList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * EventList is a list of events.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "EventList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:EventList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/LimitRange.ts
+++ b/sdk/nodejs/core/v1/LimitRange.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LimitRange sets resource usage limits for each kind of resource in a Namespace.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "LimitRange";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:LimitRange", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/LimitRangeList.ts
+++ b/sdk/nodejs/core/v1/LimitRangeList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * LimitRangeList is a list of LimitRange items.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "LimitRangeList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:LimitRangeList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Namespace.ts
+++ b/sdk/nodejs/core/v1/Namespace.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Namespace provides a scope for Names. Use of multiple namespaces is optional.
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Namespace", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/NamespaceList.ts
+++ b/sdk/nodejs/core/v1/NamespaceList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * NamespaceList is a list of Namespaces.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "NamespaceList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:NamespaceList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Node.ts
+++ b/sdk/nodejs/core/v1/Node.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Node", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/NodeList.ts
+++ b/sdk/nodejs/core/v1/NodeList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * NodeList is the whole list of all Nodes which have been registered with master.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "NodeList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:NodeList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PersistentVolume.ts
+++ b/sdk/nodejs/core/v1/PersistentVolume.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous
@@ -79,6 +80,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PersistentVolume", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PersistentVolumeClaim is a user's request for and claim to a persistent volume
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PersistentVolumeClaim", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PersistentVolumeClaimList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PersistentVolumeClaimList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PersistentVolumeList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PersistentVolumeList is a list of PersistentVolume items.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PersistentVolumeList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PersistentVolumeList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Pod.ts
+++ b/sdk/nodejs/core/v1/Pod.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Pod is a collection of containers that can run on a host. This resource is created by clients
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Pod", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PodList.ts
+++ b/sdk/nodejs/core/v1/PodList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodList is a list of Pods.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PodList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PodTemplate.ts
+++ b/sdk/nodejs/core/v1/PodTemplate.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodTemplate describes a template for creating copies of a predefined pod.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PodTemplate";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["template"] = args && args.template || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PodTemplate", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/PodTemplateList.ts
+++ b/sdk/nodejs/core/v1/PodTemplateList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodTemplateList is a list of PodTemplates.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodTemplateList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:PodTemplateList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ReplicationController.ts
+++ b/sdk/nodejs/core/v1/ReplicationController.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicationController represents the configuration of a replication controller.
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ReplicationController", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ReplicationControllerList.ts
+++ b/sdk/nodejs/core/v1/ReplicationControllerList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicationControllerList is a collection of replication controllers.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ReplicationControllerList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ReplicationControllerList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ResourceQuota.ts
+++ b/sdk/nodejs/core/v1/ResourceQuota.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ResourceQuota sets aggregate quota restrictions enforced per namespace
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ResourceQuota", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ResourceQuotaList.ts
+++ b/sdk/nodejs/core/v1/ResourceQuotaList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ResourceQuotaList is a list of ResourceQuota items.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ResourceQuotaList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ResourceQuotaList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Secret.ts
+++ b/sdk/nodejs/core/v1/Secret.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Secret holds secret data of a certain type. The total bytes of the values in the Data field
@@ -86,6 +87,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["stringData"] = args && args.stringData || undefined;
           inputs["type"] = args && args.type || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Secret", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/SecretList.ts
+++ b/sdk/nodejs/core/v1/SecretList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * SecretList is a list of Secret.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "SecretList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:SecretList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/Service.ts
+++ b/sdk/nodejs/core/v1/Service.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Service is a named abstraction of software service (for example, mysql) consisting of local
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Service", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ServiceAccount.ts
+++ b/sdk/nodejs/core/v1/ServiceAccount.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral
@@ -88,6 +89,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ServiceAccount";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["secrets"] = args && args.secrets || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ServiceAccount", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ServiceAccountList.ts
+++ b/sdk/nodejs/core/v1/ServiceAccountList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ServiceAccountList is a list of ServiceAccount objects
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ServiceAccountList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ServiceAccountList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/core/v1/ServiceList.ts
+++ b/sdk/nodejs/core/v1/ServiceList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ServiceList holds a list of services.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ServiceList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:ServiceList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/events/v1beta1/Event.ts
+++ b/sdk/nodejs/events/v1beta1/Event.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Event is a report of an event somewhere in the cluster. It generally denotes some state
@@ -148,6 +149,14 @@ import * as outputApi from "../../types/output";
           inputs["reportingInstance"] = args && args.reportingInstance || undefined;
           inputs["series"] = args && args.series || undefined;
           inputs["type"] = args && args.type || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:events.k8s.io/v1beta1:Event", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/events/v1beta1/EventList.ts
+++ b/sdk/nodejs/events/v1beta1/EventList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * EventList is a list of Event objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "EventList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:events.k8s.io/v1beta1:EventList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:DaemonSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DaemonSetList is a collection of daemon sets.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DaemonSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:DaemonSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:Deployment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DeploymentList is a list of Deployments.
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "DeploymentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:DeploymentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
@@ -80,6 +81,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:Ingress", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/IngressList.ts
+++ b/sdk/nodejs/extensions/v1beta1/IngressList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * IngressList is a collection of Ingress.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "IngressList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:IngressList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by
@@ -70,6 +71,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "NetworkPolicy";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:NetworkPolicy", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "NetworkPolicyList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:NetworkPolicyList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodSecurityPolicy governs the ability to make requests that affect the Security Context that
@@ -70,6 +71,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PodSecurityPolicy";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:PodSecurityPolicy", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodSecurityPolicyList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:PodSecurityPolicyList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See
@@ -80,6 +81,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:ReplicaSet", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ReplicaSetList is a collection of ReplicaSets.
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ReplicaSetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:extensions/v1beta1:ReplicaSetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/meta/v1/Status.ts
+++ b/sdk/nodejs/meta/v1/Status.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Status is a return value for calls that don't return other objects.
@@ -97,6 +98,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["reason"] = args && args.reason || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:core/v1:Status", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * NetworkPolicy describes what network traffic is allowed for a set of Pods
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "NetworkPolicy";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:networking.k8s.io/v1:NetworkPolicy", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/networking/v1/NetworkPolicyList.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicyList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * NetworkPolicyList is a list of NetworkPolicy objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "NetworkPolicyList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:networking.k8s.io/v1:NetworkPolicyList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:networking.k8s.io/v1beta1:Ingress", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/networking/v1beta1/IngressList.ts
+++ b/sdk/nodejs/networking/v1beta1/IngressList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * IngressList is a collection of Ingress.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "IngressList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:networking.k8s.io/v1beta1:IngressList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass
@@ -73,6 +74,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "RuntimeClass";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RuntimeClassList is a list of RuntimeClass objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RuntimeClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:node.k8s.io/v1alpha1:RuntimeClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/node/v1beta1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass
@@ -78,6 +79,14 @@ import * as outputApi from "../../types/output";
           inputs["handler"] = args && args.handler || undefined;
           inputs["kind"] = "RuntimeClass";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:node.k8s.io/v1beta1:RuntimeClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RuntimeClassList is a list of RuntimeClass objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RuntimeClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:node.k8s.io/v1beta1:RuntimeClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.1",
+        "@pulumi/pulumi": "^0.17.8",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodDisruptionBudget is an object to define the max disruption that can be caused to a
@@ -72,6 +73,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:policy/v1beta1:PodDisruptionBudget", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodDisruptionBudgetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:policy/v1beta1:PodDisruptionBudgetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodSecurityPolicy governs the ability to make requests that affect the Security Context that
@@ -69,6 +70,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PodSecurityPolicy";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:policy/v1beta1:PodSecurityPolicy", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodSecurityPolicyList is a list of PodSecurityPolicy objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodSecurityPolicyList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:policy/v1beta1:PodSecurityPolicyList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ClusterRole";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBindingList is a collection of ClusterRoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleList is a collection of ClusterRoles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Role";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:Role", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBinding references a role, but does not contain it.  It can reference a Role in the same
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/RoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBindingList is a collection of RoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:RoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1/RoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleList is a collection of Roles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1:RoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ClusterRole";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBindingList is a collection of ClusterRoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleList is a collection of ClusterRoles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Role";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBinding references a role, but does not contain it.  It can reference a Role in the same
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBindingList is a collection of RoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1alpha1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleList is a collection of Roles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a
@@ -76,6 +77,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "ClusterRole";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a
@@ -75,6 +76,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleBindingList is a collection of ClusterRoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * ClusterRoleList is a collection of ClusterRoles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "ClusterRoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "Role";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["rules"] = args && args.rules || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBinding references a role, but does not contain it.  It can reference a Role in the same
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["roleRef"] = args && args.roleRef || undefined;
           inputs["subjects"] = args && args.subjects || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleBindingList is a collection of RoleBindings
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleBindingList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBindingList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/rbac/v1beta1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * RoleList is a collection of Roles
@@ -67,6 +68,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "RoleList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PriorityClass defines mapping from a priority class name to the priority integer value. The
@@ -87,6 +88,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PriorityClass";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["value"] = args && args.value || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1:PriorityClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PriorityClassList is a collection of priority classes.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PriorityClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1:PriorityClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of PriorityClass is deprecated by
@@ -88,6 +89,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PriorityClass";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["value"] = args && args.value || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PriorityClassList is a collection of priority classes.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PriorityClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * DEPRECATED - This group version of PriorityClass is deprecated by
@@ -88,6 +89,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PriorityClass";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["value"] = args && args.value || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PriorityClassList is a collection of priority classes.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PriorityClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:scheduling.k8s.io/v1beta1:PriorityClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/settings/v1alpha1/PodPreset.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPreset.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodPreset is a policy resource that defines additional runtime requirements for a Pod.
@@ -63,6 +64,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "PodPreset";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:settings.k8s.io/v1alpha1:PodPreset", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * PodPresetList is a list of PodPreset objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "PodPresetList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:settings.k8s.io/v1alpha1:PodPresetList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1/StorageClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StorageClass describes the parameters for a class of storage for which PersistentVolumes can
@@ -117,6 +118,14 @@ import * as outputApi from "../../types/output";
           inputs["provisioner"] = args && args.provisioner || undefined;
           inputs["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
           inputs["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1:StorageClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1/StorageClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StorageClassList is a collection of storage classes.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "StorageClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1:StorageClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachment captures the intent to attach or detach the specified volume to/from the
@@ -79,6 +80,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1:VolumeAttachment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "VolumeAttachmentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1:VolumeAttachmentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachment captures the intent to attach or detach the specified volume to/from the
@@ -79,6 +80,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "VolumeAttachmentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachmentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/CSIDriver.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriver.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CSIDriver captures information about a Container Storage Interface (CSI) volume driver
@@ -77,6 +78,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "CSIDriver";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:CSIDriver", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CSIDriverList is a collection of CSIDriver objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CSIDriverList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:CSIDriverList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
@@ -73,6 +74,14 @@ import * as outputApi from "../../types/output";
           inputs["kind"] = "CSINode";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:CSINode", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/CSINodeList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINodeList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * CSINodeList is a collection of CSINode objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "CSINodeList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:CSINodeList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClass.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StorageClass describes the parameters for a class of storage for which PersistentVolumes can
@@ -117,6 +118,14 @@ import * as outputApi from "../../types/output";
           inputs["provisioner"] = args && args.provisioner || undefined;
           inputs["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
           inputs["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:StorageClass", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClassList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * StorageClassList is a collection of storage classes.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "StorageClassList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:StorageClassList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachment captures the intent to attach or detach the specified volume to/from the
@@ -79,6 +80,14 @@ import * as outputApi from "../../types/output";
           inputs["metadata"] = args && args.metadata || undefined;
           inputs["spec"] = args && args.spec || undefined;
           inputs["status"] = args && args.status || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
@@ -4,6 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as inputApi from "../../types/input";
 import * as outputApi from "../../types/output";
+import { getVersion } from "../../version";
 
     /**
      * VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -68,6 +69,14 @@ import * as outputApi from "../../types/output";
           inputs["items"] = args && args.items || undefined;
           inputs["kind"] = "VolumeAttachmentList";
           inputs["metadata"] = args && args.metadata || undefined;
+        
+          if (!opts) {
+              opts = {};
+          }
+
+          if (!opts.version) {
+              opts.version = getVersion();
+          }
           super("kubernetes:storage.k8s.io/v1beta1:VolumeAttachmentList", name, inputs, opts);
           this.__inputs = <any>args;
       }

--- a/sdk/nodejs/version.ts
+++ b/sdk/nodejs/version.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns the version of the package containing this file, obtained from the package.json
+ * of this package.
+ */
+export function getVersion(): string {
+    let version: string = require("./package.json").version;
+    // Node allows for the version to be prefixed by a "v", while semver doesn't.
+    // If there is a v, strip it off.
+    if (version.indexOf("v") === 0) {
+        version = version.slice(1);
+    }
+    return version;
+}

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class MutatingWebhookConfiguration(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
         __props__['kind'] = 'MutatingWebhookConfiguration'
         __props__['metadata'] = metadata
         __props__['webhooks'] = webhooks
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(MutatingWebhookConfiguration, self).__init__(
             "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration",

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class MutatingWebhookConfigurationList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(MutatingWebhookConfigurationList, self).__init__(
             "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfigurationList",

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ValidatingWebhookConfiguration(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
         __props__['kind'] = 'ValidatingWebhookConfiguration'
         __props__['metadata'] = metadata
         __props__['webhooks'] = webhooks
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ValidatingWebhookConfiguration, self).__init__(
             "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration",

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ValidatingWebhookConfigurationList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ValidatingWebhookConfigurationList, self).__init__(
             "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfigurationList",

--- a/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from .. import tables
+from .. import tables, version
 
 
 class CustomResource(pulumi.CustomResource):
@@ -35,6 +35,11 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CustomResource, self).__init__(
             "kubernetes:%s:%s" % (api_version, kind),

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CustomResourceDefinition(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class CustomResourceDefinition(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CustomResourceDefinition, self).__init__(
             "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition",

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CustomResourceDefinitionList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CustomResourceDefinitionList, self).__init__(
             "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinitionList",

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class APIService(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class APIService(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(APIService, self).__init__(
             "kubernetes:apiregistration/v1:APIService",

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class APIServiceList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class APIServiceList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(APIServiceList, self).__init__(
             "kubernetes:apiregistration/v1:APIServiceList",

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class APIService(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class APIService(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(APIService, self).__init__(
             "kubernetes:apiregistration/v1beta1:APIService",

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class APIServiceList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class APIServiceList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(APIServiceList, self).__init__(
             "kubernetes:apiregistration/v1beta1:APIServiceList",

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevision(pulumi.CustomResource):
@@ -35,6 +35,11 @@ class ControllerRevision(pulumi.CustomResource):
         __props__['revision'] = revision
         __props__['data'] = data
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevision, self).__init__(
             "kubernetes:apps/v1:ControllerRevision",

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevisionList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ControllerRevisionList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevisionList, self).__init__(
             "kubernetes:apps/v1:ControllerRevisionList",

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSet(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class DaemonSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSet, self).__init__(
             "kubernetes:apps/v1:DaemonSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DaemonSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSetList, self).__init__(
             "kubernetes:apps/v1:DaemonSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Deployment(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Deployment(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Deployment, self).__init__(
             "kubernetes:apps/v1:Deployment",

--- a/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DeploymentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DeploymentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DeploymentList, self).__init__(
             "kubernetes:apps/v1:DeploymentList",

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSet(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class ReplicaSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSet, self).__init__(
             "kubernetes:apps/v1:ReplicaSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ReplicaSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSetList, self).__init__(
             "kubernetes:apps/v1:ReplicaSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSet(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class StatefulSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSet, self).__init__(
             "kubernetes:apps/v1:StatefulSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class StatefulSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSetList, self).__init__(
             "kubernetes:apps/v1:StatefulSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevision(pulumi.CustomResource):
@@ -37,6 +37,11 @@ class ControllerRevision(pulumi.CustomResource):
         __props__['revision'] = revision
         __props__['data'] = data
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevision, self).__init__(
             "kubernetes:apps/v1beta1:ControllerRevision",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevisionList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ControllerRevisionList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevisionList, self).__init__(
             "kubernetes:apps/v1beta1:ControllerRevisionList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Deployment(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Deployment(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Deployment, self).__init__(
             "kubernetes:apps/v1beta1:Deployment",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DeploymentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DeploymentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DeploymentList, self).__init__(
             "kubernetes:apps/v1beta1:DeploymentList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSet(pulumi.CustomResource):
@@ -32,6 +32,11 @@ class StatefulSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSet, self).__init__(
             "kubernetes:apps/v1beta1:StatefulSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class StatefulSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSetList, self).__init__(
             "kubernetes:apps/v1beta1:StatefulSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevision(pulumi.CustomResource):
@@ -37,6 +37,11 @@ class ControllerRevision(pulumi.CustomResource):
         __props__['revision'] = revision
         __props__['data'] = data
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevision, self).__init__(
             "kubernetes:apps/v1beta2:ControllerRevision",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ControllerRevisionList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ControllerRevisionList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ControllerRevisionList, self).__init__(
             "kubernetes:apps/v1beta2:ControllerRevisionList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSet(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DaemonSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSet, self).__init__(
             "kubernetes:apps/v1beta2:DaemonSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DaemonSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSetList, self).__init__(
             "kubernetes:apps/v1beta2:DaemonSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Deployment(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Deployment(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Deployment, self).__init__(
             "kubernetes:apps/v1beta2:Deployment",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DeploymentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DeploymentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DeploymentList, self).__init__(
             "kubernetes:apps/v1beta2:DeploymentList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSet(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class ReplicaSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSet, self).__init__(
             "kubernetes:apps/v1beta2:ReplicaSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ReplicaSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSetList, self).__init__(
             "kubernetes:apps/v1beta2:ReplicaSetList",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSet(pulumi.CustomResource):
@@ -32,6 +32,11 @@ class StatefulSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSet, self).__init__(
             "kubernetes:apps/v1beta2:StatefulSet",

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StatefulSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class StatefulSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StatefulSetList, self).__init__(
             "kubernetes:apps/v1beta2:StatefulSetList",

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSink.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSink.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class AuditSink(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class AuditSink(pulumi.CustomResource):
         __props__['kind'] = 'AuditSink'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(AuditSink, self).__init__(
             "kubernetes:auditregistration.k8s.io/v1alpha1:AuditSink",

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class AuditSinkList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class AuditSinkList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(AuditSinkList, self).__init__(
             "kubernetes:auditregistration.k8s.io/v1alpha1:AuditSinkList",

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class TokenReview(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class TokenReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(TokenReview, self).__init__(
             "kubernetes:authentication.k8s.io/v1:TokenReview",

--- a/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class TokenReview(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class TokenReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(TokenReview, self).__init__(
             "kubernetes:authentication.k8s.io/v1beta1:TokenReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LocalSubjectAccessReview(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LocalSubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SelfSubjectAccessReview(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SelfSubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SelfSubjectRulesReview(pulumi.CustomResource):
@@ -35,6 +35,11 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SelfSubjectRulesReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SubjectAccessReview(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class SubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1:SubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LocalSubjectAccessReview(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LocalSubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SelfSubjectAccessReview(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SelfSubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SelfSubjectRulesReview(pulumi.CustomResource):
@@ -35,6 +35,11 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SelfSubjectRulesReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview",

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SubjectAccessReview(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class SubjectAccessReview(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SubjectAccessReview, self).__init__(
             "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscaler(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscaler, self).__init__(
             "kubernetes:autoscaling/v1:HorizontalPodAutoscaler",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscalerList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscalerList, self).__init__(
             "kubernetes:autoscaling/v1:HorizontalPodAutoscalerList",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscaler(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscaler, self).__init__(
             "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscalerList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscalerList, self).__init__(
             "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscalerList",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscaler(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscaler, self).__init__(
             "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler",

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class HorizontalPodAutoscalerList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(HorizontalPodAutoscalerList, self).__init__(
             "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscalerList",

--- a/sdk/python/pulumi_kubernetes/batch/v1/Job.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/Job.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Job(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Job(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Job, self).__init__(
             "kubernetes:batch/v1:Job",

--- a/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class JobList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class JobList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(JobList, self).__init__(
             "kubernetes:batch/v1:JobList",

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CronJob(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class CronJob(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CronJob, self).__init__(
             "kubernetes:batch/v1beta1:CronJob",

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CronJobList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class CronJobList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CronJobList, self).__init__(
             "kubernetes:batch/v1beta1:CronJobList",

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CronJob(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class CronJob(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CronJob, self).__init__(
             "kubernetes:batch/v2alpha1:CronJob",

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CronJobList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class CronJobList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CronJobList, self).__init__(
             "kubernetes:batch/v2alpha1:CronJobList",

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequest.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequest.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CertificateSigningRequest(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class CertificateSigningRequest(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CertificateSigningRequest, self).__init__(
             "kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequest",

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CertificateSigningRequestList(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class CertificateSigningRequestList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CertificateSigningRequestList, self).__init__(
             "kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequestList",

--- a/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Lease(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class Lease(pulumi.CustomResource):
         __props__['kind'] = 'Lease'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Lease, self).__init__(
             "kubernetes:coordination.k8s.io/v1:Lease",

--- a/sdk/python/pulumi_kubernetes/coordination/v1/LeaseList.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/LeaseList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LeaseList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class LeaseList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LeaseList, self).__init__(
             "kubernetes:coordination.k8s.io/v1:LeaseList",

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Lease(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class Lease(pulumi.CustomResource):
         __props__['kind'] = 'Lease'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Lease, self).__init__(
             "kubernetes:coordination.k8s.io/v1beta1:Lease",

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LeaseList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class LeaseList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LeaseList, self).__init__(
             "kubernetes:coordination.k8s.io/v1beta1:LeaseList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Binding.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Binding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Binding(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Binding(pulumi.CustomResource):
             raise TypeError('Missing required property target')
         __props__['target'] = target
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Binding, self).__init__(
             "kubernetes:core/v1:Binding",

--- a/sdk/python/pulumi_kubernetes/core/v1/ComponentStatus.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ComponentStatus.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ComponentStatus(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class ComponentStatus(pulumi.CustomResource):
         __props__['kind'] = 'ComponentStatus'
         __props__['conditions'] = conditions
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ComponentStatus, self).__init__(
             "kubernetes:core/v1:ComponentStatus",

--- a/sdk/python/pulumi_kubernetes/core/v1/ComponentStatusList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ComponentStatusList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ComponentStatusList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ComponentStatusList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ComponentStatusList, self).__init__(
             "kubernetes:core/v1:ComponentStatusList",

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ConfigMap(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class ConfigMap(pulumi.CustomResource):
         __props__['binaryData'] = binary_data
         __props__['data'] = data
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ConfigMap, self).__init__(
             "kubernetes:core/v1:ConfigMap",

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ConfigMapList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ConfigMapList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ConfigMapList, self).__init__(
             "kubernetes:core/v1:ConfigMapList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Endpoints.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Endpoints.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Endpoints(pulumi.CustomResource):
@@ -36,6 +36,11 @@ class Endpoints(pulumi.CustomResource):
         __props__['kind'] = 'Endpoints'
         __props__['metadata'] = metadata
         __props__['subsets'] = subsets
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Endpoints, self).__init__(
             "kubernetes:core/v1:Endpoints",

--- a/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class EndpointsList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class EndpointsList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(EndpointsList, self).__init__(
             "kubernetes:core/v1:EndpointsList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Event.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Event(pulumi.CustomResource):
@@ -42,6 +42,11 @@ class Event(pulumi.CustomResource):
         __props__['series'] = series
         __props__['source'] = source
         __props__['type'] = type
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Event, self).__init__(
             "kubernetes:core/v1:Event",

--- a/sdk/python/pulumi_kubernetes/core/v1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EventList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class EventList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class EventList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(EventList, self).__init__(
             "kubernetes:core/v1:EventList",

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRange.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRange.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LimitRange(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class LimitRange(pulumi.CustomResource):
         __props__['kind'] = 'LimitRange'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LimitRange, self).__init__(
             "kubernetes:core/v1:LimitRange",

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class LimitRangeList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class LimitRangeList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(LimitRangeList, self).__init__(
             "kubernetes:core/v1:LimitRangeList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Namespace.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Namespace.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Namespace(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Namespace(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Namespace, self).__init__(
             "kubernetes:core/v1:Namespace",

--- a/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NamespaceList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class NamespaceList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NamespaceList, self).__init__(
             "kubernetes:core/v1:NamespaceList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Node.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Node.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Node(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class Node(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Node, self).__init__(
             "kubernetes:core/v1:Node",

--- a/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NodeList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class NodeList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NodeList, self).__init__(
             "kubernetes:core/v1:NodeList",

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolume.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolume.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PersistentVolume(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PersistentVolume(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PersistentVolume, self).__init__(
             "kubernetes:core/v1:PersistentVolume",

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaim.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaim.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PersistentVolumeClaim(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class PersistentVolumeClaim(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PersistentVolumeClaim, self).__init__(
             "kubernetes:core/v1:PersistentVolumeClaim",

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PersistentVolumeClaimList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PersistentVolumeClaimList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PersistentVolumeClaimList, self).__init__(
             "kubernetes:core/v1:PersistentVolumeClaimList",

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PersistentVolumeList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PersistentVolumeList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PersistentVolumeList, self).__init__(
             "kubernetes:core/v1:PersistentVolumeList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Pod.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Pod.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Pod(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class Pod(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Pod, self).__init__(
             "kubernetes:core/v1:Pod",

--- a/sdk/python/pulumi_kubernetes/core/v1/PodList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodList, self).__init__(
             "kubernetes:core/v1:PodList",

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplate.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplate.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodTemplate(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class PodTemplate(pulumi.CustomResource):
         __props__['kind'] = 'PodTemplate'
         __props__['metadata'] = metadata
         __props__['template'] = template
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodTemplate, self).__init__(
             "kubernetes:core/v1:PodTemplate",

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodTemplateList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodTemplateList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodTemplateList, self).__init__(
             "kubernetes:core/v1:PodTemplateList",

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationController.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationController.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicationController(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class ReplicationController(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicationController, self).__init__(
             "kubernetes:core/v1:ReplicationController",

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicationControllerList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ReplicationControllerList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicationControllerList, self).__init__(
             "kubernetes:core/v1:ReplicationControllerList",

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuota.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuota.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ResourceQuota(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class ResourceQuota(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ResourceQuota, self).__init__(
             "kubernetes:core/v1:ResourceQuota",

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ResourceQuotaList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ResourceQuotaList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ResourceQuotaList, self).__init__(
             "kubernetes:core/v1:ResourceQuotaList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Secret.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Secret.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Secret(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Secret(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['stringData'] = string_data
         __props__['type'] = type
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Secret, self).__init__(
             "kubernetes:core/v1:Secret",

--- a/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class SecretList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class SecretList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(SecretList, self).__init__(
             "kubernetes:core/v1:SecretList",

--- a/sdk/python/pulumi_kubernetes/core/v1/Service.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Service.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Service(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Service(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Service, self).__init__(
             "kubernetes:core/v1:Service",

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccount.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccount.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ServiceAccount(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class ServiceAccount(pulumi.CustomResource):
         __props__['imagePullSecrets'] = image_pull_secrets
         __props__['metadata'] = metadata
         __props__['secrets'] = secrets
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ServiceAccount, self).__init__(
             "kubernetes:core/v1:ServiceAccount",

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ServiceAccountList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ServiceAccountList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ServiceAccountList, self).__init__(
             "kubernetes:core/v1:ServiceAccountList",

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ServiceList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ServiceList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ServiceList, self).__init__(
             "kubernetes:core/v1:ServiceList",

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Event(pulumi.CustomResource):
@@ -41,6 +41,11 @@ class Event(pulumi.CustomResource):
         __props__['reportingInstance'] = reporting_instance
         __props__['series'] = series
         __props__['type'] = type
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Event, self).__init__(
             "kubernetes:events.k8s.io/v1beta1:Event",

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class EventList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class EventList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(EventList, self).__init__(
             "kubernetes:events.k8s.io/v1beta1:EventList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSet(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DaemonSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSet, self).__init__(
             "kubernetes:extensions/v1beta1:DaemonSet",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DaemonSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DaemonSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DaemonSetList, self).__init__(
             "kubernetes:extensions/v1beta1:DaemonSetList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Deployment(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Deployment(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Deployment, self).__init__(
             "kubernetes:extensions/v1beta1:Deployment",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class DeploymentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class DeploymentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(DeploymentList, self).__init__(
             "kubernetes:extensions/v1beta1:DeploymentList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Ingress(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class Ingress(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Ingress, self).__init__(
             "kubernetes:extensions/v1beta1:Ingress",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class IngressList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class IngressList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(IngressList, self).__init__(
             "kubernetes:extensions/v1beta1:IngressList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NetworkPolicy(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class NetworkPolicy(pulumi.CustomResource):
         __props__['kind'] = 'NetworkPolicy'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NetworkPolicy, self).__init__(
             "kubernetes:extensions/v1beta1:NetworkPolicy",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NetworkPolicyList(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class NetworkPolicyList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NetworkPolicyList, self).__init__(
             "kubernetes:extensions/v1beta1:NetworkPolicyList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodSecurityPolicy(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodSecurityPolicy(pulumi.CustomResource):
         __props__['kind'] = 'PodSecurityPolicy'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodSecurityPolicy, self).__init__(
             "kubernetes:extensions/v1beta1:PodSecurityPolicy",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodSecurityPolicyList(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class PodSecurityPolicyList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodSecurityPolicyList, self).__init__(
             "kubernetes:extensions/v1beta1:PodSecurityPolicyList",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSet(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class ReplicaSet(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSet, self).__init__(
             "kubernetes:extensions/v1beta1:ReplicaSet",

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ReplicaSetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ReplicaSetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ReplicaSetList, self).__init__(
             "kubernetes:extensions/v1beta1:ReplicaSetList",

--- a/sdk/python/pulumi_kubernetes/meta/v1/Status.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/Status.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Status(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class Status(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['reason'] = reason
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Status, self).__init__(
             "kubernetes:core/v1:Status",

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NetworkPolicy(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class NetworkPolicy(pulumi.CustomResource):
         __props__['kind'] = 'NetworkPolicy'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NetworkPolicy, self).__init__(
             "kubernetes:networking.k8s.io/v1:NetworkPolicy",

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class NetworkPolicyList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class NetworkPolicyList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(NetworkPolicyList, self).__init__(
             "kubernetes:networking.k8s.io/v1:NetworkPolicyList",

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Ingress(pulumi.CustomResource):
@@ -28,6 +28,11 @@ class Ingress(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Ingress, self).__init__(
             "kubernetes:networking.k8s.io/v1beta1:Ingress",

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class IngressList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class IngressList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(IngressList, self).__init__(
             "kubernetes:networking.k8s.io/v1beta1:IngressList",

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RuntimeClass(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class RuntimeClass(pulumi.CustomResource):
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RuntimeClass, self).__init__(
             "kubernetes:node.k8s.io/v1alpha1:RuntimeClass",

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassList.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RuntimeClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RuntimeClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RuntimeClassList, self).__init__(
             "kubernetes:node.k8s.io/v1alpha1:RuntimeClassList",

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RuntimeClass(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class RuntimeClass(pulumi.CustomResource):
             raise TypeError('Missing required property handler')
         __props__['handler'] = handler
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RuntimeClass, self).__init__(
             "kubernetes:node.k8s.io/v1beta1:RuntimeClass",

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassList.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RuntimeClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RuntimeClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RuntimeClassList, self).__init__(
             "kubernetes:node.k8s.io/v1beta1:RuntimeClassList",

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudget.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudget.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodDisruptionBudget(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodDisruptionBudget(pulumi.CustomResource):
         __props__['metadata'] = metadata
         __props__['spec'] = spec
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodDisruptionBudget, self).__init__(
             "kubernetes:policy/v1beta1:PodDisruptionBudget",

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodDisruptionBudgetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodDisruptionBudgetList, self).__init__(
             "kubernetes:policy/v1beta1:PodDisruptionBudgetList",

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodSecurityPolicy(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class PodSecurityPolicy(pulumi.CustomResource):
         __props__['kind'] = 'PodSecurityPolicy'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodSecurityPolicy, self).__init__(
             "kubernetes:policy/v1beta1:PodSecurityPolicy",

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodSecurityPolicyList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodSecurityPolicyList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodSecurityPolicyList, self).__init__(
             "kubernetes:policy/v1beta1:PodSecurityPolicyList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRole(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRole(pulumi.CustomResource):
         __props__['aggregationRule'] = aggregation_rule
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRole, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBinding(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class ClusterRoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Role(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Role(pulumi.CustomResource):
         __props__['kind'] = 'Role'
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Role, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:Role",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBinding(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class RoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:RoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1:RoleList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRole(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRole(pulumi.CustomResource):
         __props__['aggregationRule'] = aggregation_rule
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRole, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBinding(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class ClusterRoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Role(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Role(pulumi.CustomResource):
         __props__['kind'] = 'Role'
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Role, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBinding(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class RoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRole(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRole(pulumi.CustomResource):
         __props__['aggregationRule'] = aggregation_rule
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRole, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBinding(pulumi.CustomResource):
@@ -29,6 +29,11 @@ class ClusterRoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class ClusterRoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class ClusterRoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(ClusterRoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class Role(pulumi.CustomResource):
@@ -26,6 +26,11 @@ class Role(pulumi.CustomResource):
         __props__['kind'] = 'Role'
         __props__['metadata'] = metadata
         __props__['rules'] = rules
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(Role, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:Role",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBinding(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class RoleBinding(pulumi.CustomResource):
         __props__['roleRef'] = role_ref
         __props__['metadata'] = metadata
         __props__['subjects'] = subjects
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBinding, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleBindingList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleBindingList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleBindingList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBindingList",

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class RoleList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class RoleList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(RoleList, self).__init__(
             "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleList",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClass(pulumi.CustomResource):
@@ -30,6 +30,11 @@ class PriorityClass(pulumi.CustomResource):
         __props__['description'] = description
         __props__['globalDefault'] = global_default
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClass, self).__init__(
             "kubernetes:scheduling.k8s.io/v1:PriorityClass",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PriorityClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClassList, self).__init__(
             "kubernetes:scheduling.k8s.io/v1:PriorityClassList",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClass(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class PriorityClass(pulumi.CustomResource):
         __props__['description'] = description
         __props__['globalDefault'] = global_default
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClass, self).__init__(
             "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PriorityClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClassList, self).__init__(
             "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClassList",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClass(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class PriorityClass(pulumi.CustomResource):
         __props__['description'] = description
         __props__['globalDefault'] = global_default
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClass, self).__init__(
             "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass",

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PriorityClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PriorityClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PriorityClassList, self).__init__(
             "kubernetes:scheduling.k8s.io/v1beta1:PriorityClassList",

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPreset.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPreset.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodPreset(pulumi.CustomResource):
@@ -25,6 +25,11 @@ class PodPreset(pulumi.CustomResource):
         __props__['kind'] = 'PodPreset'
         __props__['metadata'] = metadata
         __props__['spec'] = spec
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodPreset, self).__init__(
             "kubernetes:settings.k8s.io/v1alpha1:PodPreset",

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class PodPresetList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class PodPresetList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(PodPresetList, self).__init__(
             "kubernetes:settings.k8s.io/v1alpha1:PodPresetList",

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StorageClass(pulumi.CustomResource):
@@ -37,6 +37,11 @@ class StorageClass(pulumi.CustomResource):
         __props__['parameters'] = parameters
         __props__['reclaimPolicy'] = reclaim_policy
         __props__['volumeBindingMode'] = volume_binding_mode
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StorageClass, self).__init__(
             "kubernetes:storage.k8s.io/v1:StorageClass",

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StorageClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class StorageClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StorageClassList, self).__init__(
             "kubernetes:storage.k8s.io/v1:StorageClassList",

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachment(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class VolumeAttachment(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachment, self).__init__(
             "kubernetes:storage.k8s.io/v1:VolumeAttachment",

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachmentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class VolumeAttachmentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachmentList, self).__init__(
             "kubernetes:storage.k8s.io/v1:VolumeAttachmentList",

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachment(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class VolumeAttachment(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachment, self).__init__(
             "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment",

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachmentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class VolumeAttachmentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachmentList, self).__init__(
             "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachmentList",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriver.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriver.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CSIDriver(pulumi.CustomResource):
@@ -33,6 +33,11 @@ class CSIDriver(pulumi.CustomResource):
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CSIDriver, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:CSIDriver",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CSIDriverList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class CSIDriverList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CSIDriverList, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:CSIDriverList",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CSINode(pulumi.CustomResource):
@@ -33,6 +33,11 @@ class CSINode(pulumi.CustomResource):
             raise TypeError('Missing required property spec')
         __props__['spec'] = spec
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CSINode, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:CSINode",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodeList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodeList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class CSINodeList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class CSINodeList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(CSINodeList, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:CSINodeList",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StorageClass(pulumi.CustomResource):
@@ -37,6 +37,11 @@ class StorageClass(pulumi.CustomResource):
         __props__['parameters'] = parameters
         __props__['reclaimPolicy'] = reclaim_policy
         __props__['volumeBindingMode'] = volume_binding_mode
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StorageClass, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:StorageClass",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class StorageClassList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class StorageClassList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(StorageClassList, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:StorageClassList",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachment(pulumi.CustomResource):
@@ -31,6 +31,11 @@ class VolumeAttachment(pulumi.CustomResource):
         __props__['spec'] = spec
         __props__['metadata'] = metadata
         __props__['status'] = status
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachment, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment",

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
@@ -4,7 +4,7 @@
 import pulumi
 import pulumi.runtime
 
-from ... import tables
+from ... import tables, version
 
 
 class VolumeAttachmentList(pulumi.CustomResource):
@@ -27,6 +27,11 @@ class VolumeAttachmentList(pulumi.CustomResource):
             raise TypeError('Missing required property items')
         __props__['items'] = items
         __props__['metadata'] = metadata
+
+        if __opts__ is None:
+            __opts__ = pulumi.ResourceOptions()
+        if __opts__.version is None:
+            __opts__.version = version.get_version()
 
         super(VolumeAttachmentList, self).__init__(
             "kubernetes:storage.k8s.io/v1beta1:VolumeAttachmentList",

--- a/sdk/python/pulumi_kubernetes/version.py
+++ b/sdk/python/pulumi_kubernetes/version.py
@@ -1,0 +1,30 @@
+import pkg_resources
+
+from semver import VersionInfo as SemverVersion
+from parver import Version as PEP440Version
+
+def get_version():
+    """
+    Returns the Semver-formatted version of the package containing this file.
+    """
+
+    # __name__ is set to the fully-qualified name of the current module, In our case, it will be
+    # <some module>.utilities. <some module> is the module we want to query the version for.
+    root_package, *rest = __name__.split('.')
+    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
+    # for the currently installed version of the root package (i.e. us) and get its version.
+    # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
+    # to receive a valid semver string when receiving requests from the language host, so it's our
+    # responsibility as the library to convert our own PEP440 version into a valid semver string.
+    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version = PEP440Version.parse(pep440_version_string)
+    (major, minor, patch) = pep440_version.release
+    prerelease = None
+    if pep440_version.dev is not None:
+        prerelease = f"dev.{pep440_version.dev}"
+    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
+    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
+    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
+    # their own semver string.
+    semver_version = SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
+    return str(semver_version)

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -30,8 +30,10 @@ setup(name='pulumi_kubernetes',
       license='Apache-2.0',
       packages=find_packages(),
       install_requires=[
-          'pulumi>=0.17.1,<0.18.0',
+          'pulumi>=0.17.8,<0.18.0',
           'requests>=2.21.0,<2.22.0',
           'pyyaml>=4.2b1,<4.3',
+          'semver>=2.8.1',
+          'parver>=0.2.1',
       ],
       zip_safe=False)


### PR DESCRIPTION
Kubernetes equivalent of https://github.com/pulumi/pulumi-terraform/pull/378 and https://github.com/pulumi/pulumi-terraform/pull/369, consuming https://github.com/pulumi/pulumi/pull/2656 and completing https://github.com/pulumi/pulumi/issues/2389.

This PR is basically identical to the `tfgen` PR and the strategy is the same; when running, resources will get the version of the package that defines them and pass it to the engine so that the engine knows exactly which version to load.

I'm relying on CI a bit to smoke-test this, but I'll do some additional smoke-testing on my machine.