### PR TITLE
Fix await logic for extensions/v1beta1/Deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bug fixes
 
+-   Fix await logic for extensions/v1beta1/Deployment
+    (https://github.com/pulumi/pulumi-kubernetes/pull/794).
 -   Fix error reporting
     (https://github.com/pulumi/pulumi-kubernetes/pull/782).
     


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
The extensions/v1beta1 version of Deployment uses a different
code path because it doesn't include all of the fields we use to
check readiness on newer apiVersions. This logic was updated
in #523, but introduced a different bug in the process. The logic
should now correctly check for readiness across all Deployment
apiVersions.
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #793 
