### PR TITLE
Update aliases and deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
--   Fix deprecation warnings and docs. (https://github.com/pulumi/pulumi-kubernetes/pull/918).
+-   Fix deprecation warnings and docs. (https://github.com/pulumi/pulumi-kubernetes/pull/918 and https://github.com /pulumi/pulumi-kubernetes/pull/921).
 
 ## 1.4.0 (December 9, 2019)
 

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -1207,52 +1207,45 @@ func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 	kind := kinds.Kind(gvk.Kind)
 
 	switch kind {
-	case kinds.DaemonSet:
+	case kinds.ClusterRole, kinds.ClusterRoleBinding, kinds.Role, kinds.RoleBinding:
 		return []string{
-			"kubernetes:apps/v1:DaemonSet",
-			"kubernetes:apps/v1beta2:DaemonSet",
-			"kubernetes:extensions/v1beta1:DaemonSet",
+			fmt.Sprintf("kubernetes:rbac/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:rbac/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:rbac/v1alpha1:%s", gvk.Kind),
 		}
-	case kinds.Deployment:
+	case kinds.DaemonSet, kinds.ReplicaSet:
 		return []string{
-			"kubernetes:apps/v1:Deployment",
-			"kubernetes:apps/v1beta1:Deployment",
-			"kubernetes:apps/v1beta2:Deployment",
-			"kubernetes:extensions/v1beta1:Deployment",
+			fmt.Sprintf("kubernetes:apps/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:apps/v1beta2:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
+		}
+	case kinds.Deployment, kinds.StatefulSet:
+		return []string{
+			fmt.Sprintf("kubernetes:apps/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:apps/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:apps/v1beta2:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.Ingress:
 		return []string{
-			"kubernetes:networking/v1beta1:Ingress",
-			"kubernetes:extensions/v1beta1:Ingress",
+			fmt.Sprintf("kubernetes:networking/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.NetworkPolicy:
 		return []string{
-			"kubernetes:networking/v1:NetworkPolicy",
-			"kubernetes:extensions/v1beta1:NetworkPolicy",
+			fmt.Sprintf("kubernetes:networking/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.PodSecurityPolicy:
 		return []string{
-			"kubernetes:policy/v1beta1:PodSecurityPolicy",
-			"kubernetes:extensions/v1beta1:PodSecurityPolicy",
+			fmt.Sprintf("kubernetes:policy/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.PriorityClass:
 		return []string{
-			"kubernetes:scheduling/v1:PriorityClass",
-			"kubernetes:scheduling/v1beta1:PriorityClass",
-			"kubernetes:scheduling/v1alpha1:PriorityClass",
-		}
-	case kinds.ReplicaSet:
-		return []string{
-			"kubernetes:apps/v1:ReplicaSet",
-			"kubernetes:apps/v1beta2:ReplicaSet",
-			"kubernetes:extensions/v1beta1:ReplicaSet",
-		}
-	case kinds.StatefulSet:
-		return []string{
-			"kubernetes:apps/v1:StatefulSet",
-			"kubernetes:apps/v1beta1:StatefulSet",
-			"kubernetes:apps/v1beta2:StatefulSet",
-			"kubernetes:extensions/v1beta1:StatefulSet",
+			fmt.Sprintf("kubernetes:scheduling/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:scheduling/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:scheduling/v1alpha1:%s", gvk.Kind),
 		}
 	default:
 		return []string{}

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -1225,6 +1225,22 @@ func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 			"kubernetes:networking/v1beta1:Ingress",
 			"kubernetes:extensions/v1beta1:Ingress",
 		}
+	case kinds.NetworkPolicy:
+		return []string{
+			"kubernetes:networking/v1:NetworkPolicy",
+			"kubernetes:extensions/v1beta1:NetworkPolicy",
+		}
+	case kinds.PodSecurityPolicy:
+		return []string{
+			"kubernetes:policy/v1beta1:PodSecurityPolicy",
+			"kubernetes:extensions/v1beta1:PodSecurityPolicy",
+		}
+	case kinds.PriorityClass:
+		return []string{
+			"kubernetes:scheduling/v1:PriorityClass",
+			"kubernetes:scheduling/v1beta1:PriorityClass",
+			"kubernetes:scheduling/v1alpha1:PriorityClass",
+		}
 	case kinds.ReplicaSet:
 		return []string{
 			"kubernetes:apps/v1:ReplicaSet",

--- a/pkg/kinds/deprecated.go
+++ b/pkg/kinds/deprecated.go
@@ -45,6 +45,9 @@ func RemovedInVersion(gvk schema.GroupVersionKind) *cluster.ServerVersion {
 		} else {
 			removedIn = cluster.ServerVersion{Major: 1, Minor: 16}
 		}
+	case schema.GroupVersion{Group: "rbac", Version: "v1beta1"},
+		schema.GroupVersion{Group: "rbac", Version: "v1alpha1"}:
+		removedIn = cluster.ServerVersion{Major: 1, Minor: 20}
 	default:
 		return nil
 	}
@@ -81,6 +84,9 @@ func SuggestedApiVersion(gvk schema.GroupVersionKind) string {
 		default:
 			return gvkStr(gvk)
 		}
+	case schema.GroupVersion{Group: "rbac", Version: "v1beta1"},
+		schema.GroupVersion{Group: "rbac", Version: "v1alpha1"}:
+		return "rbac/v1/" + gvk.Kind
 	default:
 		return gvkStr(gvk)
 	}

--- a/pkg/kinds/deprecated.go
+++ b/pkg/kinds/deprecated.go
@@ -21,6 +21,36 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+//
+// Reference links:
+//
+// GVK	/ Deprecated Version / Removed Version
+// Upstream Docs Link
+// -----------------------------------------------------------
+// extensions/v1beta1/DaemonSet / 1.14 / 1.16
+// apps/v1beta1/DaemonSet / 1.14 / 1.16
+// apps/v1beta2/DaemonSet / 1.14 / 1.16
+// extensions/v1beta1/Deployment / 1.14 / 1.16
+// apps/v1beta1/Deployment / 1.14 / 1.16
+// apps/v1beta2/Deployment / 1.14 / 1.16
+// extensions/v1beta1/NetworkPolicy / 1.14 / 1.16
+// extensions/v1beta1/PodSecurityPolicy / 1.14 / 1.16
+// extensions/v1beta1/ReplicaSet / 1.14 / 1.16
+// apps/v1beta1/ReplicaSet / 1.14 / 1.16
+// apps/v1beta2/ReplicaSet / 1.14 / 1.16
+// https://git.k8s.io/kubernetes/CHANGELOG-1.14.md#deprecations
+//
+// scheduling/v1alpha1/PriorityClass / 1.14 / 1.17
+// scheduling/v1beta1/PriorityClass / 1.14 / 1.17
+// https://git.k8s.io/kubernetes/CHANGELOG-1.14.md#deprecations
+//
+// extensions/v1beta1/Ingress / 1.14 / 1.18
+// https://git.k8s.io/kubernetes/CHANGELOG-1.14.md#deprecations
+//
+// rbac/v1alpha1/* / 1.17 / 1.20
+// rbac/v1beta1/* / 1.17 / 1.20
+// https://git.k8s.io/kubernetes/CHANGELOG-1.17.md#deprecations-and-removals
+
 func gvkStr(gvk schema.GroupVersionKind) string {
 	return gvk.GroupVersion().String() + "/" + gvk.Kind
 }
@@ -48,6 +78,9 @@ func RemovedInVersion(gvk schema.GroupVersionKind) *cluster.ServerVersion {
 	case schema.GroupVersion{Group: "rbac", Version: "v1beta1"},
 		schema.GroupVersion{Group: "rbac", Version: "v1alpha1"}:
 		removedIn = cluster.ServerVersion{Major: 1, Minor: 20}
+	case schema.GroupVersion{Group: "scheduling", Version: "v1beta1"},
+		schema.GroupVersion{Group: "scheduling", Version: "v1alpha1"}:
+		removedIn = cluster.ServerVersion{Major: 1, Minor: 17}
 	default:
 		return nil
 	}
@@ -89,6 +122,9 @@ func SuggestedApiVersion(gvk schema.GroupVersionKind) string {
 	case schema.GroupVersion{Group: "rbac", Version: "v1beta1"},
 		schema.GroupVersion{Group: "rbac", Version: "v1alpha1"}:
 		return "rbac/v1/" + gvk.Kind
+	case schema.GroupVersion{Group: "scheduling", Version: "v1beta1"},
+		schema.GroupVersion{Group: "scheduling", Version: "v1alpha1"}:
+		return "scheduling/v1/" + gvk.Kind
 	default:
 		return gvkStr(gvk)
 	}
@@ -99,6 +135,8 @@ func upstreamDocsLink(version cluster.ServerVersion) string {
 	switch version {
 	case cluster.ServerVersion{Major: 1, Minor: 16}:
 		return "https://git.k8s.io/kubernetes/CHANGELOG-1.16.md#deprecations-and-removals"
+	case cluster.ServerVersion{Major: 1, Minor: 17}:
+		return "https://git.k8s.io/kubernetes/CHANGELOG-1.17.md#deprecations-and-removals"
 	default:
 		return ""
 	}

--- a/pkg/kinds/deprecated.go
+++ b/pkg/kinds/deprecated.go
@@ -75,10 +75,12 @@ func SuggestedApiVersion(gvk schema.GroupVersionKind) string {
 		return "apps/v1/" + gvk.Kind
 	case schema.GroupVersion{Group: "extensions", Version: "v1beta1"}:
 		switch Kind(gvk.Kind) {
-		case DaemonSet, Deployment, NetworkPolicy, ReplicaSet:
+		case DaemonSet, Deployment, ReplicaSet:
 			return "apps/v1/" + gvk.Kind
 		case Ingress:
 			return "networking/v1beta1/" + gvk.Kind
+		case NetworkPolicy:
+			return "networking/v1/" + gvk.Kind
 		case PodSecurityPolicy:
 			return "policy/v1beta1/" + gvk.Kind
 		default:

--- a/pkg/kinds/deprecated_test.go
+++ b/pkg/kinds/deprecated_test.go
@@ -86,6 +86,14 @@ func TestSuggestedApiVersion(t *testing.T) {
 			GroupVersionKind{Group: "rbac", Version: "v1beta1", Kind: "ClusterRole"},
 			"rbac/v1/ClusterRole",
 		},
+		{
+			GroupVersionKind{Group: "scheduling", Version: "v1beta1", Kind: "PriorityClass"},
+			"scheduling/v1/PriorityClass",
+		},
+		{
+			GroupVersionKind{Group: "scheduling", Version: "v1alpha1", Kind: "PriorityClass"},
+			"scheduling/v1/PriorityClass",
+		},
 		// Current ApiVersions return the same version string.
 		{
 			GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
@@ -122,6 +130,12 @@ func TestRemovedInVersion(t *testing.T) {
 		{"rbac/v1alpha1:ClusterRole", args{
 			GroupVersionKind{Group: "rbac", Version: "v1alpha1", Kind: "ClusterRole"},
 		}, &cluster.ServerVersion{Major: 1, Minor: 20}},
+		{"scheduling/v1beta1:PriorityClass", args{
+			GroupVersionKind{Group: "scheduling", Version: "v1beta1", Kind: "PriorityClass"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 17}},
+		{"scheduling/v1alpha1:PriorityClass", args{
+			GroupVersionKind{Group: "scheduling", Version: "v1alpha1", Kind: "PriorityClass"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 17}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kinds/deprecated_test.go
+++ b/pkg/kinds/deprecated_test.go
@@ -36,6 +36,8 @@ func TestDeprecatedApiVersion(t *testing.T) {
 		{GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "NetworkPolicy"}, true},
 		{GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"}, true},
 		{GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}, true},
+		{GroupVersionKind{Group: "rbac", Version: "v1alpha1", Kind: "ClusterRole"}, true},
+		{GroupVersionKind{Group: "rbac", Version: "v1beta1", Kind: "ClusterRole"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.gvk.String(), func(t *testing.T) {
@@ -72,6 +74,14 @@ func TestSuggestedApiVersion(t *testing.T) {
 			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"},
 			"policy/v1beta1/PodSecurityPolicy",
 		},
+		{
+			GroupVersionKind{Group: "rbac", Version: "v1alpha1", Kind: "ClusterRole"},
+			"rbac/v1/ClusterRole",
+		},
+		{
+			GroupVersionKind{Group: "rbac", Version: "v1beta1", Kind: "ClusterRole"},
+			"rbac/v1/ClusterRole",
+		},
 		// Current ApiVersions return the same version string.
 		{
 			GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
@@ -101,6 +111,12 @@ func TestRemovedInVersion(t *testing.T) {
 		}, &cluster.ServerVersion{Major: 1, Minor: 16}},
 		{"extensions/v1beta1:Ingress", args{
 			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 20}},
+		{"rbac/v1beta1:ClusterRole", args{
+			GroupVersionKind{Group: "rbac", Version: "v1beta1", Kind: "ClusterRole"},
+		}, &cluster.ServerVersion{Major: 1, Minor: 20}},
+		{"rbac/v1alpha1:ClusterRole", args{
+			GroupVersionKind{Group: "rbac", Version: "v1alpha1", Kind: "ClusterRole"},
 		}, &cluster.ServerVersion{Major: 1, Minor: 20}},
 	}
 	for _, tt := range tests {

--- a/pkg/kinds/deprecated_test.go
+++ b/pkg/kinds/deprecated_test.go
@@ -71,6 +71,10 @@ func TestSuggestedApiVersion(t *testing.T) {
 			"networking/v1beta1/Ingress",
 		},
 		{
+			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "NetworkPolicy"},
+			"networking/v1/NetworkPolicy",
+		},
+		{
 			GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"},
 			"policy/v1beta1/PodSecurityPolicy",
 		},

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(NetworkPolicy.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:networking/v1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
+              ],
+          });
+
+          super(NetworkPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(PodSecurityPolicy.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
+              ],
+          });
+
+          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -93,6 +93,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(NetworkPolicy.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:networking/v1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
+              ],
+          });
+
+          super(NetworkPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -94,6 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(PodSecurityPolicy.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
+              ],
+          });
+
+          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -101,6 +101,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRole.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+              ],
+          });
+
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -100,6 +100,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+              ],
+          });
+
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -93,6 +93,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Role.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+              ],
+          });
+
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -102,6 +102,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(RoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+              ],
+          });
+
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -102,6 +102,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRole.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+              ],
+          });
+
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -102,6 +102,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+              ],
+          });
+
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -94,6 +94,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Role.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+              ],
+          });
+
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -103,6 +103,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(RoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+              ],
+          });
+
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -102,6 +102,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRole.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+              ],
+          });
+
+          super(ClusterRole.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -102,6 +102,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ClusterRoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+              ],
+          });
+
+          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -94,6 +94,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Role.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+              ],
+          });
+
+          super(Role.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -103,6 +103,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(RoleBinding.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+              ],
+          });
+
+          super(RoleBinding.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -120,6 +120,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(PriorityClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+              ],
+          });
+
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -121,6 +121,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(PriorityClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+              ],
+          });
+
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -121,6 +121,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(PriorityClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+              ],
+          });
+
+          super(PriorityClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -75,8 +75,14 @@ class NetworkPolicy(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(NetworkPolicy, self).__init__(

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
@@ -75,8 +75,14 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(PodSecurityPolicy, self).__init__(

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -73,8 +73,14 @@ class NetworkPolicy(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(NetworkPolicy, self).__init__(

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
@@ -74,8 +74,14 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(PodSecurityPolicy, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -83,8 +83,15 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRole, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -83,8 +83,15 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -72,8 +72,15 @@ class Role(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Role, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -85,8 +85,15 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(RoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -84,8 +84,15 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRole, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -84,8 +84,15 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -73,8 +73,15 @@ class Role(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Role, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -86,8 +86,15 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(RoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -84,8 +84,15 @@ class ClusterRole(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRole, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -84,8 +84,15 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ClusterRoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -73,8 +73,15 @@ class Role(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Role, self).__init__(

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -86,8 +86,15 @@ class RoleBinding(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(RoleBinding, self).__init__(

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -114,8 +114,15 @@ class PriorityClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(PriorityClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -115,8 +115,15 @@ class PriorityClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(PriorityClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -115,8 +115,15 @@ class PriorityClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(PriorityClass, self).__init__(


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
* Add aliases for `NetworkPolicy`, `PodSecurityPolicy`, and
`PriorityClass`.
* Update "removed in" warning for `rbac/v1alpha1` and `rbac/v1beta1`
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #919 
