### PR TITLE
fix: use kubeconfig namespace, if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - v1.15.x
 - v1.14.x
 
+### Improvements
+
+-   Use `namespace` provided by `KUBECONFIG`, provided it is not explictly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/862).
+
 ## 1.3.3 (November 29, 2019)
 
 ### Supported Kubernetes versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 
--   Use `namespace` provided by `KUBECONFIG`, if it is not explicitly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/862).
+-   Use `namespace` provided by `KUBECONFIG`, if it is not explicitly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/903).
 
 ## 1.3.3 (November 29, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 
--   Use `namespace` provided by `KUBECONFIG`, provided it is not explictly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/862).
+-   Use `namespace` provided by `KUBECONFIG`, if it is not explicitly set in the provider (https://github.com/pulumi/pulumi-kubernetes/pull/862).
 
 ## 1.3.3 (November 29, 2019)
 

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -42,7 +42,11 @@ export interface ProviderArgs {
     readonly kubeconfig?: pulumi.Input<string>;
     /**
      * If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
-     * Note: if .metadata.namespace is set on a resource, that value takes precedence over the provider default.
+     *
+     * A namespace can be specified in multiple places, and the precedence is as follows:
+     * 1. `.metadata.namespace` set on the resource.
+     * 2. This `namespace` parameter.
+     * 3. `namespace` set for the active context in the kubeconfig.
      */
     readonly namespace?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -29,8 +29,11 @@ class Provider(pulumi.ProviderResource):
                                              If this is set, this config will be used instead of $KUBECONFIG.
         :param pulumi.Input[str] namespace: If present, the default namespace to use.
                                             This flag is ignored for cluster-scoped resources.
-                                            Note: if .metadata.namespace is set on a resource, that value takes
-                                            precedence over the provider default.
+                                            A namespace can be specified in multiple places, and the precedence is
+                                            as follows:
+                                            1. `.metadata.namespace` set on the resource.
+                                            2. This `namespace` parameter.
+                                            3. `namespace` set for the active context in the kubeconfig.
         :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to True, suppress apiVersion
                                                                  deprecation warnings from the CLI.
         """


### PR DESCRIPTION
Testing #862 
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
When loading a kubeconfig to a provider, if it has a namespace specified; it's not used. This change allows that configuration to be used
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
