### PR TITLE
Cache the OpenAPI schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Improvements
 
+-   Cache the OpenAPI schema to improve performance. (https://github.com/pulumi/pulumi-kubernetes/pull/833).
 -   Aggregate error messages from Pods on Job Read. (https://github.com/pulumi/pulumi-kubernetes/pull/831).
 
 ## 1.2.0 (October 4, 2019)

--- a/pkg/clients/memcache.go
+++ b/pkg/clients/memcache.go
@@ -21,6 +21,9 @@ limitations under the License.
 // mechanism, and causes unactionable error messages to appear in the CLI.
 // This error logging was disabled.
 //
+// Additionally, we improved caching of the OpenAPI schema in the OpenAPISchema method.
+// If this change merges upstream, we will reconcile those changes in a future release.
+//
 // [1] https://github.com/kubernetes/client-go/blob/2dda7ceeec102b5a60e2abf37758642118501910/discovery/cached/memcache.go
 
 package clients


### PR DESCRIPTION
For large programs, re-fetching this schema repeatedly adds up to a
significant portion of execution time. This caching reduces the
execution time of the Istio example’s `pulumi preview` by about 60-70%.

Contributes to #827.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
