### PR TITLE
Implement customTimeout for resource deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   Implement customTimeout for resource deletion. (https://github.com/pulumi/pulumi-kubernetes/pull/802).
 -   Warn for invalid usage of Helm repo parameter. (https://github.com/pulumi/pulumi-kubernetes/pull/805).
 
-## 1.0.1 (Septemeber 11, 2019)
+## 1.0.1 (September 11, 2019)
 
 ### Supported Kubernetes versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ### Improvements
 
+-   Implement customTimeout for resource deletion. (https://github.com/pulumi/pulumi-kubernetes/pull/802).
 -   Warn for invalid usage of Helm repo parameter. (https://github.com/pulumi/pulumi-kubernetes/pull/805).
 
-## 1.0.1 (September 11, 2019)
+## 1.0.1 (Septemeber 11, 2019)
 
 ### Supported Kubernetes versions
 

--- a/pkg/gen/additionalComments.go
+++ b/pkg/gen/additionalComments.go
@@ -24,9 +24,7 @@ import (
 )
 
 func timeoutComment(kind kinds.Kind) string {
-	const timeoutOverride = `setting the 'customTimeouts' option on the resource.
-Note that the timeout value for Delete is not yet supported. See
-https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.`
+	const timeoutOverride = `setting the 'customTimeouts' option on the resource.`
 
 	var v int
 	switch kind {

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -31,8 +31,6 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -26,8 +26,6 @@ import { getVersion } from "../../version";
      * If the StatefulSet has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class StatefulSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -34,8 +34,6 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -29,8 +29,6 @@ import { getVersion } from "../../version";
      * If the StatefulSet has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class StatefulSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -34,8 +34,6 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -29,8 +29,6 @@ import { getVersion } from "../../version";
      * If the StatefulSet has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class StatefulSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/core/v1/Pod.ts
+++ b/sdk/nodejs/core/v1/Pod.ts
@@ -25,8 +25,6 @@ import { getVersion } from "../../version";
      * If the Pod has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Pod extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/core/v1/Service.ts
+++ b/sdk/nodejs/core/v1/Service.ts
@@ -36,8 +36,6 @@ import { getVersion } from "../../version";
      * If the Service has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Service extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -34,8 +34,6 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 5 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -28,8 +28,6 @@ import { getVersion } from "../../version";
      * If the Ingress has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Ingress extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -25,8 +25,6 @@ import { getVersion } from "../../version";
      * If the Ingress has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
-     * Note that the timeout value for Delete is not yet supported. See
-     * https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
      */
     export class Ingress extends pulumi.CustomResource {
       /**

--- a/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
@@ -36,8 +36,6 @@ class Deployment(pulumi.CustomResource):
     If the Deployment has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -31,8 +31,6 @@ class StatefulSet(pulumi.CustomResource):
     If the StatefulSet has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -39,8 +39,6 @@ class Deployment(pulumi.CustomResource):
     If the Deployment has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -34,8 +34,6 @@ class StatefulSet(pulumi.CustomResource):
     If the StatefulSet has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -39,8 +39,6 @@ class Deployment(pulumi.CustomResource):
     If the Deployment has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -34,8 +34,6 @@ class StatefulSet(pulumi.CustomResource):
     If the StatefulSet has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/core/v1/Pod.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Pod.py
@@ -30,8 +30,6 @@ class Pod(pulumi.CustomResource):
     If the Pod has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/core/v1/Service.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Service.py
@@ -41,8 +41,6 @@ class Service(pulumi.CustomResource):
     If the Service has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -39,8 +39,6 @@ class Deployment(pulumi.CustomResource):
     If the Deployment has not reached a Ready state after 5 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -33,8 +33,6 @@ class Ingress(pulumi.CustomResource):
     If the Ingress has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -30,8 +30,6 @@ class Ingress(pulumi.CustomResource):
     If the Ingress has not reached a Ready state after 10 minutes, it will
     time out and mark the resource update as Failed. You can override the default timeout value
     by setting the 'customTimeouts' option on the resource.
-    Note that the timeout value for Delete is not yet supported. See
-    https://github.com/pulumi/pulumi-kubernetes/issues/746 for details.
     """
 
     apiVersion: pulumi.Output[str]


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
All resources now include a customTimeouts option, but
the delete field was previously ignored. Plumb this option
through and use the custom timeout if it is set.
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #746 