### PR TITLE
Remove doubled 'shell quoting' for path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Fix a bug that causes helm crash when referencing 'scoped packages' that start with '@'. (https://github.com/pulumi/pulumi-kubernetes/pull/846)
+
 ## 1.2.1 (October 10, 2019)
 
 ### Supported Kubernetes versions

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -171,7 +171,7 @@ export class Chart extends yaml.CollectionComponentResource {
                         nodepath.join(chartDir.name, fetchedChartName, "values.yaml")
                     );
                 } else {
-                    chart = path.quotePath(cfg.path);
+                    chart = cfg.path;
                     defaultValues = path.quotePath(nodepath.join(chart, "values.yaml"));
                 }
 


### PR DESCRIPTION
Signed-off-by: Matheus Miranda <matheusmirandalacerda@gmail.com>

### Proposed changes

Removed doubled call on 'quotePath' function, it adds '\\\\\\@' to the path instead of just '\\@', helm then fails on finding templates configs for NPM 'scoped packages'. E.g:

![image](https://user-images.githubusercontent.com/13803249/66828673-04d04880-ef28-11e9-945d-b8f9dc6fe54e.png)
