### PR TITLE
Fix deprecated tag in JSDoc comments

### DIFF
--- a/pkg/gen/additionalComments.go
+++ b/pkg/gen/additionalComments.go
@@ -175,7 +175,6 @@ func ApiVersionComment(gvk schema.GroupVersionKind) string {
 	} else {
 		comment += "."
 	}
-	comment += "\n\n"
 
 	return comment
 }

--- a/pkg/gen/dotnet-templates/kind.cs.mustache
+++ b/pkg/gen/dotnet-templates/kind.cs.mustache
@@ -8,7 +8,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Kubernetes.{{Group}}.{{Version}}
 {
     /// <summary>
-    /// {{{Comment}}}{{{PulumiComment}}}
+    /// {{{DeprecationComment}}}{{{Comment}}}{{{PulumiComment}}}
     /// </summary>
     public partial class {{Kind}} : Pulumi.CustomResource
     {

--- a/pkg/gen/dotnet-templates/typesInput.cs.mustache
+++ b/pkg/gen/dotnet-templates/typesInput.cs.mustache
@@ -13,7 +13,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.{{Group}}
   {
     {{#Kinds}}
     /// <summary>
-    /// {{{Comment}}}
+    /// {{{DeprecationComment}}}{{{Comment}}}
     /// </summary>
     public class {{Kind}}Args : Pulumi.ResourceArgs
     {

--- a/pkg/gen/dotnet-templates/typesOutput.cs.mustache
+++ b/pkg/gen/dotnet-templates/typesOutput.cs.mustache
@@ -13,7 +13,7 @@ namespace Pulumi.Kubernetes.Types.Outputs.{{Group}}
   {
     {{#Kinds}}
     /// <summary>
-    /// {{{Comment}}}
+    /// {{{DeprecationComment}}}{{{Comment}}}
     /// </summary>
     [OutputType]
     public sealed class {{Kind}}

--- a/pkg/gen/dotnet.go
+++ b/pkg/gen/dotnet.go
@@ -105,6 +105,7 @@ func DotnetClient(
 			for _, kind := range version.TopLevelKinds() {
 				inputMap := map[string]interface{}{
 					"RawAPIVersion":           kind.RawAPIVersion(),
+					"DeprecationComment":      kind.DeprecationComment(),
 					"Comment":                 kind.Comment(),
 					"Group":                   group.Group(),
 					"Kind":                    kind.Kind(),
@@ -115,7 +116,7 @@ func DotnetClient(
 					"Aliases":                 kind.Aliases(),
 					"URNAPIVersion":           kind.URNAPIVersion(),
 					"Version":                 version.Version(),
-					"PulumiComment":           kind.pulumiComment,
+					"PulumiComment":           kind.PulumiComment(),
 				}
 				// Since mustache templates are logic-less, we have to add some extra variables
 				// to selectively disable code generation for empty lists.

--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -8,7 +8,7 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * {{{Comment}}}{{{PulumiComment}}}
+     * {{{Comment}}}{{{PulumiComment}}}{{{DeprecationComment}}}
      */
     export class {{Kind}} extends pulumi.CustomResource {
       {{#Properties}}

--- a/pkg/gen/nodejs-templates/typesInput.ts.mustache
+++ b/pkg/gen/nodejs-templates/typesInput.ts.mustache
@@ -10,7 +10,7 @@ export namespace {{Group}} {
   export namespace {{Version}} {
     {{#Kinds}}
     /**
-     * {{{Comment}}}
+     * {{{Comment}}}{{{DeprecationComment}}}
      */
     export interface {{Kind}} {
       {{#RequiredInputProperties}}

--- a/pkg/gen/nodejs-templates/typesOutput.ts.mustache
+++ b/pkg/gen/nodejs-templates/typesOutput.ts.mustache
@@ -7,7 +7,7 @@ export namespace {{Group}} {
   export namespace {{Version}} {
     {{#Kinds}}
     /**
-     * {{{Comment}}}
+     * {{{Comment}}}{{{DeprecationComment}}}
      */
     export interface {{Kind}} {
       {{#Properties}}

--- a/pkg/gen/nodejs.go
+++ b/pkg/gen/nodejs.go
@@ -81,6 +81,7 @@ func NodeJSClient(swagger map[string]interface{}, templateDir string,
 					versionTS.Kinds = make(map[string]string)
 				}
 				inputMap := map[string]interface{}{
+					"DeprecationComment":      kind.DeprecationComment(),
 					"Comment":                 kind.Comment(),
 					"Group":                   group.Group(),
 					"Kind":                    kind.Kind(),
@@ -91,7 +92,7 @@ func NodeJSClient(swagger map[string]interface{}, templateDir string,
 					"Aliases":                 kind.Aliases(),
 					"URNAPIVersion":           kind.URNAPIVersion(),
 					"Version":                 version.Version(),
-					"PulumiComment":           kind.pulumiComment,
+					"PulumiComment":           kind.PulumiComment(),
 				}
 				// Since mustache templates are logic-less, we have to add some extra variables
 				// to selectively disable code generation for empty lists.

--- a/pkg/gen/python-templates/kind.py.mustache
+++ b/pkg/gen/python-templates/kind.py.mustache
@@ -13,7 +13,7 @@ from ... import tables, version
 
 class {{Kind}}(pulumi.CustomResource):
     """
-    {{{Comment}}}{{{PulumiComment}}}
+    {{{DeprecationComment}}}{{{Comment}}}{{{PulumiComment}}}
     """
 
     apiVersion: pulumi.Output[str]

--- a/pkg/gen/python.go
+++ b/pkg/gen/python.go
@@ -139,6 +139,7 @@ from .CustomResource import (CustomResource)
 			for _, kind := range version.TopLevelKinds() {
 				inputMap := map[string]interface{}{
 					"RawAPIVersion":           kind.RawAPIVersion(),
+					"DeprecationComment":      kind.DeprecationComment(),
 					"Comment":                 kind.Comment(),
 					"Group":                   group.Group(),
 					"Kind":                    kind.Kind(),
@@ -149,7 +150,7 @@ from .CustomResource import (CustomResource)
 					"Aliases":                 kind.Aliases(),
 					"URNAPIVersion":           kind.URNAPIVersion(),
 					"Version":                 version.Version(),
-					"PulumiComment":           kind.pulumiComment,
+					"PulumiComment":           kind.PulumiComment(),
 				}
 				// Since mustache templates are logic-less, we have to add some extra variables
 				// to selectively disable code generation for empty lists.

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -19,6 +16,9 @@ import { getVersion } from "../../version";
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export class ControllerRevision extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
-     * Kubernetes v1.16+ clusters.
-     * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 
      * This resource waits until its status is ready before registering success
@@ -34,6 +31,9 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
@@ -29,6 +26,9 @@ import { getVersion } from "../../version";
      * If the StatefulSet has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export class StatefulSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -19,6 +16,9 @@ import { getVersion } from "../../version";
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export class ControllerRevision extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -8,10 +8,10 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export class DaemonSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
-     * Kubernetes v1.16+ clusters.
-     * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 
      * This resource waits until its status is ready before registering success
@@ -34,6 +31,9 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
+     * Kubernetes v1.16+ clusters.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -8,10 +8,10 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export class ReplicaSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
@@ -29,6 +26,9 @@ import { getVersion } from "../../version";
      * If the StatefulSet has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export class StatefulSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -8,10 +8,10 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
      * by Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export class DaemonSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
-     * supported by Kubernetes v1.16+ clusters.
-     * 
      * Deployment enables declarative updates for Pods and ReplicaSets.
      * 
      * This resource waits until its status is ready before registering success
@@ -34,6 +31,9 @@ import { getVersion } from "../../version";
      * If the Deployment has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
+     * supported by Kubernetes v1.16+ clusters.
      */
     export class Deployment extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -8,9 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
-     * supported by Kubernetes v1.20+ clusters.
-     * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable
      * urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
@@ -28,6 +25,9 @@ import { getVersion } from "../../version";
      * If the Ingress has not reached a Ready state after 10 minutes, it will
      * time out and mark the resource update as Failed. You can override the default timeout value
      * by setting the 'customTimeouts' option on the resource.
+     * 
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      */
     export class Ingress extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -8,10 +8,10 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
      * supported by Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export class ReplicaSet extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -8,8 +8,6 @@ import * as outputs from "../../types/output";
 import { getVersion } from "../../version";
 
     /**
-     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
-     * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar
      * container, the kubelet will automatically populate the CSINode object for the CSI driver as
@@ -17,6 +15,8 @@ import { getVersion } from "../../version";
      * missing, it means either there are no CSI Drivers available on the node, or the Kubelet
      * version is low enough that it doesn't create this object. CSINode has an OwnerReference that
      * points to the corresponding node object.
+     * 
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
      */
     export class CSINode extends pulumi.CustomResource {
       /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -4113,9 +4113,6 @@ export namespace apps {
 
   export namespace v1beta1 {
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -4124,6 +4121,9 @@ export namespace apps {
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export interface ControllerRevision {
       /**
@@ -4202,10 +4202,10 @@ export namespace apps {
     }
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -4622,14 +4622,14 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
      * The StatefulSet guarantees that a given network identity will always map to the same storage
      * identity.
+     * 
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export interface StatefulSet {
       /**
@@ -4880,9 +4880,6 @@ export namespace apps {
 
   export namespace v1beta2 {
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -4891,6 +4888,9 @@ export namespace apps {
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export interface ControllerRevision {
       /**
@@ -4969,10 +4969,10 @@ export namespace apps {
     }
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export interface DaemonSet {
       /**
@@ -5202,10 +5202,10 @@ export namespace apps {
 
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -5441,10 +5441,10 @@ export namespace apps {
 
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export interface ReplicaSet {
       /**
@@ -5772,14 +5772,14 @@ export namespace apps {
 
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
      * The StatefulSet guarantees that a given network identity will always map to the same storage
      * identity.
+     * 
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export interface StatefulSet {
       /**
@@ -17037,10 +17037,10 @@ export namespace extensions {
 
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
      * by Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export interface DaemonSet {
       /**
@@ -17276,10 +17276,10 @@ export namespace extensions {
 
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
      * supported by Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -17678,12 +17678,12 @@ export namespace extensions {
 
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
-     * supported by Kubernetes v1.20+ clusters.
-     * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable
      * urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
+     * 
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      */
     export interface Ingress {
       /**
@@ -18339,10 +18339,10 @@ export namespace extensions {
 
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
      * supported by Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export interface ReplicaSet {
       /**
@@ -24142,8 +24142,6 @@ export namespace storage {
 
 
     /**
-     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
-     * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar
      * container, the kubelet will automatically populate the CSINode object for the CSI driver as
@@ -24151,6 +24149,8 @@ export namespace storage {
      * missing, it means either there are no CSI Drivers available on the node, or the Kubelet
      * version is low enough that it doesn't create this object. CSINode has an OwnerReference that
      * points to the corresponding node object.
+     * 
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
      */
     export interface CSINode {
       /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -4002,9 +4002,6 @@ export namespace apps {
 
   export namespace v1beta1 {
     /**
-     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -4013,6 +4010,9 @@ export namespace apps {
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export interface ControllerRevision {
       /**
@@ -4083,10 +4083,10 @@ export namespace apps {
     }
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -4490,14 +4490,14 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
      * The StatefulSet guarantees that a given network identity will always map to the same storage
      * identity.
+     * 
+     * @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export interface StatefulSet {
       /**
@@ -4742,9 +4742,6 @@ export namespace apps {
 
   export namespace v1beta2 {
     /**
-     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
-     * not supported by Kubernetes v1.16+ clusters.
-     * 
      * ControllerRevision implements an immutable snapshot of state data. Clients are responsible
      * for serializing and deserializing the objects that contain their internal state. Once a
      * ControllerRevision has been successfully created, it can not be updated. The API Server will
@@ -4753,6 +4750,9 @@ export namespace apps {
      * controllers for update and rollback, this object is beta. However, it may be subject to name
      * and representation changes in future releases, and clients should not depend on its
      * stability. It is primarily for internal use by controllers.
+     * 
+     * @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and
+     * not supported by Kubernetes v1.16+ clusters.
      */
     export interface ControllerRevision {
       /**
@@ -4823,10 +4823,10 @@ export namespace apps {
     }
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export interface DaemonSet {
       /**
@@ -5051,10 +5051,10 @@ export namespace apps {
     }
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -5283,10 +5283,10 @@ export namespace apps {
     }
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by
      * Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export interface ReplicaSet {
       /**
@@ -5608,14 +5608,14 @@ export namespace apps {
     }
 
     /**
-     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
-     * by Kubernetes v1.16+ clusters.
-     * 
      * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
      *  - Network: A single stable DNS and hostname.
      *  - Storage: As many VolumeClaims as requested.
      * The StatefulSet guarantees that a given network identity will always map to the same storage
      * identity.
+     * 
+     * @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported
+     * by Kubernetes v1.16+ clusters.
      */
     export interface StatefulSet {
       /**
@@ -16483,10 +16483,10 @@ export namespace extensions {
     }
 
     /**
+     * DaemonSet represents the configuration of a daemon set.
+     * 
      * @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported
      * by Kubernetes v1.16+ clusters.
-     * 
-     * DaemonSet represents the configuration of a daemon set.
      */
     export interface DaemonSet {
       /**
@@ -16717,10 +16717,10 @@ export namespace extensions {
     }
 
     /**
+     * Deployment enables declarative updates for Pods and ReplicaSets.
+     * 
      * @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not
      * supported by Kubernetes v1.16+ clusters.
-     * 
-     * Deployment enables declarative updates for Pods and ReplicaSets.
      */
     export interface Deployment {
       /**
@@ -17102,12 +17102,12 @@ export namespace extensions {
     }
 
     /**
-     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
-     * supported by Kubernetes v1.20+ clusters.
-     * 
      * Ingress is a collection of rules that allow inbound connections to reach the endpoints
      * defined by a backend. An Ingress can be configured to give services externally-reachable
      * urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
+     * 
+     * @deprecated extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not
+     * supported by Kubernetes v1.20+ clusters.
      */
     export interface Ingress {
       /**
@@ -17734,10 +17734,10 @@ export namespace extensions {
     }
 
     /**
+     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+     * 
      * @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not
      * supported by Kubernetes v1.16+ clusters.
-     * 
-     * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
      */
     export interface ReplicaSet {
       /**
@@ -23219,8 +23219,6 @@ export namespace storage {
     }
 
     /**
-     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
-     * 
      * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need
      * to create the CSINode object directly. As long as they use the node-driver-registrar sidecar
      * container, the kubelet will automatically populate the CSINode object for the CSI driver as
@@ -23228,6 +23226,8 @@ export namespace storage {
      * missing, it means either there are no CSI Drivers available on the node, or the Kubelet
      * version is low enough that it doesn't create this object. CSINode has an OwnerReference that
      * points to the corresponding node object.
+     * 
+     * @deprecated storage/v1beta1/CSINode is deprecated by storage/v1/CSINode.
      */
     export interface CSINode {
       /**


### PR DESCRIPTION
The description in the doc comment should come before the `@deprecated` tag, otherwise the description will be included as part of the deprecation message.

Part of https://github.com/pulumi/docs/issues/2229
Related: https://github.com/pulumi/pulumi-eks/pull/301