### PR TITLE
Fix panic condition in Job await logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Fix deprecation warnings and docs. (https://github.com/pulumi/pulumi-kubernetes/pull/929).
+
 ## 1.4.1 (December 17, 2019)
 
 ### Bug fixes

--- a/pkg/await/job.go
+++ b/pkg/await/job.go
@@ -180,12 +180,11 @@ func (jia *jobInitAwaiter) Read() error {
 }
 
 func (jia *jobInitAwaiter) processJobEvent(event watch.Event) error {
-	uns, ok := event.Object.(*unstructured.Unstructured)
-	if !ok {
+	if event.Object == nil {
 		glog.V(3).Infof("received event with nil Object: %#v", event)
 		return nil
 	}
-	job, err := clients.JobFromUnstructured(uns)
+	job, err := clients.JobFromUnstructured(event.Object.(*unstructured.Unstructured))
 	if err != nil {
 		glog.V(3).Infof("Failed to unmarshal Job event: %v", err)
 		return nil

--- a/pkg/await/job.go
+++ b/pkg/await/job.go
@@ -180,7 +180,12 @@ func (jia *jobInitAwaiter) Read() error {
 }
 
 func (jia *jobInitAwaiter) processJobEvent(event watch.Event) error {
-	job, err := clients.JobFromUnstructured(event.Object.(*unstructured.Unstructured))
+	uns, ok := event.Object.(*unstructured.Unstructured)
+	if !ok {
+		glog.V(3).Infof("received event with nil Object: %#v", event)
+		return nil
+	}
+	job, err := clients.JobFromUnstructured(uns)
 	if err != nil {
 		glog.V(3).Infof("Failed to unmarshal Job event: %v", err)
 		return nil


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
For events received by the Job awaiter, explicitly
check that the event has a non-nil Object to avoid
a possible panic.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fix #922 