### PR TITLE
Fix error messages for resources with default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 1.0.0-beta.2 (Unreleased)
 
-- Correctly compute version number for plugin to send with registration requests (fixes https://github.com/pulumi/pulumi-kubernetes/issues/732).
-- Allow a user to pass CustomTimeouts as part of ResourceOptions (fixes https://github.com/pulumi/pulumi-kubernetes/issues/672)
-
-
 ### Supported Kubernetes versions
 
 - v1.15.x
@@ -19,6 +15,12 @@
 -   Clean up Python SDK get methods. (https://github.com/pulumi/pulumi-kubernetes/pull/740).
 -   Remove undocumented kubectl replace invoke method. (https://github.com/pulumi/pulumi-kubernetes/pull/738).
 -   Don't populate `.status` in input types (https://github.com/pulumi/pulumi-kubernetes/pull/635).
+-   Allow a user to pass CustomTimeouts as part of ResourceOptions (fixes https://github.com/pulumi/pulumi-kubernetes/issues/672)
+
+### Bug fixes
+
+-   Fix error messages for resources with default namespace. (https://github.com/pulumi/pulumi-kubernetes/pull/749).
+-   Correctly compute version number for plugin to send with registration requests (fixes https://github.com/pulumi/pulumi-kubernetes/issues/732).
 
 ## 1.0.0-beta.1 (August 13, 2019)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -533,8 +533,7 @@ func (k *kubeProvider) Diff(
 			namespacedKind = true
 		} else {
 			return nil, pkgerrors.Wrapf(err,
-				"API server returned error when asked if resource type %s/%s/%s is namespaced",
-				gvk.Group, gvk.Version, gvk.Kind)
+				"API server returned error when asked if resource type %s is namespaced", gvk)
 		}
 	}
 
@@ -554,8 +553,8 @@ func (k *kubeProvider) Diff(
 	supportsDryRun, err := openapi.SupportsDryRun(k.clientSet.DiscoveryClientCached, gvk)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err,
-			"Failed to check for changes in resource %s/%s because of an error communicating with the API server",
-			newInputs.GetNamespace(), newInputs.GetName())
+			"Failed to check for changes in resource %s because of an error communicating with the API server",
+			fqObjName(newInputs))
 	}
 
 	var patch []byte
@@ -723,18 +722,16 @@ func (k *kubeProvider) Create(
 			// CustomResourceDefinition. This usually happens if the CRD was not created, and we
 			// print a more useful error message in this case.
 			return nil, pkgerrors.Wrapf(
-				awaitErr, "creation of resource %s/%s failed because the Kubernetes API server "+
+				awaitErr, "creation of resource %s failed because the Kubernetes API server "+
 					"reported that the apiVersion for this resource does not exist. "+
-					"Verify that any required CRDs have been created",
-				newInputs.GetNamespace(), newInputs.GetName())
+					"Verify that any required CRDs have been created", fqObjName(newInputs))
 		}
 		partialErr, isPartialErr := awaitErr.(await.PartialError)
 		if !isPartialErr {
 			// Object creation failed.
 			return nil, pkgerrors.Wrapf(
 				awaitErr,
-				"resource %s/%s was not successfully created by the Kubernetes API server "+
-					newInputs.GetNamespace(), newInputs.GetName())
+				"resource %s was not successfully created by the Kubernetes API server ", fqObjName(newInputs))
 		}
 
 		// Resource was created, but failed to become fully initialized.
@@ -755,9 +752,8 @@ func (k *kubeProvider) Create(
 		return nil, partialError(
 			fqObjName(initialized),
 			pkgerrors.Wrapf(
-				awaitErr, "resource %s/%s was successfully created, but the Kubernetes API server "+
-					"reported that it failed to fully initialize or become live",
-				newInputs.GetNamespace(), newInputs.GetName()),
+				awaitErr, "resource %s was successfully created, but the Kubernetes API server "+
+					"reported that it failed to fully initialize or become live", fqObjName(newInputs)),
 			inputsAndComputed,
 			nil)
 	}
@@ -1027,10 +1023,9 @@ func (k *kubeProvider) Update(
 			// CustomResourceDefinition. This usually happens if the CRD was not created, and we
 			// print a more useful error message in this case.
 			return nil, pkgerrors.Wrapf(
-				awaitErr, "update of resource %s/%s failed because the Kubernetes API server "+
+				awaitErr, "update of resource %s failed because the Kubernetes API server "+
 					"reported that the apiVersion for this resource does not exist. "+
-					"Verify that any required CRDs have been created",
-				newInputs.GetNamespace(), newInputs.GetName())
+					"Verify that any required CRDs have been created", fqObjName(newInputs))
 		}
 
 		var getErr error
@@ -1038,9 +1033,8 @@ func (k *kubeProvider) Update(
 		if getErr != nil {
 			// Object update/creation failed.
 			return nil, pkgerrors.Wrapf(
-				awaitErr, "update of resource %s/%s failed because the Kubernetes API server "+
-					"reported that it failed to fully initialize or become live",
-				newInputs.GetNamespace(), newInputs.GetName())
+				awaitErr, "update of resource %s failed because the Kubernetes API server "+
+					"reported that it failed to fully initialize or become live", fqObjName(newInputs))
 		}
 		// If we get here, resource successfully registered with the API server, but failed to
 		// initialize.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Previous:
```
error: Plan apply failed: resource foo/%!s(MISSING) was not successfully created by the Kubernetes API server : Deployment.apps "foo" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string(nil), MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: empty selector is invalid for deployment
```

Fixed:
```
error: Plan apply failed: resource foo was not successfully created by the Kubernetes API server : Deployment.apps "foo" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string(nil), MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: empty selector is invalid for deployment
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fix #735 
