### PR TITLE
Implement `kubectlReplace` Invoke call

### DIFF
--- a/tests/integration/kubectl-replace/kubectl_replace_test.go
+++ b/tests/integration/kubectl-replace/kubectl_replace_test.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/openapi"
+	"github.com/pulumi/pulumi-kubernetes/tests"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubectlReplace(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           "step1",
+		Dependencies:  []string{"@pulumi/kubernetes"},
+		Quick:         true,
+		ExpectFailure: true,
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      "step2",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[3]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					provRes := stackInfo.Deployment.Resources[2]
+					assert.True(t, providers.IsProviderType(provRes.URN.Type()))
+
+					//
+					// Assert ConfigMap was created.
+					//
+
+					cm := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, "game-config", string(cm.URN.Name()))
+				},
+			},
+			{
+				Dir:      "step3",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
+
+					tests.SortResourcesByURN(stackInfo)
+
+					stackRes := stackInfo.Deployment.Resources[3]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+
+					provRes := stackInfo.Deployment.Resources[2]
+					assert.True(t, providers.IsProviderType(provRes.URN.Type()))
+
+					//
+					// Assert ConfigMap was replaced.
+					//
+
+					data, _ := openapi.Pluck(stackInfo.Outputs, "replaced", "data", "foo")
+					assert.Equal(t, "bar", data)
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/kubectl-replace/step1/Pulumi.yaml
+++ b/tests/integration/kubectl-replace/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: autonaming-test
+description: A program that tests partial provider failure.
+runtime: nodejs

--- a/tests/integration/kubectl-replace/step1/index.ts
+++ b/tests/integration/kubectl-replace/step1/index.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+//
+// Attempt to replace a resource that doesn't exist. Should error. We'll try to replace this again
+// later, after we make sure to create it.
+//
+
+pulumi.runtime.invoke("kubernetes:kubernetes:kubectlReplace", {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+        name: "game-config",
+    },
+    data: {
+        "game.properties":
+            "enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.passphrase=UUDDLRLRBABAS\nsecret.code.allowed=true\nsecret.code.lives=30\n",
+        "ui.properties":
+            "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\nhow.nice.to.look=fairlyNice",
+    },
+});

--- a/tests/integration/kubectl-replace/step1/package.json
+++ b/tests/integration/kubectl-replace/step1/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/kubectl-replace/step1/tsconfig.json
+++ b/tests/integration/kubectl-replace/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/kubectl-replace/step2/index.ts
+++ b/tests/integration/kubectl-replace/step2/index.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+//
+// Now that replacement failed, create the resource so we can replace it in the next step.
+//
+
+const cm = new k8s.core.v1.ConfigMap("game-config", {
+    metadata: {
+        name: "game-config",
+        namespace: namespace.metadata.name,
+    },
+    data: {
+        "game.properties":
+            "enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.passphrase=UUDDLRLRBABAS\nsecret.code.allowed=true\nsecret.code.lives=30\n",
+        "ui.properties":
+            "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\nhow.nice.to.look=fairlyNice",
+    },
+});

--- a/tests/integration/kubectl-replace/step3/index.ts
+++ b/tests/integration/kubectl-replace/step3/index.ts
@@ -1,0 +1,51 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// No changes to Kubernetes resources.
+//
+
+const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+const cm = new k8s.core.v1.ConfigMap("game-config", {
+    metadata: {
+        name: "game-config",
+        namespace: namespace.metadata.name,
+    },
+    data: {
+        "game.properties":
+            "enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.passphrase=UUDDLRLRBABAS\nsecret.code.allowed=true\nsecret.code.lives=30\n",
+        "ui.properties":
+            "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\nhow.nice.to.look=fairlyNice",
+    },
+});
+
+//
+// Now run `kubectl replace` again. This time, it should work.
+//
+
+export const replaced = pulumi.all([namespace.metadata.name, cm.metadata.name]).apply(([ns]) =>
+    pulumi.runtime.invoke("kubernetes:kubernetes:kubectlReplace", {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: {
+            name: "game-config",
+            namespace: ns,
+        },
+        data: { foo: "bar" },
+    }),
+);


### PR DESCRIPTION
Fixes #509.

The Kubernetes provider will, with this commit, expose an `Invoke`
function, `kubernetes:kubernetes:kubectlReplace`. This function "waits"
for the equivalent of `kubectl replace` to run, which is to say, it
returns immediately.

This is primarily useful for cases when a cluster boots up with some
number of resources, and upon creation, we need to `replace` one of
those resources.

This API is purposefully not documented to discourage use.