### PR TITLE
Aggregate error messages from Pods on Job Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Aggregate error messages from Pods on Job Read. (https://github.com/pulumi/pulumi-kubernetes/pull/831).
+
 ## 1.2.0 (October 4, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/await/job.go
+++ b/pkg/await/job.go
@@ -165,9 +165,19 @@ func (jia *jobInitAwaiter) Read() error {
 		return nil
 	}
 
+	podAggregator, err := NewPodAggregator(ResourceIdFromUnstructured(jia.job), jia.config.clientSet)
+	if err != nil {
+		return errors.Wrapf(err, "Could not create PodAggregator for %s", jia.resource.GVKString())
+	}
+	messages := podAggregator.Read()
+	for _, message := range messages {
+		jia.errors.Add(message)
+		jia.config.logMessage(message)
+	}
+
 	return &initializationError{
 		subErrors: jia.errorMessages(),
-		object: job,
+		object:    job,
 	}
 }
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Check existing Pods related to a Job on Read operations,
and get warning/error messages.

Here's what it looks like before/after:
![Screen Shot 2019-10-07 at 2 52 05 PM](https://user-images.githubusercontent.com/9253463/66347662-160acb00-e912-11e9-9b93-5c7c65c89c85.png)
![Screen Shot 2019-10-07 at 2 52 18 PM](https://user-images.githubusercontent.com/9253463/66347665-17d48e80-e912-11e9-842f-f4a6b425fd0d.png)

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #823 