### PR TITLE
Use resourcePrefix on all code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 -   Fix hang on large YAML files. (https://github.com/pulumi/pulumi-kubernetes/pull/974).
+-   Use resourcePrefix all code paths. (https://github.com/pulumi/pulumi-kubernetes/pull/977).
 
 ## 1.4.5 (January 22, 2020)
 

--- a/pkg/gen/nodejs-templates/yaml.ts.mustache
+++ b/pkg/gen/nodejs-templates/yaml.ts.mustache
@@ -183,7 +183,11 @@ import * as outputs from "../types/output";
 
         if (config.objs !== undefined) {
             const objs: Promise<any[]> = Array.isArray(config.objs) ? Promise.resolve(config.objs) : Promise.resolve([config.objs]);
-            const docResources = parseYamlDocument({objs, transformations: config.transformations}, opts);
+            const docResources = parseYamlDocument({
+                objs,
+                transformations: config.transformations,
+                resourcePrefix: config.resourcePrefix
+            }, opts);
             resources = pulumi.all([resources, docResources]).apply(([rs, drs]) => ({...rs, ...drs}));
         }
 

--- a/sdk/nodejs/yaml/yaml.ts
+++ b/sdk/nodejs/yaml/yaml.ts
@@ -183,7 +183,11 @@ import * as outputs from "../types/output";
 
         if (config.objs !== undefined) {
             const objs: Promise<any[]> = Array.isArray(config.objs) ? Promise.resolve(config.objs) : Promise.resolve([config.objs]);
-            const docResources = parseYamlDocument({objs, transformations: config.transformations}, opts);
+            const docResources = parseYamlDocument({
+                objs,
+                transformations: config.transformations,
+                resourcePrefix: config.resourcePrefix
+            }, opts);
             resources = pulumi.all([resources, docResources]).apply(([rs, drs]) => ({...rs, ...drs}));
         }
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
One code path in yaml.ts inadvertently omitted the resourcePrefix.
Helm support recently started using this code path, so this fix
affects both Helm and YAML support.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #976 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
