### PR TITLE
Fix aliases for several resource kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Fix aliases for several resource kinds. (https://github.com/pulumi/pulumi-kubernetes/pull/990).
+
 ## 1.5.3 (February 11, 2020)
 
 ### Bug fixes

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -1231,6 +1231,8 @@ func additionalSecretOutputs(gvk schema.GroupVersionKind) []string {
 	}
 }
 
+// aliasesForGVK returns a list of alias strings for a given GVK. These values are derived from the Kubernetes
+// API docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/
 func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 	kind := kinds.Kind(gvk.Kind)
 

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -1237,9 +1237,9 @@ func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 	switch kind {
 	case kinds.ClusterRole, kinds.ClusterRoleBinding, kinds.Role, kinds.RoleBinding:
 		return []string{
-			fmt.Sprintf("kubernetes:rbac/v1:%s", gvk.Kind),
-			fmt.Sprintf("kubernetes:rbac/v1beta1:%s", gvk.Kind),
-			fmt.Sprintf("kubernetes:rbac/v1alpha1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:rbac.authorization.k8s.io/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:rbac.authorization.k8s.io/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:rbac.authorization.k8s.io/v1alpha1:%s", gvk.Kind),
 		}
 	case kinds.DaemonSet, kinds.ReplicaSet:
 		return []string{
@@ -1256,12 +1256,12 @@ func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 		}
 	case kinds.Ingress:
 		return []string{
-			fmt.Sprintf("kubernetes:networking/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:networking.k8s.io/v1beta1:%s", gvk.Kind),
 			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.NetworkPolicy:
 		return []string{
-			fmt.Sprintf("kubernetes:networking/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:networking.k8s.io/v1:%s", gvk.Kind),
 			fmt.Sprintf("kubernetes:extensions/v1beta1:%s", gvk.Kind),
 		}
 	case kinds.PodSecurityPolicy:
@@ -1271,9 +1271,9 @@ func aliasesForGVK(gvk schema.GroupVersionKind) []string {
 		}
 	case kinds.PriorityClass:
 		return []string{
-			fmt.Sprintf("kubernetes:scheduling/v1:%s", gvk.Kind),
-			fmt.Sprintf("kubernetes:scheduling/v1beta1:%s", gvk.Kind),
-			fmt.Sprintf("kubernetes:scheduling/v1alpha1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:scheduling.k8s.io/v1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:scheduling.k8s.io/v1beta1:%s", gvk.Kind),
+			fmt.Sprintf("kubernetes:scheduling.k8s.io/v1alpha1:%s", gvk.Kind),
 		}
 	default:
 		return []string{}

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -121,7 +121,7 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
               ],
           });

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -97,7 +97,7 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking/v1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
               ],
           });

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -95,7 +95,7 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking/v1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
               ],
           });

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -118,7 +118,7 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
               ],
           });

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -103,9 +103,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -102,9 +102,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -95,9 +95,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -104,9 +104,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -104,9 +104,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -104,9 +104,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -96,9 +96,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -105,9 +105,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -104,9 +104,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -104,9 +104,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -96,9 +96,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -105,9 +105,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1beta1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -122,9 +122,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -123,9 +123,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -123,9 +123,9 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1beta1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -102,7 +102,7 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -77,7 +77,7 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -75,7 +75,7 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -99,7 +99,7 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -85,9 +85,9 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -85,9 +85,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -74,9 +74,9 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -87,9 +87,9 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -86,9 +86,9 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -86,9 +86,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -75,9 +75,9 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -88,9 +88,9 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -86,9 +86,9 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -86,9 +86,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -75,9 +75,9 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -88,9 +88,9 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1beta1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -116,9 +116,9 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -117,9 +117,9 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -117,9 +117,9 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1beta1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The following resource Kinds had the wrong Group
specified in the aliases:

- ClusterRole
- ClusterRoleBinding
- Ingress
- NetworkPolicy
- PriorityClass
- Role
- RoleBinding
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #989 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
