### PR TITLE
Implement `kubernetes:kubernetes:list` and `kubernetes:kubernetes:watch`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/pkg/errors v0.8.1
-	github.com/pulumi/pulumi v1.4.1
+	github.com/pulumi/pulumi v1.4.2-0.20191105213231-1fe3f0f46eb6
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
 	google.golang.org/grpc v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/pulumi/pulumi v1.4.1 h1:9QwIb1BN84DYQcQN5MmzLXcOMLVQxZACKyidZgZMkw0=
-github.com/pulumi/pulumi v1.4.1/go.mod h1:jRL5FGhKUpth9WdmDf/hl2CeGlK3HLT/OIqvhFI987s=
+github.com/pulumi/pulumi v1.4.2-0.20191105213231-1fe3f0f46eb6 h1:HWmbuN8HdFMHU6cM085yjk4Fek+cvPgVjZdXNSAkXrI=
+github.com/pulumi/pulumi v1.4.2-0.20191105213231-1fe3f0f46eb6/go.mod h1:jRL5FGhKUpth9WdmDf/hl2CeGlK3HLT/OIqvhFI987s=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=
@@ -600,4 +600,5 @@ sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
+sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 h1:e1sMhtVq9AfcEy8AXNb8eSg6gbzfdpYhoNqnPJa+GzI=
 sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=

--- a/pkg/gen/nodejs-templates/package.json.mustache
+++ b/pkg/gen/nodejs-templates/package.json.mustache
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.4.1",
+        "@pulumi/pulumi": "1.5.0-alpha.1572979668",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.4.1",
+        "@pulumi/pulumi": "1.5.0-alpha.1572979668",
         "@types/js-yaml": "^3.11.2",
         "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",


### PR DESCRIPTION
This commit will introduce an `Invoke` personality, which allows the
Kubernetes resource provider to list resources of some type, in the
spirit of `kubectl get <whatever>`.