### PR TITLE
Cache the API server's parsed OpenAPI schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 
--   Cache the OpenAPI schema to improve performance. (https://github.com/pulumi/pulumi-kubernetes/pull/833).
+-   Cache the OpenAPI schema to improve performance. (https://github.com/pulumi/pulumi-kubernetes/pull/833, https://github.com/pulumi/pulumi-kubernetes/pull/836).
 -   Aggregate error messages from Pods on Job Read. (https://github.com/pulumi/pulumi-kubernetes/pull/831).
 -   Improve interactive status for Jobs. (https://github.com/pulumi/pulumi-kubernetes/pull/832).
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	k8sopenapi "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 )
 
 // --------------------------------------------------------------------------
@@ -57,6 +58,7 @@ type ProviderConfig struct {
 
 	ClientSet   *clients.DynamicClientSet
 	DedupLogger *logging.DedupLogger
+	Resources   k8sopenapi.Resources
 }
 
 type CreateConfig struct {
@@ -325,8 +327,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 	}
 
 	// Create merge patch (prefer strategic merge patch, fall back to JSON merge patch).
-	patch, patchType, _, err := openapi.PatchForResourceUpdate(
-		c.ClientSet.DiscoveryClientCached, c.Previous, c.Inputs, liveOldObj)
+	patch, patchType, _, err := openapi.PatchForResourceUpdate(c.Resources, c.Previous, c.Inputs, liveOldObj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -70,7 +70,7 @@ func ValidateAgainstSchema(
 	return specValidator.ValidateBytes(bytes)
 }
 
-// PatchForResourceUpdate introspects on the gevn OpenAPI spec and attempts to generate a strategic merge patch for
+// PatchForResourceUpdate introspects on the given OpenAPI spec and attempts to generate a strategic merge patch for
 // use in a resource update. If there is no specification of how to generate a strategic merge patch, we fall back
 // to JSON merge patch.
 func PatchForResourceUpdate(

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/glog"
@@ -101,7 +102,9 @@ type kubeProvider struct {
 
 	clientSet  *clients.DynamicClientSet
 	k8sVersion cluster.ServerVersion
-	resources  k8sopenapi.Resources
+
+	resources      k8sopenapi.Resources
+	resourcesMutex sync.RWMutex
 }
 
 var _ pulumirpc.ResourceProviderServer = (*kubeProvider)(nil)
@@ -119,6 +122,33 @@ func makeKubeProvider(
 		enableSecrets:               false,
 		suppressDeprecationWarnings: false,
 	}, nil
+}
+
+func (k *kubeProvider) getResources() (k8sopenapi.Resources, error) {
+	k.resourcesMutex.RLock()
+	rs := k.resources
+	k.resourcesMutex.RUnlock()
+
+	if rs != nil {
+		return rs, nil
+	}
+
+	k.resourcesMutex.Lock()
+	defer k.resourcesMutex.Unlock()
+
+	rs, err := openapi.GetResourceSchemasForClient(k.clientSet.DiscoveryClientCached)
+	if err != nil {
+		return nil, err
+	}
+	k.resources = rs
+	return k.resources, nil
+}
+
+func (k *kubeProvider) invalidateResources() {
+	k.resourcesMutex.Lock()
+	defer k.resourcesMutex.Unlock()
+
+	k.resources = nil
 }
 
 // CheckConfig validates the configuration for this provider.
@@ -313,11 +343,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 
 	k.k8sVersion = cluster.GetServerVersion(cs.DiscoveryClientCached)
 
-	resources, err := openapi.GetResourceSchemasForClient(cs.DiscoveryClientCached)
-	if err != nil {
+	if _, err = k.getResources(); err != nil {
 		return nil, fmt.Errorf("unable to load schema information from the API server: %v", err)
 	}
-	k.resources = resources
 
 	return &pulumirpc.ConfigureResponse{
 		AcceptSecrets: true,
@@ -494,9 +522,13 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 	// HACK: Do not validate against OpenAPI spec if there is a computed value. The OpenAPI spec
 	// does not know how to deal with the placeholder values for computed values.
 	if !hasComputedValue(newInputs) {
-		// Get OpenAPI schema for the GVK.
-		err = openapi.ValidateAgainstSchema(k.resources, newInputs)
-		// Validate the object according to the OpenAPI schema.
+		resources, err := k.getResources()
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+		}
+
+		// Validate the object according to the OpenAPI schema for its GVK.
+		err = openapi.ValidateAgainstSchema(resources, newInputs)
 		if err != nil {
 			resourceNotFound := errors.IsNotFound(err) ||
 				strings.Contains(err.Error(), "is not supported by the server")
@@ -777,6 +809,10 @@ func (k *kubeProvider) Create(
 			newInputs.GetNamespace(), newInputs.GetName(), lastAppliedConfigKey)
 	}
 
+	resources, err := k.getResources()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+	}
 	config := await.CreateConfig{
 		ProviderConfig: await.ProviderConfig{
 			Context:     k.canceler.context,
@@ -784,7 +820,7 @@ func (k *kubeProvider) Create(
 			URN:         urn,
 			ClientSet:   k.clientSet,
 			DedupLogger: logging.NewLogger(k.canceler.context, k.host, urn),
-			Resources:   k.resources,
+			Resources:   resources,
 		},
 		Inputs:  annotatedInputs,
 		Timeout: req.Timeout,
@@ -841,6 +877,7 @@ func (k *kubeProvider) Create(
 	// with an `errors.IsNotFound`.
 	if clients.IsCRD(newInputs) {
 		k.clientSet.RESTMapper.Reset()
+		k.invalidateResources()
 	}
 
 	return &pulumirpc.CreateResponse{
@@ -912,6 +949,10 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 		oldInputs.SetNamespace(namespace)
 	}
 
+	resources, err := k.getResources()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+	}
 	config := await.ReadConfig{
 		ProviderConfig: await.ProviderConfig{
 			Context:     k.canceler.context,
@@ -919,7 +960,7 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 			URN:         urn,
 			ClientSet:   k.clientSet,
 			DedupLogger: logging.NewLogger(k.canceler.context, k.host, urn),
-			Resources:   k.resources,
+			Resources:   resources,
 		},
 		Inputs: oldInputs,
 		Name:   name,
@@ -1097,6 +1138,10 @@ func (k *kubeProvider) Update(
 			newInputs.GetNamespace(), newInputs.GetName(), lastAppliedConfigKey)
 	}
 
+	resources, err := k.getResources()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+	}
 	config := await.UpdateConfig{
 		ProviderConfig: await.ProviderConfig{
 			Context:     k.canceler.context,
@@ -1104,7 +1149,7 @@ func (k *kubeProvider) Update(
 			URN:         urn,
 			ClientSet:   k.clientSet,
 			DedupLogger: logging.NewLogger(k.canceler.context, k.host, urn),
-			Resources:   k.resources,
+			Resources:   resources,
 		},
 		Previous: oldInputs,
 		Inputs:   annotatedInputs,
@@ -1183,6 +1228,10 @@ func (k *kubeProvider) Delete(
 	_, current := parseCheckpointObject(oldState)
 	_, name := parseFqName(req.GetId())
 
+	resources, err := k.getResources()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+	}
 	config := await.DeleteConfig{
 		ProviderConfig: await.ProviderConfig{
 			Context:     k.canceler.context, // TODO: should this just be ctx from the args?
@@ -1190,7 +1239,7 @@ func (k *kubeProvider) Delete(
 			URN:         urn,
 			ClientSet:   k.clientSet,
 			DedupLogger: logging.NewLogger(k.canceler.context, k.host, urn),
-			Resources:   k.resources,
+			Resources:   resources,
 		},
 		Inputs:  current,
 		Name:    name,
@@ -1307,7 +1356,11 @@ func (k *kubeProvider) dryRunPatch(
 	}
 	liveInputs := parseLiveInputs(liveObject, oldInputs)
 
-	patch, patchType, _, err := openapi.PatchForResourceUpdate(k.resources, liveInputs, newInputs, liveObject)
+	resources, err := k.getResources()
+	if err != nil {
+		return nil, nil, err
+	}
+	patch, patchType, _, err := openapi.PatchForResourceUpdate(resources, liveInputs, newInputs, liveObject)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Just what it says on the tin. This eliminates the last major source of
execution time in the k8s provider.

Contributes to #827.