### PR TITLE
Add Job awaiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Improvements
 
+-   Add logic to check for Job readiness. (https://github.com/pulumi/pulumi-kubernetes/pull/633).
 -   Automatically mark Secret data and stringData as secret. (https://github.com/pulumi/pulumi-kubernetes/pull/803).
 -   Provide detailed error for removed apiVersions. (https://github.com/pulumi/pulumi-kubernetes/pull/809).
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -99,6 +99,10 @@ func (r ResourceId) String() string {
 	return r.Name
 }
 
+func (r ResourceId) GVKString() string {
+	return fmt.Sprintf(`'[%s] %s'`, r.GVK, r.String())
+}
+
 func ResourceIdFromUnstructured(uns *unstructured.Unstructured) ResourceId {
 	return ResourceId{
 		Namespace:  clients.NamespaceOrDefault(uns.GetNamespace()),

--- a/pkg/await/batch_job.go
+++ b/pkg/await/batch_job.go
@@ -58,7 +58,7 @@ import (
 //   3. A timeout channel, which fires after some minutes.
 //   4. A cancellation channel, with which the user can signal cancellation (e.g., using SIGINT).
 //
-// The `deploymentInitAwaiter` will synchronously process events from the union of all these channels.
+// The `jobInitAwaiter` will synchronously process events from the union of all these channels.
 // Any time the success conditions described above are reached, we will terminate the awaiter.
 //
 // The opportunity to display intermediate results will typically appear after a container in the

--- a/pkg/await/batch_job.go
+++ b/pkg/await/batch_job.go
@@ -1,0 +1,211 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package await
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-kubernetes/pkg/await/states"
+	"github.com/pulumi/pulumi-kubernetes/pkg/clients"
+	"github.com/pulumi/pulumi-kubernetes/pkg/kinds"
+	"github.com/pulumi/pulumi-kubernetes/pkg/logging"
+	"github.com/pulumi/pulumi-kubernetes/pkg/metadata"
+	"github.com/pulumi/pulumi/pkg/diag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ------------------------------------------------------------------------------------------------
+
+// Await logic for batch/v1/Job.
+//
+// The goal of this code is to provide a fine-grained account of the status of a Kubernetes
+// Job as it runs. The idea is that if something goes wrong early, we can cancel the operation or
+// alert the user that something is going wrong.
+//
+// A Job is a construct that allows users to run a workload as a Pod that terminates with a
+// success or failure.
+//
+// A Job is considered "ready" if the following conditions are true:
+//
+//   1. `.status.startTime` is set, which indicates that the Job has started running.
+//   2. `.status.conditions` has a status with `type` equal to `Complete`, and a
+//   	`status` set to `True`.
+//   3. `.status.conditions` do not have a status with `type` equal to `Failed`, with a
+//   	`status` equal to `True`. If this condition is set, we should fail the Job immediately.
+//
+// The event loop depends on the following channels:
+//
+//   1. The Job channel, to which the Kubernetes API server will proactively push every change
+//      (additions, modifications, deletions) to any Job it knows about.
+//   2. The PodAggregator channel, which monitors Pods related to the Job, and reports any
+//		warnings/errors produced by those Pods.
+//   3. A timeout channel, which fires after some minutes.
+//   4. A cancellation channel, with which the user can signal cancellation (e.g., using SIGINT).
+//
+// The `deploymentInitAwaiter` will synchronously process events from the union of all these channels.
+// Any time the success conditions described above are reached, we will terminate the awaiter.
+//
+// The opportunity to display intermediate results will typically appear after a container in the
+// Pod fails, (e.g., volume fails to mount, image fails to pull, exited with code 1, etc.).
+//
+//
+// x-refs:
+//   * https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+// --------------------------------------------------------------------------
+
+const (
+	DefaultJobTimeoutMins = 10
+)
+
+type jobInitAwaiter struct {
+	job      *unstructured.Unstructured
+	config   createAwaitConfig
+	state    *states.StateChecker
+	errors   logging.TimeOrderedLogSet
+	resource ResourceId
+}
+
+func makeJobInitAwaiter(c createAwaitConfig) *jobInitAwaiter {
+	return &jobInitAwaiter{
+		config:   c,
+		job:      c.currentOutputs,
+		state:    states.NewJobChecker(),
+		resource: ResourceIdFromUnstructured(c.currentOutputs),
+	}
+}
+
+func (jia *jobInitAwaiter) Await() error {
+	jobClient, err := clients.ResourceClient(kinds.Job, jia.config.currentInputs.GetNamespace(), jia.config.clientSet)
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not make client to watch Job %q",
+			jia.config.currentInputs.GetName())
+	}
+	jobWatcher, err := jobClient.Watch(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Couldn't set up watch for Job object %q",
+			jia.config.currentInputs.GetName())
+	}
+	defer jobWatcher.Stop()
+
+	podAggregator, err := NewPodAggregator(ResourceIdFromUnstructured(jia.job), jia.config.clientSet)
+	if err != nil {
+		return errors.Wrapf(err, "Could not create PodAggregator for %s", jia.resource.GVKString())
+	}
+	defer podAggregator.Stop()
+
+	timeout := metadata.TimeoutDuration(jia.config.timeout, jia.config.currentInputs, DefaultJobTimeoutMins*60)
+	for {
+		if jia.state.Ready() {
+			return nil
+		}
+
+		// Else, wait for updates.
+		select {
+		case <-jia.config.ctx.Done():
+			return &cancellationError{
+				object:    jia.job,
+				subErrors: jia.errorMessages(),
+			}
+		case <-time.After(timeout):
+			return &timeoutError{
+				object:    jia.job,
+				subErrors: jia.errorMessages(),
+			}
+		case event := <-jobWatcher.ResultChan():
+			err := jia.processJobEvent(event)
+			if err != nil {
+				return err
+			}
+		case messages := <-podAggregator.ResultChan():
+			for _, message := range messages {
+				jia.errors.Add(message)
+				jia.config.logMessage(message)
+			}
+		}
+	}
+}
+
+func (jia *jobInitAwaiter) Read() error {
+	jobClient, err := clients.ResourceClient(kinds.Job, jia.config.currentInputs.GetNamespace(), jia.config.clientSet)
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not make client to get Job %q",
+			jia.config.currentInputs.GetName())
+	}
+	// Get live version of Job.
+	job, err := jobClient.Get(jia.config.currentInputs.GetName(), metav1.GetOptions{})
+	if err != nil {
+		// IMPORTANT: Do not wrap this error! If this is a 404, the provider need to know so that it
+		// can mark the Pod as having been deleted.
+		return err
+	}
+
+	_ = jia.processJobEvent(watchAddedEvent(job))
+
+	// Check whether we've succeeded.
+	if jia.state.Ready() {
+		return nil
+	}
+
+	return &initializationError{
+		subErrors: jia.errorMessages(),
+		object: job,
+	}
+}
+
+func (jia *jobInitAwaiter) processJobEvent(event watch.Event) error {
+	job, err := clients.JobFromUnstructured(event.Object.(*unstructured.Unstructured))
+	if err != nil {
+		glog.V(3).Infof("Failed to unmarshal Job event: %v", err)
+		return nil
+	}
+
+	// Do nothing if this is not the job we're waiting for.
+	if job.GetName() != jia.config.currentInputs.GetName() {
+		return nil
+	}
+
+	messages := jia.state.Update(job)
+	for _, message := range messages.MessagesWithSeverity(diag.Warning, diag.Error) {
+		jia.errors.Add(message)
+	}
+	for _, message := range messages {
+		jia.config.logMessage(message)
+	}
+
+	if len(messages.Errors()) > 0 {
+		return &initializationError{
+			subErrors: jia.errorMessages(),
+			object:    jia.job,
+		}
+	}
+
+	return nil
+}
+
+func (jia *jobInitAwaiter) errorMessages() []string {
+	messages := make([]string, 0)
+	for _, message := range jia.errors.Messages {
+		messages = append(messages, message.S)
+	}
+
+	return messages
+}

--- a/pkg/await/deployment.go
+++ b/pkg/await/deployment.go
@@ -753,7 +753,8 @@ func (dia *deploymentInitAwaiter) aggregatePodErrors() logging.Messages {
 			glog.V(3).Infof("Failed to unmarshal Pod event: %v", err)
 			return nil
 		}
-		messages = append(messages, checker.Update(pod).Warnings()...)
+		m := checker.Update(pod)
+		messages = append(messages, m.MessagesWithSeverity(diag.Warning, diag.Error)...)
 	}
 
 	return messages

--- a/pkg/await/deployment_test.go
+++ b/pkg/await/deployment_test.go
@@ -512,7 +512,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				object: deploymentProgressing(inputNamespace, deploymentInputName, revision1),
 				subErrors: []string{
 					"Minimum number of live Pods was not attained",
-					`containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
+					`[Pod foo-4setj4y6-7cdf7ddc54-kvh2w]: containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
 				}},
 		},
 		{
@@ -538,7 +538,7 @@ func Test_Apps_Deployment(t *testing.T) {
 				object: deploymentProgressing(inputNamespace, deploymentInputName, revision2),
 				subErrors: []string{
 					"Minimum number of live Pods was not attained",
-					`containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
+					`[Pod foo-4setj4y6-7cdf7ddc54-kvh2w]: containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "sdkjlsdlkj"`,
 				}},
 		},
 		{

--- a/pkg/await/recordings/states/job/backoffLimit.json
+++ b/pkg/await/recordings/states/job/backoffLimit.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":1,\"template\":{\"spec\":{\"activeDeadlineSeconds\":10,\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl-fail\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+    },
+    "creationTimestamp": "2019-09-04T18:19:35Z",
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "foo",
+    "namespace": "default",
+    "resourceVersion": "1127282",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+    "uid": "8c668c31-cf40-11e9-8c3a-025000000001"
+  },
+  "spec": {
+    "backoffLimit": 1,
+    "completions": 1,
+    "parallelism": 1,
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "8c668c31-cf40-11e9-8c3a-025000000001"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "controller-uid": "8c668c31-cf40-11e9-8c3a-025000000001",
+          "job-name": "foo"
+        }
+      },
+      "spec": {
+        "activeDeadlineSeconds": 10,
+        "containers": [
+          {
+            "command": [
+              "perl",
+              "-Mbignum=bpi",
+              "-wle",
+              "print bpi(2000)"
+            ],
+            "image": "perl-fail",
+            "imagePullPolicy": "Always",
+            "name": "pi",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": "2019-09-04T18:19:55Z",
+        "lastTransitionTime": "2019-09-04T18:19:55Z",
+        "message": "Job has reached the specified backoff limit",
+        "reason": "BackoffLimitExceeded",
+        "status": "True",
+        "type": "Failed"
+      }
+    ],
+    "failed": 2,
+    "startTime": "2019-09-04T18:19:35Z"
+  }
+}

--- a/pkg/await/recordings/states/job/deadlineExceeded.json
+++ b/pkg/await/recordings/states/job/deadlineExceeded.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"activeDeadlineSeconds\":1,\"backoffLimit\":1,\"completions\":1,\"parallelism\":1,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+    },
+    "creationTimestamp": "2019-09-09T21:53:56Z",
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "foo",
+    "namespace": "default",
+    "resourceVersion": "1336251",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+    "uid": "525855e6-d34c-11e9-9aec-025000000001"
+  },
+  "spec": {
+    "activeDeadlineSeconds": 1,
+    "backoffLimit": 1,
+    "completions": 1,
+    "parallelism": 1,
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "525855e6-d34c-11e9-9aec-025000000001"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "controller-uid": "525855e6-d34c-11e9-9aec-025000000001",
+          "job-name": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "perl",
+              "-Mbignum=bpi",
+              "-wle",
+              "print bpi(2000)"
+            ],
+            "image": "perl",
+            "imagePullPolicy": "Always",
+            "name": "pi",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": "2019-09-09T21:53:57Z",
+        "lastTransitionTime": "2019-09-09T21:53:57Z",
+        "message": "Job was active longer than specified deadline",
+        "reason": "DeadlineExceeded",
+        "status": "True",
+        "type": "Failed"
+      }
+    ],
+    "failed": 1,
+    "startTime": "2019-09-09T21:53:56Z"
+  }
+}

--- a/pkg/await/recordings/states/job/initialized.json
+++ b/pkg/await/recordings/states/job/initialized.json
@@ -1,0 +1,61 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+    },
+    "creationTimestamp": "2019-07-11T19:30:43Z",
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "foo",
+    "namespace": "default",
+    "resourceVersion": "764676",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+    "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+  },
+  "spec": {
+    "backoffLimit": 4,
+    "completions": 1,
+    "parallelism": 1,
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+          "job-name": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "perl",
+              "-Mbignum=bpi",
+              "-wle",
+              "print bpi(2000)"
+            ],
+            "image": "perl",
+            "imagePullPolicy": "Always",
+            "name": "pi",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {}
+}

--- a/pkg/await/recordings/states/job/started.json
+++ b/pkg/await/recordings/states/job/started.json
@@ -1,0 +1,64 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+    },
+    "creationTimestamp": "2019-07-11T19:30:43Z",
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "foo",
+    "namespace": "default",
+    "resourceVersion": "764679",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+    "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+  },
+  "spec": {
+    "backoffLimit": 4,
+    "completions": 1,
+    "parallelism": 1,
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+          "job-name": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "perl",
+              "-Mbignum=bpi",
+              "-wle",
+              "print bpi(2000)"
+            ],
+            "image": "perl",
+            "imagePullPolicy": "Always",
+            "name": "pi",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {
+    "active": 1,
+    "startTime": "2019-07-11T19:30:43Z"
+  }
+}

--- a/pkg/await/recordings/states/job/succeeded.json
+++ b/pkg/await/recordings/states/job/succeeded.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+    },
+    "creationTimestamp": "2019-07-11T19:30:43Z",
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "foo",
+    "namespace": "default",
+    "resourceVersion": "764704",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+    "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+  },
+  "spec": {
+    "backoffLimit": 4,
+    "completions": 1,
+    "parallelism": 1,
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+          "job-name": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "perl",
+              "-Mbignum=bpi",
+              "-wle",
+              "print bpi(2000)"
+            ],
+            "image": "perl",
+            "imagePullPolicy": "Always",
+            "name": "pi",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {
+    "completionTime": "2019-07-11T19:30:56Z",
+    "conditions": [
+      {
+        "lastProbeTime": "2019-07-11T19:30:56Z",
+        "lastTransitionTime": "2019-07-11T19:30:56Z",
+        "status": "True",
+        "type": "Complete"
+      }
+    ],
+    "startTime": "2019-07-11T19:30:43Z",
+    "succeeded": 1
+  }
+}

--- a/pkg/await/recordings/workflows/job/added.json
+++ b/pkg/await/recordings/workflows/job/added.json
@@ -1,0 +1,63 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764676",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  }
+]

--- a/pkg/await/recordings/workflows/job/backoffLimitExceeded.json
+++ b/pkg/await/recordings/workflows/job/backoffLimitExceeded.json
@@ -1,0 +1,201 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perly\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:06Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249424",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "c7e98c66-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "c7e98c66-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "c7e98c66-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perly",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perly\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:06Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249429",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "c7e98c66-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "c7e98c66-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "c7e98c66-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perly",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "active": 1,
+      "startTime": "2019-09-19T23:04:06Z"
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perly\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:06Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249443",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "c7e98c66-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "c7e98c66-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "c7e98c66-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perly",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastProbeTime": "2019-09-19T23:04:09Z",
+          "lastTransitionTime": "2019-09-19T23:04:09Z",
+          "message": "Job has reached the specified backoff limit",
+          "reason": "BackoffLimitExceeded",
+          "status": "True",
+          "type": "Failed"
+        }
+      ],
+      "failed": 1,
+      "startTime": "2019-09-19T23:04:06Z"
+    }
+  }
+]

--- a/pkg/await/recordings/workflows/job/backoffLimitResolved.json
+++ b/pkg/await/recordings/workflows/job/backoffLimitResolved.json
@@ -1,0 +1,200 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:24Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249462",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:24Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249466",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "active": 1,
+      "startTime": "2019-09-19T23:04:24Z"
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":0,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-19T23:04:24Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "249491",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "d2a7ab6f-db31-11e9-8586-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "completionTime": "2019-09-19T23:04:36Z",
+      "conditions": [
+        {
+          "lastProbeTime": "2019-09-19T23:04:36Z",
+          "lastTransitionTime": "2019-09-19T23:04:36Z",
+          "status": "True",
+          "type": "Complete"
+        }
+      ],
+      "startTime": "2019-09-19T23:04:24Z",
+      "succeeded": 1
+    }
+  }
+]

--- a/pkg/await/recordings/workflows/job/deadlineExceeded.json
+++ b/pkg/await/recordings/workflows/job/deadlineExceeded.json
@@ -1,0 +1,204 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"activeDeadlineSeconds\":1,\"backoffLimit\":1,\"completions\":1,\"parallelism\":1,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-09T21:53:56Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "1336237",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "525855e6-d34c-11e9-9aec-025000000001"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 1,
+      "backoffLimit": 1,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "525855e6-d34c-11e9-9aec-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "525855e6-d34c-11e9-9aec-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"activeDeadlineSeconds\":1,\"backoffLimit\":1,\"completions\":1,\"parallelism\":1,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-09T21:53:56Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "1336241",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "525855e6-d34c-11e9-9aec-025000000001"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 1,
+      "backoffLimit": 1,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "525855e6-d34c-11e9-9aec-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "525855e6-d34c-11e9-9aec-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "active": 1,
+      "startTime": "2019-09-09T21:53:56Z"
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"activeDeadlineSeconds\":1,\"backoffLimit\":1,\"completions\":1,\"parallelism\":1,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-09-09T21:53:56Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "1336251",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "525855e6-d34c-11e9-9aec-025000000001"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 1,
+      "backoffLimit": 1,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "525855e6-d34c-11e9-9aec-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "525855e6-d34c-11e9-9aec-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastProbeTime": "2019-09-09T21:53:57Z",
+          "lastTransitionTime": "2019-09-09T21:53:57Z",
+          "message": "Job was active longer than specified deadline",
+          "reason": "DeadlineExceeded",
+          "status": "True",
+          "type": "Failed"
+        }
+      ],
+      "failed": 1,
+      "startTime": "2019-09-09T21:53:56Z"
+    }
+  }
+]

--- a/pkg/await/recordings/workflows/job/running.json
+++ b/pkg/await/recordings/workflows/job/running.json
@@ -1,0 +1,127 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764676",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764679",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "active": 1,
+      "startTime": "2019-07-11T19:30:43Z"
+    }
+  }
+]

--- a/pkg/await/recordings/workflows/job/succeeded.json
+++ b/pkg/await/recordings/workflows/job/succeeded.json
@@ -1,0 +1,200 @@
+[
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764676",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764679",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "active": 1,
+      "startTime": "2019-07-11T19:30:43Z"
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"foo\"},\"spec\":{\"backoffLimit\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
+      },
+      "creationTimestamp": "2019-07-11T19:30:43Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "764704",
+      "selfLink": "/apis/batch/v1/namespaces/default/jobs/foo",
+      "uid": "6000eff6-a412-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "backoffLimit": 4,
+      "completions": 1,
+      "parallelism": 1,
+      "selector": {
+        "matchLabels": {
+          "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "controller-uid": "6000eff6-a412-11e9-a3c5-025000000001",
+            "job-name": "foo"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "command": [
+                "perl",
+                "-Mbignum=bpi",
+                "-wle",
+                "print bpi(2000)"
+              ],
+              "image": "perl",
+              "imagePullPolicy": "Always",
+              "name": "pi",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Never",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {
+      "completionTime": "2019-07-11T19:30:56Z",
+      "conditions": [
+        {
+          "lastProbeTime": "2019-07-11T19:30:56Z",
+          "lastTransitionTime": "2019-07-11T19:30:56Z",
+          "status": "True",
+          "type": "Complete"
+        }
+      ],
+      "startTime": "2019-07-11T19:30:43Z",
+      "succeeded": 1
+    }
+  }
+]

--- a/pkg/await/statefulset_test.go
+++ b/pkg/await/statefulset_test.go
@@ -160,7 +160,7 @@ func Test_Apps_StatefulSet(t *testing.T) {
 				object: statefulsetProgressing(inputNamespace, inputName, targetService),
 				subErrors: []string{
 					"1 out of 2 replicas succeeded readiness checks",
-					"containers with unready status: [nginx] -- [ErrImagePull] manifest for nginx:busted not found",
+					"[Pod foo-0]: containers with unready status: [nginx] -- [ErrImagePull] manifest for nginx:busted not found",
 				}},
 		},
 		{
@@ -185,7 +185,7 @@ func Test_Apps_StatefulSet(t *testing.T) {
 				subErrors: []string{
 					"0 out of 2 replicas succeeded readiness checks",
 					"StatefulSet controller failed to advance from revision \"foo-7b5cf87b78\" to revision \"foo-789c4b994f\"",
-					"containers with unready status: [nginx] -- [ErrImagePull] manifest for nginx:busted not found",
+					"[Pod foo-0]: containers with unready status: [nginx] -- [ErrImagePull] manifest for nginx:busted not found",
 				}},
 		},
 	}

--- a/pkg/await/states/job.go
+++ b/pkg/await/states/job.go
@@ -1,0 +1,151 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package states
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/logging"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewJobChecker() *StateChecker {
+	return &StateChecker{
+		conditions: []Condition{jobStarted, jobComplete},
+		readyMsg:   cmdutil.EmojiOr("✅ Job ready", "Job ready"),
+	}
+}
+
+//
+// Conditions
+//
+
+func jobStarted(obj metav1.Object) Result {
+	job := toJob(obj)
+	result := Result{Description: fmt.Sprintf("Waiting for Job %q to start", fqName(job))}
+
+	if job.Status.StartTime != nil {
+		result.Ok = true
+	}
+
+	return result
+}
+
+func jobComplete(obj metav1.Object) Result {
+	job := toJob(obj)
+	// TODO: may want to list active/succeeded/failed pods count
+	result := Result{Description: fmt.Sprintf("Waiting for Job %q to succeed", fqName(job))}
+
+	if condition, found := filterJobConditions(job.Status.Conditions, batchv1.JobFailed); found {
+		switch condition.Status {
+		case v1.ConditionTrue:
+			errs := collectJobConditionErrors(job.Status.Conditions)
+			result.Message = logging.ErrorMessage(jobError(condition, errs))
+		}
+	}
+	if condition, found := filterJobConditions(job.Status.Conditions, batchv1.JobComplete); found {
+		switch condition.Status {
+		case v1.ConditionTrue:
+			result.Ok = true
+		default:
+			errs := collectJobConditionErrors(job.Status.Conditions)
+			result.Message = logging.WarningMessage(jobError(condition, errs))
+		}
+	}
+
+	return result
+}
+
+//
+// Helpers
+//
+
+func toJob(obj interface{}) *batchv1.Job {
+	return obj.(*batchv1.Job)
+}
+
+func filterJobConditions(conditions []batchv1.JobCondition, desired batchv1.JobConditionType,
+) (*batchv1.JobCondition, bool) {
+	for _, condition := range conditions {
+		if condition.Type == desired {
+			return &condition, true
+		}
+	}
+
+	return nil, false
+}
+
+func collectJobConditionErrors(conditions []batchv1.JobCondition) []string {
+	var errs []string
+	for _, condition := range conditions {
+		if hasErr, jobErrs := hasJobConditionErrors(condition); hasErr {
+			errs = append(errs, jobErrs...)
+		}
+	}
+
+	return errs
+}
+
+func hasJobConditionErrors(condition batchv1.JobCondition) (bool, []string) {
+	var errs []string
+	if hasErr, err := hasJobBackoffLimitCondition(condition); hasErr {
+		errs = append(errs, err)
+	}
+	if hasErr, err := hasJobDeadlineExceededCondition(condition); hasErr {
+		errs = append(errs, err)
+	}
+
+	return len(errs) > 0, errs
+}
+
+func hasJobBackoffLimitCondition(condition batchv1.JobCondition) (bool, string) {
+	if condition.Reason == "BackoffLimitExceeded" &&
+		condition.Type == batchv1.JobFailed &&
+		condition.Status == v1.ConditionTrue {
+
+		msg := fmt.Sprintf("[%s] %s", condition.Reason, condition.Message)
+		return true, msg
+	}
+
+	return false, ""
+}
+
+func hasJobDeadlineExceededCondition(condition batchv1.JobCondition) (bool, string) {
+	if condition.Reason == "DeadlineExceeded" &&
+		condition.Type == batchv1.JobFailed &&
+		condition.Status == v1.ConditionTrue {
+
+		msg := fmt.Sprintf("[%s] %s", condition.Reason, condition.Message)
+		return true, msg
+	}
+
+	return false, ""
+}
+
+func jobError(condition *batchv1.JobCondition, errs []string) string {
+	var errMsg string
+	if len(condition.Reason) > 0 && len(condition.Message) > 0 {
+		errMsg = condition.Message
+	}
+
+	for _, err := range errs {
+		errMsg += fmt.Sprintf(" -- %s", err)
+	}
+
+	return errMsg
+}

--- a/pkg/await/states/job_test.go
+++ b/pkg/await/states/job_test.go
@@ -1,0 +1,199 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package states
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/pkg/await/recordings"
+	"github.com/pulumi/pulumi-kubernetes/pkg/clients"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_jobStarted(t *testing.T) {
+	type args struct {
+		obj metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"Job started",
+			args{jobStartedState()},
+			true,
+		},
+		{
+			"Job initialized",
+			args{jobInitializedState()},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobStarted(tt.args.obj); got.Ok != tt.want {
+				t.Errorf("jobStarted() = %v, want %v", got.Ok, tt.want)
+			}
+		})
+	}
+}
+
+func Test_jobComplete(t *testing.T) {
+	type args struct {
+		obj metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"Job started",
+			args{jobStartedState()},
+			false,
+		},
+		{
+			"Job initialized",
+			args{jobInitializedState()},
+			false,
+		},
+		{
+			"Job succeeded",
+			args{jobSucceededState()},
+			true,
+		},
+		{
+			"Job backoffLimit error",
+			args{jobBackoffLimitState()},
+			false,
+		},
+		{
+			"Job deadlineExceeded error",
+			args{jobDeadlineExceededState()},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobComplete(tt.args.obj); got.Ok != tt.want {
+				t.Errorf("jobComplete() = %v, want %v", got.Ok, tt.want)
+			}
+		})
+	}
+}
+
+func Test_Job_Checker(t *testing.T) {
+	workflow := func(name string) string {
+		return workflowPath("job", name)
+	}
+	const (
+		added                = "added"
+		backoffLimitExceeded = "backoffLimitExceeded"
+		backoffLimitResolved = "backoffLimitResolved"
+		deadlineExceeded     = "deadlineExceeded"
+		running              = "running"
+		succeeded            = "succeeded"
+	)
+
+	tests := []struct {
+		name           string
+		recordingPaths []string
+		expectReady    bool
+	}{
+		{
+			name:           "Job added but not running",
+			recordingPaths: []string{workflow(added)},
+			expectReady:    false,
+		},
+		{
+			name:           "Job running but not ready",
+			recordingPaths: []string{workflow(running)},
+			expectReady:    false,
+		},
+		{
+			name:           "Job succeeded",
+			recordingPaths: []string{workflow(succeeded)},
+			expectReady:    true,
+		},
+		{
+			name:           "Job backoff limit exceeded",
+			recordingPaths: []string{workflow(backoffLimitExceeded)},
+			expectReady:    false,
+		},
+		{
+			name:           "Job deadline exceeded",
+			recordingPaths: []string{workflow(deadlineExceeded)},
+			expectReady:    false,
+		},
+		{
+			name:           "Job succeeded after backoff limit reached and resolved",
+			recordingPaths: []string{workflow(backoffLimitExceeded), workflow(backoffLimitResolved)},
+			expectReady:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewJobChecker()
+
+			ready, messages := mustCheckIfRecordingsReady(tt.recordingPaths, checker)
+			if ready != tt.expectReady {
+				t.Errorf("Ready() = %t, want %t\nMessages: %s", ready, tt.expectReady, messages)
+			}
+		})
+	}
+}
+
+//
+// Helpers
+//
+
+func jobStatePath(name string) string {
+	return statePath("job", name)
+}
+
+func mustLoadJobRecording(path string) *batchv1.Job {
+	job, err := clients.JobFromUnstructured(recordings.MustLoadState(path))
+	if err != nil {
+		panic(err)
+	}
+	return job
+}
+
+// jobInitializedState returns a Job that has been initialized but not yet started.
+func jobInitializedState() *batchv1.Job {
+	return mustLoadJobRecording(jobStatePath("initialized"))
+}
+
+// jobStartedState returns a Job that passes the jobStarted await Condition.
+func jobStartedState() *batchv1.Job {
+	return mustLoadJobRecording(jobStatePath("started"))
+}
+
+// jobSucceededState returns a Job that passes the jobComplete await Condition.
+func jobSucceededState() *batchv1.Job {
+	return mustLoadJobRecording(jobStatePath("succeeded"))
+}
+
+// jobBackoffLimitState returns a Job that has failed with a BackoffLimit error.
+func jobBackoffLimitState() *batchv1.Job {
+	return mustLoadJobRecording(jobStatePath("backoffLimit"))
+}
+
+// jobDeadlineExceededState returns a Job that has failed with a DeadlineExceeded error.
+func jobDeadlineExceededState() *batchv1.Job {
+	return mustLoadJobRecording(jobStatePath("deadlineExceeded"))
+}

--- a/pkg/await/states/pod_test.go
+++ b/pkg/await/states/pod_test.go
@@ -23,22 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	podStatePath    = "../recordings/states/pod"
-	podWorkflowPath = "../recordings/workflows/pod"
-
-	added                                  = podWorkflowPath + "/added.json"
-	containerTerminatedError               = podWorkflowPath + "/containerTerminatedError.json"
-	containerTerminatedSuccess             = podWorkflowPath + "/containerTerminatedSuccess.json"
-	containerTerminatedSuccessRestartNever = podWorkflowPath + "/containerTerminatedSuccessRestartNever.json"
-	createSuccess                          = podWorkflowPath + "/createSuccess.json"
-	imagePullError                         = podWorkflowPath + "/imagePullError.json"
-	imagePullErrorResolved                 = podWorkflowPath + "/imagePullErrorResolved.json"
-	scheduled                              = podWorkflowPath + "/scheduled.json"
-	unready                                = podWorkflowPath + "/unready.json"
-	unscheduled                            = podWorkflowPath + "/unscheduled.json"
-)
-
 //
 // Test Conditions
 //
@@ -140,6 +124,22 @@ func Test_podScheduled(t *testing.T) {
 //
 
 func Test_Pod_Checker(t *testing.T) {
+	workflow := func(name string) string {
+		return workflowPath("pod", name)
+	}
+	const (
+		added                                  = "added"
+		containerTerminatedError               = "containerTerminatedError"
+		containerTerminatedSuccess             = "containerTerminatedSuccess"
+		containerTerminatedSuccessRestartNever = "containerTerminatedSuccessRestartNever"
+		createSuccess                          = "createSuccess"
+		imagePullError                         = "imagePullError"
+		imagePullErrorResolved                 = "imagePullErrorResolved"
+		scheduled                              = "scheduled"
+		unready                                = "unready"
+		unscheduled                            = "unscheduled"
+	)
+
 	tests := []struct {
 		name           string
 		recordingPaths []string
@@ -148,52 +148,52 @@ func Test_Pod_Checker(t *testing.T) {
 	}{
 		{
 			name:           "Pod added but not ready",
-			recordingPaths: []string{added},
+			recordingPaths: []string{workflow(added)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod scheduled but not ready",
-			recordingPaths: []string{scheduled},
+			recordingPaths: []string{workflow(scheduled)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod create success",
-			recordingPaths: []string{createSuccess},
+			recordingPaths: []string{workflow(createSuccess)},
 			expectReady:    true,
 		},
 		{
 			name:           "Pod image pull error",
-			recordingPaths: []string{imagePullError},
+			recordingPaths: []string{workflow(imagePullError)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod create success after image pull failure resolved",
-			recordingPaths: []string{imagePullError, imagePullErrorResolved},
+			recordingPaths: []string{workflow(imagePullError), workflow(imagePullErrorResolved)},
 			expectReady:    true,
 		},
 		{
 			name:           "Pod unscheduled",
-			recordingPaths: []string{unscheduled},
+			recordingPaths: []string{workflow(unscheduled)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod unready",
-			recordingPaths: []string{unready},
+			recordingPaths: []string{workflow(unready)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod container terminated with error",
-			recordingPaths: []string{containerTerminatedError},
+			recordingPaths: []string{workflow(containerTerminatedError)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod container terminated successfully",
-			recordingPaths: []string{containerTerminatedSuccess},
+			recordingPaths: []string{workflow(containerTerminatedSuccess)},
 			expectReady:    false,
 		},
 		{
 			name:           "Pod container terminated successfully with restartPolicy: Never",
-			recordingPaths: []string{containerTerminatedSuccessRestartNever},
+			recordingPaths: []string{workflow(containerTerminatedSuccessRestartNever)},
 			expectReady:    true,
 		},
 	}
@@ -213,6 +213,10 @@ func Test_Pod_Checker(t *testing.T) {
 // Helpers
 //
 
+func podStatePath(name string) string {
+	return statePath("pod", name)
+}
+
 func mustLoadPodRecording(path string) *corev1.Pod {
 	pod, err := clients.PodFromUnstructured(recordings.MustLoadState(path))
 	if err != nil {
@@ -223,32 +227,32 @@ func mustLoadPodRecording(path string) *corev1.Pod {
 
 // podInitializedState returns a Pod that passes the podInitialized await Condition.
 func podInitializedState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/initialized.json")
+	return mustLoadPodRecording(podStatePath("initialized"))
 }
 
 // podUninitializedState returns a Pod that fails the podInitialized await Condition.
 func podUninitializedState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/uninitialized.json")
+	return mustLoadPodRecording(podStatePath("uninitialized"))
 }
 
 // podReadyState returns a Pod that passes the podReady await Condition.
 func podReadyState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/ready.json")
+	return mustLoadPodRecording(podStatePath("ready"))
 }
 
 // podSucceededState returns a Pod that passes the podReady await Condition.
 // Note that this corresponds to a Pod that runs a command and then exits with a 0 return code, so the Ready
 // status condition is False, and the phase is Succeeded.
 func podSucceededState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/succeeded.json")
+	return mustLoadPodRecording(podStatePath("succeeded"))
 }
 
 // podScheduledState returns a Pod that passes the podScheduled await Condition.
 func podScheduledState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/scheduled.json")
+	return mustLoadPodRecording(podStatePath("scheduled"))
 }
 
 // podUnscheduledState returns a Pod that fails the podScheduled await Condition.
 func podUnscheduledState() *corev1.Pod {
-	return mustLoadPodRecording(podStatePath + "/unscheduled.json")
+	return mustLoadPodRecording(podStatePath("unscheduled"))
 }

--- a/pkg/await/states/util.go
+++ b/pkg/await/states/util.go
@@ -15,6 +15,8 @@
 package states
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,4 +28,11 @@ func fqName(obj metav1.Object) string {
 		return obj.GetNamespace() + "/" + obj.GetName()
 	}
 	return obj.GetName()
+}
+
+func statePath(kind, name string) string {
+	return fmt.Sprintf("../recordings/states/%s/%s.json", kind, name)
+}
+func workflowPath(kind, name string) string {
+	return fmt.Sprintf("../recordings/workflows/%s/%s.json", kind, name)
 }

--- a/pkg/await/watchers.go
+++ b/pkg/await/watchers.go
@@ -88,7 +88,10 @@ func (pa *PodAggregator) run() {
 			return
 		}
 		if relatedResource(pa.owner, pod) {
-			pa.messages <- pa.checker.Update(pod).MessagesWithSeverity(diag.Warning, diag.Error)
+			messages := pa.checker.Update(pod).MessagesWithSeverity(diag.Warning, diag.Error)
+			if len(messages) > 0 {
+				pa.messages <- messages
+			}
 		}
 	}
 

--- a/pkg/gen/additionalComments.go
+++ b/pkg/gen/additionalComments.go
@@ -38,6 +38,8 @@ succeeded or failed:
 			v = await.DefaultDeploymentTimeoutMins
 		case kinds.Ingress:
 			v = await.DefaultIngressTimeoutMins
+	case kinds.Job:
+		v = await.DefaultJobTimeoutMins
 		case kinds.Pod:
 			v = await.DefaultPodTimeoutMins
 		case kinds.Service:
@@ -81,11 +83,12 @@ by %s`, kind, timeoutStr, timeoutOverride)
 3.  Ingress entry exists for '.status.loadBalancer.ingress'.
 `
 	case kinds.Job:
-		comment = `This resource currently does not wait until it is ready before registering
-success for create/update and populating output properties from the current
-state of the resource. Work to add readiness checks is in progress [1].
-
-[1] https://github.com/pulumi/pulumi-kubernetes/pull/633
+		comment = `
+1. The Job's '.status.startTime' is set, which indicates that the Job has started running.
+2. The Job's '.status.conditions' has a status of type 'Complete', and a 'status' set
+   to 'True'.
+3. The Job's '.status.conditions' do not have a status of type 'Failed', with a
+	'status' set to 'True'. If this condition is set, we should fail the Job immediately.
 `
 	case kinds.Pod:
 		comment += `

--- a/pkg/provider/diff.go
+++ b/pkg/provider/diff.go
@@ -141,6 +141,8 @@ var deployment = properties{
 }
 
 var job = properties{
+	".spec.completions",
+	".spec.parallelism",
 	".spec.selector",
 	".spec.template",
 }

--- a/sdk/nodejs/batch/v1/Job.ts
+++ b/sdk/nodejs/batch/v1/Job.ts
@@ -10,12 +10,16 @@ import { getVersion } from "../../version";
     /**
      * Job represents the configuration of a single job.
      * 
-     * This resource currently does not wait until it is ready before registering
-     * success for create/update and populating output properties from the current
-     * state of the resource. Work to add readiness checks is in progress [1].
      * 
-     * [1] https://github.com/pulumi/pulumi-kubernetes/pull/633
+     * 1. The Job's '.status.startTime' is set, which indicates that the Job has started running.
+     * 2. The Job's '.status.conditions' has a status of type 'Complete', and a 'status' set
+     *    to 'True'.
+     * 3. The Job's '.status.conditions' do not have a status of type 'Failed', with a
+     * 	'status' set to 'True'. If this condition is set, we should fail the Job immediately.
      * 
+     * If the Job has not reached a Ready state after 10 minutes, it will
+     * time out and mark the resource update as Failed. You can override the default timeout value
+     * by setting the 'customTimeouts' option on the resource.
      */
     export class Job extends pulumi.CustomResource {
       /**

--- a/sdk/python/pulumi_kubernetes/batch/v1/Job.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/Job.py
@@ -15,12 +15,16 @@ class Job(pulumi.CustomResource):
     """
     Job represents the configuration of a single job.
     
-    This resource currently does not wait until it is ready before registering
-    success for create/update and populating output properties from the current
-    state of the resource. Work to add readiness checks is in progress [1].
     
-    [1] https://github.com/pulumi/pulumi-kubernetes/pull/633
+    1. The Job's '.status.startTime' is set, which indicates that the Job has started running.
+    2. The Job's '.status.conditions' has a status of type 'Complete', and a 'status' set
+       to 'True'.
+    3. The Job's '.status.conditions' do not have a status of type 'Failed', with a
+    	'status' set to 'True'. If this condition is set, we should fail the Job immediately.
     
+    If the Job has not reached a Ready state after 10 minutes, it will
+    time out and mark the resource update as Failed. You can override the default timeout value
+    by setting the 'customTimeouts' option on the resource.
     """
 
     apiVersion: pulumi.Output[str]


### PR DESCRIPTION
Fixes #449.

TODO:

- [x] Report errors
- [x] Add tests
- [x] Await deletion

Here's how things look at this point:

Failed Job:
```
[0/2] Waiting for Job "foo" to start
[1/2] Waiting for Job "foo" to succeed
warning: [Pod foo-vk6wg]: containers with unready status: [pi]

warning: [Pod foo-vk6wg]: containers with unready status: [pi] -- [ContainerCannotRun] OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"perly\": executable file not found in $PATH": unknown

error: Job has reached the specified backoff limit -- [BackoffLimitExceeded] Job has reached the specified backoff limit
 
error: Plan apply failed: 4 errors occurred:
	* resource foo was successfully created, but the Kubernetes API server reported that it failed to fully initialize or become live: Resource 'foo' was created but failed to initialize
	* [Pod foo-vk6wg]: containers with unready status: [pi]
	* [Pod foo-vk6wg]: containers with unready status: [pi] -- [ContainerCannotRun] OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"perly\": executable file not found in $PATH": unknown
	* Job has reached the specified backoff limit -- [BackoffLimitExceeded] Job has reached the specified backoff limit
```

Successful Job:
```
[0/2] Waiting for Job "foo" to start
[1/2] Waiting for Job "foo" to succeed
warning: [Pod foo-wsq8r]: containers with unready status: [pi]
Job ready
```