### PR TITLE
Implement CheckConfig/DiffConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
 
 -   Enable configuring `ResourceOptions` via `transformations` (https://github.com/pulumi/pulumi-kubernetes/pull/575).
+-   Implement CheckConfig/DiffConfig (https://github.com/pulumi/pulumi-kubernetes/pull/577).
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Improvements
 
 -   Enable configuring `ResourceOptions` via `transformations` (https://github.com/pulumi/pulumi-kubernetes/pull/575).
--   Implement CheckConfig/DiffConfig (https://github.com/pulumi/pulumi-kubernetes/pull/577).
+-   Changing k8s cluster config now correctly causes dependent resources to be replaced (https://github.com/pulumi/pulumi-kubernetes/pull/577).
 
 ### Bug fixes
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0
 	github.com/gophercloud/gophercloud v0.0.0-20190418141522-bb98932a7b3a // indirect
-	github.com/grpc/grpc-go v0.0.0-00010101000000-000000000000
+	github.com/grpc/grpc-go v0.0.0-00010101000000-000000000000 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3
 	github.com/json-iterator/go v1.1.6 // indirect

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -184,7 +184,7 @@ func (k *kubeProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffReques
 	if !reflect.DeepEqual(oldActiveCluster, activeCluster) {
 		replaces = diffs
 	}
-	glog.V(7).Infof("%s: diffs %v / replaces %v\n", label, diffs, replaces)
+	glog.V(7).Infof("%s: diffs %v / replaces %v", label, diffs, replaces)
 
 	if len(diffs) > 0 || len(replaces) > 0 {
 		return &pulumirpc.DiffResponse{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -136,6 +136,16 @@ func (k *kubeProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffReques
 		return nil, err
 	}
 
+	// We can't tell for sure if a computed value has changed, so we make the conservative choice
+	// and force a replacement.
+	if news["kubeconfig"].IsComputed() {
+		return &pulumirpc.DiffResponse{
+			Changes:  pulumirpc.DiffResponse_DIFF_SOME,
+			Diffs:    []string{"kubeconfig"},
+			Replaces: []string{"kubeconfig"},
+		}, nil
+	}
+
 	oldConfig, err := parseKubeconfigString(strings.Trim(olds["kubeconfig"].String(), "{}"))
 	if err != nil {
 		return nil, err

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/clientcmd"
+	clientapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func hasComputedValue(obj *unstructured.Unstructured) bool {
@@ -60,4 +62,45 @@ func FqName(namespace, name string) string {
 		return name
 	}
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+// --------------------------------------------------------------------------
+// Kubeconfig helpers.
+// --------------------------------------------------------------------------
+
+// parseKubeconfigPropertyValue takes a PropertyValue that possibly contains a raw kubeconfig
+// (YAML or JSON) string and attempts to unmarshal it into a Config struct. If the property value
+// is empty, an empty Config is returned.
+func parseKubeconfigPropertyValue(kubeconfig resource.PropertyValue) (*clientapi.Config, error) {
+	if kubeconfig.IsNull() {
+		return &clientapi.Config{}, nil
+	}
+
+	config, err := clientcmd.Load([]byte(kubeconfig.StringValue()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %v", err)
+	}
+
+	return config, nil
+}
+
+// getActiveClusterFromConfig gets the current cluster from a kubeconfig, accounting for provider overrides.
+func getActiveClusterFromConfig(config *clientapi.Config, overrides resource.PropertyMap) *clientapi.Cluster {
+	if len(config.Clusters) == 0 {
+		return &clientapi.Cluster{}
+	}
+
+	currentContext := config.CurrentContext
+	if val := overrides["context"]; !val.IsNull() {
+		currentContext = val.StringValue()
+	}
+
+	activeClusterName := config.Contexts[currentContext].Cluster
+
+	activeCluster := config.Clusters[activeClusterName]
+	if val := overrides["cluster"]; !val.IsNull() {
+		activeCluster = config.Clusters[val.StringValue()]
+	}
+
+	return activeCluster
 }


### PR DESCRIPTION
This change improves Pulumi's ability to correctly replace dependent
resources if the cluster they are deployed to changes. As documented
in the DiffConfig comments, this method is not foolproof, but should work
in the majority of cases.

Fixes https://github.com/pulumi/pulumi-eks/issues/107

Note: This change depends on https://github.com/pulumi/pulumi/pull/2793, and won't do anything useful if the CLI does not include that change.