### PR TITLE
Fix error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Bug fixes
 
+-   Fix error reporting
+    (https://github.com/pulumi/pulumi-kubernetes/pull/782).
+    
 ## 1.0.0 (Septemeber 3, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/await/core_pod.go
+++ b/pkg/await/core_pod.go
@@ -208,8 +208,8 @@ func (pia *podInitAwaiter) processPodEvent(event watch.Event) {
 		return
 	}
 
-	messages := pia.state.Update(pod)
-	for _, message := range messages {
+	pia.messages = pia.state.Update(pod)
+	for _, message := range pia.messages {
 		pia.config.logMessage(message)
 	}
 }

--- a/pkg/await/error.go
+++ b/pkg/await/error.go
@@ -26,7 +26,7 @@ var _ AggregatedError = (*cancellationError)(nil)
 var _ PartialError = (*cancellationError)(nil)
 
 func (ce *cancellationError) Error() string {
-	return fmt.Sprintf("Resource operation was cancelled for '%s'", ce.object.GetName())
+	return fmt.Sprintf("Resource operation was cancelled for %q", ce.object.GetName())
 }
 
 // SubErrors returns the errors that were present when cancellation occurred.


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
- Pod errors were logged during updates, but not reported properly
at the top level if the update failed
- Wrap update error messages to provide better context for
failures
- Properly extract suberrors from wrapped errors so that they are
reported

Here's what a failed Pod create looked like before:
```
  kubernetes:core:Pod (pod-test):
    error: Plan apply failed: 1 error occurred:
    	* resource pod-test-4e7xarx6 was successfully created, but the Kubernetes API server reported that it failed to fully initialize or become live: Resource operation was cancelled for 'pod-test-4e7xarx6'
```

With this change:
```
  kubernetes:core:Pod (pod-test):
    error: Plan apply failed: 2 errors occurred:
    	* resource pod-test-33ffnqif was successfully created, but the Kubernetes API server reported that it failed to fully initialize or become live: Resource operation was cancelled for "pod-test-33ffnqif"
    	* containers with unready status: [nginx] -- [ErrImagePull] manifest for nginx:1.13-fail not found: manifest unknown
```

Here's what a failed update looked like before:
```
  kubernetes:core:Pod (pod-test):
    error: Plan apply failed: 2 errors occurred:
    	* Resource operation was cancelled for 'pod-test-y8znfbm5'
    	* containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "nginx:1.13-fail"
```

With this change:
```
  kubernetes:core:Pod (pod-test):
    error: Plan apply failed: 2 errors occurred:
    	* the Kubernetes API server reported that "pod-test-xn9sqrod" failed to fully initialize or become live: Resource operation was cancelled for "pod-test-xn9sqrod"
    	* containers with unready status: [nginx] -- [ImagePullBackOff] Back-off pulling image "nginx:1.13-fail"
```
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
