### PR TITLE
Specify provider version for invokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Specify provider version for invokes. (https://github.com/pulumi/pulumi-kubernetes/pull/982).
+
 ## 1.5.0 (February 4, 2020)
 
 ### Improvements

--- a/pkg/gen/nodejs-templates/package.json.mustache
+++ b/pkg/gen/nodejs-templates/package.json.mustache
@@ -14,8 +14,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.8.1",
-        "@types/js-yaml": "^3.11.2",
-        "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",
         "tmp": "^0.0.33",
         "@types/tmp": "^0.0.33",

--- a/pkg/gen/nodejs-templates/yaml.ts.mustache
+++ b/pkg/gen/nodejs-templates/yaml.ts.mustache
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as glob from "glob";
 import fetch from "node-fetch";
 import * as k8s from "../index";
+import { getVersion } from "../version";
 import * as outputs from "../types/output";
 
     export interface ConfigGroupOpts {
@@ -120,9 +121,19 @@ import * as outputs from "../types/output";
         resourcePrefix?: string;
     }
 
-    function yamlLoadAll(text: string): Promise<any[]> {
-        const promise = pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, {async: true});
-        return promise.then(p => p.result);
+    function yamlLoadAll(text: string, opts?: pulumi.CustomResourceOptions): Promise<any[]> {
+        // Rather than using the default provider for the following invoke call, determine the
+        // provider from the parent if specified, or fallback to using the version specified
+        // in package.json.
+        let invokeOpts: pulumi.InvokeOptions = {async: true};
+        if (opts?.parent) {
+            invokeOpts = {...invokeOpts, parent: opts.parent};
+        } else {
+            invokeOpts = {...invokeOpts, version: getVersion()};
+        }
+
+        return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
+            .then((p => p.result));
     }
 
     /** @ignore */ export function parse(
@@ -172,7 +183,7 @@ import * as outputs from "../types/output";
 
             for (const text of yamlTexts) {
                 const docResources = parseYamlDocument({
-                        objs: yamlLoadAll(text),
+                        objs: yamlLoadAll(text, opts),
                         transformations: config.transformations,
                         resourcePrefix: config.resourcePrefix
                     },
@@ -320,7 +331,7 @@ import * as outputs from "../types/output";
             this.resources = pulumi.output(text.then(t => {
                 try {
                     return parseYamlDocument({
-                        objs: yamlLoadAll(t),
+                        objs: yamlLoadAll(t, opts),
                         transformations: config && config.transformations || [],
                         resourcePrefix: config && config.resourcePrefix || undefined
                     }, {parent: this})

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -14,8 +14,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.8.1",
-        "@types/js-yaml": "^3.11.2",
-        "js-yaml": "^3.12.0",
         "shell-quote": "^1.6.1",
         "tmp": "^0.0.33",
         "@types/tmp": "^0.0.33",

--- a/sdk/nodejs/yaml/yaml.ts
+++ b/sdk/nodejs/yaml/yaml.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as glob from "glob";
 import fetch from "node-fetch";
 import * as k8s from "../index";
+import { getVersion } from "../version";
 import * as outputs from "../types/output";
 
     export interface ConfigGroupOpts {
@@ -120,9 +121,19 @@ import * as outputs from "../types/output";
         resourcePrefix?: string;
     }
 
-    function yamlLoadAll(text: string): Promise<any[]> {
-        const promise = pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, {async: true});
-        return promise.then(p => p.result);
+    function yamlLoadAll(text: string, opts?: pulumi.CustomResourceOptions): Promise<any[]> {
+        // Rather than using the default provider for the following invoke call, determine the
+        // provider from the parent if specified, or fallback to using the version specified
+        // in package.json.
+        let invokeOpts: pulumi.InvokeOptions = {async: true};
+        if (opts?.parent) {
+            invokeOpts = {...invokeOpts, parent: opts.parent};
+        } else {
+            invokeOpts = {...invokeOpts, version: getVersion()};
+        }
+
+        return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
+            .then((p => p.result));
     }
 
     /** @ignore */ export function parse(
@@ -172,7 +183,7 @@ import * as outputs from "../types/output";
 
             for (const text of yamlTexts) {
                 const docResources = parseYamlDocument({
-                        objs: yamlLoadAll(text),
+                        objs: yamlLoadAll(text, opts),
                         transformations: config.transformations,
                         resourcePrefix: config.resourcePrefix
                     },
@@ -2462,7 +2473,7 @@ import * as outputs from "../types/output";
             this.resources = pulumi.output(text.then(t => {
                 try {
                     return parseYamlDocument({
-                        objs: yamlLoadAll(t),
+                        objs: yamlLoadAll(t, opts),
                         transformations: config && config.transformations || [],
                         resourcePrefix: config && config.resourcePrefix || undefined
                     }, {parent: this})

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -164,7 +164,7 @@ func TestAccHelmApiVersions(t *testing.T) {
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
 				assert.NotNil(t, stackInfo.Deployment)
-				assert.Equal(t, 7, len(stackInfo.Deployment.Resources))
+				assert.Equal(t, 6, len(stackInfo.Deployment.Resources))
 			},
 		})
 
@@ -181,7 +181,7 @@ func TestAccHelmLocal(t *testing.T) {
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
 				assert.NotNil(t, stackInfo.Deployment)
-				assert.Equal(t, 16, len(stackInfo.Deployment.Resources))
+				assert.Equal(t, 15, len(stackInfo.Deployment.Resources))
 			},
 		})
 

--- a/tests/integration/aliases/aliases_test.go
+++ b/tests/integration/aliases/aliases_test.go
@@ -37,7 +37,7 @@ func TestAliases(t *testing.T) {
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
+			assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
 
 			tests.SortResourcesByURN(stackInfo)
 
@@ -51,7 +51,7 @@ func TestAliases(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Deployment)
-					assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
 
 					tests.SortResourcesByURN(stackInfo)
 
@@ -69,7 +69,7 @@ func TestAliases(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Deployment)
-					assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
 
 					tests.SortResourcesByURN(stackInfo)
 

--- a/tests/integration/yaml-url/yaml_url_test.go
+++ b/tests/integration/yaml-url/yaml_url_test.go
@@ -37,7 +37,7 @@ func TestYAMLURL(t *testing.T) {
 			assert.NotNil(t, stackInfo.Deployment)
 
 			// Assert that we've retrieved the YAML from the URL and provisioned them.
-			assert.Equal(t, 19, len(stackInfo.Deployment.Resources))
+			assert.Equal(t, 18, len(stackInfo.Deployment.Resources))
 		},
 	})
 }


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The SDK previously used invoke for Helm and YAML support,
but was not specifying the parent or version explicitly. As a result,
the provider plugin to use was nondeterministic, and could select
an incompatible version that lead to an error.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #978 