### PR TITLE
Re-enable GOPROXY on 'make ensure'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ PYTHON          ?= python
 TESTPARALLELISM := 10
 TESTABLE_PKGS   := ./pkg/... ./examples/... ./tests/...
 
+# Set NOPROXY to true to skip GOPROXY on 'ensure'
+NOPROXY := false
+
 $(OPENAPI_FILE)::
 	@mkdir -p $(OPENAPI_DIR)
 	test -f $(OPENAPI_FILE) || $(CURL) -s -L $(SWAGGER_URL) > $(OPENAPI_FILE)

--- a/build/common.mk
+++ b/build/common.mk
@@ -106,6 +106,7 @@ PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
 
 GO_TEST_FAST = go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
 GO_TEST = go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
+GOPROXY = 'https://proxy.golang.org'
 
 .PHONY: default all ensure only_build only_test build lint install test_all core
 
@@ -141,8 +142,13 @@ all:: build install lint test_all
 
 ensure::
 	$(call STEP_MESSAGE)
+ifeq ($(NOPROXY), true)
 	@echo "GO111MODULE=on go mod tidy"; GO111MODULE=on go mod tidy
 	@echo "GO111MODULE=on go mod vendor"; GO111MODULE=on go mod vendor
+else
+	@echo "GO111MODULE=on GOPROXY=$(GOPROXY) go mod tidy"; GO111MODULE=on GOPROXY=$(GOPROXY) go mod tidy
+	@echo "GO111MODULE=on GOPROXY=$(GOPROXY) go mod vendor"; GO111MODULE=on GOPROXY=$(GOPROXY) go mod vendor
+endif
 	@if [ -e 'package.json' ]; then echo "yarn install"; yarn install; fi
 
 build::

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ replace (
 	github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v31.1.0+incompatible
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible
 	github.com/Nvveen/Gotty => github.com/ijc25/Gotty v0.0.0-20170406111628-a8b993ba6abd
+	github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/grpc/grpc-go => google.golang.org/grpc v1.20.1
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -84,9 +84,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
 github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
-github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
-github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.18 h1:G/DgkKaBP0V5lnBg/vx61nVxxAU+VqU5yMzSc0f2PPE=
 github.com/cheggaaa/pb v1.0.18/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
Using the proxy speeds up CI builds by several minutes,
so enable it by default. Add the NOPROXY env var to
optionally disable the proxy.