### PR TITLE
Improve namespaced Kind check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+-   Improve namespaced Kind check. (https://github.com/pulumi/pulumi-kubernetes/pull/947).
+
 ### Bug fixes
 
 -   Fix deprecation notice for CSINode. (https://github.com/pulumi/pulumi-kubernetes/pull/944).

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -18,13 +18,16 @@ type Kind string
 
 const (
 	APIService                     Kind = "APIService"
+	Binding                        Kind = "Binding"
 	CertificateSigningRequest      Kind = "CertificateSigningRequest"
 	ClusterRole                    Kind = "ClusterRole"
 	ClusterRoleBinding             Kind = "ClusterRoleBinding"
+	ComponentStatus                Kind = "ComponentStatus"
 	ControllerRevision             Kind = "ControllerRevision"
 	CustomResourceDefinition       Kind = "CustomResourceDefinition"
 	ConfigMap                      Kind = "ConfigMap"
 	CronJob                        Kind = "CronJob"
+	CSIDriver                      Kind = "CSIDriver"
 	CSINode                        Kind = "CSINode"
 	DaemonSet                      Kind = "DaemonSet"
 	Deployment                     Kind = "Deployment"
@@ -33,10 +36,13 @@ const (
 	HorizontalPodAutoscaler        Kind = "HorizontalPodAutoscaler"
 	Ingress                        Kind = "Ingress"
 	Job                            Kind = "Job"
+	Lease                          Kind = "Lease"
 	LimitRange                     Kind = "LimitRange"
+	LocalSubjectAccessReview       Kind = "LocalSubjectAccessReview"
 	MutatingWebhookConfiguration   Kind = "MutatingWebhookConfiguration"
 	Namespace                      Kind = "Namespace"
 	NetworkPolicy                  Kind = "NetworkPolicy"
+	Node                           Kind = "Node"
 	PersistentVolume               Kind = "PersistentVolume"
 	PersistentVolumeClaim          Kind = "PersistentVolumeClaim"
 	Pod                            Kind = "Pod"
@@ -49,10 +55,82 @@ const (
 	ResourceQuota                  Kind = "ResourceQuota"
 	Role                           Kind = "Role"
 	RoleBinding                    Kind = "RoleBinding"
+	RuntimeClass                   Kind = "RuntimeClass"
 	Secret                         Kind = "Secret"
+	SelfSubjectAccessReview        Kind = "SelfSubjectAccessReview"
+	SelfSubjectRulesReview         Kind = "SelfSubjectRulesReview"
 	Service                        Kind = "Service"
 	ServiceAccount                 Kind = "ServiceAccount"
 	StatefulSet                    Kind = "StatefulSet"
+	SubjectAccessReview            Kind = "SubjectAccessReview"
 	StorageClass                   Kind = "StorageClass"
+	TokenReview                    Kind = "TokenReview"
 	ValidatingWebhookConfiguration Kind = "ValidatingWebhookConfiguration"
+	VolumeAttachment               Kind = "VolumeAttachment"
 )
+
+// Namespaced returns whether known resource Kinds are namespaced. If the Kind is unknown (such as CRD Kinds), the
+// known return value will be false, and the namespaced value is unknown. In this case, this information can be
+// queried separately from the k8s API server.
+func (k Kind) Namespaced() (known bool, namespaced bool) {
+	switch k {
+	// Note: Use `kubectl api-resources --namespaced=true -o name` to retrieve a list of namespace-scoped resources.
+	case Binding,
+		ConfigMap,
+		ControllerRevision,
+		CronJob,
+		DaemonSet,
+		Deployment,
+		Endpoints,
+		Event,
+		HorizontalPodAutoscaler,
+		Ingress,
+		Job,
+		Lease,
+		LimitRange,
+		LocalSubjectAccessReview,
+		NetworkPolicy,
+		PersistentVolumeClaim,
+		Pod,
+		PodDisruptionBudget,
+		PodTemplate,
+		ReplicaSet,
+		ReplicationController,
+		ResourceQuota,
+		Role,
+		RoleBinding,
+		Secret,
+		Service,
+		ServiceAccount,
+		StatefulSet:
+		known, namespaced = true, true
+	// Note: Use `kubectl api-resources --namespaced=false -o name` to retrieve a list of cluster-scoped resources.
+	case APIService,
+		CertificateSigningRequest,
+		ClusterRole,
+		ClusterRoleBinding,
+		ComponentStatus,
+		CSIDriver,
+		CSINode,
+		CustomResourceDefinition,
+		MutatingWebhookConfiguration,
+		Namespace,
+		Node,
+		PersistentVolume,
+		PodSecurityPolicy,
+		PriorityClass,
+		RuntimeClass,
+		SelfSubjectAccessReview,
+		SelfSubjectRulesReview,
+		StorageClass,
+		SubjectAccessReview,
+		TokenReview,
+		ValidatingWebhookConfiguration,
+		VolumeAttachment:
+		known, namespaced = true, false
+	default:
+		known = false
+	}
+
+	return
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -823,7 +823,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 	// If a default namespace is set on the provider for this resource, check if the resource has Namespaced
 	// or Global scope. For namespaced resources, set the namespace to the default value if unset.
 	if k.defaultNamespace != "" && len(newInputs.GetNamespace()) == 0 {
-		namespacedKind, err := k.clientSet.IsNamespacedKind(gvk)
+		namespacedKind, err := clients.IsNamespacedKind(gvk, k.clientSet)
 		if err != nil {
 			if clients.IsNoNamespaceInfoErr(err) {
 				// This is probably a CustomResource without a registered CustomResourceDefinition.
@@ -946,7 +946,7 @@ func (k *kubeProvider) Diff(
 		return nil, err
 	}
 
-	namespacedKind, err := k.clientSet.IsNamespacedKind(gvk)
+	namespacedKind, err := clients.IsNamespacedKind(gvk, k.clientSet)
 	if err != nil {
 		if clients.IsNoNamespaceInfoErr(err) {
 			// This is probably a CustomResource without a registered CustomResourceDefinition.


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Create a static lookup table for all known Kinds to determine
if resources are namespace-scoped or cluster-scoped. If the
Kind is unknown (e.g., a CustomResource), attempt to look
up this information from the k8s API server. This approach
improves the reliability of the namespaced check during
previews, where the API server is often unavailable.

Additionally, move this check from a method attached to the
DynamicClientSet to a function that accepts an optional
DynamicClientSet so that it is usable in contexts without an
available API server.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
