### PR TITLE
Handle string values in the equalNumbers function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 -   Align YAML parsing with core Kubernetes supported YAML subset. (https://github.com/pulumi/pulumi-kubernetes/pull/690).
+-   Handle string values in the equalNumbers function. (https://github.com/pulumi/pulumi-kubernetes/pull/691).
 -   Properly detect readiness for Deployment scaled to 0. (https://github.com/pulumi/pulumi-kubernetes/pull/688).
 
 ## 0.25.5 (August 2, 2019)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1468,16 +1468,23 @@ func equalNumbers(a, b interface{}) bool {
 		return reflect.DeepEqual(a, b)
 	}
 
-	// If DeepEqual wasn't true, return false for string inputs. At least one of the inputs is likely unknown,
-	// so we'll be conservative and assume they are unequal.
-	if aKind == reflect.String || bKind == reflect.String {
-		return false
+	toFloat := func(v interface{}) (float64, bool) {
+		switch field := v.(type) {
+		case int64:
+			return float64(field), true
+		case float64:
+			return field, true
+		default:
+			return 0, false
+		}
 	}
 
-	if aKind == reflect.Float64 {
-		return a.(float64) == float64(b.(int64))
+	aVal, aOk := toFloat(a)
+	bVal, bOk := toFloat(b)
+	if aOk && bOk {
+		return aVal == bVal
 	}
-	return float64(a.(int64)) == b.(float64)
+	return false
 }
 
 // patchConverter carries context for convertPatchToDiff.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1481,10 +1481,7 @@ func equalNumbers(a, b interface{}) bool {
 
 	aVal, aOk := toFloat(a)
 	bVal, bOk := toFloat(b)
-	if aOk && bOk {
-		return aVal == bVal
-	}
-	return false
+	return aOk && bOk && aVal == bVal
 }
 
 // patchConverter carries context for convertPatchToDiff.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1468,6 +1468,12 @@ func equalNumbers(a, b interface{}) bool {
 		return reflect.DeepEqual(a, b)
 	}
 
+	// If DeepEqual wasn't true, return false for string inputs. At least one of the inputs is likely unknown,
+	// so we'll be conservative and assume they are unequal.
+	if aKind == reflect.String || bKind == reflect.String {
+		return false
+	}
+
 	if aKind == reflect.Float64 {
 		return a.(float64) == float64(b.(int64))
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -88,3 +88,33 @@ func TestRoundtripCheckpointObject(t *testing.T) {
 	assert.Equal(t, oldInputs, newInputs)
 	assert.Equal(t, oldLive, newLive)
 }
+
+func Test_equalNumbers(t *testing.T) {
+	type args struct {
+		a interface{}
+		b interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"a = b, int64", args{a: int64(1), b: int64(1)}, true},
+		{"a = b, float64", args{a: float64(1), b: float64(1)}, true},
+		{"a = b, int64, float64", args{a: int64(1), b: float64(1)}, true},
+		{"a = b, float64, int64", args{a: float64(1), b: int64(1)}, true},
+		{"a != b, int64", args{a: int64(1), b: int64(2)}, false},
+		{"a != b, float64", args{a: float64(1), b: float64(2)}, false},
+		{"a != b, int64, float64", args{a: int64(1), b: float64(2)}, false},
+		{"a != b, float64, int64", args{a: float64(1), b: int64(2)}, false},
+		{"unsupported a", args{a: "", b: int64(1)}, false},
+		{"unsupported b", args{a: int64(1), b: ""}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalNumbers(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("equalNumbers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The equalNumbers function wasn't expecting string inputs,
and would panic if one was present. This condition is
possible if one of the values is unknown during preview.