### PR TITLE
Automatically set Secret inputs as Pulumi secrets in .NET SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/obj/
 **/node_modules/
 **/.vs
+**/.idea
+**/.ionide
 .pulumi
 Pulumi.*.yaml
 /pkg/gen/openapi-specs

--- a/pkg/gen/dotnet-templates/typesInput.cs.mustache
+++ b/pkg/gen/dotnet-templates/typesInput.cs.mustache
@@ -25,8 +25,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.{{Group}}
         {{{Comment}}}
         public {{{InputsAPIType}}} {{LanguageName}}
         {
-            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}());
-            set => _{{Name}} = value;
+            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}(){{DefaultValue}});
+            set => _{{Name}} = value{{DefaultValue}};
         }
         {{/DotnetIsListOrMap}}
         {{^DotnetIsListOrMap}}
@@ -44,8 +44,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.{{Group}}
         {{{Comment}}}
         public {{{InputsAPIType}}} {{LanguageName}}
         {
-            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}());
-            set => _{{Name}} = value;
+            get => _{{Name}} ?? (_{{Name}} = new {{{InputsAPIType}}}(){{DefaultValue}});
+            set => _{{Name}} = value{{DefaultValue}};
         }
         {{/DotnetIsListOrMap}}
         {{^DotnetIsListOrMap}}

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -1033,6 +1033,7 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []*Gro
 							// .NET does not allow properties to be the same as the enclosing class - so special case these
 							languageName = languageName + "Value"
 						}
+						defaultValue = ""
 						dotnetVarName = "@" + name
 					default:
 						panic(fmt.Sprintf("Unsupported language '%s'", opts.language))
@@ -1047,6 +1048,8 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []*Gro
 						case python:
 							defaultValue = fmt.Sprintf("pulumi.Output.secret(%s) if %s is not None else None",
 								languageName, languageName)
+						case dotnet:
+							defaultValue = ".Apply(Output.CreateSecret)"
 						}
 					}
 

--- a/sdk/dotnet/Types/Input.cs
+++ b/sdk/dotnet/Types/Input.cs
@@ -18521,8 +18521,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Core
         /// </summary>
         public InputMap<string> Data
         {
-            get => _data ?? (_data = new InputMap<string>());
-            set => _data = value;
+            get => _data ?? (_data = new InputMap<string>().Apply(Output.CreateSecret));
+            set => _data = value.Apply(Output.CreateSecret);
         }
 
         /// <summary>
@@ -18551,8 +18551,8 @@ namespace Pulumi.Kubernetes.Types.Inputs.Core
         /// </summary>
         public InputMap<string> StringData
         {
-            get => _stringData ?? (_stringData = new InputMap<string>());
-            set => _stringData = value;
+            get => _stringData ?? (_stringData = new InputMap<string>().Apply(Output.CreateSecret));
+            set => _stringData = value.Apply(Output.CreateSecret);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #967

Arguably, this abuses the `DefaultValue` property. Let me know if you want me to make a new `dotnetXyz` one, I haven't calibrated to those templates yet.