### PR TITLE
Export input,output types for nodejs package

### DIFF
--- a/pkg/gen/nodejs-templates/providerIndex.ts.mustache
+++ b/pkg/gen/nodejs-templates/providerIndex.ts.mustache
@@ -3,8 +3,10 @@
 
 export * from "./provider";
 import * as helm from "./helm/index";
+import * as types from "./types/index";
 import * as yaml from "./yaml/index";
-export { helm, yaml };
+
+export { helm, types, yaml };
 
 // Import groups
 {{#Groups}}

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -3,8 +3,10 @@
 
 export * from "./provider";
 import * as helm from "./helm/index";
+import * as types from "./types/index";
 import * as yaml from "./yaml/index";
-export { helm, yaml };
+
+export { helm, types, yaml };
 
 // Import groups
 import * as admissionregistration from "./admissionregistration/index";

--- a/sdk/nodejs/types/index.ts
+++ b/sdk/nodejs/types/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Export members:
+import * as input from "./input";
+import * as output from "./output";
+
+export { input, output };
+


### PR DESCRIPTION
@lukehoban @hausdorff @metral Does this look like what you were expecting?

Fixes #336 

```ts
import * as k8s from "@pulumi/kubernetes";

const appLabels = {app: "nginx"};
const deploymentSpec: k8s.types.input.apps.v1.DeploymentSpec = {
    selector: {matchLabels: appLabels},
    replicas: 1,
    template: {
        metadata: {labels: appLabels},
        spec: {containers: [{name: "nginx", image: "nginx", ports: [{containerPort: 80}]}]}
    }
};
new k8s.apps.v1.Deployment("foo", {
    spec: deploymentSpec
});
```