### PR TITLE
Optionally render YAML for k8s resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+-   Optionally render YAML for k8s resources. (https://github.com/pulumi/pulumi-kubernetes/pull/936).
+
 ## 1.5.1 (February 7, 2020)
 
 ### Bug fixes
@@ -10,7 +14,6 @@
 
 ### Improvements
 
--   Optionally render YAML for k8s resources. (https://github.com/pulumi/pulumi-kubernetes/pull/936).
 -   Update nodejs SDK to use optional chaining in constructor. (https://github.com/pulumi/pulumi-kubernetes/pull/959).
 -   Automatically set Secret inputs as pulumi.secret. (https://github.com/pulumi/pulumi-kubernetes/pull/961).
 -   Create helm.v3 alias. (https://github.com/pulumi/pulumi-kubernetes/pull/970).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Improvements
 
+-   Optionally render YAML for k8s resources. (https://github.com/pulumi/pulumi-kubernetes/pull/936).
 -   Update nodejs SDK to use optional chaining in constructor. (https://github.com/pulumi/pulumi-kubernetes/pull/959).
 -   Automatically set Secret inputs as pulumi.secret. (https://github.com/pulumi/pulumi-kubernetes/pull/961).
 -   Create helm.v3 alias. (https://github.com/pulumi/pulumi-kubernetes/pull/970).

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/client-go v0.17.0
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/kubectl v0.17.0
+	sigs.k8s.io/yaml v1.1.0
 )
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.1+incompatible

--- a/pkg/gen/dotnet-templates/Provider.cs
+++ b/pkg/gen/dotnet-templates/Provider.cs
@@ -90,9 +90,12 @@ namespace Pulumi.Kubernetes
         /// <summary>
         /// If present, render resource manifests to this directory. In this mode, resources will not
         /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-        /// to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
-        /// since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
-        /// may result in an error, or the value may be empty/undefined.
+        /// to the Pulumi program.
+        ///
+        /// Note that some computed Outputs such as status fields will not be populated
+        /// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+        /// and may result in an error if they are referenced by other resources. Also note that any secret values
+        /// used in these resources will be rendered in plaintext to the resulting YAML.
         /// </summary>
         [Input("renderYamlToDirectory")]
         public Input<string>? RenderYamlToDirectory { get; set; }

--- a/pkg/gen/dotnet-templates/Provider.cs
+++ b/pkg/gen/dotnet-templates/Provider.cs
@@ -88,9 +88,9 @@ namespace Pulumi.Kubernetes
         public Input<bool>? SuppressDeprecationWarnings { get; set; }
 
         /// <summary>
-        /// If present, render resource manifests to this directory. In this mode, resources will not
+        /// BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
         /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-        /// to the Pulumi program.
+        /// to the Pulumi program. This feature is in developer preview, and is disabled by default.
         ///
         /// Note that some computed Outputs such as status fields will not be populated
         /// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,

--- a/pkg/gen/dotnet-templates/Provider.cs
+++ b/pkg/gen/dotnet-templates/Provider.cs
@@ -86,5 +86,15 @@ namespace Pulumi.Kubernetes
         /// </summary>
         [Input("suppressDeprecationWarnings")]
         public Input<bool>? SuppressDeprecationWarnings { get; set; }
+
+        /// <summary>
+        /// If present, render resource manifests to this directory. In this mode, resources will not
+        /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+        /// to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
+        /// since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
+        /// may result in an error, or the value may be empty/undefined.
+        /// </summary>
+        [Input("renderYamlToDirectory")]
+        public Input<string>? RenderYamlToDirectory { get; set; }
     }
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -198,7 +198,7 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 			switch {
 			case arg.IsString() && len(arg.StringValue()) > 0:
 				return true
-			case arg.IsBool() && arg.BoolValue() == true:
+			case arg.IsBool() && arg.BoolValue():
 				return true
 			default:
 				return false
@@ -1317,9 +1317,6 @@ func (k *kubeProvider) Create(
 	}
 
 	initialApiVersion := newInputs.GetAPIVersion()
-	if err != nil {
-		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
-	}
 
 	if len(k.yamlDirectory) > 0 {
 		if newResInputs.ContainsSecrets() {
@@ -1328,6 +1325,9 @@ func (k *kubeProvider) Create(
 				renderPathForResource(annotatedInputs, k.yamlDirectory)))
 		}
 		err := renderYaml(annotatedInputs, k.yamlDirectory)
+		if err != nil {
+			return nil, err
+		}
 
 		obj := checkpointObject(newInputs, annotatedInputs, newResInputs, initialApiVersion)
 		inputsAndComputed, err := plugin.MarshalProperties(
@@ -1350,6 +1350,9 @@ func (k *kubeProvider) Create(
 	}
 
 	resources, err := k.getResources()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "Failed to fetch OpenAPI schema from the API server")
+	}
 	config := await.CreateConfig{
 		ProviderConfig: await.ProviderConfig{
 			Context:           k.canceler.context,
@@ -1704,6 +1707,9 @@ func (k *kubeProvider) Update(
 				renderPathForResource(annotatedInputs, k.yamlDirectory)))
 		}
 		err := renderYaml(annotatedInputs, k.yamlDirectory)
+		if err != nil {
+			return nil, err
+		}
 
 		obj := checkpointObject(newInputs, annotatedInputs, newResInputs, initialApiVersion)
 		inputsAndComputed, err := plugin.MarshalProperties(

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -302,7 +302,7 @@ func (k *kubeProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffReques
 		diffs = append(diffs, "renderYamlToDirectory")
 
 		// If the render directory changes, all of the manifests will be replaced.
-		replaces = diffs
+		replaces = append(replaces, "renderYamlToDirectory")
 	}
 
 	// In general, it's not possible to tell from a kubeconfig if the k8s cluster it points to has
@@ -395,7 +395,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 	}
 
 	renderYamlToDirectory := func() string {
-		// If the provider flag is set, use that value to determine behavior. This will override the ENV var.
+		// Read the config from the Provider.
 		if directory, exists := vars["kubernetes:config:renderYamlToDirectory"]; exists {
 			return directory
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1275,6 +1275,9 @@ func (k *kubeProvider) Create(
 			return nil, err
 		}
 
+		_ = k.host.LogStatus(ctx, diag.Info, urn, fmt.Sprintf(
+			"rendered %s", yamlFilePath(annotatedInputs, k.yamlDirectory)))
+
 		return &pulumirpc.CreateResponse{
 			Id: fqObjName(annotatedInputs), Properties: inputsAndComputed,
 		}, nil
@@ -1633,6 +1636,9 @@ func (k *kubeProvider) Update(
 			return nil, err
 		}
 
+		_ = k.host.LogStatus(ctx, diag.Info, urn, fmt.Sprintf(
+			"rendered %s", yamlFilePath(annotatedInputs, k.yamlDirectory)))
+
 		return &pulumirpc.UpdateResponse{Properties: inputsAndComputed}, nil
 	}
 
@@ -1748,6 +1754,8 @@ func (k *kubeProvider) Delete(
 			// the user changed the directory out-of-band, so log the error to help debug this scenario.
 			glog.V(3).Infof("Failed to delete YAML file: %q - %v", file, err)
 		}
+
+		_ = k.host.LogStatus(ctx, diag.Info, urn, fmt.Sprintf("deleted %s", file))
 
 		return &pbempty.Empty{}, nil
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -174,15 +174,6 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 	label := fmt.Sprintf("%s.CheckConfig(%s)", k.label(), urn)
 	glog.V(9).Infof("%s executing", label)
 
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{
-		Label:        fmt.Sprintf("%s.olds", label),
-		KeepUnknowns: true,
-		SkipNulls:    true,
-		RejectAssets: true,
-	})
-	if err != nil {
-		return nil, pkgerrors.Wrapf(err, "CheckConfig failed because of malformed resource inputs")
-	}
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
 		Label:        fmt.Sprintf("%s.news", label),
 		KeepUnknowns: true,
@@ -207,8 +198,7 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 		return false
 	}
 
-	renderYamlEnabled := truthyValue("renderYamlToDirectory", olds) ||
-		truthyValue("renderYamlToDirectory", news)
+	renderYamlEnabled := truthyValue("renderYamlToDirectory", news)
 
 	errTemplate := `%q arg is not compatible with "renderYamlToDirectory" arg`
 	if renderYamlEnabled {

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -90,9 +90,12 @@ namespace Pulumi.Kubernetes
         /// <summary>
         /// If present, render resource manifests to this directory. In this mode, resources will not
         /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-        /// to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
-        /// since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
-        /// may result in an error, or the value may be empty/undefined.
+        /// to the Pulumi program.
+        ///
+        /// Note that some computed Outputs such as status fields will not be populated
+        /// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+        /// and may result in an error if they are referenced by other resources. Also note that any secret values
+        /// used in these resources will be rendered in plaintext to the resulting YAML.
         /// </summary>
         [Input("renderYamlToDirectory")]
         public Input<string>? RenderYamlToDirectory { get; set; }

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -88,9 +88,9 @@ namespace Pulumi.Kubernetes
         public Input<bool>? SuppressDeprecationWarnings { get; set; }
 
         /// <summary>
-        /// If present, render resource manifests to this directory. In this mode, resources will not
+        /// BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
         /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-        /// to the Pulumi program.
+        /// to the Pulumi program. This feature is in developer preview, and is disabled by default.
         ///
         /// Note that some computed Outputs such as status fields will not be populated
         /// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -86,5 +86,15 @@ namespace Pulumi.Kubernetes
         /// </summary>
         [Input("suppressDeprecationWarnings")]
         public Input<bool>? SuppressDeprecationWarnings { get; set; }
+
+        /// <summary>
+        /// If present, render resource manifests to this directory. In this mode, resources will not
+        /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+        /// to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
+        /// since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
+        /// may result in an error, or the value may be empty/undefined.
+        /// </summary>
+        [Input("renderYamlToDirectory")]
+        public Input<string>? RenderYamlToDirectory { get; set; }
     }
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -70,7 +70,9 @@ export interface ProviderArgs {
     /**
      * If present, render resource manifests to this directory. In this mode, resources will not
      * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-     * to the Pulumi program.
+     * to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
+     * since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
+     * may result in an error, or the value may be empty/undefined.
      */
     readonly renderYamlToDirectory?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -20,7 +20,6 @@ export class Provider extends pulumi.ProviderResource {
             "enableDryRun": args && args.enableDryRun ? "true" : undefined,
             "suppressDeprecationWarnings": args && args.suppressDeprecationWarnings ? "true" : undefined,
             "renderYamlToDirectory": args ? args.renderYamlToDirectory : undefined,
-            "skipDeploy": args && args.skipDeploy ? "true" : undefined,
         };
         super("kubernetes", name, props, opts);
     }
@@ -69,11 +68,9 @@ export interface ProviderArgs {
      */
     readonly suppressDeprecationWarnings?: pulumi.Input<boolean>;
     /**
-     * TODO: docs
+     * If present, render resource manifests to this directory. In this mode, resources will not
+     * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+     * to the Pulumi program.
      */
     readonly renderYamlToDirectory?: pulumi.Input<string>;
-    /**
-     * TODO: docs
-     */
-    readonly skipDeploy?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -18,7 +18,9 @@ export class Provider extends pulumi.ProviderResource {
             "kubeconfig": args ? args.kubeconfig : undefined,
             "namespace": args ? args.namespace : undefined,
             "enableDryRun": args && args.enableDryRun ? "true" : undefined,
-            "suppressDeprecationWarnings": args && args.suppressDeprecationWarnings ? "true" : undefined
+            "suppressDeprecationWarnings": args && args.suppressDeprecationWarnings ? "true" : undefined,
+            "renderYamlToDirectory": args ? args.renderYamlToDirectory : undefined,
+            "skipDeploy": args && args.skipDeploy ? "true" : undefined,
         };
         super("kubernetes", name, props, opts);
     }
@@ -66,4 +68,12 @@ export interface ProviderArgs {
      * 2. The `PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS` environment variable.
      */
     readonly suppressDeprecationWarnings?: pulumi.Input<boolean>;
+    /**
+     * TODO: docs
+     */
+    readonly renderYamlToDirectory?: pulumi.Input<string>;
+    /**
+     * TODO: docs
+     */
+    readonly skipDeploy?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -70,9 +70,12 @@ export interface ProviderArgs {
     /**
      * If present, render resource manifests to this directory. In this mode, resources will not
      * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-     * to the Pulumi program. Note that some computed Outputs such as status fields will not be populated
-     * since the resources are not created on a Kubernetes cluster. Attempting to reference these Outputs
-     * may result in an error, or the value may be empty/undefined.
+     * to the Pulumi program.
+     *
+     * Note that some computed Outputs such as status fields will not be populated
+     * since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+     * and may result in an error if they are referenced by other resources. Also note that any secret values
+     * used in these resources will be rendered in plaintext to the resulting YAML.
      */
     readonly renderYamlToDirectory?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -68,9 +68,9 @@ export interface ProviderArgs {
      */
     readonly suppressDeprecationWarnings?: pulumi.Input<boolean>;
     /**
-     * If present, render resource manifests to this directory. In this mode, resources will not
+     * BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
      * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
-     * to the Pulumi program.
+     * to the Pulumi program. This feature is in developer preview, and is disabled by default.
      *
      * Note that some computed Outputs such as status fields will not be populated
      * since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -45,8 +45,10 @@ class Provider(pulumi.ProviderResource):
                                  In this mode, resources will not be created on a Kubernetes cluster, but the rendered
                                  manifests will be kept in sync with changes to the Pulumi program. Note that some
                                  computed Outputs such as status fields will not be populated since the resources are
-                                 not created on a Kubernetes cluster. Attempting to reference these Outputs may result
-                                 in an error, or the value may be empty/undefined.
+                                 not created on a Kubernetes cluster. These Output values will remain undefined,
+                                 and may result in an error if they are referenced by other resources. Also note that
+                                 any secret values used in these resources will be rendered in plaintext to the
+                                 resulting YAML.
         """
         __props__ = {
             "cluster": cluster,

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -41,9 +41,10 @@ class Provider(pulumi.ProviderResource):
                                   This config can be specified in the following ways, using this precedence:
                                   1. This `suppressDeprecationWarnings` parameter.
                                   2. The `PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS` environment variable.
-        :param pulumi.Input[str] render_yaml_to_directory: If present, render resource manifests to this directory.
-                                 In this mode, resources will not be created on a Kubernetes cluster, but the rendered
-                                 manifests will be kept in sync with changes to the Pulumi program. Note that some
+        :param pulumi.Input[str] render_yaml_to_directory: BETA FEATURE - If present, render resource manifests to this
+                                 directory. In this mode, resources will not be created on a Kubernetes cluster, but
+                                 the rendered manifests will be kept in sync with changes to the Pulumi program.
+                                 This feature is in developer preview, and is disabled by default. Note that some
                                  computed Outputs such as status fields will not be populated since the resources are
                                  not created on a Kubernetes cluster. These Output values will remain undefined,
                                  and may result in an error if they are referenced by other resources. Also note that

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -14,7 +14,8 @@ class Provider(pulumi.ProviderResource):
                  enable_dry_run=None,
                  kubeconfig=None,
                  namespace=None,
-                 suppress_deprecation_warnings=None):
+                 suppress_deprecation_warnings=None,
+                 render_yaml_to_directory=None):
         """
         Create a Provider resource with the given unique name, arguments, and options.
 
@@ -40,6 +41,12 @@ class Provider(pulumi.ProviderResource):
                                   This config can be specified in the following ways, using this precedence:
                                   1. This `suppressDeprecationWarnings` parameter.
                                   2. The `PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS` environment variable.
+        :param pulumi.Input[str] render_yaml_to_directory: If present, render resource manifests to this directory.
+                                 In this mode, resources will not be created on a Kubernetes cluster, but the rendered
+                                 manifests will be kept in sync with changes to the Pulumi program. Note that some
+                                 computed Outputs such as status fields will not be populated since the resources are
+                                 not created on a Kubernetes cluster. Attempting to reference these Outputs may result
+                                 in an error, or the value may be empty/undefined.
         """
         __props__ = {
             "cluster": cluster,
@@ -48,5 +55,6 @@ class Provider(pulumi.ProviderResource):
             "kubeconfig": kubeconfig,
             "namespace": namespace,
             "suppress_deprecation_warnings": "true" if suppress_deprecation_warnings else "false",
+            "render_yaml_to_directory": render_yaml_to_directory,
         }
         super(Provider, self).__init__("kubernetes", __name__, __props__, __opts__)

--- a/tests/integration/render-yaml/render_yaml_test.go
+++ b/tests/integration/render-yaml/render_yaml_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+)
+
+func TestRenderYAML(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	// Create a temporary directory to hold rendered YAML manifests.
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Config: map[string]string{
+			"renderDir": dir,
+		},
+		Dir:           "step1",
+		Dependencies:  []string{"@pulumi/kubernetes"},
+		Quick:         true,
+		ExpectFailure: true, // step1 should fail because of an invalid Provider config.
+		EditDirs: []integration.EditDir{
+			{
+				Dir:           "step2",
+				Additive:      true,
+				ExpectFailure: false,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
+
+					// Verify that YAML directory was created.
+					files, err := ioutil.ReadDir(dir)
+					assert.NoError(t, err)
+					assert.Equal(t, len(files), 2)
+
+					// Verify that CRD manifest directory was created.
+					files, err = ioutil.ReadDir(filepath.Join(dir, "0-crd"))
+					assert.NoError(t, err)
+					assert.Equal(t, len(files), 0)
+
+					// Verify that manifest directory was created.
+					files, err = ioutil.ReadDir(filepath.Join(dir, "1-manifest"))
+					assert.NoError(t, err)
+					assert.Equal(t, len(files), 2)
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/render-yaml/step1/Pulumi.yaml
+++ b/tests/integration/render-yaml/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: render-yaml-tests
+description: Tests the option to render YAML rather than create k8s resources on a cluster.
+runtime: nodejs

--- a/tests/integration/render-yaml/step1/index.ts
+++ b/tests/integration/render-yaml/step1/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const provider = new k8s.Provider("render-yaml", {
+    renderYamlToDirectory: "rendered-yaml",
+    enableDryRun: true,
+});

--- a/tests/integration/render-yaml/step1/package.json
+++ b/tests/integration/render-yaml/step1/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "render-yaml",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "dev"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/integration/render-yaml/step1/tsconfig.json
+++ b/tests/integration/render-yaml/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/render-yaml/step2/index.ts
+++ b/tests/integration/render-yaml/step2/index.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+let config = new pulumi.Config();
+let renderDir: string = config.require("renderDir");
+
+const provider = new k8s.Provider("render-yaml", {
+    renderYamlToDirectory: renderDir,
+});
+
+const appLabels = {app: "nginx"};
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    spec: {
+        selector: {matchLabels: appLabels},
+        replicas: 1,
+        template: {
+            metadata: {labels: appLabels},
+            spec: {containers: [{name: "nginx", image: "nginx", ports: [{containerPort: 80}]}]}
+        }
+    }
+}, {provider});
+const service = new k8s.core.v1.Service("nginx", {
+    spec: {
+        ports: [{port: 80, protocol: "TCP"}],
+        selector: deployment.metadata.labels,
+    }
+}, {provider});


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This is a proof of concept for rendering YAML manifests rather than managing the resources
directly using Pulumi. The idea here is to allow users to manage k8s apps with other tooling,
while still integrating nicely with Pulumi-managed components. This would also allow users to leverage the kubernetesx (kx) library to define their applications without also requiring them to use Pulumi to deploy them.

In this prototype, I created an option on the Provider resource that allows a user to toggle the YAML rendering behavior by specifying an output directory for the manifests. When `pulumi up` runs, the provider renders the manifests to the specified directory rather than creating them on a k8s cluster.

Here's what this looks like currently:
![Screen Shot 2020-01-02 at 2 01 23 PM](https://user-images.githubusercontent.com/9253463/71694202-b3d43180-2d6b-11ea-9833-137d00396064.png)
![Screen Shot 2020-01-02 at 2 01 44 PM](https://user-images.githubusercontent.com/9253463/71694210-b6368b80-2d6b-11ea-9af5-f1e2d226b92b.png)


There are some open questions I'd like input on:
1. Should we create/update/delete the rendered manifests in lieu of the k8s resources, or simply render them to the specified directory and let users manage lifecycle beyond that?
1. Do we need to do anything special related to manifest ordering, or just let downstream users handle that? CRDs generally have to be applied prior to other resources, but it wouldn't be too hard for clients to apply `customresourcedefinition-*` prior to the rest.

**Update 1:**
Based on the early feedback, I've updated this PR to manage the full lifecycle of the rendered manifests (create/update/delete) in lieu of the k8s resources.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #29 
