### PR TITLE
WIP: Use Pyton 3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ before_install:
       fi
 
     # Install gcloud CLI.
-    - if [ ! -d ${HOME}/google-cloud-sdk ]; then
-          export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash;
+    - if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+          export CLOUDSDK_CORE_DISABLE_PROMPTS=1; rm -rf ${HOME}/google-cloud-sdk; curl https://sdk.cloud.google.com | bash;
       fi
+    - export CLOUDSDK_PYTHON=python3
+    - export PATH=${HOME}/google-cloud-sdk/bin:$PATH
+    - gcloud version
 
     # 1. Log in to gcloud using the CI GCP service account.
     # 2. Set up kubeconfig file so the integration tests can run.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION_FLAGS   := -ldflags "-X github.com/pulumi/pulumi-kubernetes/pkg/version.
 
 GO              ?= go
 CURL            ?= curl
-PYTHON          ?= python
+PYTHON          ?= python3
 
 TESTPARALLELISM := 10
 TESTABLE_PKGS   := ./pkg/... ./examples/... ./tests/...


### PR DESCRIPTION
This reacts to some recently landed changes in our shared scripts to force CI to use Python 3 instead of Python 2 (which will be EOL in like 4 months!)