### PR TITLE
Detect namespace diff for first-class providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Fall back to client-side diff if server-side diff fails. (https://github.com/pulumi/pulumi-kubernetes/pull/685).
 -   Fix namespace arg for Python Helm SDK (https://github.com/pulumi/pulumi-kubernetes/pull/670).
+-   Detect namespace diff for first-class providers. (https://github.com/pulumi/pulumi-kubernetes/pull/674).
 -   Fix values arg for Python Helm SDK (https://github.com/pulumi/pulumi-kubernetes/pull/678).
 
 ## 0.25.4 (August 1, 2019)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -169,6 +169,9 @@ func (k *kubeProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffReques
 	if olds["cluster"] != news["cluster"] {
 		diffs = append(diffs, "cluster")
 	}
+	if olds["namespace"] != news["namespace"] {
+		diffs = append(diffs, "namespace")
+	}
 	if olds["enableDryRun"] != news["enableDryRun"] {
 		diffs = append(diffs, "enableDryRun")
 	}


### PR DESCRIPTION
When DiffConfig was implemented, the namespace parameter
was overlooked, which would cause changes to the namespace
parameter to be ignored after creation.