### PR TITLE
Disable dryRun diff behavior by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 - v1.14.x
 - v1.13.x
 
+### Important
+
+This release reverts the default diff behavior back to the pre-`0.25.3` behavior. A new flag has
+been added to the provider options called `enableDryRun`, that can be used to opt in to the new
+diff behavior. This will eventually become the default behavior after further testing to ensure
+that this change is not disruptive.
+
+### Major changes
+
+-   Disable dryRun diff behavior by default. (https://github.com/pulumi/pulumi-kubernetes/pull/686)
+
 ### Improvements
 
 -   Improve error messages for StatefulSet. (https://github.com/pulumi/pulumi-kubernetes/pull/673)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -238,9 +238,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		if enabled, exists := vars["kubernetes:config:enableDryRun"]; exists {
 			return enabled == "true"
 		}
-		// If the provider flag is not set, fall back to the ENV var if set.
-		if enabled, exists := os.LookupEnv("PULUMI_K8S_ENABLE_DRY_RUN"); exists && enabled == "true" {
-			return true
+		// If the provider flag is not set, fall back to the ENV var.
+		if enabled, exists := os.LookupEnv("PULUMI_K8S_ENABLE_DRY_RUN"); exists {
+			return enabled == "true"
 		}
 		// Default to false.
 		return false

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -90,6 +90,7 @@ type kubeProvider struct {
 	providerPackage  string
 	opts             kubeOpts
 	defaultNamespace string
+	enableDryRun     bool
 
 	clientSet *clients.DynamicClientSet
 }
@@ -105,6 +106,7 @@ func makeKubeProvider(
 		name:            name,
 		version:         version,
 		providerPackage: name,
+		enableDryRun:    false,
 	}, nil
 }
 
@@ -167,6 +169,9 @@ func (k *kubeProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffReques
 	if olds["cluster"] != news["cluster"] {
 		diffs = append(diffs, "cluster")
 	}
+	if olds["enableDryRun"] != news["enableDryRun"] {
+		diffs = append(diffs, "enableDryRun")
+	}
 
 	// In general, it's not possible to tell from a kubeconfig if the k8s cluster it points to has
 	// changed. k8s clusters do not have a well defined identity, so the best we can do is check
@@ -226,6 +231,25 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 
 	if defaultNamespace := vars["kubernetes:config:namespace"]; defaultNamespace != "" {
 		k.defaultNamespace = defaultNamespace
+	}
+
+	enableDryRun := func() bool {
+		// If the provider flag is set, use that value to determine behavior. This will override the ENV var.
+		if enabled, exists := vars["kubernetes:config:enableDryRun"]; exists {
+			if enabled == "true" {
+				return true
+			}
+			return false
+		}
+		// If the provider flag is not set, fall back to the ENV var if set.
+		if enabled, exists := os.LookupEnv("PULUMI_K8S_ENABLE_DRY_RUN"); exists && enabled == "true" {
+			return true
+		}
+		// Default to false.
+		return false
+	}
+	if enableDryRun() {
+		k.enableDryRun = true
 	}
 
 	var kubeconfig clientcmd.ClientConfig
@@ -574,10 +598,12 @@ func (k *kubeProvider) Diff(
 	var isInputPatch bool
 	var patchBase *unstructured.Unstructured
 
-	// TODO: Skipping dry run entirely for resources with computed values is a hack. We will want to address this
-	// more granularly so that previews are as accurate as possible, but this is an easy workaround for a critical
-	// bug.
-	tryDryRun := supportsDryRun && oldInputs.GroupVersionKind().String() == gvk.String() &&
+	// BETA FEATURE FLAG: We are disabling the dry run behavior by default using the `enableDryRun` feature flag. For
+	// now, this flag defaults to false, but will eventually be default to true.
+	tryDryRun := k.enableDryRun && supportsDryRun && oldInputs.GroupVersionKind().String() == gvk.String() &&
+		// TODO: Skipping dry run entirely for resources with computed values is a hack. We will want to address this
+		// more granularly so that previews are as accurate as possible, but this is an easy workaround for a critical
+		// bug.
 		!hasComputedValue(newInputs) && !hasComputedValue(oldInputs)
 	if tryDryRun {
 		patch, patchBase, err = k.dryRunPatch(oldInputs, newInputs)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -236,10 +236,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 	enableDryRun := func() bool {
 		// If the provider flag is set, use that value to determine behavior. This will override the ENV var.
 		if enabled, exists := vars["kubernetes:config:enableDryRun"]; exists {
-			if enabled == "true" {
-				return true
-			}
-			return false
+			return enabled == "true"
 		}
 		// If the provider flag is not set, fall back to the ENV var if set.
 		if enabled, exists := os.LookupEnv("PULUMI_K8S_ENABLE_DRY_RUN"); exists && enabled == "true" {

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -17,6 +17,7 @@ export class Provider extends pulumi.ProviderResource {
             "context": args ? args.context : undefined,
             "kubeconfig": args ? args.kubeconfig : undefined,
             "namespace": args ? args.namespace : undefined,
+            "enableDryRun": args && args.enableDryRun ? "true" : undefined
         };
         super("kubernetes", name, inputs, opts);
     }
@@ -43,4 +44,9 @@ export interface ProviderArgs {
      * Note: if .metadata.namespace is set on a resource, that value takes precedence over the provider default.
      */
     readonly namespace?: pulumi.Input<string>;
+    /**
+     * BETA FEATURE - If present and set to true, enable server-side diff calculations.
+     * This feature is in developer preview, and is disabled by default.
+     */
+    readonly enableDryRun?: pulumi.Input<boolean>;
 }

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -1,16 +1,17 @@
 import pulumi
-from . import tables
 
 
 class Provider(pulumi.ProviderResource):
     """
     The provider type for the kubernetes package.
     """
+
     def __init__(self,
                  __name__,
                  __opts__=None,
                  cluster=None,
                  context=None,
+                 enable_dry_run=None,
                  kubeconfig=None,
                  namespace=None):
         """
@@ -20,6 +21,9 @@ class Provider(pulumi.ProviderResource):
         :param pulumi.ResourceOptions __opts__: An optional bag of options that controls this resource's behavior.
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
         :param pulumi.Input[str] context: If present, the name of the kubeconfig context to use.
+        :param pulumi.Input[bool] enable_dry_run: BETA FEATURE - If present and set to True, enable server-side diff
+                                                  calculations. This feature is in developer preview, and is disabled by
+                                                  default.
         :param pulumi.Input[str] kubeconfig: The contents of a kubeconfig file.
                                              If this is set, this config will be used instead of $KUBECONFIG.
         :param pulumi.Input[str] namespace: If present, the default namespace to use.
@@ -30,6 +34,7 @@ class Provider(pulumi.ProviderResource):
         __props__ = {
             "cluster": cluster,
             "context": context,
+            "enableDryRun": "true" if enable_dry_run else "false",
             "kubeconfig": kubeconfig,
             "namespace": namespace,
         }

--- a/tests/examples/provider/index.ts
+++ b/tests/examples/provider/index.ts
@@ -13,6 +13,12 @@ const myk8s = new k8s.Provider("myk8s", {
     kubeconfig: kubeconfig,
 });
 
+// Create a new provider with dry run enabled.
+const myk8s2 = new k8s.Provider("myk8s2", {
+    kubeconfig: kubeconfig,
+    enableDryRun: true,
+});
+
 // Create a Pod using the custom provider
 const nginxcontainer = new k8s.core.v1.Pod("nginx", {
     spec: {
@@ -23,3 +29,14 @@ const nginxcontainer = new k8s.core.v1.Pod("nginx", {
         }],
     },
 }, { provider: myk8s });
+
+// Create a Pod using the custom provider
+const nginxcontainer2 = new k8s.core.v1.Pod("nginx2", {
+    spec: {
+        containers: [{
+            image: "nginx:1.7.9",
+            name: "nginx",
+            ports: [{ containerPort: 80 }],
+        }],
+    },
+}, { provider: myk8s2 });


### PR DESCRIPTION
Add an opt-in feature flag called `enableDryRun` for the server-side
dry run diffing. In the future, this will be the default behavior.