### PR TITLE
Increase maxBuffer for helm template exec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Automatically mark Secret data and stringData as secret. (https://github.com/pulumi/pulumi-kubernetes/pull/803).
 -   Provide detailed error for removed apiVersions. (https://github.com/pulumi/pulumi-kubernetes/pull/809).
+-   Increase maxBuffer for helm template exec. (https://github.com/pulumi/pulumi-kubernetes/pull/819).
 
 ## 1.1.0 (September 18, 2019)
 

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -193,7 +193,8 @@ export class Chart extends yaml.CollectionComponentResource {
                     ? `--namespace ${shell.quote([cfg.namespace])}`
                     : "";
                 const yamlStream = execSync(
-                    `helm template ${chart} --name ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`
+                    `helm template ${chart} --name ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`,
+                    { maxBuffer: 512 * 1024 * 1024 },
                 ).toString();
                 return this.parseTemplate(yamlStream, cfg.transformations, cfg.resourcePrefix, configDeps);
             } catch (e) {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Fix #643 by increasing `maxBuffer` to `512 * 1024 * 1024` (512x the default).

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
