### PR TITLE
Use dry-run in Diff when available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
     (https://github.com/pulumi/pulumi-kubernetes/pull/637).
 -   Use `opts` instead of `__opts__` and `resource_name` instead of `__name__` in Python SDK
     (https://github.com/pulumi/pulumi-kubernetes/pull/639).
+-   Use dry-run support if available when diffing the actual and desired state of a resource
+    (https://github.com/pulumi/pulumi-kubernetes/pull/649)
 
 ## 0.25.2 (July 11, 2019)
 

--- a/pkg/provider/diff_test.go
+++ b/pkg/provider/diff_test.go
@@ -27,14 +27,15 @@ func TestPatchToDiff(t *testing.T) {
 	)
 
 	tests := []struct {
-		name     string
-		group    string
-		version  string
-		kind     string
-		old      object
-		new      object
-		inputs   object
-		expected expected
+		name      string
+		group     string
+		version   string
+		kind      string
+		old       object
+		new       object
+		inputs    object
+		oldInputs object
+		expected  expected
 	}{
 		{
 			name:  "Adding spec and nested field results in correct diffs.",
@@ -142,10 +143,20 @@ func TestPatchToDiff(t *testing.T) {
 		{
 			name:  `State diffs with no corresponding input property are ignored.`,
 			group: "core", version: "v1", kind: "Pod",
-			old:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}, "status": object{"hostIP": "10.0.0.2"}},
-			new:      object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}, "status": object{"hostIP": "10.0.0.3"}},
-			inputs:   object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
-			expected: expected{},
+			old:       object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}, "status": object{"hostIP": "10.0.0.2"}},
+			new:       object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}, "status": object{"hostIP": "10.0.0.3"}},
+			inputs:    object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			oldInputs: object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			expected:  expected{},
+		},
+		{
+			name:  `State deletes with no corresponding input properties are ignored.`,
+			group: "core", version: "v1", kind: "Pod",
+			old:       object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}, "status": object{"hostIP": "10.0.0.2"}},
+			new:       object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			inputs:    object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			oldInputs: object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
+			expected:  expected{},
 		},
 	}
 
@@ -168,13 +179,17 @@ func TestPatchToDiff(t *testing.T) {
 			if inputs == nil {
 				inputs = tt.new
 			}
+			oldInputs := tt.oldInputs
+			if oldInputs == nil {
+				oldInputs = tt.old
+			}
 
 			gvk := schema.GroupVersionKind{
 				Group:   tt.group,
 				Version: tt.version,
 				Kind:    tt.kind,
 			}
-			diff, err := convertPatchToDiff(patch, tt.old, inputs, gvk)
+			diff, err := convertPatchToDiff(patch, tt.old, inputs, oldInputs, gvk)
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, diff)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1175,12 +1175,12 @@ func (k *kubeProvider) dryRunPatch(
 	oldInputs, newInputs *unstructured.Unstructured,
 ) ([]byte, *unstructured.Unstructured, error) {
 
-	client, err := k.clientSet.ResourceClient(newInputs.GroupVersionKind(), newInputs.GetNamespace())
+	client, err := k.clientSet.ResourceClient(oldInputs.GroupVersionKind(), oldInputs.GetNamespace())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	liveObject, err := client.Get(newInputs.GetName(), metav1.GetOptions{})
+	liveObject, err := client.Get(oldInputs.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1192,7 +1192,7 @@ func (k *kubeProvider) dryRunPatch(
 		return nil, nil, err
 	}
 
-	newObject, err := client.Patch(newInputs.GetName(), patchType, patch, metav1.PatchOptions{
+	newObject, err := client.Patch(oldInputs.GetName(), patchType, patch, metav1.PatchOptions{
 		DryRun: []string{metav1.DryRunAll},
 	})
 	if err != nil {

--- a/tests/integration/dry-run/dryrun_test.go
+++ b/tests/integration/dry-run/dryrun_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+)
+
+func TestDryRun(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "step1",
+		Dependencies: []string{"@pulumi/kubernetes"},
+	})
+}

--- a/tests/integration/dry-run/step1/Pulumi.yaml
+++ b/tests/integration/dry-run/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dry-run-tests
+description: Tests whether Pulumi uses dry-run support to avoid spurious diffs.
+runtime: nodejs

--- a/tests/integration/dry-run/step1/index.ts
+++ b/tests/integration/dry-run/step1/index.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const appLabels = { app: "nginx" };
+
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    spec: {
+        selector: { matchLabels: appLabels },
+        replicas: 1,
+        template: {
+            metadata: { labels: appLabels },
+            spec: {
+                containers: [{
+                    name: "nginx",
+                    image: "nginx",
+                    resources: {
+                        limits: {
+                            // This value will be normalized by the API server to "2Gi" in the returned state. Without
+                            // dry-run support, Pulumi will detect a spurious diff due to the normalization.
+                            memory: "2048Mi",
+                        },
+                    },
+                }],
+            }
+        }
+    }
+});
+export const name = deployment.metadata.apply(m => m.name);

--- a/tests/integration/dry-run/step1/index.ts
+++ b/tests/integration/dry-run/step1/index.ts
@@ -38,4 +38,4 @@ const deployment = new k8s.apps.v1.Deployment("nginx", {
         }
     }
 });
-export const name = deployment.metadata.apply(m => m.name);
+export const name = deployment.metadata.name;

--- a/tests/integration/dry-run/step1/package.json
+++ b/tests/integration/dry-run/step1/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "dev",
+        "@pulumi/random": "dev"
+    },
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/dry-run/step1/tsconfig.json
+++ b/tests/integration/dry-run/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
These changes update `Diff` to calculate the new state for the patched
resource by requesting that the API server dry-run the patch when
possible. This avoids unexpected diffs due to server-side normalization
of values that are present in both the resource's configuration and its
state.

Fixes #644.