### PR TITLE
Add suppressDeprecationWarnings flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Implement customTimeout for resource deletion. (https://github.com/pulumi/pulumi-kubernetes/pull/802).
 -   Increase default readiness timeouts to 10 mins. (https://github.com/pulumi/pulumi-kubernetes/pull/721).
+-   Add suppressDeprecationWarnings flag. (https://github.com/pulumi/pulumi-kubernetes/pull/808).
 -   Warn for invalid usage of Helm repo parameter. (https://github.com/pulumi/pulumi-kubernetes/pull/805).
 
 ## 1.0.1 (September 11, 2019)

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -17,7 +17,8 @@ export class Provider extends pulumi.ProviderResource {
             "context": args ? args.context : undefined,
             "kubeconfig": args ? args.kubeconfig : undefined,
             "namespace": args ? args.namespace : undefined,
-            "enableDryRun": args && args.enableDryRun ? "true" : undefined
+            "enableDryRun": args && args.enableDryRun ? "true" : undefined,
+            "suppressDeprecationWarnings": args && args.suppressDeprecationWarnings ? "true" : undefined
         };
         super("kubernetes", name, props, opts);
     }
@@ -49,4 +50,8 @@ export interface ProviderArgs {
      * This feature is in developer preview, and is disabled by default.
      */
     readonly enableDryRun?: pulumi.Input<boolean>;
+    /**
+     * If present and set to true, suppress apiVersion deprecation warnings from the CLI.
+     */
+    readonly suppressDeprecationWarnings?: pulumi.Input<boolean>;
 }

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -13,7 +13,8 @@ class Provider(pulumi.ProviderResource):
                  context=None,
                  enable_dry_run=None,
                  kubeconfig=None,
-                 namespace=None):
+                 namespace=None,
+                 suppress_deprecation_warnings=None):
         """
         Create a Provider resource with the given unique name, arguments, and options.
 
@@ -30,6 +31,8 @@ class Provider(pulumi.ProviderResource):
                                             This flag is ignored for cluster-scoped resources.
                                             Note: if .metadata.namespace is set on a resource, that value takes
                                             precedence over the provider default.
+        :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to True, suppress apiVersion
+                                                                 deprecation warnings from the CLI.
         """
         __props__ = {
             "cluster": cluster,
@@ -37,5 +40,6 @@ class Provider(pulumi.ProviderResource):
             "enableDryRun": "true" if enable_dry_run else "false",
             "kubeconfig": kubeconfig,
             "namespace": namespace,
+            "suppress_deprecation_warnings": "true" if suppress_deprecation_warnings else "false",
         }
         super(Provider, self).__init__("kubernetes", __name__, __props__, __opts__)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
By default, the CLI prints deprecation warnings for k8s
resources with deprecated apiVersions. Add a flag to
opt out of these warnings.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #806 