### PR TITLE
Change Condition to use metav1.Object

### DIFF
--- a/pkg/await/states/pod.go
+++ b/pkg/await/states/pod.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi-kubernetes/pkg/logging"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewPodChecker() *StateChecker {
@@ -33,7 +34,7 @@ func NewPodChecker() *StateChecker {
 // Conditions
 //
 
-func podScheduled(obj interface{}) Result {
+func podScheduled(obj metav1.Object) Result {
 	pod := toPod(obj)
 	result := Result{Description: fmt.Sprintf("Waiting for Pod %q to be scheduled", fqName(pod))}
 
@@ -52,7 +53,7 @@ func podScheduled(obj interface{}) Result {
 	return result
 }
 
-func podInitialized(obj interface{}) Result {
+func podInitialized(obj metav1.Object) Result {
 	pod := toPod(obj)
 	result := Result{Description: fmt.Sprintf("Waiting for Pod %q to be initialized", fqName(pod))}
 
@@ -74,7 +75,7 @@ func podInitialized(obj interface{}) Result {
 	return result
 }
 
-func podReady(obj interface{}) Result {
+func podReady(obj metav1.Object) Result {
 	pod := toPod(obj)
 	result := Result{Description: fmt.Sprintf("Waiting for Pod %q to be ready", fqName(pod))}
 
@@ -100,7 +101,7 @@ func podReady(obj interface{}) Result {
 // Helpers
 //
 
-func toPod(obj interface{}) *v1.Pod {
+func toPod(obj metav1.Object) *v1.Pod {
 	return obj.(*v1.Pod)
 }
 

--- a/pkg/await/states/pod_test.go
+++ b/pkg/await/states/pod_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/pkg/await/recordings"
 	"github.com/pulumi/pulumi-kubernetes/pkg/clients"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -44,7 +45,7 @@ const (
 
 func Test_podInitialized(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj metav1.Object
 	}
 	tests := []struct {
 		name string
@@ -73,7 +74,7 @@ func Test_podInitialized(t *testing.T) {
 
 func Test_podReady(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj metav1.Object
 	}
 	tests := []struct {
 		name string
@@ -107,7 +108,7 @@ func Test_podReady(t *testing.T) {
 
 func Test_podScheduled(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj metav1.Object
 	}
 	tests := []struct {
 		name string

--- a/pkg/await/states/types.go
+++ b/pkg/await/states/types.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi-kubernetes/pkg/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Result specifies the result of a Condition applied to an input object.
@@ -38,7 +39,7 @@ func (r Result) String() string {
 }
 
 // Condition is a function that checks a state and returns a Result.
-type Condition func(s interface{}) Result
+type Condition func(s metav1.Object) Result
 
 // StateChecker holds the data required to generically implement await logic.
 type StateChecker struct {
@@ -56,7 +57,7 @@ func (s *StateChecker) Ready() bool {
 // Update runs the conditions associated with the StateChecker against the provided object. Each condition produces
 // a status message that is appended to the returned list of Messages. Iff all of the Conditions are true, the ready
 // status is set to true, otherwise, the ready condition is set to false.
-func (s *StateChecker) Update(obj interface{}) logging.Messages {
+func (s *StateChecker) Update(obj metav1.Object) logging.Messages {
 	s.ready = false
 
 	var messages logging.Messages

--- a/pkg/await/states/util.go
+++ b/pkg/await/states/util.go
@@ -15,12 +15,12 @@
 package states
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // fqName returns the fully qualified name of the object in the form `[namespace]/name`.
 // The namespace is omitted if it is "default" or "".
-func fqName(obj v1.Object) string {
+func fqName(obj metav1.Object) string {
 	ns := obj.GetNamespace()
 	if ns != "" && ns != "default" {
 		return obj.GetNamespace() + "/" + obj.GetName()


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the StateChecker Conditions accepted an interface{}.
These methods are used to check k8s resources, which all
implement the metav1.Object interface. Update Condition to
accept a metav1.Object to allow access to common methods
like GetName() and GetNamespace().
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
