### PR TITLE
Unify type representations in gen.

### DIFF
--- a/pkg/gen/dotnet-templates/kind.cs.mustache
+++ b/pkg/gen/dotnet-templates/kind.cs.mustache
@@ -15,7 +15,7 @@ namespace Pulumi.Kubernetes.{{Group}}.{{Version}}
         {{#Properties}}
         {{{Comment}}}
         [Output("{{Name}}")]
-        public {{{PropType}}} {{LanguageName}} { get; private set; } = null!;
+        public {{{ProviderType}}} {{LanguageName}} { get; private set; } = null!;
 
         {{/Properties}}
 

--- a/pkg/gen/dotnet-templates/typesInput.cs.mustache
+++ b/pkg/gen/dotnet-templates/typesInput.cs.mustache
@@ -20,38 +20,38 @@ namespace Pulumi.Kubernetes.Types.Inputs.{{Group}}
         {{#RequiredInputProperties}}
         {{#DotnetIsListOrMap}}
         [Input("{{Name}}", required: true)]
-        private {{{PropType}}}? _{{Name}};
+        private {{{InputsAPIType}}}? _{{Name}};
 
         {{{Comment}}}
-        public {{{PropType}}} {{LanguageName}}
+        public {{{InputsAPIType}}} {{LanguageName}}
         {
-            get => _{{Name}} ?? (_{{Name}} = new {{{PropType}}}());
+            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}());
             set => _{{Name}} = value;
         }
         {{/DotnetIsListOrMap}}
         {{^DotnetIsListOrMap}}
         {{{Comment}}}
         [Input("{{Name}}", required: true)]
-        public {{{PropType}}} {{LanguageName}} { get; set; } = null!;
+        public {{{InputsAPIType}}} {{LanguageName}} { get; set; } = null!;
         {{/DotnetIsListOrMap}}
 
         {{/RequiredInputProperties}}
         {{#OptionalInputProperties}}
         {{#DotnetIsListOrMap}}
         [Input("{{Name}}")]
-        private {{{PropType}}}? _{{Name}};
+        private {{{InputsAPIType}}}? _{{Name}};
 
         {{{Comment}}}
-        public {{{PropType}}} {{LanguageName}}
+        public {{{InputsAPIType}}} {{LanguageName}}
         {
-            get => _{{Name}} ?? (_{{Name}} = new {{{PropType}}}());
+            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}());
             set => _{{Name}} = value;
         }
         {{/DotnetIsListOrMap}}
         {{^DotnetIsListOrMap}}
         {{{Comment}}}
         [Input("{{Name}}")]
-        public {{{PropType}}}? {{LanguageName}} { get; set; }
+        public {{{InputsAPIType}}}? {{LanguageName}} { get; set; }
         {{/DotnetIsListOrMap}}
 
         {{/OptionalInputProperties}}

--- a/pkg/gen/dotnet-templates/typesOutput.cs.mustache
+++ b/pkg/gen/dotnet-templates/typesOutput.cs.mustache
@@ -20,13 +20,13 @@ namespace Pulumi.Kubernetes.Types.Outputs.{{Group}}
     {
       {{#Properties}}
       {{{Comment}}}
-      public readonly {{{PropType}}} {{LanguageName}};
+      public readonly {{{OutputsAPIType}}} {{LanguageName}};
 
       {{/Properties}}
       [OutputConstructor]
       private {{Kind}}(
           {{#Properties}}
-          {{{PropType}}} {{DotnetVarName}}{{^IsLast}},{{/IsLast}}{{#IsLast}}){{/IsLast}}
+          {{{OutputsAPIType}}} {{DotnetVarName}}{{^IsLast}},{{/IsLast}}{{#IsLast}}){{/IsLast}}
           {{/Properties}}
       {
           {{#Properties}}

--- a/pkg/gen/dotnet.go
+++ b/pkg/gen/dotnet.go
@@ -80,32 +80,28 @@ func DotnetClient(
 ) (inputsts, outputsts string, groups map[string]string, err error) {
 	definitions := swagger["definitions"].(map[string]interface{})
 
-	inputGroupsSlice := createGroups(definitions, dotnetInputs())
+	groupsSlice := createGroups(definitions, dotnetOpts())
+
 	inputsts, err = mustache.RenderFile(fmt.Sprintf("%s/typesInput.cs.mustache", templateDir),
 		map[string]interface{}{
-			"Groups": inputGroupsSlice,
+			"Groups": groupsSlice,
 		})
 	if err != nil {
 		return
 	}
 
-	outputGroupsSlice := createGroups(definitions, dotnetOutputs())
 	outputsts, err = mustache.RenderFile(fmt.Sprintf("%s/typesOutput.cs.mustache", templateDir),
 		map[string]interface{}{
-			"Groups": outputGroupsSlice,
+			"Groups": groupsSlice,
 		})
 	if err != nil {
 		return
 	}
 
-	groupsSlice := createGroups(definitions, dotnetProvider())
-	fmt.Printf("%v\n", groupsSlice)
-
 	groups = make(map[string]string)
-
 	for _, group := range groupsSlice {
 		for _, version := range group.Versions() {
-			for _, kind := range version.Kinds() {
+			for _, kind := range version.TopLevelKinds() {
 				inputMap := map[string]interface{}{
 					"RawAPIVersion":           kind.RawAPIVersion(),
 					"Comment":                 kind.Comment(),

--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -13,7 +13,7 @@ import { getVersion } from "../../version";
     export class {{Kind}} extends pulumi.CustomResource {
       {{#Properties}}
       {{{Comment}}}
-      public readonly {{Name}}: {{{PropType}}};
+      public readonly {{Name}}: {{{ProviderType}}};
 
       {{/Properties}}
       /**

--- a/pkg/gen/nodejs-templates/providerIndex.ts.mustache
+++ b/pkg/gen/nodejs-templates/providerIndex.ts.mustache
@@ -8,11 +8,13 @@ export { helm, yaml };
 
 // Import groups
 {{#Groups}}
+{{#HasTopLevelKinds}}
 import * as {{Group}} from "./{{Group}}/index";
+{{/HasTopLevelKinds}}
 {{/Groups}}
 
 // Export sub-modules
-export { {{#Groups}}{{Group}}, {{/Groups}} };
+export { {{#Groups}}{{#HasTopLevelKinds}}{{Group}}, {{/HasTopLevelKinds}}{{/Groups}} };
 
 // Import and export sub-modules for all Kubernetes types.
 import * as types from "./types";

--- a/pkg/gen/nodejs-templates/typesInput.ts.mustache
+++ b/pkg/gen/nodejs-templates/typesInput.ts.mustache
@@ -15,12 +15,12 @@ export namespace {{Group}} {
     export interface {{Kind}} {
       {{#RequiredInputProperties}}
       {{{Comment}}}
-      {{Name}}: {{{PropType}}}
+      {{Name}}: {{{InputsAPIType}}}
 
       {{/RequiredInputProperties}}
       {{#OptionalInputProperties}}
       {{{Comment}}}
-      {{Name}}?: {{{PropType}}}
+      {{Name}}?: {{{InputsAPIType}}}
 
       {{/OptionalInputProperties}}
     }

--- a/pkg/gen/nodejs-templates/typesOutput.ts.mustache
+++ b/pkg/gen/nodejs-templates/typesOutput.ts.mustache
@@ -12,7 +12,7 @@ export namespace {{Group}} {
     export interface {{Kind}} {
       {{#Properties}}
       {{{Comment}}}
-      readonly {{Name}}: {{{PropType}}}
+      readonly {{Name}}: {{{OutputsAPIType}}}
 
       {{/Properties}}
     }

--- a/pkg/gen/nodejs-templates/yaml.ts.mustache
+++ b/pkg/gen/nodejs-templates/yaml.ts.mustache
@@ -212,10 +212,10 @@ import * as outputs from "../types/output";
          */
         {{#Groups}}
         {{#Versions}}
-        {{#KindsAndAliases}}
+        {{#TopLevelKindsAndAliases}}
         public getResource(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", name: string): pulumi.Output<k8s.{{Group}}.{{Version}}.{{Kind}}>;
         public getResource(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", namespace: string, name: string): pulumi.Output<k8s.{{Group}}.{{Version}}.{{Kind}}>;
-        {{/KindsAndAliases}}
+        {{/TopLevelKindsAndAliases}}
         {{/Versions}}
         {{/Groups}}
         public getResource(groupVersionKind: string, namespaceOrName: string, name?: string): pulumi.Output<pulumi.CustomResource> {
@@ -230,12 +230,12 @@ import * as outputs from "../types/output";
          */
         {{#Groups}}
         {{#Versions}}
-        {{#KindsAndAliases}}
+        {{#TopLevelKindsAndAliases}}
         {{#Properties}}
-        public getResourceProperty(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", name: string, property: "{{LanguageName}}"): {{{PropType}}};
-        public getResourceProperty(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", namespace: string, name: string, property: "{{LanguageName}}"): {{{PropType}}};
+        public getResourceProperty(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", name: string, property: "{{LanguageName}}"): {{{ProviderType}}};
+        public getResourceProperty(groupVersionKind: "{{RawAPIVersion}}/{{Kind}}", namespace: string, name: string, property: "{{LanguageName}}"): {{{ProviderType}}};
         {{/Properties}}
-        {{/KindsAndAliases}}
+        {{/TopLevelKindsAndAliases}}
         {{/Versions}}
         {{/Groups}}
         public getResourceProperty(groupVersionKind: string, namespaceOrName: string, nameOrProperty: string, property?: string): pulumi.Output<any> {
@@ -400,9 +400,9 @@ import * as outputs from "../types/output";
                (apiVersion == "v1" && kind == "List")
             {{#Groups}}
             {{#Versions}}
-            {{#ListKindsAndAliases}}
+            {{#ListTopLevelKindsAndAliases}}
             || (apiVersion == "{{RawAPIVersion}}" && kind == "{{Kind}}")
-            {{/ListKindsAndAliases}}
+            {{/ListTopLevelKindsAndAliases}}
             {{/Versions}}
             {{/Groups}}
         ) {
@@ -430,13 +430,13 @@ import * as outputs from "../types/output";
         switch (`${apiVersion}/${kind}`) {
             {{#Groups}}
             {{#Versions}}
-            {{#KindsAndAliases}}
+            {{#TopLevelKindsAndAliases}}
             case "{{RawAPIVersion}}/{{Kind}}":
                 return [id.apply(id => ({
                     name: `{{RawAPIVersion}}/{{Kind}}::${id}`,
                     resource: new k8s.{{Group}}.{{Version}}.{{Kind}}(id, obj, opts),
                 }))];
-            {{/KindsAndAliases}}
+            {{/TopLevelKindsAndAliases}}
             {{/Versions}}
             {{/Groups}}
             default:

--- a/pkg/gen/python-templates/kind.py.mustache
+++ b/pkg/gen/python-templates/kind.py.mustache
@@ -31,7 +31,7 @@ class {{Kind}}(pulumi.CustomResource):
     """
 
     {{#Properties}}
-    {{LanguageName}}: {{{PropType}}}
+    {{LanguageName}}: {{{ProviderType}}}
     {{{Comment}}}
 
     {{/Properties}}
@@ -42,10 +42,10 @@ class {{Kind}}(pulumi.CustomResource):
         :param str resource_name: The _unique_ name of the resource.
         :param pulumi.ResourceOptions opts: A bag of options that control this resource's behavior.
         {{#RequiredInputProperties}}
-        :param {{{PythonConstructorPropType}}} {{LanguageName}}: {{{PythonConstructorComment}}}
+        :param {{{InputsAPIType}}} {{LanguageName}}: {{{PythonConstructorComment}}}
         {{/RequiredInputProperties}}
         {{#OptionalInputProperties}}
-        :param {{{PythonConstructorPropType}}} {{LanguageName}}: {{{PythonConstructorComment}}}
+        :param {{{InputsAPIType}}} {{LanguageName}}: {{{PythonConstructorComment}}}
         {{/OptionalInputProperties}}
         """
         if __name__ is not None:

--- a/pkg/gen/python-templates/root__init__.py.mustache
+++ b/pkg/gen/python-templates/root__init__.py.mustache
@@ -5,7 +5,9 @@
 # Make subpackages available:
 __all__ = [
     {{#Groups}}
+	{{#HasTopLevelKinds}}
     "{{Group}}",
+	{{/HasTopLevelKinds}}
     {{/Groups}}
     "helm",
     "provider",

--- a/pkg/gen/python-templates/version__init__.py.mustache
+++ b/pkg/gen/python-templates/version__init__.py.mustache
@@ -3,6 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 # Export this package's modules as members:
-{{#Kinds}}
+{{#TopLevelKinds}}
 from .{{Kind}} import ({{Kind}})
-{{/Kinds}}
+{{/TopLevelKinds}}

--- a/pkg/gen/python-templates/yaml.py.mustache
+++ b/pkg/gen/python-templates/yaml.py.mustache
@@ -188,14 +188,14 @@ def _parse_yaml_object(
     gvk = f"{api_version}/{kind}"
 {{#Groups}}
 {{#Versions}}
-{{#Kinds}}
+{{#TopLevelKinds}}
     if gvk == "{{RawAPIVersion}}/{{Kind}}":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.{{Group}}.{{Version}} import {{Kind}}
         return [identifier.apply(
             lambda x: (f"{{RawAPIVersion}}/{{Kind}}:{x}",
                        {{Kind}}(f"{x}", opts, **obj)))]
-{{/Kinds}}
+{{/TopLevelKinds}}
 {{/Versions}}
 {{/Groups}}
     return [identifier.apply(


### PR DESCRIPTION
Rather than importing all types three times--once each for the
inputs, outputs, and provider APIs--simply import the types once, and
calculate the input, output, and provider API type for each property.

These changes also track whether or not a kind is nested s.t. the
unified set of types can be used to generate the input, output, and
provider APIs.

This is in preparation for Go codegen, which needs all of this
information at once.