### PR TITLE
Fix Deployment await logic for extensions/v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
     (https://github.com/pulumi/pulumi-kubernetes/pull/637).
 -   Use `opts` instead of `__opts__` and `resource_name` instead of `__name__` in Python SDK
     (https://github.com/pulumi/pulumi-kubernetes/pull/639).
--   Properly detect failed Deployment on rollout. (https://github.com/pulumi/pulumi-kubernetes/pull/646).
+-   Properly detect failed Deployment on rollout. (https://github.com/pulumi/pulumi-kubernetes/pull/646
+    and https://github.com/pulumi/pulumi-kubernetes/pull/657).
 -   Use dry-run support if available when diffing the actual and desired state of a resource
     (https://github.com/pulumi/pulumi-kubernetes/pull/649)
 

--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -589,7 +589,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 		rs.GetName(), specReplicas, readyReplicas)
 
 	if dia.changeTriggeredRollout() {
-	    if extensionsv1beta1API {
+		if extensionsv1beta1API {
 			dia.updatedReplicaSetReady = lastGeneration != dia.currentGeneration && updatedReplicaSetCreated &&
 				readyReplicasExists && readyReplicas >= specReplicas && !unavailableReplicasPresent && !tooManyReplicas &&
 				expectedNumberOfUpdatedReplicas
@@ -598,7 +598,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 				readyReplicasExists && readyReplicas >= specReplicas
 		}
 	} else {
-	    if extensionsv1beta1API {
+		if extensionsv1beta1API {
 			dia.updatedReplicaSetReady = updatedReplicaSetCreated &&
 				readyReplicasExists && readyReplicas >= specReplicas && !tooManyReplicas
 		} else {

--- a/pkg/await/apps_deployment_test.go
+++ b/pkg/await/apps_deployment_test.go
@@ -2,7 +2,6 @@ package await
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -18,8 +17,6 @@ const (
 	replicaSetGeneratedName = "foo-4setj4y6-7cdf7ddc54"
 	revision1               = "1"
 	revision2               = "2"
-	revision3               = "3"
-	revision4               = "4"
 )
 
 func Test_Apps_Deployment(t *testing.T) {
@@ -65,6 +62,139 @@ func Test_Apps_Deployment(t *testing.T) {
 
 				replicaSets <- watchAddedEvent(
 					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "[Revision 1] Succeed if ReplicaSet becomes available before Deployment repots it",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully creates and initializes Deployment and ReplicaSet
+				// objects.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentProgressingUnavailable(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "[Revision 2] Succeed if ReplicaSet becomes available before Deployment repots it",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// API server successfully creates and initializes Deployment and ReplicaSet
+				// objects.
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision2))
+				deployments <- watchAddedEvent(
+					deploymentProgressing(inputNamespace, deploymentInputName, revision2))
+				deployments <- watchAddedEvent(
+					deploymentProgressingUnavailable(inputNamespace, deploymentInputName, revision2))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision2))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "[Revision 2] Should succeed if update has rolled out",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				// Deployment is updated by the user. The controller creates and successfully
+				// initializes the ReplicaSet.
+				deployments <- watchAddedEvent(
+					deploymentUpdated(inputNamespace, deploymentInputName, revision2))
+				deployments <- watchAddedEvent(
+					deploymentUpdatedReplicaSetProgressing(inputNamespace, deploymentInputName, revision2))
+				deployments <- watchAddedEvent(
+					deploymentUpdatedReplicaSetProgressed(inputNamespace, deploymentInputName, revision2))
+
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "[Revision 1] Should fail if unrelated Deployment succeeds",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				deployments <- watchAddedEvent(deploymentRolloutComplete(inputNamespace, "bar", revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision1))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				object: deploymentAdded(inputNamespace, deploymentInputName, revision1),
+				subErrors: []string{
+					"Minimum number of live Pods was not attained",
+				}},
+		},
+		{
+			description: "[Revision 2] Should fail if unrelated Deployment succeeds",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentAdded(inputNamespace, deploymentInputName, revision2))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
+
+				deployments <- watchAddedEvent(deploymentRolloutComplete(inputNamespace, "bar", revision2))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision2))
+
+				// Timeout. Failure.
+				timeout <- time.Now()
+			},
+			expectedError: &timeoutError{
+				object: deploymentAdded(inputNamespace, deploymentInputName, revision2),
+				subErrors: []string{
+					"Minimum number of live Pods was not attained",
+				}},
+		},
+		{
+			description: "[Revision 1] Should succeed when unrelated deployment fails",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision1))
+
+				deployments <- watchAddedEvent(deploymentAdded(inputNamespace, "bar", revision1))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision1))
+
+				// Timeout. Success.
+				timeout <- time.Now()
+			},
+		},
+		{
+			description: "[Revision 2] Should succeed when unrelated deployment fails",
+			do: func(deployments, replicaSets, pods chan watch.Event, timeout chan time.Time) {
+				deployments <- watchAddedEvent(
+					deploymentRolloutComplete(inputNamespace, deploymentInputName, revision2))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
+
+				deployments <- watchAddedEvent(deploymentAdded(inputNamespace, "bar", revision2))
+				replicaSets <- watchAddedEvent(
+					availableReplicaSet(inputNamespace, "bar-ablksd", "bar", revision2))
 
 				// Timeout. Success.
 				timeout <- time.Now()
@@ -245,7 +375,7 @@ func Test_Apps_Deployment(t *testing.T) {
 			expectedError: &timeoutError{
 				object: deploymentRevision2Created(inputNamespace, deploymentInputName),
 				subErrors: []string{
-					"Minimum number of live Pods was not attained"}},
+					"Minimum number of Pods to consider the application live was not attained"}},
 		},
 		{
 			description: "[Revision 2] Deployment should fail if Deployment reports 'Progressing' failure",
@@ -253,19 +383,19 @@ func Test_Apps_Deployment(t *testing.T) {
 				// User submits a deployment. Controller creates ReplicaSet, and it tries to
 				// progress, but it fails.
 				deployments <- watchAddedEvent(
-					deploymentAdded(inputNamespace, deploymentInputName, revision3))
+					deploymentAdded(inputNamespace, deploymentInputName, revision2))
 				deployments <- watchAddedEvent(
-					deploymentProgressing(inputNamespace, deploymentInputName, revision3))
+					deploymentProgressing(inputNamespace, deploymentInputName, revision2))
 				deployments <- watchAddedEvent(
-					deploymentNotProgressing(inputNamespace, deploymentInputName, revision3))
+					deploymentNotProgressing(inputNamespace, deploymentInputName, revision2))
 				replicaSets <- watchAddedEvent(
-					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision3))
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
 
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				object: deploymentNotProgressing(inputNamespace, deploymentInputName, revision3),
+				object: deploymentNotProgressing(inputNamespace, deploymentInputName, revision2),
 				subErrors: []string{
 					`[ProgressDeadlineExceeded] ReplicaSet "foo-13y9rdnu-b94df86d6" has timed ` +
 						`out progressing.`,
@@ -277,19 +407,19 @@ func Test_Apps_Deployment(t *testing.T) {
 				// User submits a deployment. Controller creates ReplicaSet, and it tries to
 				// progress, but it will not, because it is using an invalid container image.
 				deployments <- watchAddedEvent(
-					deploymentAdded(inputNamespace, deploymentInputName, revision4))
+					deploymentAdded(inputNamespace, deploymentInputName, revision2))
 				deployments <- watchAddedEvent(
-					deploymentProgressing(inputNamespace, deploymentInputName, revision4))
+					deploymentProgressing(inputNamespace, deploymentInputName, revision2))
 				deployments <- watchAddedEvent(
-					deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision4))
+					deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision2))
 				replicaSets <- watchAddedEvent(
-					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision4))
+					availableReplicaSet(inputNamespace, replicaSetGeneratedName, deploymentInputName, revision2))
 
 				// Timeout. Failure.
 				timeout <- time.Now()
 			},
 			expectedError: &timeoutError{
-				object: deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision4),
+				object: deploymentProgressingInvalidContainer(inputNamespace, deploymentInputName, revision2),
 				subErrors: []string{
 					"Minimum number of Pods to consider the application live was not attained",
 				}},
@@ -650,9 +780,9 @@ func Test_Core_Deployment_Read(t *testing.T) {
 		{
 			description:        "[Revision 2] Read should fail if Deployment Progressing status set to False",
 			deployment:         deploymentNotProgressing,
-			deploymentRevision: revision3,
+			deploymentRevision: revision2,
 			replicaset:         availableReplicaSet,
-			replicaSetRevision: revision3,
+			replicaSetRevision: revision2,
 			expectedSubErrors: []string{
 				"[ProgressDeadlineExceeded] ReplicaSet \"foo-13y9rdnu-b94df86d6\" has timed out progressing.",
 				"Minimum number of Pods to consider the application live was not attained",
@@ -661,9 +791,9 @@ func Test_Core_Deployment_Read(t *testing.T) {
 		{
 			description:        "[Revision 2] Read should fail if Deployment has invalid container",
 			deployment:         deploymentProgressingInvalidContainer,
-			deploymentRevision: revision4,
+			deploymentRevision: revision2,
 			replicaset:         availableReplicaSet,
-			replicaSetRevision: revision4,
+			replicaSetRevision: revision2,
 			expectedSubErrors: []string{
 				"Minimum number of Pods to consider the application live was not attained"},
 		},
@@ -693,7 +823,7 @@ func Test_Core_Deployment_Read(t *testing.T) {
 			replicaset:         availableReplicaSet,
 			replicaSetRevision: revision2,
 			expectedSubErrors: []string{
-				"Minimum number of live Pods was not attained"},
+				"Minimum number of Pods to consider the application live was not attained"},
 		},
 		{
 			description:        "[Revision 2] Read should succeed if rollout completes",
@@ -1049,14 +1179,13 @@ func deploymentProgressingInvalidContainer(namespace, name, revision string) *un
 }
 
 func deploymentProgressingUnavailable(namespace, name, revision string) *unstructured.Unstructured {
-    generation, _ := strconv.Atoi(revision)
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
     "kind": "Deployment",
     "apiVersion": "apps/v1",
     "metadata": {
         "namespace": "%s",
         "name": "%s",
-        "generation": %v,
+        "generation": 1,
         "labels": {
             "app": "foo"
         },
@@ -1090,7 +1219,7 @@ func deploymentProgressingUnavailable(namespace, name, revision string) *unstruc
         }
     },
     "status": {
-        "observedGeneration": %v,
+        "observedGeneration": 1,
         "replicas": 1,
         "updatedReplicas": 1,
         "unavailableReplicas": 1,
@@ -1113,7 +1242,7 @@ func deploymentProgressingUnavailable(namespace, name, revision string) *unstruc
             }
         ]
     }
-}`, namespace, name, int64(generation), revision, int64(generation)))
+}`, namespace, name, revision))
 	if err != nil {
 		panic(err)
 	}
@@ -1254,14 +1383,13 @@ func deploymentRevision2Created(namespace, name string) *unstructured.Unstructur
 }
 
 func deploymentRolloutComplete(namespace, name, revision string) *unstructured.Unstructured {
-    generation, _ := strconv.Atoi(revision)
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
     "kind": "Deployment",
     "apiVersion": "apps/v1",
     "metadata": {
         "namespace": "%s",
         "name": "%s",
-        "generation": %v,
+        "generation": 1,
         "labels": {
             "app": "foo"
         },
@@ -1295,7 +1423,7 @@ func deploymentRolloutComplete(namespace, name, revision string) *unstructured.U
         }
     },
     "status": {
-        "observedGeneration": %v,
+        "observedGeneration": 1,
         "replicas": 1,
         "updatedReplicas": 1,
         "readyReplicas": 1,
@@ -1319,7 +1447,7 @@ func deploymentRolloutComplete(namespace, name, revision string) *unstructured.U
             }
         ]
     }
-}`, namespace, name, int64(generation), revision, int64(generation)))
+}`, namespace, name, revision))
 	if err != nil {
 		panic(err)
 	}
@@ -1327,14 +1455,13 @@ func deploymentRolloutComplete(namespace, name, revision string) *unstructured.U
 }
 
 func deploymentUpdated(namespace, name, revision string) *unstructured.Unstructured {
-	generation, _ := strconv.Atoi(revision)
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
     "kind": "Deployment",
     "apiVersion": "apps/v1",
     "metadata": {
         "namespace": "%s",
         "name": "%s",
-        "generation": %v,
+        "generation": 2,
         "labels": {
             "app": "foo"
         },
@@ -1368,7 +1495,7 @@ func deploymentUpdated(namespace, name, revision string) *unstructured.Unstructu
         }
     },
     "status": {
-        "observedGeneration": %v,
+        "observedGeneration": 1,
         "replicas": 1,
         "updatedReplicas": 1,
         "readyReplicas": 1,
@@ -1392,7 +1519,7 @@ func deploymentUpdated(namespace, name, revision string) *unstructured.Unstructu
             }
         ]
     }
-}`, namespace, name, int64(generation), revision, int64(generation)))
+}`, namespace, name, revision))
 	if err != nil {
 		panic(err)
 	}
@@ -1684,12 +1811,11 @@ func deploymentWithPVCProgressing(namespace, name, revision, pvcName string) *un
 }
 
 func deploymentWithPVCNotProgressing(namespace, name, revision, pvcName string) *unstructured.Unstructured {
-    generation, _ := strconv.Atoi(revision)
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
     "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
-        "generation": %v,
+        "generation": 3,
         "labels": {
             "app": "foo"
         },
@@ -1758,13 +1884,13 @@ func deploymentWithPVCNotProgressing(namespace, name, revision, pvcName string) 
                 "type": "Progressing"
             }
         ],
-        "observedGeneration": %v,
+        "observedGeneration": 3,
         "readyReplicas": 1,
         "replicas": 2,
         "unavailableReplicas": 1,
         "updatedReplicas": 1
     }
-}`, int64(generation), namespace, name, revision, pvcName, int64(generation)))
+}`, namespace, name, revision, pvcName))
 	if err != nil {
 		panic(err)
 	}
@@ -2389,7 +2515,7 @@ func availableReplicaSet(namespace, name, deploymentName, revision string) *unst
         ]
     },
     "spec": {
-        "replicas": 1,
+        "replicas": 3,
         "selector": {
             "matchLabels": {
                 "app": "foo",
@@ -2439,11 +2565,11 @@ func availableReplicaSet(namespace, name, deploymentName, revision string) *unst
         }
     },
     "status": {
-        "availableReplicas": 1,
-        "fullyLabeledReplicas": 1,
+        "availableReplicas": 3,
+        "fullyLabeledReplicas": 3,
         "observedGeneration": 3,
-        "readyReplicas": 1,
-        "replicas": 1
+        "readyReplicas": 3,
+        "replicas": 3
     }
 }
 `, revision, namespace, name, deploymentName))

--- a/pkg/await/core_pod.go
+++ b/pkg/await/core_pod.go
@@ -56,7 +56,7 @@ import (
 // The subtlety of this that "Running" actually just means that the Pod has been bound to a node,
 // all containers have been created, and at least one is still "alive" -- a status is set once the
 // liveness and readiness probes (which usually simply ping some endpoint, and which are
-// customizable by the user) return success. Along the say several things can go wrong (e.g., image
+// customizable by the user) return success. Along the way several things can go wrong (e.g., image
 // pull error, container exits with code 1), but each of these things would prevent the probes from
 // reporting success, or they would be picked up by the Kubelet.
 //


### PR DESCRIPTION
The Deployment await logic was not correctly checking rollout
success for the `extensions/v1beta1` apiVersion, which was
causing the await logic to erroneously pass for change
triggered rollouts, even if the Deployment was invalid.

Added additional logic to the readiness check based on
status fields present in all apiVersions.

Fixes #611 
Fixes #656 