### PR TITLE
Auto-generate aliases for all resource kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+-   Auto-generate aliases for all resource kinds. (https://github.com/pulumi/pulumi-kubernetes/pull/991).
+
 ### Bug fixes
 
 -   Fix aliases for several resource kinds. (https://github.com/pulumi/pulumi-kubernetes/pull/990).

--- a/pkg/gen/nodejs-templates/kind.ts.mustache
+++ b/pkg/gen/nodejs-templates/kind.ts.mustache
@@ -74,7 +74,7 @@ import { getVersion } from "../../version";
           }
 
           {{#MergeOptsRequired}}
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               {{#AdditionalSecretOutputsPresent}}
               additionalSecretOutputs: [
                   {{#AdditionalSecretOutputs}}
@@ -85,16 +85,12 @@ import { getVersion } from "../../version";
               {{#AliasesPresent}}
               aliases: [
                   {{#Aliases}}
-                  { parent: opts.parent, type: "{{.}}", name: name },
+                  { type: "{{.}}" },
                   {{/Aliases}}
               ],
               {{/AliasesPresent}}
           });
-
-          super({{Kind}}.__pulumiType, name, props, _opts);
           {{/MergeOptsRequired}}
-          {{^MergeOptsRequired}}
           super({{Kind}}.__pulumiType, name, props, opts);
-          {{/MergeOptsRequired}}
       }
     }

--- a/pkg/gen/python-templates/kind.py.mustache
+++ b/pkg/gen/python-templates/kind.py.mustache
@@ -87,7 +87,7 @@ class {{Kind}}(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             {{#Aliases}}
-            pulumi.Alias(parent=parent, type_="{{.}}", name=resource_name),
+            pulumi.Alias(type_="{{.}}"),
             {{/Aliases}}
         ]
         {{/AliasesPresent}}

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -927,10 +927,9 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []*Gro
 		WhereT(func(d *definition) bool { return isTopLevel(d) && !strings.HasSuffix(d.gvk.Kind, "List") }).
 		OrderByT(func(d *definition) string { return d.gvk.String() }).
 		SelectManyT(func(d *definition) linq.Query {
-			// Make fully-qualified and "default" GroupVersion. The "default" GV is the `apiVersion` that
-			// appears when writing Kubernetes YAML (e.g., `v1` instead of `core/v1`), while the
-			// fully-qualified version is the "official" GV (e.g., `core/v1` instead of `v1` or
-			// `admissionregistration.k8s.io/v1alpha1` instead of `admissionregistration/v1alpha1`).
+			// Make fully-qualified GroupVersion. The fully-qualified version is the "official" GV
+			// (e.g., `core/v1` instead of `v1` or `admissionregistration.k8s.io/v1alpha1` instead of
+			// `admissionregistration/v1alpha1`).
 			var fqGroupVersion string
 			if gvks, gvkExists := d.data["x-kubernetes-group-version-kind"].([]interface{}); gvkExists && len(gvks) > 0 {
 				gvk := gvks[0].(map[string]interface{})
@@ -943,11 +942,6 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []*Gro
 				}
 			} else {
 				gv := d.gvk.GroupVersion().String()
-				if strings.HasPrefix(gv, "apiextensions/") && strings.HasPrefix(d.gvk.Kind, "CustomResource") {
-					// Special case. Kubernetes OpenAPI spec should have an `x-kubernetes-group-version-kind`
-					// CustomResource, but it doesn't. Hence, we hard-code it.
-					gv = fmt.Sprintf("apiextensions.k8s.io/%s", d.gvk.Version)
-				}
 				fqGroupVersion = gv
 			}
 

--- a/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
@@ -94,13 +94,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name: name },
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name: name },
+                  { type: "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration" },
               ],
           });
-
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/MutatingWebhookConfiguration.ts
@@ -94,6 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name: name },
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name: name },
+              ],
+          });
+
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
@@ -94,13 +94,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name: name },
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name: name },
+                  { type: "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration" },
               ],
           });
-
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1/ValidatingWebhookConfiguration.ts
@@ -94,6 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name: name },
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name: name },
+              ],
+          });
+
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name: name },
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name: name },
+                  { type: "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration" },
               ],
           });
-
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/MutatingWebhookConfiguration.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(MutatingWebhookConfiguration.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name: name },
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name: name },
+              ],
+          });
+
+          super(MutatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name: name },
-                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name: name },
+                  { type: "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration" },
               ],
           });
-
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/ValidatingWebhookConfiguration.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ValidatingWebhookConfiguration.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name: name },
+                  { parent: opts.parent, type: "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name: name },
+              ],
+          });
+
+          super(ValidatingWebhookConfiguration.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
@@ -96,6 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CustomResourceDefinition.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name: name },
+                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name: name },
+              ],
+          });
+
+          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1/CustomResourceDefinition.ts
@@ -96,13 +96,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name: name },
-                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name: name },
+                  { type: "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition" },
               ],
           });
-
-          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
+          super(CustomResourceDefinition.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
@@ -97,6 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CustomResourceDefinition.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name: name },
+                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name: name },
+              ],
+          });
+
+          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/CustomResourceDefinition.ts
@@ -97,13 +97,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name: name },
-                  { parent: opts.parent, type: "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name: name },
+                  { type: "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition" },
               ],
           });
-
-          super(CustomResourceDefinition.__pulumiType, name, props, _opts);
+          super(CustomResourceDefinition.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(APIService.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1:APIService", name: name },
+                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService", name: name },
+              ],
+          });
+
+          super(APIService.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1:APIService", name: name },
-                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService", name: name },
+                  { type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService" },
               ],
           });
-
-          super(APIService.__pulumiType, name, props, _opts);
+          super(APIService.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(APIService.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1:APIService", name: name },
+                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService", name: name },
+              ],
+          });
+
+          super(APIService.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1:APIService", name: name },
-                  { parent: opts.parent, type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService", name: name },
+                  { type: "kubernetes:apiregistration.k8s.io/v1:APIService" },
               ],
           });
-
-          super(APIService.__pulumiType, name, props, _opts);
+          super(APIService.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevision.ts
@@ -106,14 +106,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+                  { type: "kubernetes:apps/v1beta1:ControllerRevision" },
+                  { type: "kubernetes:apps/v1beta2:ControllerRevision" },
               ],
           });
-
-          super(ControllerRevision.__pulumiType, name, props, _opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1/ControllerRevision.ts
@@ -106,6 +106,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+              ],
+          });
+
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1/DaemonSet.ts
@@ -101,14 +101,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+                  { type: "kubernetes:apps/v1beta2:DaemonSet" },
+                  { type: "kubernetes:extensions/v1beta1:DaemonSet" },
               ],
           });
-
-          super(DaemonSet.__pulumiType, name, props, _opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/Deployment.ts
+++ b/sdk/nodejs/apps/v1/Deployment.ts
@@ -119,15 +119,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+                  { type: "kubernetes:apps/v1beta1:Deployment" },
+                  { type: "kubernetes:apps/v1beta2:Deployment" },
+                  { type: "kubernetes:extensions/v1beta1:Deployment" },
               ],
           });
-
-          super(Deployment.__pulumiType, name, props, _opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1/ReplicaSet.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+                  { type: "kubernetes:apps/v1beta2:ReplicaSet" },
+                  { type: "kubernetes:extensions/v1beta1:ReplicaSet" },
               ],
           });
-
-          super(ReplicaSet.__pulumiType, name, props, _opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -118,7 +118,6 @@ import { getVersion } from "../../version";
                   { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
               ],
           });
 

--- a/sdk/nodejs/apps/v1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1/StatefulSet.ts
@@ -113,14 +113,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { type: "kubernetes:apps/v1beta1:StatefulSet" },
+                  { type: "kubernetes:apps/v1beta2:StatefulSet" },
               ],
           });
-
-          super(StatefulSet.__pulumiType, name, props, _opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -109,6 +109,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+              ],
+          });
+
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -109,14 +109,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+                  { type: "kubernetes:apps/v1:ControllerRevision" },
+                  { type: "kubernetes:apps/v1beta2:ControllerRevision" },
               ],
           });
-
-          super(ControllerRevision.__pulumiType, name, props, _opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -122,15 +122,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+                  { type: "kubernetes:apps/v1:Deployment" },
+                  { type: "kubernetes:apps/v1beta2:Deployment" },
+                  { type: "kubernetes:extensions/v1beta1:Deployment" },
               ],
           });
-
-          super(Deployment.__pulumiType, name, props, _opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -116,14 +116,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { type: "kubernetes:apps/v1:StatefulSet" },
+                  { type: "kubernetes:apps/v1beta2:StatefulSet" },
               ],
           });
-
-          super(StatefulSet.__pulumiType, name, props, _opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -121,7 +121,6 @@ import { getVersion } from "../../version";
                   { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
               ],
           });
 

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -109,6 +109,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(ControllerRevision.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
+                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+              ],
+          });
+
+          super(ControllerRevision.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -109,14 +109,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:ControllerRevision", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ControllerRevision", name: name },
+                  { type: "kubernetes:apps/v1:ControllerRevision" },
+                  { type: "kubernetes:apps/v1beta1:ControllerRevision" },
               ],
           });
-
-          super(ControllerRevision.__pulumiType, name, props, _opts);
+          super(ControllerRevision.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -104,14 +104,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+                  { type: "kubernetes:apps/v1:DaemonSet" },
+                  { type: "kubernetes:extensions/v1beta1:DaemonSet" },
               ],
           });
-
-          super(DaemonSet.__pulumiType, name, props, _opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -122,15 +122,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+                  { type: "kubernetes:apps/v1:Deployment" },
+                  { type: "kubernetes:apps/v1beta1:Deployment" },
+                  { type: "kubernetes:extensions/v1beta1:Deployment" },
               ],
           });
-
-          super(Deployment.__pulumiType, name, props, _opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -105,14 +105,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+                  { type: "kubernetes:apps/v1:ReplicaSet" },
+                  { type: "kubernetes:extensions/v1beta1:ReplicaSet" },
               ],
           });
-
-          super(ReplicaSet.__pulumiType, name, props, _opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -116,14 +116,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
+                  { type: "kubernetes:apps/v1:StatefulSet" },
+                  { type: "kubernetes:apps/v1beta1:StatefulSet" },
               ],
           });
-
-          super(StatefulSet.__pulumiType, name, props, _opts);
+          super(StatefulSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -121,7 +121,6 @@ import { getVersion } from "../../version";
                   { parent: opts.parent, type: "kubernetes:apps/v1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta1:StatefulSet", name: name },
                   { parent: opts.parent, type: "kubernetes:apps/v1beta2:StatefulSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:StatefulSet", name: name },
               ],
           });
 

--- a/sdk/nodejs/authentication/v1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1/TokenReview.ts
@@ -96,6 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(TokenReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1:TokenReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1beta1:TokenReview", name: name },
+              ],
+          });
+
+          super(TokenReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authentication/v1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1/TokenReview.ts
@@ -96,13 +96,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1:TokenReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1beta1:TokenReview", name: name },
+                  { type: "kubernetes:authentication.k8s.io/v1beta1:TokenReview" },
               ],
           });
-
-          super(TokenReview.__pulumiType, name, props, _opts);
+          super(TokenReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authentication/v1beta1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1beta1/TokenReview.ts
@@ -96,6 +96,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(TokenReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1:TokenReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1beta1:TokenReview", name: name },
+              ],
+          });
+
+          super(TokenReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authentication/v1beta1/TokenReview.ts
+++ b/sdk/nodejs/authentication/v1beta1/TokenReview.ts
@@ -96,13 +96,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1:TokenReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authentication.k8s.io/v1beta1:TokenReview", name: name },
+                  { type: "kubernetes:authentication.k8s.io/v1:TokenReview" },
               ],
           });
-
-          super(TokenReview.__pulumiType, name, props, _opts);
+          super(TokenReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
@@ -98,13 +98,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview" },
               ],
           });
-
-          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/LocalSubjectAccessReview.ts
@@ -98,6 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name: name },
+              ],
+          });
+
+          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
@@ -97,13 +97,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview" },
               ],
           });
-
-          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectAccessReview.ts
@@ -97,6 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name: name },
+              ],
+          });
+
+          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
@@ -102,13 +102,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview" },
               ],
           });
-
-          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1/SelfSubjectRulesReview.ts
@@ -102,6 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name: name },
+              ],
+          });
+
+          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview" },
               ],
           });
-
-          super(SubjectAccessReview.__pulumiType, name, props, _opts);
+          super(SubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1/SubjectAccessReview.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name: name },
+              ],
+          });
+
+          super(SubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
@@ -98,6 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name: name },
+              ],
+          });
+
+          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/LocalSubjectAccessReview.ts
@@ -98,13 +98,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview" },
               ],
           });
-
-          super(LocalSubjectAccessReview.__pulumiType, name, props, _opts);
+          super(LocalSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
@@ -97,6 +97,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name: name },
+              ],
+          });
+
+          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectAccessReview.ts
@@ -97,13 +97,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview" },
               ],
           });
-
-          super(SelfSubjectAccessReview.__pulumiType, name, props, _opts);
+          super(SelfSubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
@@ -102,13 +102,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview" },
               ],
           });
-
-          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
+          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SelfSubjectRulesReview.ts
@@ -102,6 +102,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SelfSubjectRulesReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name: name },
+              ],
+          });
+
+          super(SelfSubjectRulesReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name: name },
-                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name: name },
+                  { type: "kubernetes:authorization.k8s.io/v1:SubjectAccessReview" },
               ],
           });
-
-          super(SubjectAccessReview.__pulumiType, name, props, _opts);
+          super(SubjectAccessReview.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
+++ b/sdk/nodejs/authorization/v1beta1/SubjectAccessReview.ts
@@ -95,6 +95,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(SubjectAccessReview.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name: name },
+                  { parent: opts.parent, type: "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name: name },
+              ],
+          });
+
+          super(SubjectAccessReview.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
@@ -99,14 +99,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+                  { type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler" },
+                  { type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler" },
               ],
           });
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v1/HorizontalPodAutoscaler.ts
@@ -99,6 +99,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+              ],
+          });
+
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
@@ -101,14 +101,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+                  { type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler" },
+                  { type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler" },
               ],
           });
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/HorizontalPodAutoscaler.ts
@@ -101,6 +101,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+              ],
+          });
+
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
@@ -101,14 +101,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
-                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+                  { type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler" },
+                  { type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler" },
               ],
           });
-
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/HorizontalPodAutoscaler.ts
@@ -101,6 +101,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(HorizontalPodAutoscaler.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name: name },
+                  { parent: opts.parent, type: "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name: name },
+              ],
+          });
+
+          super(HorizontalPodAutoscaler.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJob.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJob.ts
@@ -100,13 +100,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:batch/v1beta1:CronJob", name: name },
-                  { parent: opts.parent, type: "kubernetes:batch/v2alpha1:CronJob", name: name },
+                  { type: "kubernetes:batch/v2alpha1:CronJob" },
               ],
           });
-
-          super(CronJob.__pulumiType, name, props, _opts);
+          super(CronJob.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/batch/v1beta1/CronJob.ts
+++ b/sdk/nodejs/batch/v1beta1/CronJob.ts
@@ -100,6 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CronJob.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:batch/v1beta1:CronJob", name: name },
+                  { parent: opts.parent, type: "kubernetes:batch/v2alpha1:CronJob", name: name },
+              ],
+          });
+
+          super(CronJob.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJob.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJob.ts
@@ -100,6 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CronJob.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:batch/v1beta1:CronJob", name: name },
+                  { parent: opts.parent, type: "kubernetes:batch/v2alpha1:CronJob", name: name },
+              ],
+          });
+
+          super(CronJob.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/batch/v2alpha1/CronJob.ts
+++ b/sdk/nodejs/batch/v2alpha1/CronJob.ts
@@ -100,13 +100,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:batch/v1beta1:CronJob", name: name },
-                  { parent: opts.parent, type: "kubernetes:batch/v2alpha1:CronJob", name: name },
+                  { type: "kubernetes:batch/v1beta1:CronJob" },
               ],
           });
-
-          super(CronJob.__pulumiType, name, props, _opts);
+          super(CronJob.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/Lease.ts
+++ b/sdk/nodejs/coordination/v1/Lease.ts
@@ -94,6 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Lease.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1:Lease", name: name },
+                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1beta1:Lease", name: name },
+              ],
+          });
+
+          super(Lease.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1/Lease.ts
+++ b/sdk/nodejs/coordination/v1/Lease.ts
@@ -94,13 +94,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1:Lease", name: name },
-                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1beta1:Lease", name: name },
+                  { type: "kubernetes:coordination.k8s.io/v1beta1:Lease" },
               ],
           });
-
-          super(Lease.__pulumiType, name, props, _opts);
+          super(Lease.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/Lease.ts
+++ b/sdk/nodejs/coordination/v1beta1/Lease.ts
@@ -94,6 +94,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Lease.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1:Lease", name: name },
+                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1beta1:Lease", name: name },
+              ],
+          });
+
+          super(Lease.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/coordination/v1beta1/Lease.ts
+++ b/sdk/nodejs/coordination/v1beta1/Lease.ts
@@ -94,13 +94,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1:Lease", name: name },
-                  { parent: opts.parent, type: "kubernetes:coordination.k8s.io/v1beta1:Lease", name: name },
+                  { type: "kubernetes:coordination.k8s.io/v1:Lease" },
               ],
           });
-
-          super(Lease.__pulumiType, name, props, _opts);
+          super(Lease.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Event.ts
+++ b/sdk/nodejs/core/v1/Event.ts
@@ -172,6 +172,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Event.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:core/v1:Event", name: name },
+                  { parent: opts.parent, type: "kubernetes:events.k8s.io/v1beta1:Event", name: name },
+              ],
+          });
+
+          super(Event.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/core/v1/Event.ts
+++ b/sdk/nodejs/core/v1/Event.ts
@@ -172,13 +172,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:core/v1:Event", name: name },
-                  { parent: opts.parent, type: "kubernetes:events.k8s.io/v1beta1:Event", name: name },
+                  { type: "kubernetes:events.k8s.io/v1beta1:Event" },
               ],
           });
-
-          super(Event.__pulumiType, name, props, _opts);
+          super(Event.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/core/v1/Secret.ts
+++ b/sdk/nodejs/core/v1/Secret.ts
@@ -121,13 +121,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               additionalSecretOutputs: [
                   "data",
                   "stringData",
               ],
           });
-
-          super(Secret.__pulumiType, name, props, _opts);
+          super(Secret.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/Event.ts
+++ b/sdk/nodejs/events/v1beta1/Event.ts
@@ -173,13 +173,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:core/v1:Event", name: name },
-                  { parent: opts.parent, type: "kubernetes:events.k8s.io/v1beta1:Event", name: name },
+                  { type: "kubernetes:core/v1:Event" },
               ],
           });
-
-          super(Event.__pulumiType, name, props, _opts);
+          super(Event.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/events/v1beta1/Event.ts
+++ b/sdk/nodejs/events/v1beta1/Event.ts
@@ -173,6 +173,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(Event.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:core/v1:Event", name: name },
+                  { parent: opts.parent, type: "kubernetes:events.k8s.io/v1beta1:Event", name: name },
+              ],
+          });
+
+          super(Event.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -104,14 +104,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:DaemonSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:DaemonSet", name: name },
+                  { type: "kubernetes:apps/v1:DaemonSet" },
+                  { type: "kubernetes:apps/v1beta2:DaemonSet" },
               ],
           });
-
-          super(DaemonSet.__pulumiType, name, props, _opts);
+          super(DaemonSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -122,15 +122,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta1:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:Deployment", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Deployment", name: name },
+                  { type: "kubernetes:apps/v1:Deployment" },
+                  { type: "kubernetes:apps/v1beta1:Deployment" },
+                  { type: "kubernetes:apps/v1beta2:Deployment" },
               ],
           });
-
-          super(Deployment.__pulumiType, name, props, _opts);
+          super(Deployment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -121,8 +121,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
               ],
           });
 

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -119,13 +119,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
+                  { type: "kubernetes:networking.k8s.io/v1beta1:Ingress" },
               ],
           });
-
-          super(Ingress.__pulumiType, name, props, _opts);
+          super(Ingress.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -97,8 +97,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
               ],
           });
 

--- a/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/NetworkPolicy.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
+                  { type: "kubernetes:networking.k8s.io/v1:NetworkPolicy" },
               ],
           });
-
-          super(NetworkPolicy.__pulumiType, name, props, _opts);
+          super(NetworkPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -95,13 +95,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
-                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
+                  { type: "kubernetes:policy/v1beta1:PodSecurityPolicy" },
               ],
           });
-
-          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/extensions/v1beta1/PodSecurityPolicy.ts
@@ -97,8 +97,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
               ],
           });
 

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -105,14 +105,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:apps/v1:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:apps/v1beta2:ReplicaSet", name: name },
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:ReplicaSet", name: name },
+                  { type: "kubernetes:apps/v1:ReplicaSet" },
+                  { type: "kubernetes:apps/v1beta2:ReplicaSet" },
               ],
           });
-
-          super(ReplicaSet.__pulumiType, name, props, _opts);
+          super(ReplicaSet.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -95,8 +95,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
               ],
           });
 

--- a/sdk/nodejs/networking/v1/NetworkPolicy.ts
+++ b/sdk/nodejs/networking/v1/NetworkPolicy.ts
@@ -93,13 +93,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:NetworkPolicy", name: name },
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1:NetworkPolicy", name: name },
+                  { type: "kubernetes:extensions/v1beta1:NetworkPolicy" },
               ],
           });
-
-          super(NetworkPolicy.__pulumiType, name, props, _opts);
+          super(NetworkPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -116,13 +116,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
+                  { type: "kubernetes:extensions/v1beta1:Ingress" },
               ],
           });
-
-          super(Ingress.__pulumiType, name, props, _opts);
+          super(Ingress.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/networking/v1beta1/Ingress.ts
+++ b/sdk/nodejs/networking/v1beta1/Ingress.ts
@@ -118,8 +118,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:Ingress", name: name },
+                  { parent: opts.parent, type: "kubernetes:networking.k8s.io/v1beta1:Ingress", name: name },
               ],
           });
 

--- a/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
@@ -99,6 +99,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(RuntimeClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1beta1:RuntimeClass", name: name },
+              ],
+          });
+
+          super(RuntimeClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1alpha1/RuntimeClass.ts
@@ -99,13 +99,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1beta1:RuntimeClass", name: name },
+                  { type: "kubernetes:node.k8s.io/v1beta1:RuntimeClass" },
               ],
           });
-
-          super(RuntimeClass.__pulumiType, name, props, _opts);
+          super(RuntimeClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClass.ts
@@ -122,6 +122,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(RuntimeClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1beta1:RuntimeClass", name: name },
+              ],
+          });
+
+          super(RuntimeClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/node/v1beta1/RuntimeClass.ts
+++ b/sdk/nodejs/node/v1beta1/RuntimeClass.ts
@@ -122,13 +122,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:node.k8s.io/v1beta1:RuntimeClass", name: name },
+                  { type: "kubernetes:node.k8s.io/v1alpha1:RuntimeClass" },
               ],
           });
-
-          super(RuntimeClass.__pulumiType, name, props, _opts);
+          super(RuntimeClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -94,13 +94,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
-                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
+                  { type: "kubernetes:extensions/v1beta1:PodSecurityPolicy" },
               ],
           });
-
-          super(PodSecurityPolicy.__pulumiType, name, props, _opts);
+          super(PodSecurityPolicy.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
+++ b/sdk/nodejs/policy/v1beta1/PodSecurityPolicy.ts
@@ -96,8 +96,8 @@ import { getVersion } from "../../version";
 
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
                   { parent: opts.parent, type: "kubernetes:extensions/v1beta1:PodSecurityPolicy", name: name },
+                  { parent: opts.parent, type: "kubernetes:policy/v1beta1:PodSecurityPolicy", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -104,8 +104,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRole.ts
@@ -101,14 +101,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole" },
               ],
           });
-
-          super(ClusterRole.__pulumiType, name, props, _opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -100,14 +100,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding" },
               ],
           });
-
-          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/ClusterRoleBinding.ts
@@ -103,8 +103,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -93,14 +93,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role" },
               ],
           });
-
-          super(Role.__pulumiType, name, props, _opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1/Role.ts
+++ b/sdk/nodejs/rbac/v1/Role.ts
@@ -96,8 +96,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -105,8 +105,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1/RoleBinding.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding" },
               ],
           });
-
-          super(RoleBinding.__pulumiType, name, props, _opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole" },
               ],
           });
-
-          super(ClusterRole.__pulumiType, name, props, _opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRole.ts
@@ -105,8 +105,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding" },
               ],
           });
-
-          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/ClusterRoleBinding.ts
@@ -105,8 +105,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -94,14 +94,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:Role" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role" },
               ],
           });
-
-          super(Role.__pulumiType, name, props, _opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/Role.ts
+++ b/sdk/nodejs/rbac/v1alpha1/Role.ts
@@ -97,8 +97,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -103,14 +103,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding" },
               ],
           });
-
-          super(RoleBinding.__pulumiType, name, props, _opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1alpha1/RoleBinding.ts
@@ -106,8 +106,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole" },
               ],
           });
-
-          super(ClusterRole.__pulumiType, name, props, _opts);
+          super(ClusterRole.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRole.ts
@@ -105,8 +105,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -102,14 +102,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding" },
               ],
           });
-
-          super(ClusterRoleBinding.__pulumiType, name, props, _opts);
+          super(ClusterRoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/ClusterRoleBinding.ts
@@ -105,8 +105,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -94,14 +94,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:Role" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role" },
               ],
           });
-
-          super(Role.__pulumiType, name, props, _opts);
+          super(Role.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/Role.ts
+++ b/sdk/nodejs/rbac/v1beta1/Role.ts
@@ -97,8 +97,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:Role", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name: name },
               ],
           });
 

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -103,14 +103,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding" },
+                  { type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding" },
               ],
           });
-
-          super(RoleBinding.__pulumiType, name, props, _opts);
+          super(RoleBinding.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
+++ b/sdk/nodejs/rbac/v1beta1/RoleBinding.ts
@@ -106,8 +106,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name: name },
-                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
                   { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name: name },
+                  { parent: opts.parent, type: "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -123,8 +123,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1/PriorityClass.ts
@@ -120,14 +120,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass" },
+                  { type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass" },
               ],
           });
-
-          super(PriorityClass.__pulumiType, name, props, _opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -124,8 +124,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/PriorityClass.ts
@@ -121,14 +121,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { type: "kubernetes:scheduling.k8s.io/v1:PriorityClass" },
+                  { type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass" },
               ],
           });
-
-          super(PriorityClass.__pulumiType, name, props, _opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -121,14 +121,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
+                  { type: "kubernetes:scheduling.k8s.io/v1:PriorityClass" },
+                  { type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass" },
               ],
           });
-
-          super(PriorityClass.__pulumiType, name, props, _opts);
+          super(PriorityClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
+++ b/sdk/nodejs/scheduling/v1beta1/PriorityClass.ts
@@ -124,8 +124,8 @@ import { getVersion } from "../../version";
           const _opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1:PriorityClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
                   { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name: name },
               ],
           });
 

--- a/sdk/nodejs/storage/v1/CSINode.ts
+++ b/sdk/nodejs/storage/v1/CSINode.ts
@@ -98,6 +98,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CSINode.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:CSINode", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:CSINode", name: name },
+              ],
+          });
+
+          super(CSINode.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/CSINode.ts
+++ b/sdk/nodejs/storage/v1/CSINode.ts
@@ -98,13 +98,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:CSINode", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:CSINode", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1beta1:CSINode" },
               ],
           });
-
-          super(CSINode.__pulumiType, name, props, _opts);
+          super(CSINode.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1/StorageClass.ts
@@ -142,6 +142,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(StorageClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:StorageClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:StorageClass", name: name },
+              ],
+          });
+
+          super(StorageClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1/StorageClass.ts
@@ -142,13 +142,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:StorageClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:StorageClass", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1beta1:StorageClass" },
               ],
           });
-
-          super(StorageClass.__pulumiType, name, props, _opts);
+          super(StorageClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachment.ts
@@ -103,6 +103,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+              ],
+          });
+
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1/VolumeAttachment.ts
@@ -103,14 +103,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment" },
+                  { type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment" },
               ],
           });
-
-          super(VolumeAttachment.__pulumiType, name, props, _opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
@@ -103,6 +103,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+              ],
+          });
+
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1alpha1/VolumeAttachment.ts
@@ -103,14 +103,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1:VolumeAttachment" },
+                  { type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment" },
               ],
           });
-
-          super(VolumeAttachment.__pulumiType, name, props, _opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -100,6 +100,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(CSINode.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:CSINode", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:CSINode", name: name },
+              ],
+          });
+
+          super(CSINode.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -100,13 +100,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:CSINode", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:CSINode", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1:CSINode" },
               ],
           });
-
-          super(CSINode.__pulumiType, name, props, _opts);
+          super(CSINode.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClass.ts
@@ -142,6 +142,13 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(StorageClass.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:StorageClass", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:StorageClass", name: name },
+              ],
+          });
+
+          super(StorageClass.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/StorageClass.ts
+++ b/sdk/nodejs/storage/v1beta1/StorageClass.ts
@@ -142,13 +142,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:StorageClass", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:StorageClass", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1:StorageClass" },
               ],
           });
-
-          super(StorageClass.__pulumiType, name, props, _opts);
+          super(StorageClass.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
@@ -103,6 +103,14 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          super(VolumeAttachment.__pulumiType, name, props, opts);
+          const _opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
+                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+              ],
+          });
+
+          super(VolumeAttachment.__pulumiType, name, props, _opts);
       }
     }

--- a/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
+++ b/sdk/nodejs/storage/v1beta1/VolumeAttachment.ts
@@ -103,14 +103,12 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
-          const _opts = pulumi.mergeOptions(opts, {
+          opts = pulumi.mergeOptions(opts, {
               aliases: [
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name: name },
-                  { parent: opts.parent, type: "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name: name },
+                  { type: "kubernetes:storage.k8s.io/v1:VolumeAttachment" },
+                  { type: "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment" },
               ],
           });
-
-          super(VolumeAttachment.__pulumiType, name, props, _opts);
+          super(VolumeAttachment.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
@@ -76,8 +76,7 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(type_="kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
@@ -74,8 +74,14 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(MutatingWebhookConfiguration, self).__init__(

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
@@ -74,8 +74,14 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ValidatingWebhookConfiguration, self).__init__(

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
@@ -76,8 +76,7 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(type_="kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
@@ -77,8 +77,7 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(type_="kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
@@ -75,8 +75,14 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(MutatingWebhookConfiguration, self).__init__(

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
@@ -77,8 +77,7 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(type_="kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
@@ -75,8 +75,14 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ValidatingWebhookConfiguration, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
@@ -77,8 +77,14 @@ class CustomResourceDefinition(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CustomResourceDefinition, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
@@ -79,8 +79,7 @@ class CustomResourceDefinition(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
@@ -80,8 +80,7 @@ class CustomResourceDefinition(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
@@ -78,8 +78,14 @@ class CustomResourceDefinition(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CustomResourceDefinition, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
@@ -76,8 +76,7 @@ class APIService(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1:APIService", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
@@ -74,8 +74,14 @@ class APIService(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1:APIService", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(APIService, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
@@ -76,8 +76,7 @@ class APIService(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1:APIService", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apiregistration.k8s.io/v1:APIService"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
@@ -74,8 +74,14 @@ class APIService(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1:APIService", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(APIService, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
@@ -91,9 +91,8 @@ class ControllerRevision(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:ControllerRevision"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:ControllerRevision"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
@@ -89,8 +89,15 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ControllerRevision, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
@@ -84,9 +84,8 @@ class DaemonSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:DaemonSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:DaemonSet"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:DaemonSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
@@ -100,10 +100,9 @@ class Deployment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Deployment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:Deployment"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:Deployment"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:Deployment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
@@ -86,9 +86,8 @@ class ReplicaSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:ReplicaSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:ReplicaSet"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:ReplicaSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -97,7 +97,6 @@ class StatefulSet(pulumi.CustomResource):
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:StatefulSet", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -94,9 +94,8 @@ class StatefulSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:StatefulSet"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:StatefulSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -94,9 +94,8 @@ class ControllerRevision(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:ControllerRevision"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:ControllerRevision"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -92,8 +92,15 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ControllerRevision, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -103,10 +103,9 @@ class Deployment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Deployment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:Deployment"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:Deployment"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:Deployment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -97,9 +97,8 @@ class StatefulSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:StatefulSet"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:StatefulSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -100,7 +100,6 @@ class StatefulSet(pulumi.CustomResource):
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:StatefulSet", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -94,9 +94,8 @@ class ControllerRevision(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:ControllerRevision"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:ControllerRevision"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -92,8 +92,15 @@ class ControllerRevision(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:ControllerRevision", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ControllerRevision", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(ControllerRevision, self).__init__(

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
@@ -87,9 +87,8 @@ class DaemonSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:DaemonSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:DaemonSet"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:DaemonSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -103,10 +103,9 @@ class Deployment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Deployment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:Deployment"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:Deployment"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:Deployment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
@@ -89,9 +89,8 @@ class ReplicaSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:ReplicaSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:ReplicaSet"),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:ReplicaSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -97,9 +97,8 @@ class StatefulSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:StatefulSet"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:StatefulSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -100,7 +100,6 @@ class StatefulSet(pulumi.CustomResource):
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:StatefulSet", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:StatefulSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:StatefulSet", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
@@ -77,8 +77,14 @@ class TokenReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1:TokenReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1beta1:TokenReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(TokenReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenReview.py
@@ -79,8 +79,7 @@ class TokenReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1:TokenReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1beta1:TokenReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authentication.k8s.io/v1beta1:TokenReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
@@ -77,8 +77,14 @@ class TokenReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1:TokenReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1beta1:TokenReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(TokenReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReview.py
@@ -79,8 +79,7 @@ class TokenReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1:TokenReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authentication.k8s.io/v1beta1:TokenReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authentication.k8s.io/v1:TokenReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
@@ -80,8 +80,14 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(LocalSubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReview.py
@@ -82,8 +82,7 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
@@ -79,8 +79,14 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SelfSubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReview.py
@@ -81,8 +81,7 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
@@ -85,8 +85,7 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReview.py
@@ -83,8 +83,14 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SelfSubjectRulesReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
@@ -78,8 +78,7 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReview.py
@@ -76,8 +76,14 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
@@ -80,8 +80,14 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(LocalSubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReview.py
@@ -82,8 +82,7 @@ class LocalSubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
@@ -79,8 +79,14 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SelfSubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReview.py
@@ -81,8 +81,7 @@ class SelfSubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
@@ -83,8 +83,14 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SelfSubjectRulesReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReview.py
@@ -85,8 +85,7 @@ class SelfSubjectRulesReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
@@ -78,8 +78,7 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name=resource_name),
+            pulumi.Alias(type_="kubernetes:authorization.k8s.io/v1:SubjectAccessReview"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReview.py
@@ -76,8 +76,14 @@ class SubjectAccessReview(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(SubjectAccessReview, self).__init__(

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
@@ -80,8 +80,15 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(HorizontalPodAutoscaler, self).__init__(

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
@@ -82,9 +82,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler"),
+            pulumi.Alias(type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
@@ -84,9 +84,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler"),
+            pulumi.Alias(type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
@@ -82,8 +82,15 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(HorizontalPodAutoscaler, self).__init__(

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
@@ -82,8 +82,15 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(HorizontalPodAutoscaler, self).__init__(

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
@@ -84,9 +84,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name=resource_name),
+            pulumi.Alias(type_="kubernetes:autoscaling/v1:HorizontalPodAutoscaler"),
+            pulumi.Alias(type_="kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
@@ -82,8 +82,14 @@ class CronJob(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:batch/v1beta1:CronJob", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:batch/v2alpha1:CronJob", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CronJob, self).__init__(

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
@@ -84,8 +84,7 @@ class CronJob(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:batch/v1beta1:CronJob", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:batch/v2alpha1:CronJob", name=resource_name),
+            pulumi.Alias(type_="kubernetes:batch/v2alpha1:CronJob"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
@@ -82,8 +82,14 @@ class CronJob(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:batch/v1beta1:CronJob", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:batch/v2alpha1:CronJob", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CronJob, self).__init__(

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
@@ -84,8 +84,7 @@ class CronJob(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:batch/v1beta1:CronJob", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:batch/v2alpha1:CronJob", name=resource_name),
+            pulumi.Alias(type_="kubernetes:batch/v1beta1:CronJob"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
@@ -75,8 +75,14 @@ class Lease(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1:Lease", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1beta1:Lease", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Lease, self).__init__(

--- a/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
@@ -77,8 +77,7 @@ class Lease(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1:Lease", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1beta1:Lease", name=resource_name),
+            pulumi.Alias(type_="kubernetes:coordination.k8s.io/v1beta1:Lease"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
@@ -75,8 +75,14 @@ class Lease(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1:Lease", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1beta1:Lease", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Lease, self).__init__(

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
@@ -77,8 +77,7 @@ class Lease(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1:Lease", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:coordination.k8s.io/v1beta1:Lease", name=resource_name),
+            pulumi.Alias(type_="kubernetes:coordination.k8s.io/v1:Lease"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/core/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Event.py
@@ -171,8 +171,14 @@ class Event(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:core/v1:Event", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:events.k8s.io/v1beta1:Event", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Event, self).__init__(

--- a/sdk/python/pulumi_kubernetes/core/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Event.py
@@ -173,8 +173,7 @@ class Event(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:core/v1:Event", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:events.k8s.io/v1beta1:Event", name=resource_name),
+            pulumi.Alias(type_="kubernetes:events.k8s.io/v1beta1:Event"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
@@ -174,8 +174,7 @@ class Event(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:core/v1:Event", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:events.k8s.io/v1beta1:Event", name=resource_name),
+            pulumi.Alias(type_="kubernetes:core/v1:Event"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
@@ -172,8 +172,14 @@ class Event(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:core/v1:Event", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:events.k8s.io/v1beta1:Event", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(Event, self).__init__(

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
@@ -87,9 +87,8 @@ class DaemonSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:DaemonSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:DaemonSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:DaemonSet"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:DaemonSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -103,10 +103,9 @@ class Deployment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta1:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:Deployment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Deployment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:Deployment"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta1:Deployment"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:Deployment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -102,8 +102,7 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(type_="kubernetes:networking.k8s.io/v1beta1:Ingress"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -102,8 +102,8 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -77,8 +77,8 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -77,8 +77,7 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(type_="kubernetes:networking.k8s.io/v1:NetworkPolicy"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
@@ -77,8 +77,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
@@ -77,8 +77,7 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(type_="kubernetes:policy/v1beta1:PodSecurityPolicy"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
@@ -89,9 +89,8 @@ class ReplicaSet(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:apps/v1beta2:ReplicaSet", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:ReplicaSet", name=resource_name),
+            pulumi.Alias(type_="kubernetes:apps/v1:ReplicaSet"),
+            pulumi.Alias(type_="kubernetes:apps/v1beta2:ReplicaSet"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -75,8 +75,7 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:NetworkPolicy"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -75,8 +75,8 @@ class NetworkPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:NetworkPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1:NetworkPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -99,8 +99,8 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -99,8 +99,7 @@ class Ingress(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:Ingress", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:networking.k8s.io/v1beta1:Ingress", name=resource_name),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:Ingress"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
@@ -81,8 +81,14 @@ class RuntimeClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1beta1:RuntimeClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(RuntimeClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
@@ -83,8 +83,7 @@ class RuntimeClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1beta1:RuntimeClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:node.k8s.io/v1beta1:RuntimeClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
@@ -115,8 +115,14 @@ class RuntimeClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1beta1:RuntimeClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(RuntimeClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
@@ -117,8 +117,7 @@ class RuntimeClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:node.k8s.io/v1beta1:RuntimeClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:node.k8s.io/v1alpha1:RuntimeClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
@@ -76,8 +76,7 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(type_="kubernetes:extensions/v1beta1:PodSecurityPolicy"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
@@ -76,8 +76,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:extensions/v1beta1:PodSecurityPolicy", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:policy/v1beta1:PodSecurityPolicy", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -85,9 +85,8 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -86,8 +86,8 @@ class ClusterRole(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -86,8 +86,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -85,9 +85,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -74,9 +74,8 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -75,8 +75,8 @@ class Role(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -87,9 +87,8 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -88,8 +88,8 @@ class RoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -87,8 +87,8 @@ class ClusterRole(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -86,9 +86,8 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -87,8 +87,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -86,9 +86,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -76,8 +76,8 @@ class Role(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -75,9 +75,8 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:Role"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -88,9 +88,8 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -89,8 +89,8 @@ class RoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -87,8 +87,8 @@ class ClusterRole(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -86,9 +86,8 @@ class ClusterRole(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRole"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -87,8 +87,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -86,9 +86,8 @@ class ClusterRoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -76,8 +76,8 @@ class Role(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -75,9 +75,8 @@ class Role(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:Role"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:Role"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -89,8 +89,8 @@ class RoleBinding(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -88,9 +88,8 @@ class RoleBinding(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name=resource_name),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1:RoleBinding"),
+            pulumi.Alias(type_="kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -117,8 +117,8 @@ class PriorityClass(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -116,9 +116,8 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass"),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -117,9 +117,8 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1:PriorityClass"),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -118,8 +118,8 @@ class PriorityClass(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -118,8 +118,8 @@ class PriorityClass(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
             pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -117,9 +117,8 @@ class PriorityClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1:PriorityClass"),
+            pulumi.Alias(type_="kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
@@ -79,8 +79,14 @@ class CSINode(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:CSINode", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:CSINode", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CSINode, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
@@ -81,8 +81,7 @@ class CSINode(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:CSINode", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:CSINode", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1beta1:CSINode"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
@@ -139,8 +139,14 @@ class StorageClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:StorageClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:StorageClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(StorageClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
@@ -141,8 +141,7 @@ class StorageClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:StorageClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:StorageClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1beta1:StorageClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
@@ -85,8 +85,15 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(VolumeAttachment, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
@@ -87,9 +87,8 @@ class VolumeAttachment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment"),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
@@ -87,9 +87,8 @@ class VolumeAttachment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1:VolumeAttachment"),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
@@ -85,8 +85,15 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(VolumeAttachment, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -83,8 +83,7 @@ class CSINode(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:CSINode", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:CSINode", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1:CSINode"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -81,8 +81,14 @@ class CSINode(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:CSINode", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:CSINode", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(CSINode, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
@@ -139,8 +139,14 @@ class StorageClass(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:StorageClass", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:StorageClass", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(StorageClass, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
@@ -141,8 +141,7 @@ class StorageClass(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:StorageClass", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:StorageClass", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1:StorageClass"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
@@ -85,8 +85,15 @@ class VolumeAttachment(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(VolumeAttachment, self).__init__(

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
@@ -87,9 +87,8 @@ class VolumeAttachment(pulumi.CustomResource):
 
         parent = opts.parent if opts and opts.parent else None
         aliases = [
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name=resource_name),
-            pulumi.Alias(parent=parent, type_="kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name=resource_name),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1:VolumeAttachment"),
+            pulumi.Alias(type_="kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Rather than manually curating resource aliases, auto-generate
the aliases from the OpenAPI spec.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #828 