### PR TITLE
Fix the query test

### DIFF
--- a/tests/integration/query/step1/Pulumi.yaml
+++ b/tests/integration/query/step1/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: autonaming-test
-description: A program that tests partial provider failure.
+name: query-test
+description: A program that tests the query API.
 runtime: nodejs

--- a/tests/integration/query/step1/index.ts
+++ b/tests/integration/query/step1/index.ts
@@ -21,7 +21,7 @@ import * as k8s from "@pulumi/kubernetes";
 
 const namespace = new k8s.core.v1.Namespace("test-namespace");
 
-const pod = new k8s.core.v1.Pod("query-test", {
+new k8s.core.v1.Pod("query-test", {
     metadata: {
         namespace: namespace.metadata.name,
     },

--- a/tests/integration/query/step2/index.ts
+++ b/tests/integration/query/step2/index.ts
@@ -28,7 +28,7 @@ pulumi.runtime
         // namespace resources.
         //
         if (pods.length !== 1) {
-            throw Error("Expected 1 pod");
+            throw Error("Expected 1 pod, got " + pods.length);
         }
 
         //
@@ -36,6 +36,6 @@ pulumi.runtime
         // access its fields.
         //
         if (pods[0].kind === "Pod") {
-            throw Error("Expected Pods to have `.kind == 'Pod'`");
+            throw Error("Expected Pods to have `.kind == 'Pod'`, got " + pods[0].kind);
         }
     });

--- a/tests/integration/query/step2/index.ts
+++ b/tests/integration/query/step2/index.ts
@@ -35,7 +35,7 @@ pulumi.runtime
         // Test that query is well-typed. `pod[0]` should be a Pod, and the compiler should let us
         // access its fields.
         //
-        if (pods[0].kind === "Pod") {
+        if (pods[0].kind == "Pod") {
             throw Error("Expected Pods to have `.kind == 'Pod'`, got " + pods[0].kind);
         }
     });

--- a/tests/integration/query/step2/index.ts
+++ b/tests/integration/query/step2/index.ts
@@ -35,7 +35,7 @@ pulumi.runtime
         // Test that query is well-typed. `pod[0]` should be a Pod, and the compiler should let us
         // access its fields.
         //
-        if (pods[0].kind == "Pod") {
-            throw Error("Expected Pods to have `.kind == 'Pod'`, got " + pods[0].kind);
+        if (pods[0].kind !== "Pod") {
+            throw Error("Expected Pods to have `.kind === 'Pod'`, got " + pods[0].kind);
         }
     });


### PR DESCRIPTION
Fixes #592 

Note: This turned out to be several different issues causing test failures.
1. Query changes require a node version >= 7.0.0 -- Pulumi docs hadn't been updated to reflect that, and I was using an older LTS version locally.
1. Test conditional was inverted, so was failing erroneously even though the related query was working.
1. Package versions were out of sync, so I pinned the dependency as part of #591 