### PR TITLE
Increase default readiness timeouts to 10 mins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improvements
 
 -   Implement customTimeout for resource deletion. (https://github.com/pulumi/pulumi-kubernetes/pull/802).
+-   Increase default readiness timeouts to 10 mins. (https://github.com/pulumi/pulumi-kubernetes/pull/721).
 -   Warn for invalid usage of Helm repo parameter. (https://github.com/pulumi/pulumi-kubernetes/pull/805).
 
 ## 1.0.1 (September 11, 2019)
@@ -38,8 +39,6 @@
 - v1.15.x
 - v1.14.x
 - v1.13.x
-
-### Improvements
 
 ### Bug fixes
 

--- a/pkg/await/apps_deployment.go
+++ b/pkg/await/apps_deployment.go
@@ -88,7 +88,7 @@ import (
 
 const (
 	revision                     = "deployment.kubernetes.io/revision"
-	DefaultDeploymentTimeoutMins = 5
+	DefaultDeploymentTimeoutMins = 10
 )
 
 type deploymentInitAwaiter struct {

--- a/pkg/await/apps_statefulset.go
+++ b/pkg/await/apps_statefulset.go
@@ -101,7 +101,7 @@ import (
 // ------------------------------------------------------------------------------------------------
 
 const (
-	DefaultStatefulSetTimeoutMins = 5
+	DefaultStatefulSetTimeoutMins = 10
 )
 
 type statefulsetInitAwaiter struct {

--- a/pkg/await/core_pod.go
+++ b/pkg/await/core_pod.go
@@ -85,7 +85,7 @@ import (
 // --------------------------------------------------------------------------
 
 const (
-	DefaultPodTimeoutMins = 5
+	DefaultPodTimeoutMins = 10
 )
 
 type podInitAwaiter struct {

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -28,7 +28,7 @@ import { getVersion } from "../../version";
      *    because it doesn't do a rollout (i.e., it simply creates the Deployment and
      *    corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
      * 
-     * If the Deployment has not reached a Ready state after 5 minutes, it will
+     * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -23,7 +23,7 @@ import { getVersion } from "../../version";
      *    and '.status.readyReplicas'.
      * 2. The value of '.status.updateRevision' matches '.status.currentRevision'.
      * 
-     * If the StatefulSet has not reached a Ready state after 5 minutes, it will
+     * If the StatefulSet has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -31,7 +31,7 @@ import { getVersion } from "../../version";
      *    because it doesn't do a rollout (i.e., it simply creates the Deployment and
      *    corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
      * 
-     * If the Deployment has not reached a Ready state after 5 minutes, it will
+     * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -26,7 +26,7 @@ import { getVersion } from "../../version";
      *    and '.status.readyReplicas'.
      * 2. The value of '.status.updateRevision' matches '.status.currentRevision'.
      * 
-     * If the StatefulSet has not reached a Ready state after 5 minutes, it will
+     * If the StatefulSet has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -31,7 +31,7 @@ import { getVersion } from "../../version";
      *    because it doesn't do a rollout (i.e., it simply creates the Deployment and
      *    corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
      * 
-     * If the Deployment has not reached a Ready state after 5 minutes, it will
+     * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -26,7 +26,7 @@ import { getVersion } from "../../version";
      *    and '.status.readyReplicas'.
      * 2. The value of '.status.updateRevision' matches '.status.currentRevision'.
      * 
-     * If the StatefulSet has not reached a Ready state after 5 minutes, it will
+     * If the StatefulSet has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/core/v1/Pod.ts
+++ b/sdk/nodejs/core/v1/Pod.ts
@@ -22,7 +22,7 @@ import { getVersion } from "../../version";
      *    set to "Running".
      * Or (for Jobs): The Pod succeeded ('.status.phase' set to "Succeeded").
      * 
-     * If the Pod has not reached a Ready state after 5 minutes, it will
+     * If the Pod has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -31,7 +31,7 @@ import { getVersion } from "../../version";
      *    because it doesn't do a rollout (i.e., it simply creates the Deployment and
      *    corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
      * 
-     * If the Deployment has not reached a Ready state after 5 minutes, it will
+     * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
      */

--- a/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
@@ -33,7 +33,7 @@ class Deployment(pulumi.CustomResource):
        because it doesn't do a rollout (i.e., it simply creates the Deployment and
        corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
     
-    If the Deployment has not reached a Ready state after 5 minutes, it will
+    If the Deployment has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -28,7 +28,7 @@ class StatefulSet(pulumi.CustomResource):
        and '.status.readyReplicas'.
     2. The value of '.status.updateRevision' matches '.status.currentRevision'.
     
-    If the StatefulSet has not reached a Ready state after 5 minutes, it will
+    If the StatefulSet has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -36,7 +36,7 @@ class Deployment(pulumi.CustomResource):
        because it doesn't do a rollout (i.e., it simply creates the Deployment and
        corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
     
-    If the Deployment has not reached a Ready state after 5 minutes, it will
+    If the Deployment has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -31,7 +31,7 @@ class StatefulSet(pulumi.CustomResource):
        and '.status.readyReplicas'.
     2. The value of '.status.updateRevision' matches '.status.currentRevision'.
     
-    If the StatefulSet has not reached a Ready state after 5 minutes, it will
+    If the StatefulSet has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -36,7 +36,7 @@ class Deployment(pulumi.CustomResource):
        because it doesn't do a rollout (i.e., it simply creates the Deployment and
        corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
     
-    If the Deployment has not reached a Ready state after 5 minutes, it will
+    If the Deployment has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -31,7 +31,7 @@ class StatefulSet(pulumi.CustomResource):
        and '.status.readyReplicas'.
     2. The value of '.status.updateRevision' matches '.status.currentRevision'.
     
-    If the StatefulSet has not reached a Ready state after 5 minutes, it will
+    If the StatefulSet has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/core/v1/Pod.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Pod.py
@@ -27,7 +27,7 @@ class Pod(pulumi.CustomResource):
        set to "Running".
     Or (for Jobs): The Pod succeeded ('.status.phase' set to "Succeeded").
     
-    If the Pod has not reached a Ready state after 5 minutes, it will
+    If the Pod has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -36,7 +36,7 @@ class Deployment(pulumi.CustomResource):
        because it doesn't do a rollout (i.e., it simply creates the Deployment and
        corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
     
-    If the Deployment has not reached a Ready state after 5 minutes, it will
+    If the Deployment has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
     """


### PR DESCRIPTION
Deployment, Pod and StatefulSet resources previously
had default timeouts set to 5 minutes. Increase the
timeout to 10 minutes for consistency with other
resources.