### PR TITLE
Properly reference override values in Python Helm SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 0.25.4 (Unreleased)
 
+### Supported Kubernetes versions
+
+- v1.15.x
+- v1.14.x
+- v1.13.x
+
+### Bug fixes
+
+-   Properly reference override values in Python Helm SDK (https://github.com/pulumi/pulumi-kubernetes/pull/676).
+
 ## 0.25.3 (July 29, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/gen/python-templates/helm/v2/helm.py
+++ b/pkg/gen/python-templates/helm/v2/helm.py
@@ -325,6 +325,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
             vals = config.values if config.values is not None else {}
             data = json.dumps(vals).encode('utf-8')
             overrides.write(data)
+            overrides.flush()
 
             namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -325,6 +325,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
             vals = config.values if config.values is not None else {}
             data = json.dumps(vals).encode('utf-8')
             overrides.write(data)
+            overrides.flush()
 
             namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 

--- a/tests/examples/python/helm/__main__.py
+++ b/tests/examples/python/helm/__main__.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 from pulumi_kubernetes.helm.v2 import Chart, ChartOpts
 
-Chart("unbound", ChartOpts("stable/unbound"))
+values = {"unbound": {"image": {"pullPolicy": "Always"}}}
+
+Chart("unbound", ChartOpts("stable/unbound", values=values))
 
 # Deploy a duplicate chart with a different resource prefix to verify that multiple instances of the Chart
 # can be managed in the same stack.
-Chart("unbound", ChartOpts("stable/unbound", resource_prefix="dup"))
+Chart("unbound", ChartOpts("stable/unbound", resource_prefix="dup", values=values))

--- a/tests/examples/python/python_test.go
+++ b/tests/examples/python/python_test.go
@@ -290,6 +290,41 @@ func TestHelm(t *testing.T) {
 	options := baseOptions.With(integration.ProgramTestOptions{
 		Dir:                  filepath.Join(cwd, "helm"),
 		ExpectRefreshChanges: true, // PodDisruptionBudget status gets updated by the Deployment.
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Deployment)
+			assert.Equal(t, 12, len(stackInfo.Deployment.Resources))
+
+			sort.Slice(stackInfo.Deployment.Resources, func(i, j int) bool {
+				ri := stackInfo.Deployment.Resources[i]
+				rj := stackInfo.Deployment.Resources[j]
+				riname, _ := openapi.Pluck(ri.Outputs, "metadata", "name")
+				rinamespace, _ := openapi.Pluck(ri.Outputs, "metadata", "namespace")
+				rjname, _ := openapi.Pluck(rj.Outputs, "metadata", "name")
+				rjnamespace, _ := openapi.Pluck(rj.Outputs, "metadata", "namespace")
+				return fmt.Sprintf("%s/%s/%s", ri.URN.Type(), rinamespace, riname) <
+					fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
+			})
+
+			// Verify override value was set.
+			unboundDepl := stackInfo.Deployment.Resources[5]
+			assert.Equal(t, tokens.Type("kubernetes:extensions/v1beta1:Deployment"), unboundDepl.URN.Type())
+			containersRaw, _ := openapi.Pluck(unboundDepl.Outputs, "spec", "template", "spec", "containers")
+			containers := containersRaw.([]interface{})
+			assert.Equal(t, 2, len(containers))
+			container := containers[0].(map[string]interface{})
+			containerName, _ := openapi.Pluck(container, "name")
+			assert.True(t, strings.HasPrefix(containerName.(string), "unbound"))
+			pullPolicy, _ := openapi.Pluck(container, "imagePullPolicy")
+			assert.True(t, strings.HasPrefix(pullPolicy.(string), "Always"))
+
+			// Verify the provider resource.
+			provRes := stackInfo.Deployment.Resources[10]
+			assert.True(t, providers.IsProviderType(provRes.URN.Type()))
+
+			// Verify root resource.
+			stackRes := stackInfo.Deployment.Resources[11]
+			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+		},
 	})
 	integration.ProgramTest(t, &options)
 }


### PR DESCRIPTION
The overrides file was being written, but not flushed, so the
values were not present during the subsequent helm template
step, and were effectively being silently ignored.

Fixes #675 