### PR TITLE
fix: use kubeconfig namespace, if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Use `namespace` provided by `KUBECONFIG`, provided it is not explictly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/862).
+
 ## 1.2.3 (October 17, 2019)
 
 ### Supported Kubernetes versions
@@ -100,7 +104,7 @@
     (https://github.com/pulumi/pulumi-kubernetes/pull/794).
 -   Fix error reporting
     (https://github.com/pulumi/pulumi-kubernetes/pull/782).
-    
+
 ## 1.0.0 (September 3, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -276,10 +276,6 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		CurrentContext: vars["kubernetes:config:context"],
 	}
 
-	if defaultNamespace := vars["kubernetes:config:namespace"]; defaultNamespace != "" {
-		k.defaultNamespace = defaultNamespace
-	}
-
 	enableDryRun := func() bool {
 		// If the provider flag is set, use that value to determine behavior. This will override the ENV var.
 		if enabled, exists := vars["kubernetes:config:enableDryRun"]; exists {
@@ -321,6 +317,10 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 				"a filename or path")
 		}
 		kubeconfig = clientcmd.NewDefaultClientConfig(*config, overrides)
+		configurationNamespace, _, err := kubeconfig.Namespace()
+		if err == nil {
+			k.defaultNamespace = configurationNamespace
+		}
 	} else {
 		// Use client-go to resolve the final configuration values for the client. Typically these
 		// values would would reside in the $KUBECONFIG file, but can also be altered in several
@@ -329,6 +329,10 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 		kubeconfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
+	}
+
+	if defaultNamespace := vars["kubernetes:config:namespace"]; defaultNamespace != "" {
+		k.defaultNamespace = defaultNamespace
 	}
 
 	conf, err := kubeconfig.ClientConfig()


### PR DESCRIPTION
### Proposed changes

When loading a kubeconfig to a provider, if it has a namespace specified; it's not used. This change allows that configuration to be used
