### PR TITLE
Fix panics during preview when `metadata` is a computed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.23.2 (Unreleased)
 
+### Improvements
+
+- Fix an issue where the provider would panic during preview if and object's
+  `metadata` property ended up being computed from one or more unknown
+  values. (Fixes [#559](https://github.com/pulumi/pulumi-kubernetes/issues/559)).
+
 ## 0.23.1 (May 10, 2019)
 
 ### Supported Kubernetes versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ## 0.23.2 (Unreleased)
 
+### Major changes
+
+-   None
+
 ### Improvements
 
-- Fix an issue where the provider would panic during preview if and object's
-  `metadata` property ended up being computed from one or more unknown
-  values. (Fixes [#559](https://github.com/pulumi/pulumi-kubernetes/issues/559)).
+-   None
+
+### Bug fixes
+
+-   Fix panics during preview when `metadata` is a computed value (https://github.com/pulumi/pulumi-kubernetes/pull/572)
 
 ## 0.23.1 (May 10, 2019)
 

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -49,8 +49,8 @@ func IsInternalAnnotation(key string) bool {
 // SetAnnotation sets the specified key, value annotation on the provided Unstructured object.
 func SetAnnotation(obj *unstructured.Unstructured, key, value string) {
 	// Note: Cannot use obj.GetAnnotations() here because it doesn't properly handle computed values from preview.
-	// during preview, our strategy for if metdata or annotations end up being computed values, is to just not
-	// apply an annotiation (since there's no way to insert data into the computed object)
+	// During preview, don't set annotations if the metadata or annotation contains a computed value since there's
+	// no way to insert data into the computed object.
 	metadataRaw := obj.Object["metadata"]
 	if isComputedValue(metadataRaw) {
 		return

--- a/pkg/metadata/annotations_test.go
+++ b/pkg/metadata/annotations_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSetAnnotationMetadataComputed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": resource.Computed{Element: resource.NewObjectProperty(nil)},
+	}}
+
+	// Since metadata is a computed property, we can't really set an annotation of the object, but we should not fail
+	// as the metadata property of an object could be computed during previews.
+	SetAnnotation(obj, "foo", "bar")
+}
+
+func TestSetAnnotationMetadataAnnotationsComputed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": resource.Computed{Element: resource.NewObjectProperty(nil)},
+		},
+	}}
+
+	// Since metadata is a computed property, we can't really set an annotation of the object, but we should not fail
+	// as the metadata property of an object could be computed during previews.
+	SetAnnotation(obj, "foo", "bar")
+}

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -21,8 +21,8 @@ import (
 // SetLabel sets the specified key/value pair as a label on the provided Unstructured object.
 func SetLabel(obj *unstructured.Unstructured, key, value string) {
 	// Note: Cannot use obj.GetLabels() here because it doesn't properly handle computed values from preview.
-	// during preview, our strategy for if metdata or annotations end up being computed values, is to just not
-	// apply an annotiation (since there's no way to insert data into the computed object)
+	// During preview, don't set labels if the metadata or label contains a computed value since there's
+	// no way to insert data into the computed object.
 	metadataRaw := obj.Object["metadata"]
 	if isComputedValue(metadataRaw) {
 		return

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -21,9 +21,17 @@ import (
 // SetLabel sets the specified key/value pair as a label on the provided Unstructured object.
 func SetLabel(obj *unstructured.Unstructured, key, value string) {
 	// Note: Cannot use obj.GetLabels() here because it doesn't properly handle computed values from preview.
+	// during preview, our strategy for if metdata or annotations end up being computed values, is to just not
+	// apply an annotiation (since there's no way to insert data into the computed object)
 	metadataRaw := obj.Object["metadata"]
+	if isComputedValue(metadataRaw) {
+		return
+	}
 	metadata := metadataRaw.(map[string]interface{})
 	labelsRaw, ok := metadata["labels"]
+	if isComputedValue(labelsRaw) {
+		return
+	}
 	var labels map[string]interface{}
 	if !ok {
 		labels = make(map[string]interface{})

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSetLabelMetadataComputed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": resource.Computed{Element: resource.NewObjectProperty(nil)},
+	}}
+
+	// Since metadata is a computed property, we can't really set an annotation of the object, but we should not fail
+	// as the metadata property of an object could be computed during previews.
+	SetLabel(obj, "foo", "bar")
+}
+
+func TestSetLabelMetadataLabelsComputed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": resource.Computed{Element: resource.NewObjectProperty(nil)},
+		},
+	}}
+
+	// Since metadata is a computed property, we can't really set an annotation of the object, but we should not fail
+	// as the metadata property of an object could be computed during previews.
+	SetLabel(obj, "foo", "bar")
+}


### PR DESCRIPTION
During preview, an object's metadata bag may be computed (or be known
but contain values which are computed). This could happen, for
example, by using `apply` to take an output property from a yet to be
created resource and use it to build part of an object's metadata,
like we saw in #559.

In these cases, we incorrectly panic while attempting to extract out
the metadata.lables or metadata.annotations members of the metadata
object, when trying to set an annotation or label.

To fix this, we now treat requests to set annotations or labels as
no-ops if the metadata object is computed (or the label or annotation
values inside the metadata object are computed). This allows preview
to continue, as expected. During a real update, we will not have
computed values and so we will be able to correctly set the labels as
we expected.

Fixes #559