### PR TITLE
Correctly merge provided opts for k8s resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - v1.15.x
 - v1.14.x
 
-### Improvements
+### Bug fixes
 
+-   Correctly merge provided opts for k8s resources. (https://github.com/pulumi/pulumi-kubernetes/pull/850).
 -   Fix a bug that causes helm crash when referencing 'scoped packages' that start with '@'. (https://github.com/pulumi/pulumi-kubernetes/pull/846)
 
 ## 1.2.1 (October 10, 2019)

--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -73,21 +73,19 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              {{#AdditionalSecretOutputs}}
-              "{{.}}",
-              {{/AdditionalSecretOutputs}}
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+                  {{#AdditionalSecretOutputs}}
+                  "{{.}}",
+                  {{/AdditionalSecretOutputs}}
+              ],
+              aliases: [
+                  {{#Aliases}}
+                  { parent: opts.parent, type: "{{.}}", name: name },
+                  {{/Aliases}}
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-          {{#Aliases}}
-              { parent: opts.parent, type: "{{.}}", name: name },
-          {{/Aliases}}
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super({{Kind}}.__pulumiType, name, props, opts);
+          super({{Kind}}.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfigurationList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(MutatingWebhookConfigurationList.__pulumiType, name, props, opts);
+          super(MutatingWebhookConfigurationList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfigurationList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ValidatingWebhookConfigurationList.__pulumiType, name, props, opts);
+          super(ValidatingWebhookConfigurationList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfigurationList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(MutatingWebhookConfigurationList.__pulumiType, name, props, opts);
+          super(MutatingWebhookConfigurationList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ValidatingWebhookConfigurationList.__pulumiType, name, props, opts);
+          super(ValidatingWebhookConfigurationList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
@@ -96,15 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CustomResourceDefinition.__pulumiType, name, props, opts);
+          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1/CustomResourceDefinitionList.ts
+++ b/sdk/nodejs/apiextensions/v1/CustomResourceDefinitionList.ts
@@ -90,15 +90,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CustomResourceDefinitionList.__pulumiType, name, props, opts);
+          super(CustomResourceDefinitionList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
@@ -97,15 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CustomResourceDefinition.__pulumiType, name, props, opts);
+          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinitionList.ts
@@ -90,15 +90,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CustomResourceDefinitionList.__pulumiType, name, props, opts);
+          super(CustomResourceDefinitionList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(APIService.__pulumiType, name, props, opts);
+          super(APIService.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1/APIServiceList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(APIServiceList.__pulumiType, name, props, opts);
+          super(APIServiceList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(APIService.__pulumiType, name, props, opts);
+          super(APIService.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(APIServiceList.__pulumiType, name, props, opts);
+          super(APIServiceList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevision.ts
@@ -106,15 +106,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevisionList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevisionList.__pulumiType, name, props, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1/DaemonSet.ts
@@ -101,18 +101,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSet.__pulumiType, name, props, opts);
+          super(DaemonSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1/DaemonSetList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSetList.__pulumiType, name, props, opts);
+          super(DaemonSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -119,19 +119,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Deployment.__pulumiType, name, props, opts);
+          super(Deployment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1/DeploymentList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DeploymentList.__pulumiType, name, props, opts);
+          super(DeploymentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSet.ts
@@ -102,18 +102,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSet.__pulumiType, name, props, opts);
+          super(ReplicaSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSetList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSetList.__pulumiType, name, props, opts);
+          super(ReplicaSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -113,19 +113,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSet.__pulumiType, name, props, opts);
+          super(StatefulSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1/StatefulSetList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSetList.__pulumiType, name, props, opts);
+          super(StatefulSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -109,15 +109,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevisionList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevisionList.__pulumiType, name, props, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -122,19 +122,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Deployment.__pulumiType, name, props, opts);
+          super(Deployment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta1/DeploymentList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DeploymentList.__pulumiType, name, props, opts);
+          super(DeploymentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -116,19 +116,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSet.__pulumiType, name, props, opts);
+          super(StatefulSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSetList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSetList.__pulumiType, name, props, opts);
+          super(StatefulSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -109,15 +109,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevisionList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ControllerRevisionList.__pulumiType, name, props, opts);
+          super(ControllerRevisionList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -104,18 +104,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSet.__pulumiType, name, props, opts);
+          super(DaemonSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSetList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSetList.__pulumiType, name, props, opts);
+          super(DaemonSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -122,19 +122,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Deployment.__pulumiType, name, props, opts);
+          super(Deployment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DeploymentList.ts
+++ b/sdk/nodejs/apps/v1beta2/DeploymentList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DeploymentList.__pulumiType, name, props, opts);
+          super(DeploymentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -105,18 +105,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSet.__pulumiType, name, props, opts);
+          super(ReplicaSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSetList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSetList.__pulumiType, name, props, opts);
+          super(ReplicaSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -116,19 +116,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSet.__pulumiType, name, props, opts);
+          super(StatefulSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSetList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StatefulSetList.__pulumiType, name, props, opts);
+          super(StatefulSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSink.ts
@@ -90,15 +90,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(AuditSink.__pulumiType, name, props, opts);
+          super(AuditSink.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/AuditSinkList.ts
@@ -90,15 +90,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(AuditSinkList.__pulumiType, name, props, opts);
+          super(AuditSinkList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authentication/v1/TokenRequest.ts
+++ b/sdk/nodejs/authentication/v1/TokenRequest.ts
@@ -91,15 +91,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(TokenRequest.__pulumiType, name, props, opts);
+          super(TokenRequest.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authentication/v1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1/TokenReview.ts
@@ -96,15 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(TokenReview.__pulumiType, name, props, opts);
+          super(TokenReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authentication/v1beta1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1beta1/TokenReview.ts
@@ -96,15 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(TokenReview.__pulumiType, name, props, opts);
+          super(TokenReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
@@ -98,15 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
@@ -97,15 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
@@ -102,15 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SubjectAccessReview.__pulumiType, name, props, opts);
+          super(SubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
@@ -98,15 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
@@ -97,15 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
@@ -102,15 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SubjectAccessReview.__pulumiType, name, props, opts);
+          super(SubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
@@ -99,15 +99,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscalerList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscalerList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscalerList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(HorizontalPodAutoscalerList.__pulumiType, name, props, opts);
+          super(HorizontalPodAutoscalerList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v1/Job.ts
+++ b/sdk/nodejs/batch/v1/Job.ts
@@ -115,15 +115,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Job.__pulumiType, name, props, opts);
+          super(Job.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v1/JobList.ts
+++ b/sdk/nodejs/batch/v1/JobList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(JobList.__pulumiType, name, props, opts);
+          super(JobList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJob.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJob.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CronJob.__pulumiType, name, props, opts);
+          super(CronJob.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJobList.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJobList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CronJobList.__pulumiType, name, props, opts);
+          super(CronJobList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJob.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJob.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CronJob.__pulumiType, name, props, opts);
+          super(CronJob.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJobList.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJobList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CronJobList.__pulumiType, name, props, opts);
+          super(CronJobList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequest.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CertificateSigningRequest.__pulumiType, name, props, opts);
+          super(CertificateSigningRequest.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
+++ b/sdk/nodejs/certificates/v1beta1/CertificateSigningRequestList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CertificateSigningRequestList.__pulumiType, name, props, opts);
+          super(CertificateSigningRequestList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/Lease.ts
+++ b/sdk/nodejs/coordination/v1/Lease.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Lease.__pulumiType, name, props, opts);
+          super(Lease.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1/LeaseList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LeaseList.__pulumiType, name, props, opts);
+          super(LeaseList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/Lease.ts
+++ b/sdk/nodejs/coordination/v1beta1/Lease.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Lease.__pulumiType, name, props, opts);
+          super(Lease.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/LeaseList.ts
+++ b/sdk/nodejs/coordination/v1beta1/LeaseList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LeaseList.__pulumiType, name, props, opts);
+          super(LeaseList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Binding.ts
+++ b/sdk/nodejs/core/v1/Binding.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Binding.__pulumiType, name, props, opts);
+          super(Binding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ComponentStatus.ts
+++ b/sdk/nodejs/core/v1/ComponentStatus.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ComponentStatus.__pulumiType, name, props, opts);
+          super(ComponentStatus.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ComponentStatusList.ts
+++ b/sdk/nodejs/core/v1/ComponentStatusList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ComponentStatusList.__pulumiType, name, props, opts);
+          super(ComponentStatusList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ConfigMap.ts
+++ b/sdk/nodejs/core/v1/ConfigMap.ts
@@ -105,15 +105,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ConfigMap.__pulumiType, name, props, opts);
+          super(ConfigMap.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ConfigMapList.ts
+++ b/sdk/nodejs/core/v1/ConfigMapList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ConfigMapList.__pulumiType, name, props, opts);
+          super(ConfigMapList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Endpoints.ts
+++ b/sdk/nodejs/core/v1/Endpoints.ts
@@ -109,15 +109,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Endpoints.__pulumiType, name, props, opts);
+          super(Endpoints.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/EndpointsList.ts
+++ b/sdk/nodejs/core/v1/EndpointsList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(EndpointsList.__pulumiType, name, props, opts);
+          super(EndpointsList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Event.ts
+++ b/sdk/nodejs/core/v1/Event.ts
@@ -172,15 +172,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Event.__pulumiType, name, props, opts);
+          super(Event.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/EventList.ts
+++ b/sdk/nodejs/core/v1/EventList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(EventList.__pulumiType, name, props, opts);
+          super(EventList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/LimitRange.ts
+++ b/sdk/nodejs/core/v1/LimitRange.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LimitRange.__pulumiType, name, props, opts);
+          super(LimitRange.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/LimitRangeList.ts
+++ b/sdk/nodejs/core/v1/LimitRangeList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(LimitRangeList.__pulumiType, name, props, opts);
+          super(LimitRangeList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Namespace.ts
+++ b/sdk/nodejs/core/v1/Namespace.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Namespace.__pulumiType, name, props, opts);
+          super(Namespace.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/NamespaceList.ts
+++ b/sdk/nodejs/core/v1/NamespaceList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NamespaceList.__pulumiType, name, props, opts);
+          super(NamespaceList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Node.ts
+++ b/sdk/nodejs/core/v1/Node.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Node.__pulumiType, name, props, opts);
+          super(Node.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/NodeList.ts
+++ b/sdk/nodejs/core/v1/NodeList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NodeList.__pulumiType, name, props, opts);
+          super(NodeList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolume.ts
+++ b/sdk/nodejs/core/v1/PersistentVolume.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PersistentVolume.__pulumiType, name, props, opts);
+          super(PersistentVolume.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaim.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PersistentVolumeClaim.__pulumiType, name, props, opts);
+          super(PersistentVolumeClaim.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeClaimList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PersistentVolumeClaimList.__pulumiType, name, props, opts);
+          super(PersistentVolumeClaimList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PersistentVolumeList.ts
+++ b/sdk/nodejs/core/v1/PersistentVolumeList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PersistentVolumeList.__pulumiType, name, props, opts);
+          super(PersistentVolumeList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Pod.ts
+++ b/sdk/nodejs/core/v1/Pod.ts
@@ -117,15 +117,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Pod.__pulumiType, name, props, opts);
+          super(Pod.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodList.ts
+++ b/sdk/nodejs/core/v1/PodList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodList.__pulumiType, name, props, opts);
+          super(PodList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodTemplate.ts
+++ b/sdk/nodejs/core/v1/PodTemplate.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodTemplate.__pulumiType, name, props, opts);
+          super(PodTemplate.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/PodTemplateList.ts
+++ b/sdk/nodejs/core/v1/PodTemplateList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodTemplateList.__pulumiType, name, props, opts);
+          super(PodTemplateList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ReplicationController.ts
+++ b/sdk/nodejs/core/v1/ReplicationController.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicationController.__pulumiType, name, props, opts);
+          super(ReplicationController.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ReplicationControllerList.ts
+++ b/sdk/nodejs/core/v1/ReplicationControllerList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicationControllerList.__pulumiType, name, props, opts);
+          super(ReplicationControllerList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ResourceQuota.ts
+++ b/sdk/nodejs/core/v1/ResourceQuota.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ResourceQuota.__pulumiType, name, props, opts);
+          super(ResourceQuota.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ResourceQuotaList.ts
+++ b/sdk/nodejs/core/v1/ResourceQuotaList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ResourceQuotaList.__pulumiType, name, props, opts);
+          super(ResourceQuotaList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Secret.ts
+++ b/sdk/nodejs/core/v1/Secret.ts
@@ -121,17 +121,15 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              "data",
-              "stringData",
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+                  "data",
+                  "stringData",
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Secret.__pulumiType, name, props, opts);
+          super(Secret.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/SecretList.ts
+++ b/sdk/nodejs/core/v1/SecretList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(SecretList.__pulumiType, name, props, opts);
+          super(SecretList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Service.ts
+++ b/sdk/nodejs/core/v1/Service.ts
@@ -128,15 +128,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Service.__pulumiType, name, props, opts);
+          super(Service.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceAccount.ts
+++ b/sdk/nodejs/core/v1/ServiceAccount.ts
@@ -113,15 +113,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ServiceAccount.__pulumiType, name, props, opts);
+          super(ServiceAccount.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceAccountList.ts
+++ b/sdk/nodejs/core/v1/ServiceAccountList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ServiceAccountList.__pulumiType, name, props, opts);
+          super(ServiceAccountList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/ServiceList.ts
+++ b/sdk/nodejs/core/v1/ServiceList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ServiceList.__pulumiType, name, props, opts);
+          super(ServiceList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/discovery/v1alpha1/EndpointSlice.ts
+++ b/sdk/nodejs/discovery/v1alpha1/EndpointSlice.ts
@@ -111,15 +111,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(EndpointSlice.__pulumiType, name, props, opts);
+          super(EndpointSlice.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/discovery/v1alpha1/EndpointSliceList.ts
+++ b/sdk/nodejs/discovery/v1alpha1/EndpointSliceList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(EndpointSliceList.__pulumiType, name, props, opts);
+          super(EndpointSliceList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/Event.ts
+++ b/sdk/nodejs/events/v1beta1/Event.ts
@@ -173,15 +173,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Event.__pulumiType, name, props, opts);
+          super(Event.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/EventList.ts
+++ b/sdk/nodejs/events/v1beta1/EventList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(EventList.__pulumiType, name, props, opts);
+          super(EventList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -104,18 +104,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSet.__pulumiType, name, props, opts);
+          super(DaemonSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSetList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DaemonSetList.__pulumiType, name, props, opts);
+          super(DaemonSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -122,19 +122,17 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Deployment.__pulumiType, name, props, opts);
+          super(Deployment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
+++ b/sdk/nodejs/extensions/v1beta1/DeploymentList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(DeploymentList.__pulumiType, name, props, opts);
+          super(DeploymentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -119,17 +119,15 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Ingress.__pulumiType, name, props, opts);
+          super(Ingress.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/IngressList.ts
+++ b/sdk/nodejs/extensions/v1beta1/IngressList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(IngressList.__pulumiType, name, props, opts);
+          super(IngressList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NetworkPolicy.__pulumiType, name, props, opts);
+          super(NetworkPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicyList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NetworkPolicyList.__pulumiType, name, props, opts);
+          super(NetworkPolicyList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -95,15 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodSecurityPolicy.__pulumiType, name, props, opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicyList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodSecurityPolicyList.__pulumiType, name, props, opts);
+          super(PodSecurityPolicyList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -105,18 +105,16 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSet.__pulumiType, name, props, opts);
+          super(ReplicaSet.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSetList.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ReplicaSetList.__pulumiType, name, props, opts);
+          super(ReplicaSetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/meta/v1/Status.ts
+++ b/sdk/nodejs/meta/v1/Status.ts
@@ -121,15 +121,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Status.__pulumiType, name, props, opts);
+          super(Status.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NetworkPolicy.__pulumiType, name, props, opts);
+          super(NetworkPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicyList.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicyList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(NetworkPolicyList.__pulumiType, name, props, opts);
+          super(NetworkPolicyList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -116,17 +116,15 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
-              { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Ingress.__pulumiType, name, props, opts);
+          super(Ingress.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/IngressList.ts
+++ b/sdk/nodejs/networking/v1beta1/IngressList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(IngressList.__pulumiType, name, props, opts);
+          super(IngressList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
@@ -99,15 +99,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RuntimeClass.__pulumiType, name, props, opts);
+          super(RuntimeClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RuntimeClassList.__pulumiType, name, props, opts);
+          super(RuntimeClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClass.ts
@@ -122,15 +122,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RuntimeClass.__pulumiType, name, props, opts);
+          super(RuntimeClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RuntimeClassList.__pulumiType, name, props, opts);
+          super(RuntimeClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudget.ts
@@ -96,15 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodDisruptionBudget.__pulumiType, name, props, opts);
+          super(PodDisruptionBudget.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodDisruptionBudgetList.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodDisruptionBudgetList.__pulumiType, name, props, opts);
+          super(PodDisruptionBudgetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -94,15 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodSecurityPolicy.__pulumiType, name, props, opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicyList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodSecurityPolicyList.__pulumiType, name, props, opts);
+          super(PodSecurityPolicyList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRole.__pulumiType, name, props, opts);
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleList.__pulumiType, name, props, opts);
+          super(ClusterRoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Role.__pulumiType, name, props, opts);
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -102,15 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBinding.__pulumiType, name, props, opts);
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1/RoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBindingList.__pulumiType, name, props, opts);
+          super(RoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1/RoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleList.__pulumiType, name, props, opts);
+          super(RoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRole.__pulumiType, name, props, opts);
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleList.__pulumiType, name, props, opts);
+          super(ClusterRoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Role.__pulumiType, name, props, opts);
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -102,15 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBinding.__pulumiType, name, props, opts);
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBindingList.__pulumiType, name, props, opts);
+          super(RoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleList.__pulumiType, name, props, opts);
+          super(RoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -101,15 +101,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRole.__pulumiType, name, props, opts);
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -100,15 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleBindingList.__pulumiType, name, props, opts);
+          super(ClusterRoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(ClusterRoleList.__pulumiType, name, props, opts);
+          super(ClusterRoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(Role.__pulumiType, name, props, opts);
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -102,15 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBinding.__pulumiType, name, props, opts);
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBindingList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleBindingList.__pulumiType, name, props, opts);
+          super(RoleBindingList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleList.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleList.ts
@@ -92,15 +92,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(RoleList.__pulumiType, name, props, opts);
+          super(RoleList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -120,15 +120,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClass.__pulumiType, name, props, opts);
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClassList.__pulumiType, name, props, opts);
+          super(PriorityClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -121,15 +121,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClass.__pulumiType, name, props, opts);
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClassList.__pulumiType, name, props, opts);
+          super(PriorityClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -121,15 +121,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClass.__pulumiType, name, props, opts);
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PriorityClassList.__pulumiType, name, props, opts);
+          super(PriorityClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/settings/v1alpha1/PodPreset.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPreset.ts
@@ -88,15 +88,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodPreset.__pulumiType, name, props, opts);
+          super(PodPreset.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
+++ b/sdk/nodejs/settings/v1alpha1/PodPresetList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(PodPresetList.__pulumiType, name, props, opts);
+          super(PodPresetList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1/StorageClass.ts
@@ -142,15 +142,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StorageClass.__pulumiType, name, props, opts);
+          super(StorageClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1/StorageClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StorageClassList.__pulumiType, name, props, opts);
+          super(StorageClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachment.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachmentList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachmentList.__pulumiType, name, props, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachmentList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachmentList.__pulumiType, name, props, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSIDriver.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriver.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CSIDriver.__pulumiType, name, props, opts);
+          super(CSIDriver.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSIDriverList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CSIDriverList.__pulumiType, name, props, opts);
+          super(CSIDriverList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -98,15 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CSINode.__pulumiType, name, props, opts);
+          super(CSINode.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINodeList.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINodeList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(CSINodeList.__pulumiType, name, props, opts);
+          super(CSINodeList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClass.ts
@@ -142,15 +142,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StorageClass.__pulumiType, name, props, opts);
+          super(StorageClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClassList.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClassList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(StorageClassList.__pulumiType, name, props, opts);
+          super(StorageClassList.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
@@ -103,15 +103,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachmentList.ts
@@ -93,15 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          opts.additionalSecretOutputs = [
-              ...((opts && opts.additionalSecretOutputs) || []),
+          const _opts = pulumi.mergeOptions(opts, {
+              additionalSecretOutputs: [
+              ],
+              aliases: [
+              ]
+          });
 
-          ];
-
-          opts.aliases = [
-              ...((opts && opts.aliases) || []),
-          ];
-
-          super(VolumeAttachmentList.__pulumiType, name, props, opts);
+          super(VolumeAttachmentList.__pulumiType, name, props, _opts);
       }
     }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
~It seems like the construct we were using in case of empty opts was not working properly for the auto-aliases. This change fixes the linked issue, but I don't quite understand what the problem was.~

We were not merging user-provided `opts` properly in k8s resources. The bug reported in #849 was caused by mutating the provided `opts` object in multiple resources, which resulted in every resource being aliased to every other resource type sharing that object.

This also fixes the same issue for `additionalSecretOutputs`.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #849 