### PR TITLE
Use HELM_HOME as default if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Improvements
 
+-   Use HELM_HOME as default if set. (https://github.com/pulumi/pulumi-kubernetes/pull/855).
 -   Use `namespace` provided by `KUBECONFIG`, if it is not explicitly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/903).
 
 ## 1.3.3 (November 29, 2019)

--- a/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -197,7 +197,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Use the HELM_HOME environment variable value if set.
                 const home = process.env.HELM_HOME || undefined;
                 if (home !== undefined) {
-                    cmd += ` --home ${home}`;
+                    cmd += ` --home ${path.quotePath(home)}`;
                 }
 
                 const yamlStream = execSync(
@@ -403,13 +403,8 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        if (opts.home !== undefined) {
-            flags.push(`--home ${path.quotePath(opts.home)}`);
-        } else {
-            const home = process.env.HELM_HOME || undefined;
-            if (home !== undefined) {
-                flags.push(`--home ${home}`);
-            }
+        if (!opts.home) {
+            opts.home = process.env.HELM_HOME || undefined;
         }
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
@@ -425,6 +420,7 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if (opts.repo !== undefined)        { flags.push(`--repo ${path.quotePath(opts.repo)}`);               }
         if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);  }
+        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                           }
         if (opts.prov === true)             { flags.push(`--prov`);                                            }
         if (opts.verify === true)           { flags.push(`--verify`);                                          }

--- a/pkg/gen/python-templates/helm/v2/helm.py
+++ b/pkg/gen/python-templates/helm/v2/helm.py
@@ -338,10 +338,14 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
+    home = os.environ.get('HELM_HOME')
+    home_arg = ['--home', home] if home else []
+
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
+    cmd.extend(home_arg)
 
     chart_resources = pulumi.Output.all(cmd, data).apply(_run_helm_cmd)
 
@@ -359,6 +363,11 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     # Untar by default.
     if opts.untar is not False:
         cmd.append('--untar')
+
+    if opts.home:
+        cmd.extend(['--home', opts.home])
+    elif os.environ.get('HELM_HOME'):
+        cmd.extend(['--home', os.environ.get('HELM_HOME')])
 
     if opts.version:
         cmd.extend(['--version', opts.version])
@@ -380,8 +389,6 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
         cmd.extend(['--untardir', opts.untar_dir])
     if opts.username:
         cmd.extend(['--username', opts.username])
-    if opts.home:
-        cmd.extend(['--home', opts.home])
     if opts.devel:
         cmd.append('--devel')
     if opts.prov:

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -197,7 +197,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Use the HELM_HOME environment variable value if set.
                 const home = process.env.HELM_HOME || undefined;
                 if (home !== undefined) {
-                    cmd += ` --home ${home}`;
+                    cmd += ` --home ${path.quotePath(home)}`;
                 }
 
                 const yamlStream = execSync(
@@ -403,13 +403,8 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        if (opts.home !== undefined) {
-            flags.push(`--home ${path.quotePath(opts.home)}`);
-        } else {
-            const home = process.env.HELM_HOME || undefined;
-            if (home !== undefined) {
-                flags.push(`--home ${home}`);
-            }
+        if (!opts.home) {
+            opts.home = process.env.HELM_HOME || undefined;
         }
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
@@ -425,6 +420,7 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if (opts.repo !== undefined)        { flags.push(`--repo ${path.quotePath(opts.repo)}`);               }
         if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);  }
+        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                           }
         if (opts.prov === true)             { flags.push(`--prov`);                                            }
         if (opts.verify === true)           { flags.push(`--verify`);                                          }

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -338,10 +338,14 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
+    home = os.environ.get('HELM_HOME')
+    home_arg = ['--home', home] if home else []
+
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
+    cmd.extend(home_arg)
 
     chart_resources = pulumi.Output.all(cmd, data).apply(_run_helm_cmd)
 
@@ -359,6 +363,11 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     # Untar by default.
     if opts.untar is not False:
         cmd.append('--untar')
+
+    if opts.home:
+        cmd.extend(['--home', opts.home])
+    elif os.environ.get('HELM_HOME'):
+        cmd.extend(['--home', os.environ.get('HELM_HOME')])
 
     if opts.version:
         cmd.extend(['--version', opts.version])
@@ -380,8 +389,6 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
         cmd.extend(['--untardir', opts.untar_dir])
     if opts.username:
         cmd.extend(['--username', opts.username])
-    if opts.home:
-        cmd.extend(['--home', opts.home])
     if opts.devel:
         cmd.append('--devel')
     if opts.prov:


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the Chart resource ignored the HELM_HOME
environment variable. This value is now used as a default
if set. Note that the fetch `home` option still takes
precedence over HELM_HOME.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #854 