### PR TITLE
Change URN for apiregistration resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+-   Change URN for apiregistration resources. (https://github.com/pulumi/pulumi-kubernetes/pull/1021).
 -   Replace PersistentVolume if volume source changes. (https://github.com/pulumi/pulumi-kubernetes/pull/1015).
 -   Fix bool Python provider opts. (https://github.com/pulumi/pulumi-kubernetes/pull/1027).
 

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -992,15 +992,16 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []Grou
 
 			// "apiregistration.k8s.io" was previously called "apiregistration", so create aliases for backward compat
 			if strings.Contains(fqGroupVersion, "apiregistration.k8s.io") {
-				results = append(results,
-					strings.Replace(aliasString, "apiregistration.k8s.io", "apiregistration", -1))
+				parts := strings.Split(aliasString, ":")
+				parts[1] = "apiregistration" + strings.TrimPrefix(parts[1], "apiregistration.k8s.io")
+				results = append(results, strings.Join(parts, ":"))
 			}
 		}
 
 		// "apiregistration.k8s.io" was previously called "apiregistration", so create aliases for backward compat
 		if strings.Contains(fqGroupVersion, "apiregistration.k8s.io") {
-			apiVersion := strings.Replace(fqGroupVersion, "apiregistration.k8s.io", "apiregistration", -1)
-			results = append(results, fmt.Sprintf("kubernetes:%s:%s", apiVersion, kind))
+			results = append(results, fmt.Sprintf("kubernetes:%s:%s",
+				"apiregistration"+strings.TrimPrefix(fqGroupVersion, "apiregistration.k8s.io"), kind))
 		}
 
 		return results

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -211,8 +211,7 @@ func (kc KindConfig) APIVersion() string { return kc.apiVersion }
 // DefaultAPIVersion returns the default apiVersion (e.g., `v1` rather than `core/v1`).
 func (kc KindConfig) DefaultAPIVersion() string { return kc.defaultAPIVersion }
 
-// URNAPIVersion returns API version that can be used in a URN (e.g., using the backwards-compatible
-// alias `apiextensions` instead of `apiextensions.k8s.io`).
+// URNAPIVersion returns API version that can be used in a URN.
 func (kc KindConfig) URNAPIVersion() string { return kc.apiVersion }
 
 // TypeGuard returns the text of a TypeScript type guard for the given kind.

--- a/pkg/gen/typegen.go
+++ b/pkg/gen/typegen.go
@@ -213,12 +213,7 @@ func (kc KindConfig) DefaultAPIVersion() string { return kc.defaultAPIVersion }
 
 // URNAPIVersion returns API version that can be used in a URN (e.g., using the backwards-compatible
 // alias `apiextensions` instead of `apiextensions.k8s.io`).
-func (kc KindConfig) URNAPIVersion() string {
-	if strings.HasPrefix(kc.apiVersion, apiRegistration) {
-		return "apiregistration" + strings.TrimPrefix(kc.apiVersion, apiRegistration)
-	}
-	return kc.apiVersion
-}
+func (kc KindConfig) URNAPIVersion() string { return kc.apiVersion }
 
 // TypeGuard returns the text of a TypeScript type guard for the given kind.
 func (kc KindConfig) TypeGuard() string { return kc.typeGuard }
@@ -995,7 +990,20 @@ func createGroups(definitionsJSON map[string]interface{}, opts groupOpts) []Grou
 				continue
 			}
 			results = append(results, aliasString)
+
+			// "apiregistration.k8s.io" was previously called "apiregistration", so create aliases for backward compat
+			if strings.Contains(fqGroupVersion, "apiregistration.k8s.io") {
+				results = append(results,
+					strings.Replace(aliasString, "apiregistration.k8s.io", "apiregistration", -1))
+			}
 		}
+
+		// "apiregistration.k8s.io" was previously called "apiregistration", so create aliases for backward compat
+		if strings.Contains(fqGroupVersion, "apiregistration.k8s.io") {
+			apiVersion := strings.Replace(fqGroupVersion, "apiregistration.k8s.io", "apiregistration", -1)
+			results = append(results, fmt.Sprintf("kubernetes:%s:%s", apiVersion, kind))
+		}
+
 		return results
 	}
 

--- a/sdk/dotnet/ApiRegistration/V1/APIService.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIService.cs
@@ -54,12 +54,12 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIService(string name, Types.Inputs.ApiRegistration.V1.APIServiceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
+            : base("kubernetes:apiregistration.k8s.io/v1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
         internal APIService(string name, ImmutableDictionary<string, object?> dictionary, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIService", name, dictionary, options)
+            : base("kubernetes:apiregistration.k8s.io/v1:APIService", name, dictionary, options)
         {
         }
 
@@ -78,6 +78,8 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
                 Aliases =
                 {
                     new Alias { Type = "kubernetes:apiregistration.k8s.io/v1beta1:APIService" },
+                    new Alias { Type = "kubernetes:apiregistration/v1beta1:APIService" },
+                    new Alias { Type = "kubernetes:apiregistration/v1:APIService" },
                 }
             };
 

--- a/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
@@ -46,12 +46,12 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIServiceList(string name, Types.Inputs.ApiRegistration.V1.APIServiceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
+            : base("kubernetes:apiregistration.k8s.io/v1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
         internal APIServiceList(string name, ImmutableDictionary<string, object?> dictionary, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIServiceList", name, dictionary, options)
+            : base("kubernetes:apiregistration.k8s.io/v1:APIServiceList", name, dictionary, options)
         {
         }
 
@@ -65,7 +65,15 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
 
         private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
         {
-            return options;
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiregistration/v1:APIServiceList" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
         }
 
         /// <summary>

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIService.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIService.cs
@@ -54,12 +54,12 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIService(string name, Types.Inputs.ApiRegistration.V1Beta1.APIServiceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
+            : base("kubernetes:apiregistration.k8s.io/v1beta1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
         internal APIService(string name, ImmutableDictionary<string, object?> dictionary, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIService", name, dictionary, options)
+            : base("kubernetes:apiregistration.k8s.io/v1beta1:APIService", name, dictionary, options)
         {
         }
 
@@ -78,6 +78,8 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
                 Aliases =
                 {
                     new Alias { Type = "kubernetes:apiregistration.k8s.io/v1:APIService" },
+                    new Alias { Type = "kubernetes:apiregistration/v1:APIService" },
+                    new Alias { Type = "kubernetes:apiregistration/v1beta1:APIService" },
                 }
             };
 

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
@@ -46,12 +46,12 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIServiceList(string name, Types.Inputs.ApiRegistration.V1Beta1.APIServiceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
+            : base("kubernetes:apiregistration.k8s.io/v1beta1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
         internal APIServiceList(string name, ImmutableDictionary<string, object?> dictionary, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIServiceList", name, dictionary, options)
+            : base("kubernetes:apiregistration.k8s.io/v1beta1:APIServiceList", name, dictionary, options)
         {
         }
 
@@ -65,7 +65,15 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
 
         private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
         {
-            return options;
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiregistration/v1beta1:APIServiceList" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
         }
 
         /// <summary>

--- a/sdk/nodejs/apiregistration/v1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1/APIService.ts
@@ -56,7 +56,7 @@ import { getVersion } from "../../version";
       }
 
       /** @internal */
-      private static readonly __pulumiType = "kubernetes:apiregistration/v1:APIService";
+      private static readonly __pulumiType = "kubernetes:apiregistration.k8s.io/v1:APIService";
 
       /**
        * Returns true if the given object is an instance of APIService.  This is designed to work even
@@ -98,6 +98,8 @@ import { getVersion } from "../../version";
           opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { type: "kubernetes:apiregistration.k8s.io/v1beta1:APIService" },
+                  { type: "kubernetes:apiregistration/v1beta1:APIService" },
+                  { type: "kubernetes:apiregistration/v1:APIService" },
               ],
           });
           super(APIService.__pulumiType, name, props, opts);

--- a/sdk/nodejs/apiregistration/v1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1/APIServiceList.ts
@@ -49,7 +49,7 @@ import { getVersion } from "../../version";
       }
 
       /** @internal */
-      private static readonly __pulumiType = "kubernetes:apiregistration/v1:APIServiceList";
+      private static readonly __pulumiType = "kubernetes:apiregistration.k8s.io/v1:APIServiceList";
 
       /**
        * Returns true if the given object is an instance of APIServiceList.  This is designed to work even
@@ -88,6 +88,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
+          opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { type: "kubernetes:apiregistration/v1:APIServiceList" },
+              ],
+          });
           super(APIServiceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/nodejs/apiregistration/v1beta1/APIService.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIService.ts
@@ -56,7 +56,7 @@ import { getVersion } from "../../version";
       }
 
       /** @internal */
-      private static readonly __pulumiType = "kubernetes:apiregistration/v1beta1:APIService";
+      private static readonly __pulumiType = "kubernetes:apiregistration.k8s.io/v1beta1:APIService";
 
       /**
        * Returns true if the given object is an instance of APIService.  This is designed to work even
@@ -98,6 +98,8 @@ import { getVersion } from "../../version";
           opts = pulumi.mergeOptions(opts, {
               aliases: [
                   { type: "kubernetes:apiregistration.k8s.io/v1:APIService" },
+                  { type: "kubernetes:apiregistration/v1:APIService" },
+                  { type: "kubernetes:apiregistration/v1beta1:APIService" },
               ],
           });
           super(APIService.__pulumiType, name, props, opts);

--- a/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/APIServiceList.ts
@@ -49,7 +49,7 @@ import { getVersion } from "../../version";
       }
 
       /** @internal */
-      private static readonly __pulumiType = "kubernetes:apiregistration/v1beta1:APIServiceList";
+      private static readonly __pulumiType = "kubernetes:apiregistration.k8s.io/v1beta1:APIServiceList";
 
       /**
        * Returns true if the given object is an instance of APIServiceList.  This is designed to work even
@@ -88,6 +88,11 @@ import { getVersion } from "../../version";
               opts.version = getVersion();
           }
 
+          opts = pulumi.mergeOptions(opts, {
+              aliases: [
+                  { type: "kubernetes:apiregistration/v1beta1:APIServiceList" },
+              ],
+          });
           super(APIServiceList.__pulumiType, name, props, opts);
       }
     }

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
@@ -77,6 +77,8 @@ class APIService(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(type_="kubernetes:apiregistration.k8s.io/v1beta1:APIService"),
+            pulumi.Alias(type_="kubernetes:apiregistration/v1beta1:APIService"),
+            pulumi.Alias(type_="kubernetes:apiregistration/v1:APIService"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
@@ -84,7 +86,7 @@ class APIService(pulumi.CustomResource):
         ))
 
         super(APIService, self).__init__(
-            "kubernetes:apiregistration/v1:APIService",
+            "kubernetes:apiregistration.k8s.io/v1:APIService",
             resource_name,
             __props__,
             opts)

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
@@ -69,12 +69,17 @@ class APIServiceList(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(type_="kubernetes:apiregistration/v1:APIServiceList"),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(APIServiceList, self).__init__(
-            "kubernetes:apiregistration/v1:APIServiceList",
+            "kubernetes:apiregistration.k8s.io/v1:APIServiceList",
             resource_name,
             __props__,
             opts)

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
@@ -77,6 +77,8 @@ class APIService(pulumi.CustomResource):
         parent = opts.parent if opts and opts.parent else None
         aliases = [
             pulumi.Alias(type_="kubernetes:apiregistration.k8s.io/v1:APIService"),
+            pulumi.Alias(type_="kubernetes:apiregistration/v1:APIService"),
+            pulumi.Alias(type_="kubernetes:apiregistration/v1beta1:APIService"),
         ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
@@ -84,7 +86,7 @@ class APIService(pulumi.CustomResource):
         ))
 
         super(APIService, self).__init__(
-            "kubernetes:apiregistration/v1beta1:APIService",
+            "kubernetes:apiregistration.k8s.io/v1beta1:APIService",
             resource_name,
             __props__,
             opts)

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
@@ -69,12 +69,17 @@ class APIServiceList(pulumi.CustomResource):
 
         __props__['status'] = None
 
+        parent = opts.parent if opts and opts.parent else None
+        aliases = [
+            pulumi.Alias(type_="kubernetes:apiregistration/v1beta1:APIServiceList"),
+        ]
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(
             version=version.get_version(),
+            aliases=aliases,
         ))
 
         super(APIServiceList, self).__init__(
-            "kubernetes:apiregistration/v1beta1:APIServiceList",
+            "kubernetes:apiregistration.k8s.io/v1beta1:APIServiceList",
             resource_name,
             __props__,
             opts)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the URN for apiregistration resources was of the form
`apiregistration/Version:Kind`. This has been updated to the
canonical form `apiregistration.k8s.io/Version:Kind`. Aliases have
been added for the old URNs, so this change should not cause
any resources to be updated.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
