### PR TITLE
Handle invalid kubeconfig context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Handle invalid kubeconfig context. (https://github.com/pulumi/pulumi-kubernetes/pull/960).
+
 ## 1.4.4 (January 21, 2020)
 
 ### Improvements


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Rather than immediately returning an error for an invalid kubeconfig
context, mark the cluster as unreachable, and only fail with an error
on operations that need to talk to the cluster. This will allow invoke
methods to operate using the default provider even if no local cluster
is configured.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Related to #939 