### PR TITLE
Properly detect readiness for Deployment scaled to 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 0.25.6 (Unreleased)
 
+### Supported Kubernetes versions
+
+- v1.15.x
+- v1.14.x
+- v1.13.x
+
+### Bug fixes
+
+-   Properly detect readiness for Deployment scaled to 0. (https://github.com/pulumi/pulumi-kubernetes/pull/688).
+
 ## 0.25.5 (August 2, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -625,6 +625,12 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 			fmt.Sprintf("[1/2] Waiting for app ReplicaSet be marked available (%d/%d Pods available)",
 				readyReplicas, specReplicas))
 	}
+
+	if dia.updatedReplicaSetReady && specReplicasExists && specReplicas == 0 {
+		dia.config.logStatus(
+			diag.Warning,
+			fmt.Sprintf("Replicas scaled to 0 for Deployment %q", dia.deployment.GetName()))
+	}
 }
 
 func (dia *deploymentInitAwaiter) changeTriggeredRollout() bool {


### PR DESCRIPTION
Previously, the provider would incorrectly flag a Deployment
as unready if the replicas spec was set to 0.

Partial fix for #605 -- Still need to fix Service that references a Deployment scaled to 0