### PR TITLE
Rename `inputs` variable to `props` to not conflict with import

### DIFF
--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -52,9 +52,9 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.{{Group}}.{{Version}}.{{Kind}}, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
+          const props: pulumi.Inputs = {};
           {{#Properties}}
-          inputs["{{Name}}"] = {{{DefaultValue}}};
+          props["{{Name}}"] = {{{DefaultValue}}};
           {{/Properties}}
 
           if (!opts) {
@@ -64,6 +64,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super({{Kind}}.__pulumiType, name, inputs, opts);
+          super({{Kind}}.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.admissionregistration.v1beta1.MutatingWebhookConfiguration, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
-          inputs["kind"] = "MutatingWebhookConfiguration";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["webhooks"] = args && args.webhooks || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
+          props["kind"] = "MutatingWebhookConfiguration";
+          props["metadata"] = args && args.metadata || undefined;
+          props["webhooks"] = args && args.webhooks || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(MutatingWebhookConfiguration.__pulumiType, name, inputs, opts);
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.admissionregistration.v1beta1.MutatingWebhookConfigurationList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "MutatingWebhookConfigurationList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "MutatingWebhookConfigurationList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(MutatingWebhookConfigurationList.__pulumiType, name, inputs, opts);
+          super(MutatingWebhookConfigurationList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.admissionregistration.v1beta1.ValidatingWebhookConfiguration, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
-          inputs["kind"] = "ValidatingWebhookConfiguration";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["webhooks"] = args && args.webhooks || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
+          props["kind"] = "ValidatingWebhookConfiguration";
+          props["metadata"] = args && args.metadata || undefined;
+          props["webhooks"] = args && args.webhooks || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ValidatingWebhookConfiguration.__pulumiType, name, inputs, opts);
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.admissionregistration.v1beta1.ValidatingWebhookConfigurationList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ValidatingWebhookConfigurationList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "admissionregistration.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ValidatingWebhookConfigurationList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ValidatingWebhookConfigurationList.__pulumiType, name, inputs, opts);
+          super(ValidatingWebhookConfigurationList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiextensions/CustomResource.ts
+++ b/sdk/nodejs/apiextensions/CustomResource.ts
@@ -134,9 +134,9 @@ export class CustomResource extends pulumi.CustomResource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(name: string, args: CustomResourceArgs, opts?: pulumi.CustomResourceOptions) {
-        let inputs: pulumi.Inputs = {};
+        const props: pulumi.Inputs = {};
         for (const key of Object.keys(args)) {
-            inputs[key] = (args as any)[key];
+            props[key] = (args as any)[key];
         }
 
         if (!opts) {
@@ -145,7 +145,7 @@ export class CustomResource extends pulumi.CustomResource {
         if (!opts.version) {
             opts.version = getVersion();
         }
-        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, inputs, opts);
+        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, props, opts);
         this.__inputs = args;
     }
 }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
@@ -79,12 +79,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiextensions.v1beta1.CustomResourceDefinition, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiextensions.k8s.io/v1beta1";
-          inputs["kind"] = "CustomResourceDefinition";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiextensions.k8s.io/v1beta1";
+          props["kind"] = "CustomResourceDefinition";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -93,6 +93,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CustomResourceDefinition.__pulumiType, name, inputs, opts);
+          super(CustomResourceDefinition.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
@@ -73,11 +73,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiextensions.v1beta1.CustomResourceDefinitionList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiextensions.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CustomResourceDefinitionList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiextensions.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CustomResourceDefinitionList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -86,6 +86,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CustomResourceDefinitionList.__pulumiType, name, inputs, opts);
+          super(CustomResourceDefinitionList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -78,12 +78,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiregistration.v1.APIService, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiregistration.k8s.io/v1";
-          inputs["kind"] = "APIService";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiregistration.k8s.io/v1";
+          props["kind"] = "APIService";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -92,6 +92,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(APIService.__pulumiType, name, inputs, opts);
+          super(APIService.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1/APIServiceList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiregistration.v1.APIServiceList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiregistration.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "APIServiceList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiregistration.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "APIServiceList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(APIServiceList.__pulumiType, name, inputs, opts);
+          super(APIServiceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -78,12 +78,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiregistration.v1beta1.APIService, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiregistration.k8s.io/v1beta1";
-          inputs["kind"] = "APIService";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiregistration.k8s.io/v1beta1";
+          props["kind"] = "APIService";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -92,6 +92,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(APIService.__pulumiType, name, inputs, opts);
+          super(APIService.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apiregistration.v1beta1.APIServiceList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apiregistration.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "APIServiceList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apiregistration.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "APIServiceList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(APIServiceList.__pulumiType, name, inputs, opts);
+          super(APIServiceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevision.ts
@@ -88,12 +88,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.ControllerRevision, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["data"] = args && args.data || undefined;
-          inputs["kind"] = "ControllerRevision";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["revision"] = args && args.revision || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["data"] = args && args.data || undefined;
+          props["kind"] = "ControllerRevision";
+          props["metadata"] = args && args.metadata || undefined;
+          props["revision"] = args && args.revision || undefined;
 
           if (!opts) {
               opts = {};
@@ -102,6 +102,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevision.__pulumiType, name, inputs, opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevisionList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.ControllerRevisionList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ControllerRevisionList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ControllerRevisionList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevisionList.__pulumiType, name, inputs, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1/DaemonSet.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.DaemonSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["kind"] = "DaemonSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["kind"] = "DaemonSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSet.__pulumiType, name, inputs, opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1/DaemonSetList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.DaemonSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DaemonSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DaemonSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSetList.__pulumiType, name, inputs, opts);
+          super(DaemonSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -80,12 +80,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.Deployment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["kind"] = "Deployment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["kind"] = "Deployment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -94,6 +94,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Deployment.__pulumiType, name, inputs, opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1/DeploymentList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.DeploymentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DeploymentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DeploymentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DeploymentList.__pulumiType, name, inputs, opts);
+          super(DeploymentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSet.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.ReplicaSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["kind"] = "ReplicaSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["kind"] = "ReplicaSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSet.__pulumiType, name, inputs, opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSetList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.ReplicaSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ReplicaSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ReplicaSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSetList.__pulumiType, name, inputs, opts);
+          super(ReplicaSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.StatefulSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["kind"] = "StatefulSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["kind"] = "StatefulSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSet.__pulumiType, name, inputs, opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1/StatefulSetList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1.StatefulSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "StatefulSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "StatefulSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSetList.__pulumiType, name, inputs, opts);
+          super(StatefulSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -90,12 +90,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.ControllerRevision, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["data"] = args && args.data || undefined;
-          inputs["kind"] = "ControllerRevision";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["revision"] = args && args.revision || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["data"] = args && args.data || undefined;
+          props["kind"] = "ControllerRevision";
+          props["metadata"] = args && args.metadata || undefined;
+          props["revision"] = args && args.revision || undefined;
 
           if (!opts) {
               opts = {};
@@ -104,6 +104,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevision.__pulumiType, name, inputs, opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.ControllerRevisionList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ControllerRevisionList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ControllerRevisionList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevisionList.__pulumiType, name, inputs, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.Deployment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["kind"] = "Deployment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["kind"] = "Deployment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Deployment.__pulumiType, name, inputs, opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta1/DeploymentList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.DeploymentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DeploymentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DeploymentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DeploymentList.__pulumiType, name, inputs, opts);
+          super(DeploymentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.StatefulSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["kind"] = "StatefulSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["kind"] = "StatefulSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSet.__pulumiType, name, inputs, opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta1.StatefulSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "StatefulSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "StatefulSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSetList.__pulumiType, name, inputs, opts);
+          super(StatefulSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -90,12 +90,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.ControllerRevision, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["data"] = args && args.data || undefined;
-          inputs["kind"] = "ControllerRevision";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["revision"] = args && args.revision || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["data"] = args && args.data || undefined;
+          props["kind"] = "ControllerRevision";
+          props["metadata"] = args && args.metadata || undefined;
+          props["revision"] = args && args.revision || undefined;
 
           if (!opts) {
               opts = {};
@@ -104,6 +104,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevision.__pulumiType, name, inputs, opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.ControllerRevisionList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ControllerRevisionList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ControllerRevisionList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ControllerRevisionList.__pulumiType, name, inputs, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.DaemonSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["kind"] = "DaemonSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["kind"] = "DaemonSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSet.__pulumiType, name, inputs, opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.DaemonSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DaemonSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DaemonSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSetList.__pulumiType, name, inputs, opts);
+          super(DaemonSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.Deployment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["kind"] = "Deployment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["kind"] = "Deployment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Deployment.__pulumiType, name, inputs, opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta2/DeploymentList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.DeploymentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DeploymentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DeploymentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DeploymentList.__pulumiType, name, inputs, opts);
+          super(DeploymentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -87,12 +87,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.ReplicaSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["kind"] = "ReplicaSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["kind"] = "ReplicaSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -101,6 +101,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSet.__pulumiType, name, inputs, opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.ReplicaSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ReplicaSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ReplicaSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSetList.__pulumiType, name, inputs, opts);
+          super(ReplicaSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.StatefulSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["kind"] = "StatefulSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["kind"] = "StatefulSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSet.__pulumiType, name, inputs, opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.apps.v1beta2.StatefulSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "apps/v1beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "StatefulSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "apps/v1beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "StatefulSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StatefulSetList.__pulumiType, name, inputs, opts);
+          super(StatefulSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
@@ -73,11 +73,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.auditregistration.v1alpha1.AuditSink, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "auditregistration.k8s.io/v1alpha1";
-          inputs["kind"] = "AuditSink";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "auditregistration.k8s.io/v1alpha1";
+          props["kind"] = "AuditSink";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -86,6 +86,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(AuditSink.__pulumiType, name, inputs, opts);
+          super(AuditSink.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
@@ -73,11 +73,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.auditregistration.v1alpha1.AuditSinkList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "auditregistration.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "AuditSinkList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "auditregistration.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "AuditSinkList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -86,6 +86,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(AuditSinkList.__pulumiType, name, inputs, opts);
+          super(AuditSinkList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authentication/v1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1/TokenReview.ts
@@ -79,12 +79,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authentication.v1.TokenReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authentication.k8s.io/v1";
-          inputs["kind"] = "TokenReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authentication.k8s.io/v1";
+          props["kind"] = "TokenReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -93,6 +93,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(TokenReview.__pulumiType, name, inputs, opts);
+          super(TokenReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authentication/v1beta1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1beta1/TokenReview.ts
@@ -79,12 +79,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authentication.v1beta1.TokenReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authentication.k8s.io/v1beta1";
-          inputs["kind"] = "TokenReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authentication.k8s.io/v1beta1";
+          props["kind"] = "TokenReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -93,6 +93,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(TokenReview.__pulumiType, name, inputs, opts);
+          super(TokenReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
@@ -81,12 +81,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1.LocalSubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1";
-          inputs["kind"] = "LocalSubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1";
+          props["kind"] = "LocalSubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -95,6 +95,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LocalSubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
@@ -80,12 +80,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1.SelfSubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1";
-          inputs["kind"] = "SelfSubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1";
+          props["kind"] = "SelfSubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -94,6 +94,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SelfSubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1.SelfSubjectRulesReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1";
-          inputs["kind"] = "SelfSubjectRulesReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1";
+          props["kind"] = "SelfSubjectRulesReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SelfSubjectRulesReview.__pulumiType, name, inputs, opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
@@ -78,12 +78,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1.SubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1";
-          inputs["kind"] = "SubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1";
+          props["kind"] = "SubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -92,6 +92,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(SubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
@@ -81,12 +81,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1beta1.LocalSubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1beta1";
-          inputs["kind"] = "LocalSubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1beta1";
+          props["kind"] = "LocalSubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -95,6 +95,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LocalSubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
@@ -80,12 +80,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1beta1.SelfSubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1beta1";
-          inputs["kind"] = "SelfSubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1beta1";
+          props["kind"] = "SelfSubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -94,6 +94,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SelfSubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1beta1.SelfSubjectRulesReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1beta1";
-          inputs["kind"] = "SelfSubjectRulesReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1beta1";
+          props["kind"] = "SelfSubjectRulesReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SelfSubjectRulesReview.__pulumiType, name, inputs, opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
@@ -78,12 +78,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.authorization.v1beta1.SubjectAccessReview, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "authorization.k8s.io/v1beta1";
-          inputs["kind"] = "SubjectAccessReview";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "authorization.k8s.io/v1beta1";
+          props["kind"] = "SubjectAccessReview";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -92,6 +92,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SubjectAccessReview.__pulumiType, name, inputs, opts);
+          super(SubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v1.HorizontalPodAutoscaler, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v1";
-          inputs["kind"] = "HorizontalPodAutoscaler";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v1";
+          props["kind"] = "HorizontalPodAutoscaler";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscaler.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v1.HorizontalPodAutoscalerList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "HorizontalPodAutoscalerList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "HorizontalPodAutoscalerList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscalerList.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v2beta1.HorizontalPodAutoscaler, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v2beta1";
-          inputs["kind"] = "HorizontalPodAutoscaler";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v2beta1";
+          props["kind"] = "HorizontalPodAutoscaler";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscaler.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v2beta1.HorizontalPodAutoscalerList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v2beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "HorizontalPodAutoscalerList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v2beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "HorizontalPodAutoscalerList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscalerList.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v2beta2.HorizontalPodAutoscaler, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v2beta2";
-          inputs["kind"] = "HorizontalPodAutoscaler";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v2beta2";
+          props["kind"] = "HorizontalPodAutoscaler";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscaler.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.autoscaling.v2beta2.HorizontalPodAutoscalerList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "autoscaling/v2beta2";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "HorizontalPodAutoscalerList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "autoscaling/v2beta2";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "HorizontalPodAutoscalerList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(HorizontalPodAutoscalerList.__pulumiType, name, inputs, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v1/Job.ts
+++ b/sdk/nodejs/batch/v1/Job.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v1.Job, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v1";
-          inputs["kind"] = "Job";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v1";
+          props["kind"] = "Job";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Job.__pulumiType, name, inputs, opts);
+          super(Job.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v1/JobList.ts
+++ b/sdk/nodejs/batch/v1/JobList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v1.JobList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "JobList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "JobList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(JobList.__pulumiType, name, inputs, opts);
+          super(JobList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJob.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJob.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v1beta1.CronJob, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v1beta1";
-          inputs["kind"] = "CronJob";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v1beta1";
+          props["kind"] = "CronJob";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CronJob.__pulumiType, name, inputs, opts);
+          super(CronJob.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJobList.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJobList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v1beta1.CronJobList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CronJobList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CronJobList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CronJobList.__pulumiType, name, inputs, opts);
+          super(CronJobList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJob.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJob.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v2alpha1.CronJob, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v2alpha1";
-          inputs["kind"] = "CronJob";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v2alpha1";
+          props["kind"] = "CronJob";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CronJob.__pulumiType, name, inputs, opts);
+          super(CronJob.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJobList.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJobList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.batch.v2alpha1.CronJobList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "batch/v2alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CronJobList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "batch/v2alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CronJobList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CronJobList.__pulumiType, name, inputs, opts);
+          super(CronJobList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
@@ -78,12 +78,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.certificates.v1beta1.CertificateSigningRequest, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "certificates.k8s.io/v1beta1";
-          inputs["kind"] = "CertificateSigningRequest";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "certificates.k8s.io/v1beta1";
+          props["kind"] = "CertificateSigningRequest";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -92,6 +92,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CertificateSigningRequest.__pulumiType, name, inputs, opts);
+          super(CertificateSigningRequest.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
@@ -69,11 +69,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.certificates.v1beta1.CertificateSigningRequestList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "certificates.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CertificateSigningRequestList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "certificates.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CertificateSigningRequestList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -82,6 +82,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CertificateSigningRequestList.__pulumiType, name, inputs, opts);
+          super(CertificateSigningRequestList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/Lease.ts
+++ b/sdk/nodejs/coordination/v1/Lease.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.coordination.v1.Lease, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "coordination.k8s.io/v1";
-          inputs["kind"] = "Lease";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "coordination.k8s.io/v1";
+          props["kind"] = "Lease";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Lease.__pulumiType, name, inputs, opts);
+          super(Lease.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1/LeaseList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.coordination.v1.LeaseList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "coordination.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "LeaseList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "coordination.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "LeaseList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LeaseList.__pulumiType, name, inputs, opts);
+          super(LeaseList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/Lease.ts
+++ b/sdk/nodejs/coordination/v1beta1/Lease.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.coordination.v1beta1.Lease, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "coordination.k8s.io/v1beta1";
-          inputs["kind"] = "Lease";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "coordination.k8s.io/v1beta1";
+          props["kind"] = "Lease";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Lease.__pulumiType, name, inputs, opts);
+          super(Lease.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1beta1/LeaseList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.coordination.v1beta1.LeaseList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "coordination.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "LeaseList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "coordination.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "LeaseList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LeaseList.__pulumiType, name, inputs, opts);
+          super(LeaseList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Binding.ts
+++ b/sdk/nodejs/core/v1/Binding.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Binding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Binding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["target"] = args && args.target || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Binding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["target"] = args && args.target || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Binding.__pulumiType, name, inputs, opts);
+          super(Binding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ComponentStatus.ts
+++ b/sdk/nodejs/core/v1/ComponentStatus.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ComponentStatus, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["conditions"] = args && args.conditions || undefined;
-          inputs["kind"] = "ComponentStatus";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["conditions"] = args && args.conditions || undefined;
+          props["kind"] = "ComponentStatus";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ComponentStatus.__pulumiType, name, inputs, opts);
+          super(ComponentStatus.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ComponentStatusList.ts
+++ b/sdk/nodejs/core/v1/ComponentStatusList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ComponentStatusList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ComponentStatusList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ComponentStatusList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ComponentStatusList.__pulumiType, name, inputs, opts);
+          super(ComponentStatusList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ConfigMap.ts
+++ b/sdk/nodejs/core/v1/ConfigMap.ts
@@ -87,12 +87,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ConfigMap, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["binaryData"] = args && args.binaryData || undefined;
-          inputs["data"] = args && args.data || undefined;
-          inputs["kind"] = "ConfigMap";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["binaryData"] = args && args.binaryData || undefined;
+          props["data"] = args && args.data || undefined;
+          props["kind"] = "ConfigMap";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -101,6 +101,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ConfigMap.__pulumiType, name, inputs, opts);
+          super(ConfigMap.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ConfigMapList.ts
+++ b/sdk/nodejs/core/v1/ConfigMapList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ConfigMapList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ConfigMapList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ConfigMapList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ConfigMapList.__pulumiType, name, inputs, opts);
+          super(ConfigMapList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Endpoints.ts
+++ b/sdk/nodejs/core/v1/Endpoints.ts
@@ -92,11 +92,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Endpoints, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Endpoints";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["subsets"] = args && args.subsets || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Endpoints";
+          props["metadata"] = args && args.metadata || undefined;
+          props["subsets"] = args && args.subsets || undefined;
 
           if (!opts) {
               opts = {};
@@ -105,6 +105,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Endpoints.__pulumiType, name, inputs, opts);
+          super(Endpoints.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/EndpointsList.ts
+++ b/sdk/nodejs/core/v1/EndpointsList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.EndpointsList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "EndpointsList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "EndpointsList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(EndpointsList.__pulumiType, name, inputs, opts);
+          super(EndpointsList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Event.ts
+++ b/sdk/nodejs/core/v1/Event.ts
@@ -142,24 +142,24 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Event, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["action"] = args && args.action || undefined;
-          inputs["apiVersion"] = "v1";
-          inputs["count"] = args && args.count || undefined;
-          inputs["eventTime"] = args && args.eventTime || undefined;
-          inputs["firstTimestamp"] = args && args.firstTimestamp || undefined;
-          inputs["involvedObject"] = args && args.involvedObject || undefined;
-          inputs["kind"] = "Event";
-          inputs["lastTimestamp"] = args && args.lastTimestamp || undefined;
-          inputs["message"] = args && args.message || undefined;
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["reason"] = args && args.reason || undefined;
-          inputs["related"] = args && args.related || undefined;
-          inputs["reportingComponent"] = args && args.reportingComponent || undefined;
-          inputs["reportingInstance"] = args && args.reportingInstance || undefined;
-          inputs["series"] = args && args.series || undefined;
-          inputs["source"] = args && args.source || undefined;
-          inputs["type"] = args && args.type || undefined;
+          const props: pulumi.Inputs = {};
+          props["action"] = args && args.action || undefined;
+          props["apiVersion"] = "v1";
+          props["count"] = args && args.count || undefined;
+          props["eventTime"] = args && args.eventTime || undefined;
+          props["firstTimestamp"] = args && args.firstTimestamp || undefined;
+          props["involvedObject"] = args && args.involvedObject || undefined;
+          props["kind"] = "Event";
+          props["lastTimestamp"] = args && args.lastTimestamp || undefined;
+          props["message"] = args && args.message || undefined;
+          props["metadata"] = args && args.metadata || undefined;
+          props["reason"] = args && args.reason || undefined;
+          props["related"] = args && args.related || undefined;
+          props["reportingComponent"] = args && args.reportingComponent || undefined;
+          props["reportingInstance"] = args && args.reportingInstance || undefined;
+          props["series"] = args && args.series || undefined;
+          props["source"] = args && args.source || undefined;
+          props["type"] = args && args.type || undefined;
 
           if (!opts) {
               opts = {};
@@ -168,6 +168,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Event.__pulumiType, name, inputs, opts);
+          super(Event.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/EventList.ts
+++ b/sdk/nodejs/core/v1/EventList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.EventList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "EventList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "EventList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(EventList.__pulumiType, name, inputs, opts);
+          super(EventList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/LimitRange.ts
+++ b/sdk/nodejs/core/v1/LimitRange.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.LimitRange, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "LimitRange";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "LimitRange";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LimitRange.__pulumiType, name, inputs, opts);
+          super(LimitRange.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/LimitRangeList.ts
+++ b/sdk/nodejs/core/v1/LimitRangeList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.LimitRangeList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "LimitRangeList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "LimitRangeList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(LimitRangeList.__pulumiType, name, inputs, opts);
+          super(LimitRangeList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Namespace.ts
+++ b/sdk/nodejs/core/v1/Namespace.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Namespace, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Namespace";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Namespace";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Namespace.__pulumiType, name, inputs, opts);
+          super(Namespace.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/NamespaceList.ts
+++ b/sdk/nodejs/core/v1/NamespaceList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.NamespaceList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "NamespaceList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "NamespaceList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NamespaceList.__pulumiType, name, inputs, opts);
+          super(NamespaceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Node.ts
+++ b/sdk/nodejs/core/v1/Node.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Node, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Node";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Node";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Node.__pulumiType, name, inputs, opts);
+          super(Node.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/NodeList.ts
+++ b/sdk/nodejs/core/v1/NodeList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.NodeList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "NodeList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "NodeList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NodeList.__pulumiType, name, inputs, opts);
+          super(NodeList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolume.ts
+++ b/sdk/nodejs/core/v1/PersistentVolume.ts
@@ -86,12 +86,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PersistentVolume, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "PersistentVolume";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "PersistentVolume";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -100,6 +100,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PersistentVolume.__pulumiType, name, inputs, opts);
+          super(PersistentVolume.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PersistentVolumeClaim, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "PersistentVolumeClaim";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "PersistentVolumeClaim";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PersistentVolumeClaim.__pulumiType, name, inputs, opts);
+          super(PersistentVolumeClaim.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PersistentVolumeClaimList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PersistentVolumeClaimList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PersistentVolumeClaimList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PersistentVolumeClaimList.__pulumiType, name, inputs, opts);
+          super(PersistentVolumeClaimList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PersistentVolumeList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PersistentVolumeList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PersistentVolumeList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PersistentVolumeList.__pulumiType, name, inputs, opts);
+          super(PersistentVolumeList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Pod.ts
+++ b/sdk/nodejs/core/v1/Pod.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Pod, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Pod";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Pod";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Pod.__pulumiType, name, inputs, opts);
+          super(Pod.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodList.ts
+++ b/sdk/nodejs/core/v1/PodList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PodList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodList.__pulumiType, name, inputs, opts);
+          super(PodList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodTemplate.ts
+++ b/sdk/nodejs/core/v1/PodTemplate.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PodTemplate, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "PodTemplate";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["template"] = args && args.template || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "PodTemplate";
+          props["metadata"] = args && args.metadata || undefined;
+          props["template"] = args && args.template || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodTemplate.__pulumiType, name, inputs, opts);
+          super(PodTemplate.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodTemplateList.ts
+++ b/sdk/nodejs/core/v1/PodTemplateList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.PodTemplateList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodTemplateList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodTemplateList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodTemplateList.__pulumiType, name, inputs, opts);
+          super(PodTemplateList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ReplicationController.ts
+++ b/sdk/nodejs/core/v1/ReplicationController.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ReplicationController, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "ReplicationController";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "ReplicationController";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicationController.__pulumiType, name, inputs, opts);
+          super(ReplicationController.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ReplicationControllerList.ts
+++ b/sdk/nodejs/core/v1/ReplicationControllerList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ReplicationControllerList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ReplicationControllerList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ReplicationControllerList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicationControllerList.__pulumiType, name, inputs, opts);
+          super(ReplicationControllerList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ResourceQuota.ts
+++ b/sdk/nodejs/core/v1/ResourceQuota.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ResourceQuota, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "ResourceQuota";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "ResourceQuota";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ResourceQuota.__pulumiType, name, inputs, opts);
+          super(ResourceQuota.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ResourceQuotaList.ts
+++ b/sdk/nodejs/core/v1/ResourceQuotaList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ResourceQuotaList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ResourceQuotaList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ResourceQuotaList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ResourceQuotaList.__pulumiType, name, inputs, opts);
+          super(ResourceQuotaList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Secret.ts
+++ b/sdk/nodejs/core/v1/Secret.ts
@@ -92,13 +92,13 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Secret, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["data"] = args && args.data || undefined;
-          inputs["kind"] = "Secret";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["stringData"] = args && args.stringData || undefined;
-          inputs["type"] = args && args.type || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["data"] = args && args.data || undefined;
+          props["kind"] = "Secret";
+          props["metadata"] = args && args.metadata || undefined;
+          props["stringData"] = args && args.stringData || undefined;
+          props["type"] = args && args.type || undefined;
 
           if (!opts) {
               opts = {};
@@ -107,6 +107,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Secret.__pulumiType, name, inputs, opts);
+          super(Secret.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/SecretList.ts
+++ b/sdk/nodejs/core/v1/SecretList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.SecretList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "SecretList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "SecretList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(SecretList.__pulumiType, name, inputs, opts);
+          super(SecretList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Service.ts
+++ b/sdk/nodejs/core/v1/Service.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.Service, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["kind"] = "Service";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["kind"] = "Service";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Service.__pulumiType, name, inputs, opts);
+          super(Service.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceAccount.ts
+++ b/sdk/nodejs/core/v1/ServiceAccount.ts
@@ -94,13 +94,13 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ServiceAccount, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["automountServiceAccountToken"] = args && args.automountServiceAccountToken || undefined;
-          inputs["imagePullSecrets"] = args && args.imagePullSecrets || undefined;
-          inputs["kind"] = "ServiceAccount";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["secrets"] = args && args.secrets || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["automountServiceAccountToken"] = args && args.automountServiceAccountToken || undefined;
+          props["imagePullSecrets"] = args && args.imagePullSecrets || undefined;
+          props["kind"] = "ServiceAccount";
+          props["metadata"] = args && args.metadata || undefined;
+          props["secrets"] = args && args.secrets || undefined;
 
           if (!opts) {
               opts = {};
@@ -109,6 +109,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ServiceAccount.__pulumiType, name, inputs, opts);
+          super(ServiceAccount.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceAccountList.ts
+++ b/sdk/nodejs/core/v1/ServiceAccountList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ServiceAccountList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ServiceAccountList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ServiceAccountList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ServiceAccountList.__pulumiType, name, inputs, opts);
+          super(ServiceAccountList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceList.ts
+++ b/sdk/nodejs/core/v1/ServiceList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.core.v1.ServiceList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ServiceList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ServiceList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ServiceList.__pulumiType, name, inputs, opts);
+          super(ServiceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/Event.ts
+++ b/sdk/nodejs/events/v1beta1/Event.ts
@@ -143,24 +143,24 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.events.v1beta1.Event, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["action"] = args && args.action || undefined;
-          inputs["apiVersion"] = "events.k8s.io/v1beta1";
-          inputs["deprecatedCount"] = args && args.deprecatedCount || undefined;
-          inputs["deprecatedFirstTimestamp"] = args && args.deprecatedFirstTimestamp || undefined;
-          inputs["deprecatedLastTimestamp"] = args && args.deprecatedLastTimestamp || undefined;
-          inputs["deprecatedSource"] = args && args.deprecatedSource || undefined;
-          inputs["eventTime"] = args && args.eventTime || undefined;
-          inputs["kind"] = "Event";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["note"] = args && args.note || undefined;
-          inputs["reason"] = args && args.reason || undefined;
-          inputs["regarding"] = args && args.regarding || undefined;
-          inputs["related"] = args && args.related || undefined;
-          inputs["reportingController"] = args && args.reportingController || undefined;
-          inputs["reportingInstance"] = args && args.reportingInstance || undefined;
-          inputs["series"] = args && args.series || undefined;
-          inputs["type"] = args && args.type || undefined;
+          const props: pulumi.Inputs = {};
+          props["action"] = args && args.action || undefined;
+          props["apiVersion"] = "events.k8s.io/v1beta1";
+          props["deprecatedCount"] = args && args.deprecatedCount || undefined;
+          props["deprecatedFirstTimestamp"] = args && args.deprecatedFirstTimestamp || undefined;
+          props["deprecatedLastTimestamp"] = args && args.deprecatedLastTimestamp || undefined;
+          props["deprecatedSource"] = args && args.deprecatedSource || undefined;
+          props["eventTime"] = args && args.eventTime || undefined;
+          props["kind"] = "Event";
+          props["metadata"] = args && args.metadata || undefined;
+          props["note"] = args && args.note || undefined;
+          props["reason"] = args && args.reason || undefined;
+          props["regarding"] = args && args.regarding || undefined;
+          props["related"] = args && args.related || undefined;
+          props["reportingController"] = args && args.reportingController || undefined;
+          props["reportingInstance"] = args && args.reportingInstance || undefined;
+          props["series"] = args && args.series || undefined;
+          props["type"] = args && args.type || undefined;
 
           if (!opts) {
               opts = {};
@@ -169,6 +169,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Event.__pulumiType, name, inputs, opts);
+          super(Event.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/EventList.ts
+++ b/sdk/nodejs/events/v1beta1/EventList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.events.v1beta1.EventList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "events.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "EventList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "events.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "EventList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(EventList.__pulumiType, name, inputs, opts);
+          super(EventList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.DaemonSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "DaemonSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "DaemonSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSet.__pulumiType, name, inputs, opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.DaemonSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DaemonSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DaemonSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DaemonSetList.__pulumiType, name, inputs, opts);
+          super(DaemonSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.Deployment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "Deployment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "Deployment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Deployment.__pulumiType, name, inputs, opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.DeploymentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "DeploymentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "DeploymentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(DeploymentList.__pulumiType, name, inputs, opts);
+          super(DeploymentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -87,12 +87,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.Ingress, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "Ingress";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "Ingress";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -101,6 +101,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Ingress.__pulumiType, name, inputs, opts);
+          super(Ingress.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/IngressList.ts
+++ b/sdk/nodejs/extensions/v1beta1/IngressList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.IngressList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "IngressList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "IngressList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(IngressList.__pulumiType, name, inputs, opts);
+          super(IngressList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -78,11 +78,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.NetworkPolicy, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "NetworkPolicy";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "NetworkPolicy";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -91,6 +91,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NetworkPolicy.__pulumiType, name, inputs, opts);
+          super(NetworkPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.NetworkPolicyList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "NetworkPolicyList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "NetworkPolicyList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NetworkPolicyList.__pulumiType, name, inputs, opts);
+          super(NetworkPolicyList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -78,11 +78,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.PodSecurityPolicy, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "PodSecurityPolicy";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "PodSecurityPolicy";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -91,6 +91,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodSecurityPolicy.__pulumiType, name, inputs, opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.PodSecurityPolicyList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodSecurityPolicyList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodSecurityPolicyList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodSecurityPolicyList.__pulumiType, name, inputs, opts);
+          super(PodSecurityPolicyList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -87,12 +87,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.ReplicaSet, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["kind"] = "ReplicaSet";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["kind"] = "ReplicaSet";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -101,6 +101,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSet.__pulumiType, name, inputs, opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.extensions.v1beta1.ReplicaSetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "extensions/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ReplicaSetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "extensions/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ReplicaSetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ReplicaSetList.__pulumiType, name, inputs, opts);
+          super(ReplicaSetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/meta/v1/Status.ts
+++ b/sdk/nodejs/meta/v1/Status.ts
@@ -101,15 +101,15 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.meta.v1.Status, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "v1";
-          inputs["code"] = args && args.code || undefined;
-          inputs["details"] = args && args.details || undefined;
-          inputs["kind"] = "Status";
-          inputs["message"] = args && args.message || undefined;
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["reason"] = args && args.reason || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "v1";
+          props["code"] = args && args.code || undefined;
+          props["details"] = args && args.details || undefined;
+          props["kind"] = "Status";
+          props["message"] = args && args.message || undefined;
+          props["metadata"] = args && args.metadata || undefined;
+          props["reason"] = args && args.reason || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -118,6 +118,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Status.__pulumiType, name, inputs, opts);
+          super(Status.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.networking.v1.NetworkPolicy, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "networking.k8s.io/v1";
-          inputs["kind"] = "NetworkPolicy";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "networking.k8s.io/v1";
+          props["kind"] = "NetworkPolicy";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NetworkPolicy.__pulumiType, name, inputs, opts);
+          super(NetworkPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicyList.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicyList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.networking.v1.NetworkPolicyList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "networking.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "NetworkPolicyList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "networking.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "NetworkPolicyList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(NetworkPolicyList.__pulumiType, name, inputs, opts);
+          super(NetworkPolicyList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -85,12 +85,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.networking.v1beta1.Ingress, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "networking.k8s.io/v1beta1";
-          inputs["kind"] = "Ingress";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "networking.k8s.io/v1beta1";
+          props["kind"] = "Ingress";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Ingress.__pulumiType, name, inputs, opts);
+          super(Ingress.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/IngressList.ts
+++ b/sdk/nodejs/networking/v1beta1/IngressList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.networking.v1beta1.IngressList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "networking.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "IngressList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "networking.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "IngressList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(IngressList.__pulumiType, name, inputs, opts);
+          super(IngressList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
@@ -81,11 +81,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.node.v1alpha1.RuntimeClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "node.k8s.io/v1alpha1";
-          inputs["kind"] = "RuntimeClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "node.k8s.io/v1alpha1";
+          props["kind"] = "RuntimeClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -94,6 +94,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RuntimeClass.__pulumiType, name, inputs, opts);
+          super(RuntimeClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.node.v1alpha1.RuntimeClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "node.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RuntimeClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "node.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RuntimeClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RuntimeClassList.__pulumiType, name, inputs, opts);
+          super(RuntimeClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClass.ts
@@ -86,11 +86,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.node.v1beta1.RuntimeClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "node.k8s.io/v1beta1";
-          inputs["handler"] = args && args.handler || undefined;
-          inputs["kind"] = "RuntimeClass";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "node.k8s.io/v1beta1";
+          props["handler"] = args && args.handler || undefined;
+          props["kind"] = "RuntimeClass";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -99,6 +99,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RuntimeClass.__pulumiType, name, inputs, opts);
+          super(RuntimeClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.node.v1beta1.RuntimeClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "node.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RuntimeClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "node.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RuntimeClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RuntimeClassList.__pulumiType, name, inputs, opts);
+          super(RuntimeClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
@@ -79,12 +79,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.policy.v1beta1.PodDisruptionBudget, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "policy/v1beta1";
-          inputs["kind"] = "PodDisruptionBudget";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "policy/v1beta1";
+          props["kind"] = "PodDisruptionBudget";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -93,6 +93,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodDisruptionBudget.__pulumiType, name, inputs, opts);
+          super(PodDisruptionBudget.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.policy.v1beta1.PodDisruptionBudgetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "policy/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodDisruptionBudgetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "policy/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodDisruptionBudgetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodDisruptionBudgetList.__pulumiType, name, inputs, opts);
+          super(PodDisruptionBudgetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -77,11 +77,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.policy.v1beta1.PodSecurityPolicy, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "policy/v1beta1";
-          inputs["kind"] = "PodSecurityPolicy";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "policy/v1beta1";
+          props["kind"] = "PodSecurityPolicy";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -90,6 +90,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodSecurityPolicy.__pulumiType, name, inputs, opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.policy.v1beta1.PodSecurityPolicyList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "policy/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodSecurityPolicyList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "policy/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodSecurityPolicyList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodSecurityPolicyList.__pulumiType, name, inputs, opts);
+          super(PodSecurityPolicyList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -12,14 +12,14 @@ export class Provider extends pulumi.ProviderResource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(name: string, args: ProviderArgs, opts?: pulumi.ResourceOptions) {
-        let inputs: pulumi.Inputs = {
+        const props: pulumi.Inputs = {
             "cluster": args ? args.cluster : undefined,
             "context": args ? args.context : undefined,
             "kubeconfig": args ? args.kubeconfig : undefined,
             "namespace": args ? args.namespace : undefined,
             "enableDryRun": args && args.enableDryRun ? "true" : undefined
         };
-        super("kubernetes", name, inputs, opts);
+        super("kubernetes", name, props, opts);
     }
 }
 

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.ClusterRole, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["aggregationRule"] = args && args.aggregationRule || undefined;
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["kind"] = "ClusterRole";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["aggregationRule"] = args && args.aggregationRule || undefined;
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["kind"] = "ClusterRole";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRole.__pulumiType, name, inputs, opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.ClusterRoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["kind"] = "ClusterRoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["kind"] = "ClusterRoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBinding.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.ClusterRoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBindingList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.ClusterRoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.Role, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["kind"] = "Role";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["kind"] = "Role";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Role.__pulumiType, name, inputs, opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.RoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["kind"] = "RoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["kind"] = "RoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBinding.__pulumiType, name, inputs, opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/RoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.RoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBindingList.__pulumiType, name, inputs, opts);
+          super(RoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1/RoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1.RoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleList.__pulumiType, name, inputs, opts);
+          super(RoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.ClusterRole, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["aggregationRule"] = args && args.aggregationRule || undefined;
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["kind"] = "ClusterRole";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["aggregationRule"] = args && args.aggregationRule || undefined;
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["kind"] = "ClusterRole";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRole.__pulumiType, name, inputs, opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.ClusterRoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["kind"] = "ClusterRoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["kind"] = "ClusterRoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBinding.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.ClusterRoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBindingList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.ClusterRoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.Role, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["kind"] = "Role";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["kind"] = "Role";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Role.__pulumiType, name, inputs, opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.RoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["kind"] = "RoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["kind"] = "RoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBinding.__pulumiType, name, inputs, opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.RoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBindingList.__pulumiType, name, inputs, opts);
+          super(RoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1alpha1.RoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleList.__pulumiType, name, inputs, opts);
+          super(RoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -83,12 +83,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.ClusterRole, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["aggregationRule"] = args && args.aggregationRule || undefined;
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["kind"] = "ClusterRole";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["aggregationRule"] = args && args.aggregationRule || undefined;
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["kind"] = "ClusterRole";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -97,6 +97,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRole.__pulumiType, name, inputs, opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -82,12 +82,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.ClusterRoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["kind"] = "ClusterRoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["kind"] = "ClusterRoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -96,6 +96,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBinding.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.ClusterRoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleBindingList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.ClusterRoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "ClusterRoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "ClusterRoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(ClusterRoleList.__pulumiType, name, inputs, opts);
+          super(ClusterRoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.Role, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["kind"] = "Role";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["rules"] = args && args.rules || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["kind"] = "Role";
+          props["metadata"] = args && args.metadata || undefined;
+          props["rules"] = args && args.rules || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(Role.__pulumiType, name, inputs, opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -84,12 +84,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.RoleBinding, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["kind"] = "RoleBinding";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["roleRef"] = args && args.roleRef || undefined;
-          inputs["subjects"] = args && args.subjects || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["kind"] = "RoleBinding";
+          props["metadata"] = args && args.metadata || undefined;
+          props["roleRef"] = args && args.roleRef || undefined;
+          props["subjects"] = args && args.subjects || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBinding.__pulumiType, name, inputs, opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.RoleBindingList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleBindingList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleBindingList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleBindingList.__pulumiType, name, inputs, opts);
+          super(RoleBindingList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleList.ts
@@ -75,11 +75,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.rbac.v1beta1.RoleList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "RoleList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "rbac.authorization.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "RoleList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -88,6 +88,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(RoleList.__pulumiType, name, inputs, opts);
+          super(RoleList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -100,14 +100,14 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1.PriorityClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1";
-          inputs["description"] = args && args.description || undefined;
-          inputs["globalDefault"] = args && args.globalDefault || undefined;
-          inputs["kind"] = "PriorityClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
-          inputs["value"] = args && args.value || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1";
+          props["description"] = args && args.description || undefined;
+          props["globalDefault"] = args && args.globalDefault || undefined;
+          props["kind"] = "PriorityClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
+          props["value"] = args && args.value || undefined;
 
           if (!opts) {
               opts = {};
@@ -116,6 +116,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClass.__pulumiType, name, inputs, opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1.PriorityClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PriorityClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PriorityClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClassList.__pulumiType, name, inputs, opts);
+          super(PriorityClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -101,14 +101,14 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1alpha1.PriorityClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1alpha1";
-          inputs["description"] = args && args.description || undefined;
-          inputs["globalDefault"] = args && args.globalDefault || undefined;
-          inputs["kind"] = "PriorityClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
-          inputs["value"] = args && args.value || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1alpha1";
+          props["description"] = args && args.description || undefined;
+          props["globalDefault"] = args && args.globalDefault || undefined;
+          props["kind"] = "PriorityClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
+          props["value"] = args && args.value || undefined;
 
           if (!opts) {
               opts = {};
@@ -117,6 +117,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClass.__pulumiType, name, inputs, opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1alpha1.PriorityClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PriorityClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PriorityClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClassList.__pulumiType, name, inputs, opts);
+          super(PriorityClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -101,14 +101,14 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1beta1.PriorityClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1beta1";
-          inputs["description"] = args && args.description || undefined;
-          inputs["globalDefault"] = args && args.globalDefault || undefined;
-          inputs["kind"] = "PriorityClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
-          inputs["value"] = args && args.value || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1beta1";
+          props["description"] = args && args.description || undefined;
+          props["globalDefault"] = args && args.globalDefault || undefined;
+          props["kind"] = "PriorityClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["preemptionPolicy"] = args && args.preemptionPolicy || undefined;
+          props["value"] = args && args.value || undefined;
 
           if (!opts) {
               opts = {};
@@ -117,6 +117,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClass.__pulumiType, name, inputs, opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.scheduling.v1beta1.PriorityClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "scheduling.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PriorityClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "scheduling.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PriorityClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PriorityClassList.__pulumiType, name, inputs, opts);
+          super(PriorityClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/settings/v1alpha1/PodPreset.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPreset.ts
@@ -71,11 +71,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.settings.v1alpha1.PodPreset, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "settings.k8s.io/v1alpha1";
-          inputs["kind"] = "PodPreset";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "settings.k8s.io/v1alpha1";
+          props["kind"] = "PodPreset";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -84,6 +84,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodPreset.__pulumiType, name, inputs, opts);
+          super(PodPreset.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.settings.v1alpha1.PodPresetList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "settings.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "PodPresetList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "settings.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "PodPresetList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(PodPresetList.__pulumiType, name, inputs, opts);
+          super(PodPresetList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1/StorageClass.ts
@@ -119,17 +119,17 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1.StorageClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["allowVolumeExpansion"] = args && args.allowVolumeExpansion || undefined;
-          inputs["allowedTopologies"] = args && args.allowedTopologies || undefined;
-          inputs["apiVersion"] = "storage.k8s.io/v1";
-          inputs["kind"] = "StorageClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["mountOptions"] = args && args.mountOptions || undefined;
-          inputs["parameters"] = args && args.parameters || undefined;
-          inputs["provisioner"] = args && args.provisioner || undefined;
-          inputs["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
-          inputs["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
+          const props: pulumi.Inputs = {};
+          props["allowVolumeExpansion"] = args && args.allowVolumeExpansion || undefined;
+          props["allowedTopologies"] = args && args.allowedTopologies || undefined;
+          props["apiVersion"] = "storage.k8s.io/v1";
+          props["kind"] = "StorageClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["mountOptions"] = args && args.mountOptions || undefined;
+          props["parameters"] = args && args.parameters || undefined;
+          props["provisioner"] = args && args.provisioner || undefined;
+          props["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
+          props["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
 
           if (!opts) {
               opts = {};
@@ -138,6 +138,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StorageClass.__pulumiType, name, inputs, opts);
+          super(StorageClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1/StorageClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1.StorageClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "StorageClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "StorageClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StorageClassList.__pulumiType, name, inputs, opts);
+          super(StorageClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachment.ts
@@ -86,12 +86,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1.VolumeAttachment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1";
-          inputs["kind"] = "VolumeAttachment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1";
+          props["kind"] = "VolumeAttachment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -100,6 +100,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachment.__pulumiType, name, inputs, opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1.VolumeAttachmentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "VolumeAttachmentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "VolumeAttachmentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachmentList.__pulumiType, name, inputs, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
@@ -86,12 +86,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1alpha1.VolumeAttachment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1alpha1";
-          inputs["kind"] = "VolumeAttachment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1alpha1";
+          props["kind"] = "VolumeAttachment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -100,6 +100,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachment.__pulumiType, name, inputs, opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1alpha1.VolumeAttachmentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1alpha1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "VolumeAttachmentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1alpha1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "VolumeAttachmentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachmentList.__pulumiType, name, inputs, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSIDriver.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriver.ts
@@ -85,11 +85,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.CSIDriver, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["kind"] = "CSIDriver";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["kind"] = "CSIDriver";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -98,6 +98,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CSIDriver.__pulumiType, name, inputs, opts);
+          super(CSIDriver.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.CSIDriverList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CSIDriverList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CSIDriverList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CSIDriverList.__pulumiType, name, inputs, opts);
+          super(CSIDriverList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -81,11 +81,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.CSINode, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["kind"] = "CSINode";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["kind"] = "CSINode";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
 
           if (!opts) {
               opts = {};
@@ -94,6 +94,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CSINode.__pulumiType, name, inputs, opts);
+          super(CSINode.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINodeList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINodeList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.CSINodeList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "CSINodeList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "CSINodeList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(CSINodeList.__pulumiType, name, inputs, opts);
+          super(CSINodeList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClass.ts
@@ -119,17 +119,17 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.StorageClass, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["allowVolumeExpansion"] = args && args.allowVolumeExpansion || undefined;
-          inputs["allowedTopologies"] = args && args.allowedTopologies || undefined;
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["kind"] = "StorageClass";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["mountOptions"] = args && args.mountOptions || undefined;
-          inputs["parameters"] = args && args.parameters || undefined;
-          inputs["provisioner"] = args && args.provisioner || undefined;
-          inputs["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
-          inputs["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
+          const props: pulumi.Inputs = {};
+          props["allowVolumeExpansion"] = args && args.allowVolumeExpansion || undefined;
+          props["allowedTopologies"] = args && args.allowedTopologies || undefined;
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["kind"] = "StorageClass";
+          props["metadata"] = args && args.metadata || undefined;
+          props["mountOptions"] = args && args.mountOptions || undefined;
+          props["parameters"] = args && args.parameters || undefined;
+          props["provisioner"] = args && args.provisioner || undefined;
+          props["reclaimPolicy"] = args && args.reclaimPolicy || undefined;
+          props["volumeBindingMode"] = args && args.volumeBindingMode || undefined;
 
           if (!opts) {
               opts = {};
@@ -138,6 +138,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StorageClass.__pulumiType, name, inputs, opts);
+          super(StorageClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClassList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.StorageClassList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "StorageClassList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "StorageClassList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(StorageClassList.__pulumiType, name, inputs, opts);
+          super(StorageClassList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
@@ -86,12 +86,12 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.VolumeAttachment, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["kind"] = "VolumeAttachment";
-          inputs["metadata"] = args && args.metadata || undefined;
-          inputs["spec"] = args && args.spec || undefined;
-          inputs["status"] = args && args.status || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["kind"] = "VolumeAttachment";
+          props["metadata"] = args && args.metadata || undefined;
+          props["spec"] = args && args.spec || undefined;
+          props["status"] = args && args.status || undefined;
 
           if (!opts) {
               opts = {};
@@ -100,6 +100,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachment.__pulumiType, name, inputs, opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
@@ -76,11 +76,11 @@ import { getVersion } from "../../version";
        * @param opts A bag of options that control this resource's behavior.
        */
       constructor(name: string, args?: inputs.storage.v1beta1.VolumeAttachmentList, opts?: pulumi.CustomResourceOptions) {
-          let inputs: pulumi.Inputs = {};
-          inputs["apiVersion"] = "storage.k8s.io/v1beta1";
-          inputs["items"] = args && args.items || undefined;
-          inputs["kind"] = "VolumeAttachmentList";
-          inputs["metadata"] = args && args.metadata || undefined;
+          const props: pulumi.Inputs = {};
+          props["apiVersion"] = "storage.k8s.io/v1beta1";
+          props["items"] = args && args.items || undefined;
+          props["kind"] = "VolumeAttachmentList";
+          props["metadata"] = args && args.metadata || undefined;
 
           if (!opts) {
               opts = {};
@@ -89,6 +89,6 @@ import { getVersion } from "../../version";
           if (!opts.version) {
               opts.version = getVersion();
           }
-          super(VolumeAttachmentList.__pulumiType, name, inputs, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, opts);
       }
     }


### PR DESCRIPTION
Use `props` instead, which is the name of the [parameter](https://github.com/pulumi/pulumi/blob/24e2c6f7910aafbf33c23347d912b3e49884216c/sdk/nodejs/resource.ts#L592) passed to `CustomResource`'s constructor. Make it `const` because it can be, while making changes here.

Fixes #715