### PR TITLE
Fix array output property typing for .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Fix projection of array-valued output properties in .NET. (https://github.com/pulumi/pulumi-kubernetes/pull/931)
+
 ## 1.4.1 (December 17, 2019)
 
 ### Bug fixes

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -634,8 +634,8 @@ func makeDotnetType(resourceType, propName string, prop map[string]interface{}, 
 			switch gentype {
 			case provider:
 				elemType := makeDotnetType(
-					resourceType, propName, prop["items"].(map[string]interface{}), gentype, forceNoWrap)
-				return fmt.Sprintf("%s[]>", elemType[:len(elemType)-1])
+					resourceType, propName, prop["items"].(map[string]interface{}), gentype, true)
+				return fmt.Sprintf("Output<ImmutableArray<%s>>", elemType)
 			case outputsAPI:
 				elemType := makeDotnetType(
 					resourceType, propName, prop["items"].(map[string]interface{}), gentype, forceNoWrap)

--- a/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfiguration.cs
@@ -42,7 +42,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// Webhooks is a list of webhooks and the affected resources and operations.
         /// </summary>
         [Output("webhooks")]
-        public Output<Types.Outputs.AdmissionRegistration.V1.MutatingWebhook[]> Webhooks { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1.MutatingWebhook>> Webhooks { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// List of MutatingWebhookConfiguration.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.AdmissionRegistration.V1.MutatingWebhookConfiguration[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1.MutatingWebhookConfiguration>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfiguration.cs
@@ -42,7 +42,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// Webhooks is a list of webhooks and the affected resources and operations.
         /// </summary>
         [Output("webhooks")]
-        public Output<Types.Outputs.AdmissionRegistration.V1.ValidatingWebhook[]> Webhooks { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1.ValidatingWebhook>> Webhooks { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// List of ValidatingWebhookConfiguration.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.AdmissionRegistration.V1.ValidatingWebhookConfiguration[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1.ValidatingWebhookConfiguration>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfiguration.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// Webhooks is a list of webhooks and the affected resources and operations.
         /// </summary>
         [Output("webhooks")]
-        public Output<Types.Outputs.AdmissionRegistration.V1Beta1.MutatingWebhook[]> Webhooks { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1Beta1.MutatingWebhook>> Webhooks { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// List of MutatingWebhookConfiguration.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfiguration[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfiguration>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfiguration.cs
@@ -43,7 +43,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// Webhooks is a list of webhooks and the affected resources and operations.
         /// </summary>
         [Output("webhooks")]
-        public Output<Types.Outputs.AdmissionRegistration.V1Beta1.ValidatingWebhook[]> Webhooks { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1Beta1.ValidatingWebhook>> Webhooks { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// List of ValidatingWebhookConfiguration.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfiguration[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfiguration>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionList.cs
+++ b/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
         /// items list individual CustomResourceDefinition objects
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.ApiExtensions.V1.CustomResourceDefinition[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.ApiExtensions.V1.CustomResourceDefinition>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionList.cs
+++ b/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
         /// items list individual CustomResourceDefinition objects
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.ApiExtensions.V1Beta1.CustomResourceDefinition[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.ApiExtensions.V1Beta1.CustomResourceDefinition>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
 
         
         [Output("items")]
-        public Output<Types.Outputs.ApiRegistration.V1.APIService[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.ApiRegistration.V1.APIService>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
 
         
         [Output("items")]
-        public Output<Types.Outputs.ApiRegistration.V1Beta1.APIService[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.ApiRegistration.V1Beta1.APIService>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1/ControllerRevisionList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// Items is the list of ControllerRevisions
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1.ControllerRevision[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1.ControllerRevision>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1/DaemonSetList.cs
+++ b/sdk/dotnet/Apps/V1/DaemonSetList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// A list of daemon sets.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1.DaemonSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1.DaemonSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1/DeploymentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// Items is the list of Deployments.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1.Deployment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1.Deployment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1/ReplicaSetList.cs
+++ b/sdk/dotnet/Apps/V1/ReplicaSetList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1.ReplicaSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1.ReplicaSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1/StatefulSetList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.Apps.V1
 
         
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1.StatefulSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1.StatefulSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta1/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/ControllerRevisionList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// Items is the list of ControllerRevisions
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta1.ControllerRevision[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta1.ControllerRevision>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta1/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/DeploymentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// Items is the list of Deployments.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta1.Deployment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta1.Deployment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta1/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/StatefulSetList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
 
         
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta1.StatefulSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta1.StatefulSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta2/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ControllerRevisionList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// Items is the list of ControllerRevisions
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta2.ControllerRevision[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta2.ControllerRevision>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta2/DaemonSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DaemonSetList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// A list of daemon sets.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta2.DaemonSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta2.DaemonSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta2/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DeploymentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// Items is the list of Deployments.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta2.Deployment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta2.Deployment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta2/ReplicaSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ReplicaSetList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta2.ReplicaSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta2.ReplicaSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Apps/V1Beta2/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/StatefulSetList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
 
         
         [Output("items")]
-        public Output<Types.Outputs.Apps.V1Beta2.StatefulSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Apps.V1Beta2.StatefulSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkList.cs
+++ b/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
         /// List of audit configurations.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.AuditRegistraion.V1Alpha1.AuditSink[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.AuditRegistraion.V1Alpha1.AuditSink>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
         /// list of horizontal pod autoscaler objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Autoscaling.V1.HorizontalPodAutoscaler[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Autoscaling.V1.HorizontalPodAutoscaler>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
         /// items is the list of horizontal pod autoscaler objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Autoscaling.V2Beta1.HorizontalPodAutoscaler[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Autoscaling.V2Beta1.HorizontalPodAutoscaler>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
         /// items is the list of horizontal pod autoscaler objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Autoscaling.V2Beta2.HorizontalPodAutoscaler[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Autoscaling.V2Beta2.HorizontalPodAutoscaler>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Batch/V1/JobList.cs
+++ b/sdk/dotnet/Batch/V1/JobList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Batch.V1
         /// items is the list of Jobs.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Batch.V1.Job[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Batch.V1.Job>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Batch/V1Beta1/CronJobList.cs
+++ b/sdk/dotnet/Batch/V1Beta1/CronJobList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
         /// items is the list of CronJobs.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Batch.V1Beta1.CronJob[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Batch.V1Beta1.CronJob>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Batch/V2Alpha1/CronJobList.cs
+++ b/sdk/dotnet/Batch/V2Alpha1/CronJobList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
         /// items is the list of CronJobs.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Batch.V2Alpha1.CronJob[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Batch.V2Alpha1.CronJob>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestList.cs
+++ b/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
 
         
         [Output("items")]
-        public Output<Types.Outputs.Certificates.V1Beta1.CertificateSigningRequest[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Certificates.V1Beta1.CertificateSigningRequest>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Coordination/V1/LeaseList.cs
+++ b/sdk/dotnet/Coordination/V1/LeaseList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Coordination.V1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Coordination.V1.Lease[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Coordination.V1.Lease>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Coordination/V1Beta1/LeaseList.cs
+++ b/sdk/dotnet/Coordination/V1Beta1/LeaseList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Coordination.V1Beta1.Lease[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Coordination.V1Beta1.Lease>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ComponentStatus.cs
+++ b/sdk/dotnet/Core/V1/ComponentStatus.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of component conditions observed
         /// </summary>
         [Output("conditions")]
-        public Output<Types.Outputs.Core.V1.ComponentCondition[]> Conditions { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ComponentCondition>> Conditions { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ComponentStatusList.cs
+++ b/sdk/dotnet/Core/V1/ComponentStatusList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of ComponentStatus objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.ComponentStatus[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ComponentStatus>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ConfigMapList.cs
+++ b/sdk/dotnet/Core/V1/ConfigMapList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// Items is the list of ConfigMaps.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.ConfigMap[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ConfigMap>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/Endpoints.cs
+++ b/sdk/dotnet/Core/V1/Endpoints.cs
@@ -57,7 +57,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// addresses and ports that comprise a service.
         /// </summary>
         [Output("subsets")]
-        public Output<Types.Outputs.Core.V1.EndpointSubset[]> Subsets { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.EndpointSubset>> Subsets { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Core/V1/EndpointsList.cs
+++ b/sdk/dotnet/Core/V1/EndpointsList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of endpoints.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Endpoints[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Endpoints>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/EventList.cs
+++ b/sdk/dotnet/Core/V1/EventList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of events
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Event[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Event>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/LimitRangeList.cs
+++ b/sdk/dotnet/Core/V1/LimitRangeList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.LimitRange[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.LimitRange>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/NamespaceList.cs
+++ b/sdk/dotnet/Core/V1/NamespaceList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Namespace[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Namespace>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/NodeList.cs
+++ b/sdk/dotnet/Core/V1/NodeList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of nodes
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Node[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Node>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/PersistentVolumeClaimList.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeClaimList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.PersistentVolumeClaim[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.PersistentVolumeClaim>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/PersistentVolumeList.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/storage/persistent-volumes
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.PersistentVolume[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.PersistentVolume>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/PodList.cs
+++ b/sdk/dotnet/Core/V1/PodList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Pod[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Pod>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/PodTemplateList.cs
+++ b/sdk/dotnet/Core/V1/PodTemplateList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of pod templates
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.PodTemplate[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.PodTemplate>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ReplicationControllerList.cs
+++ b/sdk/dotnet/Core/V1/ReplicationControllerList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.ReplicationController[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ReplicationController>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ResourceQuotaList.cs
+++ b/sdk/dotnet/Core/V1/ResourceQuotaList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/policy/resource-quotas/
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.ResourceQuota[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ResourceQuota>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/SecretList.cs
+++ b/sdk/dotnet/Core/V1/SecretList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/configuration/secret
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Secret[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Secret>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ServiceAccount.cs
+++ b/sdk/dotnet/Core/V1/ServiceAccount.cs
@@ -38,7 +38,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
         /// </summary>
         [Output("imagePullSecrets")]
-        public Output<Types.Outputs.Core.V1.LocalObjectReference[]> ImagePullSecrets { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.LocalObjectReference>> ImagePullSecrets { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
         /// </summary>
         [Output("secrets")]
-        public Output<Types.Outputs.Core.V1.ObjectReference[]> Secrets { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ObjectReference>> Secrets { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Core/V1/ServiceAccountList.cs
+++ b/sdk/dotnet/Core/V1/ServiceAccountList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.ServiceAccount[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.ServiceAccount>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Core/V1/ServiceList.cs
+++ b/sdk/dotnet/Core/V1/ServiceList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// List of services
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Core.V1.Service[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.Service>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Discovery/V1Beta1/EndpointSlice.cs
+++ b/sdk/dotnet/Discovery/V1Beta1/EndpointSlice.cs
@@ -37,7 +37,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
         /// of 1000 endpoints.
         /// </summary>
         [Output("endpoints")]
-        public Output<Types.Outputs.Discovery.V1Beta1.Endpoint[]> Endpoints { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Discovery.V1Beta1.Endpoint>> Endpoints { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
         /// Each slice may include a maximum of 100 ports.
         /// </summary>
         [Output("ports")]
-        public Output<Types.Outputs.Discovery.V1Beta1.EndpointPort[]> Ports { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Discovery.V1Beta1.EndpointPort>> Ports { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Discovery/V1Beta1/EndpointSliceList.cs
+++ b/sdk/dotnet/Discovery/V1Beta1/EndpointSliceList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
         /// List of endpoint slices
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Discovery.V1Beta1.EndpointSlice[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Discovery.V1Beta1.EndpointSlice>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Events/V1Beta1/EventList.cs
+++ b/sdk/dotnet/Events/V1Beta1/EventList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Events.V1Beta1.Event[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Events.V1Beta1.Event>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/DaemonSetList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DaemonSetList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// A list of daemon sets.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.DaemonSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.DaemonSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/DeploymentList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DeploymentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// Items is the list of Deployments.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.Deployment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.Deployment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/IngressList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/IngressList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// Items is the list of Ingress.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.Ingress[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.Ingress>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.NetworkPolicy[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.NetworkPolicy>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.PodSecurityPolicy[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.PodSecurityPolicy>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Extensions/V1Beta1/ReplicaSetList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/ReplicaSetList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Extensions.V1Beta1.ReplicaSet[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Extensions.V1Beta1.ReplicaSet>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaList.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// `items` is a list of FlowSchemas.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.FlowControl.V1Alpha1.FlowSchema[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.FlowControl.V1Alpha1.FlowSchema>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationList.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// `items` is a list of request-priorities.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.FlowControl.V1Alpha1.PriorityLevelConfiguration[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.FlowControl.V1Alpha1.PriorityLevelConfiguration>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Networking/V1/NetworkPolicyList.cs
+++ b/sdk/dotnet/Networking/V1/NetworkPolicyList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Networking.V1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Networking.V1.NetworkPolicy[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Networking.V1.NetworkPolicy>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Networking/V1Beta1/IngressList.cs
+++ b/sdk/dotnet/Networking/V1Beta1/IngressList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
         /// Items is the list of Ingress.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Networking.V1Beta1.Ingress[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Networking.V1Beta1.Ingress>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Node/V1Alpha1/RuntimeClassList.cs
+++ b/sdk/dotnet/Node/V1Alpha1/RuntimeClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Node.V1Alpha1.RuntimeClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Node.V1Alpha1.RuntimeClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Node/V1Beta1/RuntimeClassList.cs
+++ b/sdk/dotnet/Node/V1Beta1/RuntimeClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Node.V1Beta1.RuntimeClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Node.V1Beta1.RuntimeClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetList.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetList.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
 
         
         [Output("items")]
-        public Output<Types.Outputs.Policy.V1Beta1.PodDisruptionBudget[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Policy.V1Beta1.PodDisruptionBudget>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyList.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
         /// items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Policy.V1Beta1.PodSecurityPolicy[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Policy.V1Beta1.PodSecurityPolicy>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRole.cs
@@ -49,7 +49,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Rules holds all the PolicyRules for this ClusterRole
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleBinding.cs
@@ -48,7 +48,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleBindingList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Items is a list of ClusterRoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1.ClusterRoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.ClusterRoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Items is a list of ClusterRoles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1.ClusterRole[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.ClusterRole>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1/Role.cs
+++ b/sdk/dotnet/Rbac/V1/Role.cs
@@ -41,7 +41,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Rules holds all the PolicyRules for this Role
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1/RoleBinding.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1/RoleBindingList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Items is a list of RoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1.RoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.RoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1/RoleList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// Items is a list of Roles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1.Role[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1.Role>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRole.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Rules holds all the PolicyRules for this ClusterRole
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBinding.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Items is a list of ClusterRoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.ClusterRoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.ClusterRoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Items is a list of ClusterRoles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.ClusterRole[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.ClusterRole>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Alpha1/Role.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/Role.cs
@@ -42,7 +42,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Rules holds all the PolicyRules for this Role
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleBinding.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleBindingList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Items is a list of RoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.RoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.RoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// Items is a list of Roles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Alpha1.Role[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Alpha1.Role>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRole.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Rules holds all the PolicyRules for this ClusterRole
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1Beta1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBinding.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1Beta1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingList.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Items is a list of ClusterRoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Beta1.ClusterRoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.ClusterRoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Items is a list of ClusterRoles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Beta1.ClusterRole[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.ClusterRole>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Beta1/Role.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/Role.cs
@@ -42,7 +42,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Rules holds all the PolicyRules for this Role
         /// </summary>
         [Output("rules")]
-        public Output<Types.Outputs.Rbac.V1Beta1.PolicyRule[]> Rules { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.PolicyRule>> Rules { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Beta1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleBinding.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Subjects holds references to the objects the role applies to.
         /// </summary>
         [Output("subjects")]
-        public Output<Types.Outputs.Rbac.V1Beta1.Subject[]> Subjects { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.Subject>> Subjects { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Rbac/V1Beta1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleBindingList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Items is a list of RoleBindings
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Beta1.RoleBinding[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.RoleBinding>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Rbac/V1Beta1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleList.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// Items is a list of Roles
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Rbac.V1Beta1.Role[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Rbac.V1Beta1.Role>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Scheduling/V1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1/PriorityClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1
         /// items is the list of PriorityClasses
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Scheduling.V1.PriorityClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Scheduling.V1.PriorityClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
         /// items is the list of PriorityClasses
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Scheduling.V1Alpha1.PriorityClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Scheduling.V1Alpha1.PriorityClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Scheduling/V1Beta1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1Beta1/PriorityClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
         /// items is the list of PriorityClasses
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Scheduling.V1Beta1.PriorityClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Scheduling.V1Beta1.PriorityClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Settings/V1Alpha1/PodPresetList.cs
+++ b/sdk/dotnet/Settings/V1Alpha1/PodPresetList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
         /// Items is a list of schema objects.
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Settings.V1Alpha1.PodPreset[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Settings.V1Alpha1.PodPreset>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1/CSINodeList.cs
+++ b/sdk/dotnet/Storage/V1/CSINodeList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// items is the list of CSINode
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1.CSINode[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1.CSINode>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1/StorageClass.cs
+++ b/sdk/dotnet/Storage/V1/StorageClass.cs
@@ -29,7 +29,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// enable the VolumeScheduling feature.
         /// </summary>
         [Output("allowedTopologies")]
-        public Output<Types.Outputs.Core.V1.TopologySelectorTerm[]> AllowedTopologies { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.TopologySelectorTerm>> AllowedTopologies { get; private set; } = null!;
 
         /// <summary>
         /// APIVersion defines the versioned schema of this representation of an object. Servers
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// one is invalid.
         /// </summary>
         [Output("mountOptions")]
-        public Output<string[]> MountOptions { get; private set; } = null!;
+        public Output<ImmutableArray<string>> MountOptions { get; private set; } = null!;
 
         /// <summary>
         /// Parameters holds the parameters for the provisioner that should create volumes of this

--- a/sdk/dotnet/Storage/V1/StorageClassList.cs
+++ b/sdk/dotnet/Storage/V1/StorageClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// Items is the list of StorageClasses
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1.StorageClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1.StorageClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1/VolumeAttachmentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// Items is the list of VolumeAttachments
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1.VolumeAttachment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1.VolumeAttachment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
         /// Items is the list of VolumeAttachments
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1Alpha1.VolumeAttachment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1Alpha1.VolumeAttachment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1Beta1/CSIDriverList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSIDriverList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// items is the list of CSIDriver
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1Beta1.CSIDriver[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1Beta1.CSIDriver>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1Beta1/CSINodeList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSINodeList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// items is the list of CSINode
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1Beta1.CSINode[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1Beta1.CSINode>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1Beta1/StorageClass.cs
+++ b/sdk/dotnet/Storage/V1Beta1/StorageClass.cs
@@ -29,7 +29,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// enable the VolumeScheduling feature.
         /// </summary>
         [Output("allowedTopologies")]
-        public Output<Types.Outputs.Core.V1.TopologySelectorTerm[]> AllowedTopologies { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Core.V1.TopologySelectorTerm>> AllowedTopologies { get; private set; } = null!;
 
         /// <summary>
         /// APIVersion defines the versioned schema of this representation of an object. Servers
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// one is invalid.
         /// </summary>
         [Output("mountOptions")]
-        public Output<string[]> MountOptions { get; private set; } = null!;
+        public Output<ImmutableArray<string>> MountOptions { get; private set; } = null!;
 
         /// <summary>
         /// Parameters holds the parameters for the provisioner that should create volumes of this

--- a/sdk/dotnet/Storage/V1Beta1/StorageClassList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/StorageClassList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// Items is the list of StorageClasses
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1Beta1.StorageClass[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1Beta1.StorageClass>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentList.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// Items is the list of VolumeAttachments
         /// </summary>
         [Output("items")]
-        public Output<Types.Outputs.Storage.V1Beta1.VolumeAttachment[]> Items { get; private set; } = null!;
+        public Output<ImmutableArray<Types.Outputs.Storage.V1Beta1.VolumeAttachment>> Items { get; private set; } = null!;
 
         /// <summary>
         /// Kind is a string value representing the REST resource this object represents. Servers

--- a/tests/integration/dotnet/basic/Basic.csproj
+++ b/tests/integration/dotnet/basic/Basic.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Kubernetes" Version="1.4.0-preview-alpha.1574471668" />
+    <PackageReference Include="Pulumi.Kubernetes" Version="1.5.0-preview-alpha.1576717735" />
   </ItemGroup>
 
 </Project>

--- a/tests/integration/dotnet/basic/Program.cs
+++ b/tests/integration/dotnet/basic/Program.cs
@@ -127,7 +127,7 @@ class Program
                 },
                 RoleRef = new RoleRefArgs
                 {
-                    Kind = "ClusterRole",
+                    Kind = "Role",
                     Name = role.Metadata.Apply(metadata => metadata.Name),
                     ApiGroup = "rbac.authorization.k8s.io",
                 },

--- a/tests/integration/dotnet/basic/Program.cs
+++ b/tests/integration/dotnet/basic/Program.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 using Pulumi;
 using Pulumi.Kubernetes.Core.V1;
 using Pulumi.Kubernetes.Apps.V1;
+using Pulumi.Kubernetes.Rbac.V1;
 using Pulumi.Kubernetes.Types.Inputs.Core.V1;
 using Pulumi.Kubernetes.Types.Inputs.Apps.V1;
 using Pulumi.Kubernetes.Types.Inputs.Meta.V1;
+using Pulumi.Kubernetes.Types.Inputs.Rbac.V1;
 using Pulumi.Kubernetes.Types.Inputs.ApiExtensions.V1Beta1;
 
 class Program
@@ -92,6 +94,44 @@ class Program
                         },
                     },
                 }
+            });
+
+            var role = new Role("role", new RoleArgs
+            {
+                Metadata = new ObjectMetaArgs {
+                    Name = "secret-reader",
+                },
+                Rules = {
+                    new PolicyRuleArgs
+                    {
+                        ApiGroups = { "" },
+                        Resources = { "secrets" },
+                        Verbs = { "get", "watch", "list" }, 
+                    },
+                }
+            });
+
+            var binding = new RoleBinding("binding", new RoleBindingArgs
+            {   
+                Metadata = new ObjectMetaArgs
+                {
+                    Name = "read-secrets",
+                    Namespace = "default",
+                },
+                Subjects = {
+                    new SubjectArgs
+                    {
+                        Kind = "User",
+                        Name = "dave",
+                        ApiGroup = "rbac.authorization.k8s.io",
+                    },
+                },
+                RoleRef = new RoleRefArgs
+                {
+                    Kind = "ClusterRole",
+                    Name = "secret-reader",
+                    ApiGroup = "rbac.authorization.k8s.io",
+                },
             });
 
             var ns = Pulumi.Kubernetes.Core.V1.Namespace.Get("default", "default");

--- a/tests/integration/dotnet/basic/Program.cs
+++ b/tests/integration/dotnet/basic/Program.cs
@@ -104,7 +104,7 @@ class Program
                 Rules = {
                     new PolicyRuleArgs
                     {
-                        ApiGroups = { "" },
+                        ApiGroups = { "namespace" },
                         Resources = { "secrets" },
                         Verbs = { "get", "list" }, 
                     },
@@ -138,6 +138,7 @@ class Program
             return new Dictionary<string, object>{
                 { "namespacePhase", ns.Status.Apply(status => status.Phase) },
                 { "revisionData", revision.Data },
+                { "subjects", binding.Subjects.Apply(subjs => subjs.Select(subj => subj.Name).ToArray()) },
             };
 
         });

--- a/tests/integration/dotnet/basic/Program.cs
+++ b/tests/integration/dotnet/basic/Program.cs
@@ -106,7 +106,7 @@ class Program
                     {
                         ApiGroups = { "" },
                         Resources = { "secrets" },
-                        Verbs = { "get", "watch", "list" }, 
+                        Verbs = { "get", "list" }, 
                     },
                 }
             });
@@ -116,7 +116,6 @@ class Program
                 Metadata = new ObjectMetaArgs
                 {
                     Name = "read-secrets",
-                    Namespace = "default",
                 },
                 Subjects = {
                     new SubjectArgs
@@ -129,7 +128,7 @@ class Program
                 RoleRef = new RoleRefArgs
                 {
                     Kind = "ClusterRole",
-                    Name = "secret-reader",
+                    Name = role.Metadata.Apply(metadata => metadata.Name),
                     ApiGroup = "rbac.authorization.k8s.io",
                 },
             });

--- a/tests/integration/dotnet/basic/Program.cs
+++ b/tests/integration/dotnet/basic/Program.cs
@@ -96,49 +96,50 @@ class Program
                 }
             });
 
-            var role = new Role("role", new RoleArgs
-            {
-                Metadata = new ObjectMetaArgs {
-                    Name = "secret-reader",
-                },
-                Rules = {
-                    new PolicyRuleArgs
-                    {
-                        ApiGroups = { "namespace" },
-                        Resources = { "secrets" },
-                        Verbs = { "get", "list" }, 
-                    },
-                }
-            });
+            // TODO: Re-enable these tests once CI GKE account has the appropriate permissions to create the RoleBinding below.
+            // var role = new Role("role", new RoleArgs
+            // {
+            //     Metadata = new ObjectMetaArgs {
+            //         Name = "secret-reader",
+            //     },
+            //     Rules = {
+            //         new PolicyRuleArgs
+            //         {
+            //             ApiGroups = { "" },
+            //             Resources = { "secrets" },
+            //             Verbs = { "get", "list" }, 
+            //         },
+            //     }
+            // });
 
-            var binding = new RoleBinding("binding", new RoleBindingArgs
-            {   
-                Metadata = new ObjectMetaArgs
-                {
-                    Name = "read-secrets",
-                },
-                Subjects = {
-                    new SubjectArgs
-                    {
-                        Kind = "User",
-                        Name = "dave",
-                        ApiGroup = "rbac.authorization.k8s.io",
-                    },
-                },
-                RoleRef = new RoleRefArgs
-                {
-                    Kind = "Role",
-                    Name = role.Metadata.Apply(metadata => metadata.Name),
-                    ApiGroup = "rbac.authorization.k8s.io",
-                },
-            });
+            // var binding = new RoleBinding("binding", new RoleBindingArgs
+            // {   
+            //     Metadata = new ObjectMetaArgs
+            //     {
+            //         Name = "read-secrets",
+            //     },
+            //     Subjects = {
+            //         new SubjectArgs
+            //         {
+            //             Kind = "User",
+            //             Name = "dave",
+            //             ApiGroup = "rbac.authorization.k8s.io",
+            //         },
+            //     },
+            //     RoleRef = new RoleRefArgs
+            //     {
+            //         Kind = "Role",
+            //         Name = role.Metadata.Apply(metadata => metadata.Name),
+            //         ApiGroup = "rbac.authorization.k8s.io",
+            //     },
+            // });
 
             var ns = Pulumi.Kubernetes.Core.V1.Namespace.Get("default", "default");
 
             return new Dictionary<string, object>{
                 { "namespacePhase", ns.Status.Apply(status => status.Phase) },
                 { "revisionData", revision.Data },
-                { "subjects", binding.Subjects.Apply(subjs => subjs.Select(subj => subj.Name).ToArray()) },
+                // { "subjects", binding.Subjects.Apply(subjs => subjs.Select(subj => subj.Name).ToArray()) },
             };
 
         });


### PR DESCRIPTION
We were typing these as `Output<T[]>`, but the .NET deserialization only supports `Output<ImmutableArray<T>>`.

Fixes #926.