### PR TITLE
WIP (don't merge) - Change Service readiness condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.14.x
 - v1.13.x
 
+### Major changes
+
+-   Change Service readiness condition. (https://github.com/pulumi/pulumi-kubernetes/pull/703).
+
 ### Improvements
 
 ### Bug fixes

--- a/pkg/clients/unstructured.go
+++ b/pkg/clients/unstructured.go
@@ -36,6 +36,8 @@ func FromUnstructured(obj *unstructured.Unstructured) (metav1.Object, error) {
 	switch kinds.Kind(obj.GetKind()) {
 	case kinds.Deployment:
 		output = new(appsv1.Deployment)
+	case kinds.Endpoints:
+		output = new(corev1.Endpoints)
 	case kinds.Ingress:
 		output = new(v1beta1.Ingress)
 	case kinds.PersistentVolume:
@@ -76,4 +78,22 @@ func PodFromUnstructured(uns *unstructured.Unstructured) (*corev1.Pod, error) {
 	}
 
 	return obj.(*corev1.Pod), nil
+}
+
+func EndpointsFromUnstructured(uns *unstructured.Unstructured) (*corev1.Endpoints, error) {
+	const expectedApiVersion = "v1"
+
+	kind := kinds.Kind(uns.GetKind())
+	if kind != kinds.Endpoints {
+		return nil, fmt.Errorf("expected Endpoints, got %s", kind)
+	}
+	if version := uns.GetAPIVersion(); version != expectedApiVersion {
+		return nil, fmt.Errorf(`expected apiVersion = "%s", got %s`, expectedApiVersion, version)
+	}
+	obj, err := FromUnstructured(uns)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*corev1.Endpoints), nil
 }


### PR DESCRIPTION
Previously, the await logic for a Service checked that Endpoints
targeted at least one address before being marked ready. This
had two problems:

1. The logic didn't account for `notReadyAddresses` in the
endpoints. Even if the selected Pods were unready, the
Service would be marked ready in this case.
2. The logic would not work for Deployments, etc., with replicas
set to 0. While uncommon, this is a valid scenario, and should
not cause the Service to be unready.

The new readiness condition is that the Endpoints do not include
any `notReadyAddresses`. Given the loose coupling between
Services and selected Pods, it's not possible to tell how many
Pods we are waiting for, so we are removing this as a readiness
condition. It's possible that this could erroneously mark a Service
as ready, but this seems better than the alternative of marking
a ready Service as unready.

Fixes #605 