### PR TITLE
Stop using initialApiVersion annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Stop using initialApiVersion annotation. (https://github.com/pulumi/pulumi-kubernetes/pull/837).
+
 ## 1.2.1 (October 8, 2019)
+
+### Supported Kubernetes versions
+
+- v1.16.x
+- v1.15.x
+- v1.14.x
 
 ### Improvements
 

--- a/pkg/await/await.go
+++ b/pkg/await/await.go
@@ -52,9 +52,10 @@ import (
 // --------------------------------------------------------------------------
 
 type ProviderConfig struct {
-	Context context.Context
-	Host    *pulumiprovider.HostClient
-	URN     resource.URN
+	Context           context.Context
+	Host              *pulumiprovider.HostClient
+	URN               resource.URN
+	InitialApiVersion string
 
 	ClientSet   *clients.DynamicClientSet
 	DedupLogger *logging.DedupLogger
@@ -176,14 +177,15 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 		} else {
 			if awaiter.awaitCreation != nil {
 				conf := createAwaitConfig{
-					host:           c.Host,
-					ctx:            c.Context,
-					urn:            c.URN,
-					clientSet:      c.ClientSet,
-					currentInputs:  c.Inputs,
-					currentOutputs: outputs,
-					logger:         c.DedupLogger,
-					timeout:        c.Timeout,
+					host:              c.Host,
+					ctx:               c.Context,
+					urn:               c.URN,
+					initialApiVersion: c.InitialApiVersion,
+					clientSet:         c.ClientSet,
+					currentInputs:     c.Inputs,
+					currentOutputs:    outputs,
+					logger:            c.DedupLogger,
+					timeout:           c.Timeout,
 				}
 				waitErr := awaiter.awaitCreation(conf)
 				if waitErr != nil {
@@ -230,13 +232,14 @@ func Read(c ReadConfig) (*unstructured.Unstructured, error) {
 		} else {
 			if awaiter.awaitRead != nil {
 				conf := createAwaitConfig{
-					host:           c.Host,
-					ctx:            c.Context,
-					urn:            c.URN,
-					clientSet:      c.ClientSet,
-					currentInputs:  c.Inputs,
-					currentOutputs: outputs,
-					logger:         c.DedupLogger,
+					host:              c.Host,
+					ctx:               c.Context,
+					urn:               c.URN,
+					initialApiVersion: c.InitialApiVersion,
+					clientSet:         c.ClientSet,
+					currentInputs:     c.Inputs,
+					currentOutputs:    outputs,
+					logger:            c.DedupLogger,
 				}
 				waitErr := awaiter.awaitRead(conf)
 				if waitErr != nil {
@@ -351,14 +354,15 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 			if awaiter.awaitUpdate != nil {
 				conf := updateAwaitConfig{
 					createAwaitConfig: createAwaitConfig{
-						host:           c.Host,
-						ctx:            c.Context,
-						urn:            c.URN,
-						clientSet:      c.ClientSet,
-						currentInputs:  c.Inputs,
-						currentOutputs: currentOutputs,
-						logger:         c.DedupLogger,
-						timeout:        c.Timeout,
+						host:              c.Host,
+						ctx:               c.Context,
+						urn:               c.URN,
+						initialApiVersion: c.InitialApiVersion,
+						clientSet:         c.ClientSet,
+						currentInputs:     c.Inputs,
+						currentOutputs:    currentOutputs,
+						logger:            c.DedupLogger,
+						timeout:           c.Timeout,
 					},
 					lastInputs:  c.Previous,
 					lastOutputs: liveOldObj,
@@ -444,13 +448,14 @@ func Deletion(c DeleteConfig) error {
 		} else {
 			waitErr = awaiter.awaitDeletion(deleteAwaitConfig{
 				createAwaitConfig: createAwaitConfig{
-					host:          c.Host,
-					ctx:           c.Context,
-					urn:           c.URN,
-					clientSet:     c.ClientSet,
-					currentInputs: c.Inputs,
-					logger:        c.DedupLogger,
-					timeout:       c.Timeout,
+					host:              c.Host,
+					ctx:               c.Context,
+					urn:               c.URN,
+					initialApiVersion: c.InitialApiVersion,
+					clientSet:         c.ClientSet,
+					currentInputs:     c.Inputs,
+					logger:            c.DedupLogger,
+					timeout:           c.Timeout,
 				},
 				clientForResource: client,
 			})

--- a/pkg/await/awaiters.go
+++ b/pkg/await/awaiters.go
@@ -43,14 +43,15 @@ const (
 // live number of Pods reaches the minimum liveness threshold. `pool` and `disco` are provided
 // typically from a client pool so that polling is reasonably efficient.
 type createAwaitConfig struct {
-	host           *provider.HostClient
-	ctx            context.Context
-	urn            resource.URN
-	logger         *logging.DedupLogger
-	clientSet      *clients.DynamicClientSet
-	currentInputs  *unstructured.Unstructured
-	currentOutputs *unstructured.Unstructured
-	timeout        float64
+	host              *provider.HostClient
+	ctx               context.Context
+	urn               resource.URN
+	initialApiVersion string
+	logger            *logging.DedupLogger
+	clientSet         *clients.DynamicClientSet
+	currentInputs     *unstructured.Unstructured
+	currentOutputs    *unstructured.Unstructured
+	timeout           float64
 }
 
 func (cac *createAwaitConfig) logStatus(sev diag.Severity, message string) {

--- a/pkg/await/deployment.go
+++ b/pkg/await/deployment.go
@@ -393,8 +393,7 @@ func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
 	// Note: We must use the annotated creation apiVersion rather than the API-reported apiVersion, because
 	// the Progressing status field will not be present if the Deployment was created with the `extensions/v1beta1` API,
 	// regardless of what the Event apiVersion says.
-	extensionsV1Beta1API := metadata.GetAnnotationValue(
-		dia.config.createAwaitConfig.currentInputs, metadata.AnnotationInitialApiVersion) == "extensions/v1beta1"
+	extensionsV1Beta1API := dia.config.initialApiVersion == "extensions/v1beta1"
 
 	// Get generation of the Deployment's ReplicaSet.
 	dia.replicaSetGeneration = deployment.GetAnnotations()[revision]
@@ -550,8 +549,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 	// Note: We must use the annotated apiVersion rather than the API-reported apiVersion, because
 	// the Progressing status field will not be present if the Deployment was created with the `extensions/v1beta1` API,
 	// regardless of what the Event apiVersion says.
-	extensionsV1Beta1API := metadata.GetAnnotationValue(
-		dia.config.createAwaitConfig.currentInputs, metadata.AnnotationInitialApiVersion) == "extensions/v1beta1"
+	extensionsV1Beta1API := dia.config.initialApiVersion == "extensions/v1beta1"
 	if extensionsV1Beta1API {
 		rawReadyReplicas, readyReplicasExists = openapi.Pluck(dia.deployment.Object, "status", "readyReplicas")
 		readyReplicas, _ = rawReadyReplicas.(int64)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1469,7 +1469,9 @@ func legacyInitialApiVersion(oldConfig, newConfig *unstructured.Unstructured) (*
 		newAnnotations[metadata.AnnotationInitialApiVersion] = apiVersion
 	}
 
-	newConfig.SetAnnotations(newAnnotations)
+	if len(newConfig.GetAnnotations()) > 0 {
+		newConfig.SetAnnotations(newAnnotations)
+	}
 
 	return newConfig, nil
 }
@@ -1487,7 +1489,7 @@ func initialApiVersion(state resource.PropertyMap, oldConfig *unstructured.Unstr
 		return apiVersion, nil
 	}
 
-	return "", fmt.Errorf("failed to find initialApiVersion information for resource: %s", oldConfig.GetName())
+	return oldConfig.GetAPIVersion(), nil
 }
 
 func withLastAppliedConfig(config *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -31,6 +31,7 @@ var (
 		},
 	}
 	objLive = map[string]interface{}{
+		initialApiVersionKey: "",
 		"oof": "bar",
 		"zab": float64(4321),
 		"xuq": map[string]interface{}{

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -63,7 +63,7 @@ func TestCheckpointObject(t *testing.T) {
 	inputs := &unstructured.Unstructured{Object: objInputs}
 	live := &unstructured.Unstructured{Object: objLive}
 
-	obj := checkpointObject(inputs, live, nil)
+	obj := checkpointObject(inputs, live, nil, "")
 	assert.NotNil(t, obj)
 
 	oldInputs := obj["__inputs"]
@@ -81,7 +81,7 @@ func TestRoundtripCheckpointObject(t *testing.T) {
 	assert.Equal(t, objInputs, oldInputs.Object)
 	assert.Equal(t, objLive, oldLive.Object)
 
-	obj := checkpointObject(oldInputs, oldLive, nil)
+	obj := checkpointObject(oldInputs, oldLive, nil, "")
 	assert.Equal(t, old, obj)
 
 	newInputs, newLive := parseCheckpointObject(obj)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
In the 1.2.0 release, we added the pulumi.com/initialApiVersion annotation,
which was used internally by the provider. This caused the side effect of
requiring updates to all existing resources.

This change instead stores that information in the state file, and no longer
creates an annotation. To avoid further disruption, the annotation is not
removed if it already exists, but will be ignored by the provider.
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #834 