### PR TITLE
Fix panic condition in Pod await logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   Fix aliases for several resource kinds. (https://github.com/pulumi/pulumi-kubernetes/pull/990).
 -   Fix .NET resources with empty arguments. (https://github.com/pulumi/pulumi-kubernetes/pull/983).
+-   Fix panic condition in Pod await logic. (https://github.com/pulumi/pulumi-kubernetes/pull/998).
 
 ## 1.5.3 (February 11, 2020)
 

--- a/pkg/await/pod.go
+++ b/pkg/await/pod.go
@@ -197,6 +197,10 @@ func (pia *podInitAwaiter) Read() error {
 }
 
 func (pia *podInitAwaiter) processPodEvent(event watch.Event) {
+	if event.Object == nil {
+		glog.V(3).Infof("received event with nil Object: %#v", event)
+		return
+	}
 	pod, err := clients.PodFromUnstructured(event.Object.(*unstructured.Unstructured))
 	if err != nil {
 		glog.V(3).Infof("Failed to unmarshal Pod event: %v", err)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
For events received by the Pod awaiter, explicitly check that
the event has a non-nil Object to avoid a possible panic.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #994 