### PR TITLE
Fix panic condition in Ingress await logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Fix panic condition in Ingress await logic. (https://github.com/pulumi/pulumi-kubernetes/pull/928).
+
 ## 1.4.1 (December 17, 2019)
 
 ### Bug fixes

--- a/pkg/await/ingress.go
+++ b/pkg/await/ingress.go
@@ -319,6 +319,11 @@ func (iia *ingressInitAwaiter) checkIfEndpointsReady() bool {
 	}
 
 	for _, rule := range obj.Spec.Rules {
+		if rule.HTTP == nil {
+			iia.config.logStatus(diag.Error, fmt.Sprintf("expected value %q is unset for ingress: %s",
+				".spec.rules[*].http", obj.Name))
+			return false
+		}
 		for _, path := range rule.HTTP.Paths {
 			// Ignore ExternalName services
 			if iia.knownExternalNameServices.Has(path.Backend.ServiceName) {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The `.spec.rules[*].http` value is optional in the client,
but semantically required. Check that this value is
set before accessing to avoid a panic in the await logic.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #923 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
