### PR TITLE
Display appropriate error when pulumi plugin install fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug fixes
+
+-   Display error when pulumi plugin install fails. (https://github.com/pulumi/pulumi-kubernetes/pull/1010).
+
 ## 1.5.5 (February 25, 2020)
 
 ### Bug fixes

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,13 +1,26 @@
+import errno
+
 from subprocess import check_call
 
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
-        check_call(['pulumi', 'plugin', 'install', 'resource', 'kubernetes', '${PLUGIN_VERSION}'])
+        try:
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'kubernetes', '${PLUGIN_VERSION}'])
+        except OSError as error:
+            if error.errno == errno.ENOENT:
+                print("""
+                There was an error installing the kubernetes resource provider plugin.
+                It looks like `pulumi` is not installed on your system.
+                Please visit https://pulumi.com/ to install the Pulumi CLI.
+                You may try manually installing the plugin by running
+                `pulumi plugin install resource kubernetes ${PLUGIN_VERSION}`
+                """)
+            else:
+                raise
 
 
 def readme():


### PR DESCRIPTION
Fixes: #1009

This ensures we don't error but instead display an appropriate
error message to ensure that Pulumi is available on the users system


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->