### PR TITLE
Fix deprecation warnings and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Fix deprecation warnings and docs. (https://github.com/pulumi/pulumi-kubernetes/pull/918).
+
 ## 1.4.0 (December 9, 2019)
 
 ### Important

--- a/pkg/gen/additionalComments.go
+++ b/pkg/gen/additionalComments.go
@@ -164,9 +164,10 @@ func PulumiComment(kind string) string {
 }
 
 func ApiVersionComment(gvk schema.GroupVersionKind) string {
-	const template = `%s is not supported by Kubernetes 1.16+ clusters. Use %s instead.
+	const template = `%s is deprecated by %s and not supported by Kubernetes v%v+ clusters.
 
 `
 	gvkStr := gvk.GroupVersion().String() + "/" + gvk.Kind
-	return fmt.Sprintf(template, gvkStr, kinds.SuggestedApiVersion(gvk))
+	removedIn := kinds.RemovedInVersion(gvk)
+	return fmt.Sprintf(template, gvkStr, kinds.SuggestedApiVersion(gvk), removedIn)
 }

--- a/pkg/kinds/deprecated_test.go
+++ b/pkg/kinds/deprecated_test.go
@@ -87,6 +87,32 @@ func TestSuggestedApiVersion(t *testing.T) {
 	}
 }
 
+func TestRemovedInVersion(t *testing.T) {
+	type args struct {
+		gvk GroupVersionKind
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantVersion *cluster.ServerVersion
+	}{
+		{"extensions/v1beta1:Deployment", args{
+			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 16}},
+		{"extensions/v1beta1:Ingress", args{
+			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 20}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemovedInVersion(tt.args.gvk)
+			if !reflect.DeepEqual(got, tt.wantVersion) {
+				t.Errorf("RemovedInVersion() got = %v, want %v", got, tt.wantVersion)
+			}
+		})
+	}
+}
+
 func TestRemovedApiVersion(t *testing.T) {
 	type args struct {
 		gvk     GroupVersionKind

--- a/sdk/dotnet/Apps/V1Beta1/ControllerRevision.cs
+++ b/sdk/dotnet/Apps/V1Beta1/ControllerRevision.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/dotnet/Apps/V1Beta1/Deployment.cs
+++ b/sdk/dotnet/Apps/V1Beta1/Deployment.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Apps/V1Beta1/StatefulSet.cs
+++ b/sdk/dotnet/Apps/V1Beta1/StatefulSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.

--- a/sdk/dotnet/Apps/V1Beta2/ControllerRevision.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ControllerRevision.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta2
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/dotnet/Apps/V1Beta2/DaemonSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DaemonSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta2
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+    /// Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta2/Deployment.cs
+++ b/sdk/dotnet/Apps/V1Beta2/Deployment.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta2
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Apps/V1Beta2/ReplicaSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ReplicaSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta2
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/ReplicaSet instead.
+    /// DEPRECATED - apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta2/StatefulSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/StatefulSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Apps.V1Beta2
 {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.

--- a/sdk/dotnet/Extensions/V1Beta1/DaemonSet.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DaemonSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Extensions.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>

--- a/sdk/dotnet/Extensions/V1Beta1/Deployment.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/Deployment.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Extensions.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/Deployment instead.
+    /// DEPRECATED - extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Extensions/V1Beta1/Ingress.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/Ingress.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Extensions.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-    /// networking/v1beta1/Ingress instead.
+    /// DEPRECATED - extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+    /// supported by Kubernetes v1.20+ clusters.
     /// 
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints
     /// defined by a backend. An Ingress can be configured to give services externally-reachable

--- a/sdk/dotnet/Extensions/V1Beta1/ReplicaSet.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/ReplicaSet.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Extensions.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ReplicaSet instead.
+    /// DEPRECATED - extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>

--- a/sdk/dotnet/Storage/V1Beta1/CSINode.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSINode.cs
@@ -8,8 +8,8 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.Storage.V1Beta1
 {
     /// <summary>
-    /// DEPRECATED - storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-    /// storage/v1beta1/CSINode instead.
+    /// DEPRECATED - storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+    /// supported by Kubernetes v&amp;lt;nil&amp;gt;+ clusters.
     /// 
     /// CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
     /// to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/dotnet/Types/Input.cs
+++ b/sdk/dotnet/Types/Input.cs
@@ -5012,8 +5012,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
   namespace V1Beta1
   {
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a
@@ -5110,8 +5110,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -5593,8 +5593,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.
@@ -5897,8 +5897,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
   namespace V1Beta2
   {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a
@@ -5995,8 +5995,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+    /// Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>
@@ -6267,8 +6267,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -6545,8 +6545,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/ReplicaSet instead.
+    /// DEPRECATED - apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
@@ -6921,8 +6921,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Apps
     }
 
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.
@@ -20600,8 +20600,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Extensions
     }
 
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>
@@ -20878,8 +20878,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Extensions
     }
 
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/Deployment instead.
+    /// DEPRECATED - extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -21359,8 +21359,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Extensions
     }
 
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-    /// networking/v1beta1/Ingress instead.
+    /// DEPRECATED - extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+    /// supported by Kubernetes v1.20+ clusters.
     /// 
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints
     /// defined by a backend. An Ingress can be configured to give services externally-reachable
@@ -22219,8 +22219,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Extensions
     }
 
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ReplicaSet instead.
+    /// DEPRECATED - extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
@@ -29351,8 +29351,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Storage
     }
 
     /// <summary>
-    /// DEPRECATED - storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-    /// storage/v1beta1/CSINode instead.
+    /// DEPRECATED - storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+    /// supported by Kubernetes v&amp;lt;nil&amp;gt;+ clusters.
     /// 
     /// CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
     /// to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/dotnet/Types/Output.cs
+++ b/sdk/dotnet/Types/Output.cs
@@ -5579,8 +5579,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
   namespace V1Beta1
   {
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a
@@ -5690,8 +5690,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -6280,8 +6280,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.
@@ -6636,8 +6636,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
   namespace V1Beta2
   {
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ControllerRevision instead.
+    /// DEPRECATED - apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+    /// not supported by Kubernetes v1.16+ clusters.
     /// 
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible
     /// for serializing and deserializing the objects that contain their internal state. Once a
@@ -6747,8 +6747,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+    /// Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>
@@ -7076,8 +7076,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/Deployment instead.
+    /// DEPRECATED - apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -7411,8 +7411,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/ReplicaSet instead.
+    /// DEPRECATED - apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
@@ -7877,8 +7877,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Apps
 
     }
     /// <summary>
-    /// DEPRECATED - apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/StatefulSet instead.
+    /// DEPRECATED - apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+    /// by Kubernetes v1.16+ clusters.
     /// 
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.
@@ -23503,8 +23503,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Extensions
 
     }
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    /// apps/v1/DaemonSet instead.
+    /// DEPRECATED - extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>
@@ -23839,8 +23839,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Extensions
 
     }
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/Deployment instead.
+    /// DEPRECATED - extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
@@ -24405,8 +24405,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Extensions
 
     }
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-    /// networking/v1beta1/Ingress instead.
+    /// DEPRECATED - extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+    /// supported by Kubernetes v1.20+ clusters.
     /// 
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints
     /// defined by a backend. An Ingress can be configured to give services externally-reachable
@@ -25285,8 +25285,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Extensions
 
     }
     /// <summary>
-    /// DEPRECATED - extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters.
-    /// Use apps/v1/ReplicaSet instead.
+    /// DEPRECATED - extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+    /// supported by Kubernetes v1.16+ clusters.
     /// 
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
@@ -33109,8 +33109,8 @@ namespace Pulumi.Kubernetes.Types.Outputs.Storage
 
     }
     /// <summary>
-    /// DEPRECATED - storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-    /// storage/v1beta1/CSINode instead.
+    /// DEPRECATED - storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+    /// supported by Kubernetes v&amp;lt;nil&amp;gt;+ clusters.
     /// 
     /// CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
     /// to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-     * networking/v1beta1/Ingress instead.
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -8,8 +8,8 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-     * storage/v1beta1/CSINode instead.
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+     * supported by Kubernetes v<nil>+ clusters.
      * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -4113,8 +4113,8 @@ export namespace apps {
 
   export namespace v1beta1 {
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
@@ -4202,8 +4202,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -4622,8 +4622,8 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
@@ -4880,8 +4880,8 @@ export namespace apps {
 
   export namespace v1beta2 {
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
@@ -4969,8 +4969,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */
@@ -5202,8 +5202,8 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -5441,8 +5441,8 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
@@ -5772,8 +5772,8 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
@@ -17037,8 +17037,8 @@ export namespace extensions {
 
 
     /**
-     * @deprecated extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */
@@ -17276,8 +17276,8 @@ export namespace extensions {
 
 
     /**
-     * @deprecated extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -17678,8 +17678,8 @@ export namespace extensions {
 
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-     * networking/v1beta1/Ingress instead.
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable
@@ -18339,8 +18339,8 @@ export namespace extensions {
 
 
     /**
-     * @deprecated extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
@@ -24142,8 +24142,8 @@ export namespace storage {
 
 
     /**
-     * @deprecated storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-     * storage/v1beta1/CSINode instead.
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+     * supported by Kubernetes v<nil>+ clusters.
      * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -4002,8 +4002,8 @@ export namespace apps {
 
   export namespace v1beta1 {
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
@@ -4083,8 +4083,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -4490,8 +4490,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
@@ -4742,8 +4742,8 @@ export namespace apps {
 
   export namespace v1beta2 {
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters.
-     * Use apps/v1/ControllerRevision instead.
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
@@ -4823,8 +4823,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */
@@ -5051,8 +5051,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -5283,8 +5283,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
+     * Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
@@ -5608,8 +5608,8 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/StatefulSet instead.
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
@@ -16483,8 +16483,8 @@ export namespace extensions {
     }
 
     /**
-     * @deprecated extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/DaemonSet instead.
+     * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
+     * by Kubernetes v1.16+ clusters.
      * 
      * DaemonSet represents the configuration of a daemon set.
      */
@@ -16717,8 +16717,8 @@ export namespace extensions {
     }
 
     /**
-     * @deprecated extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/Deployment instead.
+     * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      */
@@ -17102,8 +17102,8 @@ export namespace extensions {
     }
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-     * networking/v1beta1/Ingress instead.
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable
@@ -17734,8 +17734,8 @@ export namespace extensions {
     }
 
     /**
-     * @deprecated extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-     * apps/v1/ReplicaSet instead.
+     * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
+     * supported by Kubernetes v1.16+ clusters.
      * 
      * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
@@ -23219,8 +23219,8 @@ export namespace storage {
     }
 
     /**
-     * @deprecated storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-     * storage/v1beta1/CSINode instead.
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not
+     * supported by Kubernetes v<nil>+ clusters.
      * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class ControllerRevision(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta1/ControllerRevision is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/ControllerRevision instead.
+    DEPRECATED - apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not
+    supported by Kubernetes v1.16+ clusters.
     
     ControllerRevision implements an immutable snapshot of state data. Clients are responsible for
     serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class Deployment(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/Deployment instead.
+    DEPRECATED - apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
+    Kubernetes v1.16+ clusters.
     
     Deployment enables declarative updates for Pods and ReplicaSets.
     

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class StatefulSet(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta1/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/StatefulSet instead.
+    DEPRECATED - apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by
+    Kubernetes v1.16+ clusters.
     
     StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      - Network: A single stable DNS and hostname.

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class ControllerRevision(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta2/ControllerRevision is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/ControllerRevision instead.
+    DEPRECATED - apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not
+    supported by Kubernetes v1.16+ clusters.
     
     ControllerRevision implements an immutable snapshot of state data. Clients are responsible for
     serializing and deserializing the objects that contain their internal state. Once a

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class DaemonSet(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta2/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/DaemonSet instead.
+    DEPRECATED - apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
+    Kubernetes v1.16+ clusters.
     
     DaemonSet represents the configuration of a daemon set.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class Deployment(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta2/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/Deployment instead.
+    DEPRECATED - apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
+    Kubernetes v1.16+ clusters.
     
     Deployment enables declarative updates for Pods and ReplicaSets.
     

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class ReplicaSet(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta2/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/ReplicaSet instead.
+    DEPRECATED - apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
+    Kubernetes v1.16+ clusters.
     
     ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     """

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class StatefulSet(pulumi.CustomResource):
     """
-    DEPRECATED - apps/v1beta2/StatefulSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/StatefulSet instead.
+    DEPRECATED - apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by
+    Kubernetes v1.16+ clusters.
     
     StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      - Network: A single stable DNS and hostname.

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class DaemonSet(pulumi.CustomResource):
     """
-    DEPRECATED - extensions/v1beta1/DaemonSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/DaemonSet instead.
+    DEPRECATED - extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
+    by Kubernetes v1.16+ clusters.
     
     DaemonSet represents the configuration of a daemon set.
     """

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class Deployment(pulumi.CustomResource):
     """
-    DEPRECATED - extensions/v1beta1/Deployment is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/Deployment instead.
+    DEPRECATED - extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported
+    by Kubernetes v1.16+ clusters.
     
     Deployment enables declarative updates for Pods and ReplicaSets.
     

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class Ingress(pulumi.CustomResource):
     """
-    DEPRECATED - extensions/v1beta1/Ingress is not supported by Kubernetes 1.16+ clusters. Use
-    networking/v1beta1/Ingress instead.
+    DEPRECATED - extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+    supported by Kubernetes v1.20+ clusters.
     
     Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
     by a backend. An Ingress can be configured to give services externally-reachable urls, load

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class ReplicaSet(pulumi.CustomResource):
     """
-    DEPRECATED - extensions/v1beta1/ReplicaSet is not supported by Kubernetes 1.16+ clusters. Use
-    apps/v1/ReplicaSet instead.
+    DEPRECATED - extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported
+    by Kubernetes v1.16+ clusters.
     
     ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     """

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -13,8 +13,8 @@ from ... import tables, version
 
 class CSINode(pulumi.CustomResource):
     """
-    DEPRECATED - storage/v1beta1/CSINode is not supported by Kubernetes 1.16+ clusters. Use
-    storage/v1beta1/CSINode instead.
+    DEPRECATED - storage/v1beta1/CSINode is deprecated by storage/v1beta1/CSINode and not supported
+    by Kubernetes v<nil>+ clusters.
     
     CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to
     create the CSINode object directly. As long as they use the node-driver-registrar sidecar


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
extensions/v1beta1:Ingress was erroneously marked as removed
in k8s 1.16. Update to the correct version (1.20), and revise the
wording of the docs/warnings to make this more clear.

Here's how this looks now:
![Screen Shot 2019-12-11 at 12 06 20 PM](https://user-images.githubusercontent.com/9253463/70651775-b335f880-1c0e-11ea-9395-c0205db5114a.png)

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #910 