### PR TITLE
Fix buggy python test

### DIFF
--- a/tests/examples/python/get/__main__.py
+++ b/tests/examples/python/get/__main__.py
@@ -44,5 +44,4 @@ cr = CustomResource(
     spec={"foo": "bar"},
     opts=pulumi.ResourceOptions(depends_on=[crd]))
 
-cr_id = pulumi.Output.concat(ns.metadata["name"], '/', cr.metadata["name"])
-cr_get = CustomResource.get(resource_name="bar", api_version="python.test/v1", kind="GetTest", id=cr_id)
+cr_get = CustomResource.get(resource_name="bar", api_version="python.test/v1", kind="GetTest", id=cr.id)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This test was failing with version 1.3.0 of the CLI.

```
$ pulumi version && pulumi up
v1.3.0
Previewing update (python-get):

     Type                                                         Name            Plan       Info
 +   pulumi:pulumi:Stack                                          get-python-get  create     1 error
 +   ├─ kubernetes:apiextensions.k8s.io:CustomResourceDefinition  foo             create
 +   ├─ kubernetes:core:Namespace                                 ns              create
 +   ├─ kubernetes:python.test:GetTest                            foo             create
     ├─ kubernetes:python.test:GetTest                            bar                        1 error
     └─ kubernetes:core:Service                                   kube-api

Diagnostics:
  pulumi:pulumi:Stack (get-python-get):
    error: preview failed

  kubernetes:python.test:GetTest (bar):
    error: Preview failed: resource 'ns-lxe2agnl/foo-txbbrlhf' does not exist

$ ~/downloads/pulumi/pulumi version && ~/downloads/pulumi/pulumi up
warning: A new version of Pulumi is available. To upgrade from version '1.2.0' to '1.3.0', visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
v1.2.0
warning: A new version of Pulumi is available. To upgrade from version '1.2.0' to '1.3.0', visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
Previewing update (python-get):

     Type                                                         Name            Plan
 +   pulumi:pulumi:Stack                                          get-python-get  create
 +   ├─ kubernetes:apiextensions.k8s.io:CustomResourceDefinition  foo             create
 +   ├─ kubernetes:core:Namespace                                 ns              create
 +   ├─ kubernetes:python.test:GetTest                            foo             create
     └─ kubernetes:core:Service                                   kube-api

Resources:
    + 4 to create
```
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
