### PR TITLE
Fix Deployment await logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     (https://github.com/pulumi/pulumi-kubernetes/pull/637).
 -   Use `opts` instead of `__opts__` and `resource_name` instead of `__name__` in Python SDK
     (https://github.com/pulumi/pulumi-kubernetes/pull/639).
+-   Properly detect failed Deployment on rollout. (https://github.com/pulumi/pulumi-kubernetes/pull/646).
 -   Use dry-run support if available when diffing the actual and desired state of a resource
     (https://github.com/pulumi/pulumi-kubernetes/pull/649)
 


### PR DESCRIPTION
The Deployment await logic had a bug for the old `extensions/v1beta1`
apiVersion which was causing the await logic to erroneously pass for
change triggered rollouts, even if the Deployment was invalid.

For some reason, the resource client was defaulting to
the old apiVersion, even though recent versions were available on the
cluster. Updated the client to ignore `extensions/v1beta1`, and
reverted the buggy await logic related to that apiVersion.

Fixes #611 