### PR TITLE
Custom resource options for provider

### DIFF
--- a/pkg/gen/dotnet-templates/Provider.cs
+++ b/pkg/gen/dotnet-templates/Provider.cs
@@ -14,18 +14,18 @@ namespace Pulumi.Kubernetes
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="args">The arguments used to populate this resource's properties.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
-        public Provider(string name, ProviderArgs? args = null, ResourceOptions? options = null)
-            : base("kubernetes", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, ""))
+        public Provider(string name, ProviderArgs? args = null, CustomResourceOptions? options = null)
+            : base("kubernetes", name, args ?? CustomResourceArgs.Empty, MakeResourceOptions(options, ""))
         {
         }
 
-        private static ResourceOptions MakeResourceOptions(ResourceOptions? options, Input<string>? id)
+        private static CustomResourceOptions MakeResourceOptions(CustomResourceOptions? options, Input<string>? id)
         {
-            var defaultOptions = new ResourceOptions
+            var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
             };
-            var merged = ResourceOptions.Merge(defaultOptions, options);
+            var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
             merged.Id = id ?? merged.Id;
             return merged;

--- a/pkg/gen/dotnet-templates/Provider.cs
+++ b/pkg/gen/dotnet-templates/Provider.cs
@@ -15,7 +15,7 @@ namespace Pulumi.Kubernetes
         /// <param name="args">The arguments used to populate this resource's properties.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         public Provider(string name, ProviderArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes", name, args ?? CustomResourceArgs.Empty, MakeResourceOptions(options, ""))
+            : base("kubernetes", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, ""))
         {
         }
 

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -14,18 +14,18 @@ namespace Pulumi.Kubernetes
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="args">The arguments used to populate this resource's properties.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
-        public Provider(string name, ProviderArgs? args = null, ResourceOptions? options = null)
+        public Provider(string name, ProviderArgs? args = null, CustomResourceOptions? options = null)
             : base("kubernetes", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, ""))
         {
         }
 
-        private static ResourceOptions MakeResourceOptions(ResourceOptions? options, Input<string>? id)
+        private static CustomResourceOptions MakeResourceOptions(CustomResourceOptions? options, Input<string>? id)
         {
-            var defaultOptions = new ResourceOptions
+            var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
             };
-            var merged = ResourceOptions.Merge(defaultOptions, options);
+            var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
             merged.Id = id ?? merged.Id;
             return merged;


### PR DESCRIPTION
`ResourceOptions` becomes an abstract class in pulumi/pulumi#3857.
Pass `CustomResourceOptions` to the provider.