### PR TITLE
Handle Output values in diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 -   Properly reference override values in Python Helm SDK (https://github.com/pulumi/pulumi-kubernetes/pull/676).
+-   Handle Output values in diffs. (https://github.com/pulumi/pulumi-kubernetes/pull/682).
 
 ## 0.25.3 (July 29, 2019)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -574,6 +574,9 @@ func (k *kubeProvider) Diff(
 	var isInputPatch bool
 	var patchBase *unstructured.Unstructured
 
+	// TODO: Skipping dry run entirely for resources with computed values is a hack. We will want to address this
+	// more granularly so that previews are as accurate as possible, but this is an easy workaround for a critical
+	// bug.
 	tryDryRun := supportsDryRun && oldInputs.GroupVersionKind().String() == gvk.String() &&
 		!hasComputedValue(newInputs) && !hasComputedValue(oldInputs)
 	if tryDryRun {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -574,7 +574,8 @@ func (k *kubeProvider) Diff(
 	var isInputPatch bool
 	var patchBase *unstructured.Unstructured
 
-	tryDryRun := supportsDryRun && oldInputs.GroupVersionKind().String() == gvk.String()
+	tryDryRun := supportsDryRun && oldInputs.GroupVersionKind().String() == gvk.String() &&
+		!hasComputedValue(newInputs) && !hasComputedValue(oldInputs)
 	if tryDryRun {
 		patch, patchBase, err = k.dryRunPatch(oldInputs, newInputs)
 

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -37,16 +37,6 @@ func hasComputedValue(obj *unstructured.Unstructured) bool {
 			case []map[string]interface{}:
 				objects = append(objects, field...)
 			}
-			if field, isSlice := v.([]interface{}); isSlice {
-				for _, v := range field {
-					if _, isComputed := v.(resource.Computed); isComputed {
-						return true
-					}
-					if field, isMap := v.(map[string]interface{}); isMap {
-						objects = append(objects, field)
-					}
-				}
-			}
 		}
 	}
 

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -25,11 +25,17 @@ func hasComputedValue(obj *unstructured.Unstructured) bool {
 		}
 		curr, objects = objects[0], objects[1:]
 		for _, v := range curr {
-			if _, isComputed := v.(resource.Computed); isComputed {
+			switch field := v.(type) {
+			case resource.Computed:
 				return true
-			}
-			if field, isMap := v.(map[string]interface{}); isMap {
+			case map[string]interface{}:
 				objects = append(objects, field)
+			case []interface{}:
+				for _, v := range field {
+					objects = append(objects, map[string]interface{}{"": v})
+				}
+			case []map[string]interface{}:
+				objects = append(objects, field...)
 			}
 			if field, isSlice := v.([]interface{}); isSlice {
 				for _, v := range field {
@@ -40,9 +46,6 @@ func hasComputedValue(obj *unstructured.Unstructured) bool {
 						objects = append(objects, field)
 					}
 				}
-			}
-			if field, isSlice := v.([]map[string]interface{}); isSlice {
-				objects = append(objects, field...)
 			}
 		}
 	}

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -31,6 +31,19 @@ func hasComputedValue(obj *unstructured.Unstructured) bool {
 			if field, isMap := v.(map[string]interface{}); isMap {
 				objects = append(objects, field)
 			}
+			if field, isSlice := v.([]interface{}); isSlice {
+				for _, v := range field {
+					if _, isComputed := v.(resource.Computed); isComputed {
+						return true
+					}
+					if field, isMap := v.(map[string]interface{}); isMap {
+						objects = append(objects, field)
+					}
+				}
+			}
+			if field, isSlice := v.([]map[string]interface{}); isSlice {
+				objects = append(objects, field...)
+			}
 		}
 	}
 

--- a/pkg/provider/util_test.go
+++ b/pkg/provider/util_test.go
@@ -124,6 +124,38 @@ func TestHasComputedValue(t *testing.T) {
 			}},
 			hasComputedValue: true,
 		},
+		{
+			name: "Complex nested object with computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": []map[string]interface{}{
+					{"field3": []interface{}{
+						[]map[string]interface{}{
+							{"field4": []interface{}{
+								resource.Computed{},
+							}},
+						},
+					}},
+				},
+			}},
+			hasComputedValue: true,
+		},
+		{
+			name: "Complex nested object with no computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": []map[string]interface{}{
+					{"field3": []interface{}{
+						[]map[string]interface{}{
+							{"field4": []interface{}{
+								"field5",
+							}},
+						},
+					}},
+				},
+			}},
+			hasComputedValue: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/util_test.go
+++ b/pkg/provider/util_test.go
@@ -92,6 +92,26 @@ func TestHasComputedValue(t *testing.T) {
 			}},
 			hasComputedValue: true,
 		},
+		{
+			name: "Object with nested slice of map[string]interface{} has a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": []map[string]interface{}{
+					{"field3": resource.Computed{}},
+				},
+			}},
+			hasComputedValue: true,
+		},
+		{
+			name: "Object with nested slice of interface{} has a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": []interface{}{
+					resource.Computed{},
+				},
+			}},
+			hasComputedValue: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/util_test.go
+++ b/pkg/provider/util_test.go
@@ -112,6 +112,18 @@ func TestHasComputedValue(t *testing.T) {
 			}},
 			hasComputedValue: true,
 		},
+		{
+			name: "Object with nested slice of map[string]interface{} with nested slice of interface{} has a computed value",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"field1": 1,
+				"field2": []map[string]interface{}{
+					{"field3": []interface{}{
+						resource.Computed{},
+					}},
+				},
+			}},
+			hasComputedValue: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The server-side diff based on a dryRun doesn't understand Pulumi
Outputs, so it would cause an error for any update that depended
a calculated value.

As a workaround, fallback to a client-side diff if a dryRun diff
returns an error.

Fixes #679 