### PR TITLE
Change provider test to use ambient kubeconfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
 if: branch = master OR branch =~ ^features/ OR branch =~ ^release/ OR tag IS present
 language: go
-go: 1.12.9
+go: "1.12"
 sudo: true # give us 7.5GB and >2 bursted cores.
 git:
     depth: false
@@ -58,4 +58,5 @@ after_failure:
 after_script:
     - scripts/ci-cluster-destroy.sh
 notifications:
-    webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis
+  webhooks:
+    - https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/tests/examples/provider/index.ts
+++ b/tests/examples/provider/index.ts
@@ -1,21 +1,12 @@
 // Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
 
 import * as k8s from "@pulumi/kubernetes";
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
-
-// Use the existing ~/.kube/config kubeconfig
-const kubeconfig = fs.readFileSync(path.join(os.homedir(), ".kube", "config")).toString();
 
 // Create a new provider
-const myk8s = new k8s.Provider("myk8s", {
-    kubeconfig: kubeconfig,
-});
+const myk8s = new k8s.Provider("myk8s", {});
 
 // Create a new provider with dry run enabled.
 const myk8s2 = new k8s.Provider("myk8s2", {
-    kubeconfig: kubeconfig,
     enableDryRun: true,
 });
 


### PR DESCRIPTION
The provider test previously tried to load `~/.kube/config` explicitly,
but this file is not guaranteed to be present. Don't set a kubeconfig
explicitly on the provider, and it will pick up the ambient config if one
exists.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
