### PR TITLE
Update badge URLs for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.com/pulumi/pulumi-kubernetes.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=master)](https://travis-ci.com/pulumi/pulumi-kubernetes)
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)
-[![NPM version](https://badge.fury.io/js/%40pulumi%2Fpulumi.svg)](https://npmjs.com/package/@pulumi/pulumi)
-[![Python version](https://badge.fury.io/py/pulumi.svg)](https://pypi.org/project/pulumi)
-[![GoDoc](https://godoc.org/github.com/pulumi/pulumi?status.svg)](https://godoc.org/github.com/pulumi/pulumi)
-[![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi/blob/master/LICENSE)
+[![NPM version](https://badge.fury.io/js/%40pulumi%2Fkubernetes.svg)](https://www.npmjs.com/package/@pulumi/kubernetes)
+[![Python version](https://badge.fury.io/py/pulumi-kubernetes.svg)](https://pypi.org/project/pulumi-kubernetes/)
+[![GoDoc](https://godoc.org/github.com/pulumi/pulumi-kubernetes?status.svg)](https://godoc.org/github.com/pulumi/pulumi-kubernetes)
+[![License](https://img.shields.io/github/license/pulumi/pulumi-kubernetes)](https://github.com/pulumi/pulumi-kubernetes/blob/master/LICENSE)
 
 # Pulumi Kubernetes Resource Provider
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.com/pulumi/pulumi-kubernetes.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=master)](https://travis-ci.com/pulumi/pulumi-kubernetes)
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)
-[![NPM version](https://badge.fury.io/js/%40pulumi%2Fpulumi.svg)](https://npmjs.com/package/@pulumi/pulumi)
-[![Python version](https://badge.fury.io/py/pulumi.svg)](https://pypi.org/project/pulumi)
-[![GoDoc](https://godoc.org/github.com/pulumi/pulumi?status.svg)](https://godoc.org/github.com/pulumi/pulumi)
-[![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi/blob/master/LICENSE)
+[![NPM version](https://badge.fury.io/js/%40pulumi%2Fkubernetes.svg)](https://www.npmjs.com/package/@pulumi/kubernetes)
+[![Python version](https://badge.fury.io/py/pulumi-kubernetes.svg)](https://pypi.org/project/pulumi-kubernetes/)
+[![GoDoc](https://godoc.org/github.com/pulumi/pulumi-kubernetes?status.svg)](https://godoc.org/github.com/pulumi/pulumi-kubernetes)
+[![License](https://img.shields.io/github/license/pulumi/pulumi-kubernetes)](https://github.com/pulumi/pulumi-kubernetes/blob/master/LICENSE)
 
 # Pulumi Kubernetes Resource Provider
 


### PR DESCRIPTION
We were previously linking to pulumi instead of pulumi-kubernetes

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
