### PR TITLE
Update args to support either helm 2 or 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,12 @@ install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
 
     # Install Helm CLI. Do not install Tiller.
-    - curl -LO  https://storage.googleapis.com/kubernetes-helm/helm-v2.14.3-linux-amd64.tar.gz
-    - tar -xvf helm-v2.14.3-linux-amd64.tar.gz
+    - curl -LO  https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz
+    - tar -xvf helm-v3.0.0-linux-amd64.tar.gz
     - sudo mv linux-amd64/helm /usr/local/bin
     - helm init --client-only
+    - helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+    - helm repo update
 
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ install:
     - curl -LO  https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz
     - tar -xvf helm-v3.0.0-linux-amd64.tar.gz
     - sudo mv linux-amd64/helm /usr/local/bin
-    - helm init --client-only
     - helm repo add stable https://kubernetes-charts.storage.googleapis.com/
     - helm repo update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Add support for helm 3 CLI tool. (https://github.com/pulumi/pulumi-kubernetes/pull/882).
+
 ## 1.3.0 (November 13, 2019)
 
 ### Supported Kubernetes versions

--- a/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -193,7 +193,7 @@ export class Chart extends yaml.CollectionComponentResource {
                     ? `--namespace ${shell.quote([cfg.namespace])}`
                     : "";
                 const yamlStream = execSync(
-                    `helm template ${chart} --name ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`,
+                    `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`,
                     {
                         maxBuffer: 512 * 1024 * 1024 // 512 MB
                     },

--- a/pkg/gen/python-templates/helm/v2/helm.py
+++ b/pkg/gen/python-templates/helm/v2/helm.py
@@ -339,7 +339,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
     # Use 'helm template' to create a combined YAML manifest.
-    cmd = ['helm', 'template', chart, '--name', release_name,
+    cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
 

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -193,7 +193,7 @@ export class Chart extends yaml.CollectionComponentResource {
                     ? `--namespace ${shell.quote([cfg.namespace])}`
                     : "";
                 const yamlStream = execSync(
-                    `helm template ${chart} --name ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`,
+                    `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${namespaceArg}`,
                     {
                         maxBuffer: 512 * 1024 * 1024 // 512 MB
                     },

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -339,7 +339,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
     # Use 'helm template' to create a combined YAML manifest.
-    cmd = ['helm', 'template', chart, '--name', release_name,
+    cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The `--name` arg is no longer present in helm v3 for `helm template`, but `--name-template` appears to accomplish the same thing in both versions. Updated the `helm fetch` command to use that parameter instead, which should work for both.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #797 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
