### PR TITLE
Add type aliases and secret outputs to .NET resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+- Automatically populate type aliases and additional secret outputs in the .NET SDK.
+  (https://github.com/pulumi/pulumi-kubernetes/pull/1026).  
+
 ### Bug fixes
 
 -   Replace PersistentVolume if volume source changes. (https://github.com/pulumi/pulumi-kubernetes/pull/1015).

--- a/pkg/gen/dotnet-templates/kind.cs.mustache
+++ b/pkg/gen/dotnet-templates/kind.cs.mustache
@@ -26,7 +26,7 @@ namespace Pulumi.Kubernetes.{{Group}}.{{Version}}
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public {{Kind}}(string name, Types.Inputs.{{Group}}.{{Version}}.{{Kind}}Args? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:{{URNAPIVersion}}:{{Kind}}", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:{{URNAPIVersion}}:{{Kind}}", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -43,6 +43,36 @@ namespace Pulumi.Kubernetes.{{Group}}.{{Version}}
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            {{#MergeOptsRequired}}
+            var extraOptions = new CustomResourceOptions
+            {
+                {{#AdditionalSecretOutputsPresent}}
+                AdditionalSecretOutputs =
+                {
+                    {{#AdditionalSecretOutputs}}
+                    "{{.}}",
+                    {{/AdditionalSecretOutputs}}
+                },
+                {{/AdditionalSecretOutputsPresent}}
+                {{#AliasesPresent}}
+                Aliases =
+                {
+                    {{#Aliases}}
+                    new Alias { Type = "{{.}}" },
+                    {{/Aliases}}
+                }
+                {{/AliasesPresent}}
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+            {{/MergeOptsRequired}}
+            {{^MergeOptsRequired}}
+            return options;
+            {{/MergeOptsRequired}}
+        }
+
         /// <summary>
         /// Get an existing {{Kind}} resource's state with the given name and ID.
         /// </summary>
@@ -54,6 +84,5 @@ namespace Pulumi.Kubernetes.{{Group}}.{{Version}}
             return new {{Kind}}(name, default(Types.Inputs.{{Group}}.{{Version}}.{{Kind}}Args),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfiguration.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public MutatingWebhookConfiguration(string name, Types.Inputs.AdmissionRegistration.V1.MutatingWebhookConfigurationArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,19 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing MutatingWebhookConfiguration resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +93,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return new MutatingWebhookConfiguration(name, default(Types.Inputs.AdmissionRegistration.V1.MutatingWebhookConfigurationArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public MutatingWebhookConfigurationList(string name, Types.Inputs.AdmissionRegistration.V1.MutatingWebhookConfigurationListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing MutatingWebhookConfigurationList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return new MutatingWebhookConfigurationList(name, default(Types.Inputs.AdmissionRegistration.V1.MutatingWebhookConfigurationListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfiguration.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ValidatingWebhookConfiguration(string name, Types.Inputs.AdmissionRegistration.V1.ValidatingWebhookConfigurationArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,19 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ValidatingWebhookConfiguration resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +93,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return new ValidatingWebhookConfiguration(name, default(Types.Inputs.AdmissionRegistration.V1.ValidatingWebhookConfigurationArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ValidatingWebhookConfigurationList(string name, Types.Inputs.AdmissionRegistration.V1.ValidatingWebhookConfigurationListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ValidatingWebhookConfigurationList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
             return new ValidatingWebhookConfigurationList(name, default(Types.Inputs.AdmissionRegistration.V1.ValidatingWebhookConfigurationListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfiguration.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public MutatingWebhookConfiguration(string name, Types.Inputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfigurationArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfiguration", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -70,6 +70,19 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:admissionregistration.k8s.io/v1:MutatingWebhookConfiguration" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing MutatingWebhookConfiguration resource's state with the given name and ID.
         /// </summary>
@@ -81,6 +94,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return new MutatingWebhookConfiguration(name, default(Types.Inputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfigurationArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public MutatingWebhookConfigurationList(string name, Types.Inputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfigurationListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1beta1:MutatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing MutatingWebhookConfigurationList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return new MutatingWebhookConfigurationList(name, default(Types.Inputs.AdmissionRegistration.V1Beta1.MutatingWebhookConfigurationListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfiguration.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfiguration.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ValidatingWebhookConfiguration(string name, Types.Inputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfigurationArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfiguration", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -70,6 +70,19 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:admissionregistration.k8s.io/v1:ValidatingWebhookConfiguration" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ValidatingWebhookConfiguration resource's state with the given name and ID.
         /// </summary>
@@ -81,6 +94,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return new ValidatingWebhookConfiguration(name, default(Types.Inputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfigurationArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationList.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ValidatingWebhookConfigurationList(string name, Types.Inputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfigurationListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:admissionregistration.k8s.io/v1beta1:ValidatingWebhookConfigurationList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ValidatingWebhookConfigurationList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
             return new ValidatingWebhookConfigurationList(name, default(Types.Inputs.AdmissionRegistration.V1Beta1.ValidatingWebhookConfigurationListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinition.cs
+++ b/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinition.cs
@@ -55,7 +55,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CustomResourceDefinition(string name, Types.Inputs.ApiExtensions.V1.CustomResourceDefinitionArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -72,6 +72,19 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CustomResourceDefinition resource's state with the given name and ID.
         /// </summary>
@@ -83,6 +96,5 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
             return new CustomResourceDefinition(name, default(Types.Inputs.ApiExtensions.V1.CustomResourceDefinitionArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionList.cs
+++ b/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionList.cs
@@ -48,7 +48,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CustomResourceDefinitionList(string name, Types.Inputs.ApiExtensions.V1.CustomResourceDefinitionListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinitionList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinitionList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -65,6 +65,11 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CustomResourceDefinitionList resource's state with the given name and ID.
         /// </summary>
@@ -76,6 +81,5 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
             return new CustomResourceDefinitionList(name, default(Types.Inputs.ApiExtensions.V1.CustomResourceDefinitionListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinition.cs
+++ b/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinition.cs
@@ -57,7 +57,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CustomResourceDefinition(string name, Types.Inputs.ApiExtensions.V1Beta1.CustomResourceDefinitionArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinition", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -74,6 +74,19 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CustomResourceDefinition resource's state with the given name and ID.
         /// </summary>
@@ -85,6 +98,5 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
             return new CustomResourceDefinition(name, default(Types.Inputs.ApiExtensions.V1Beta1.CustomResourceDefinitionArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionList.cs
+++ b/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionList.cs
@@ -48,7 +48,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CustomResourceDefinitionList(string name, Types.Inputs.ApiExtensions.V1Beta1.CustomResourceDefinitionListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinitionList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiextensions.k8s.io/v1beta1:CustomResourceDefinitionList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -65,6 +65,11 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CustomResourceDefinitionList resource's state with the given name and ID.
         /// </summary>
@@ -76,6 +81,5 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
             return new CustomResourceDefinitionList(name, default(Types.Inputs.ApiExtensions.V1Beta1.CustomResourceDefinitionListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiRegistration/V1/APIService.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIService.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIService(string name, Types.Inputs.ApiRegistration.V1.APIServiceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIService", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiregistration/v1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -71,6 +71,19 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiregistration.k8s.io/v1beta1:APIService" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing APIService resource's state with the given name and ID.
         /// </summary>
@@ -82,6 +95,5 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
             return new APIService(name, default(Types.Inputs.ApiRegistration.V1.APIServiceArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIServiceList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIServiceList(string name, Types.Inputs.ApiRegistration.V1.APIServiceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1:APIServiceList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiregistration/v1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing APIServiceList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
             return new APIServiceList(name, default(Types.Inputs.ApiRegistration.V1.APIServiceListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIService.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIService.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIService(string name, Types.Inputs.ApiRegistration.V1Beta1.APIServiceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIService", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiregistration/v1beta1:APIService", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -71,6 +71,19 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apiregistration.k8s.io/v1:APIService" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing APIService resource's state with the given name and ID.
         /// </summary>
@@ -82,6 +95,5 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
             return new APIService(name, default(Types.Inputs.ApiRegistration.V1Beta1.APIServiceArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIServiceList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public APIServiceList(string name, Types.Inputs.ApiRegistration.V1Beta1.APIServiceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apiregistration/v1beta1:APIServiceList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apiregistration/v1beta1:APIServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing APIServiceList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
             return new APIServiceList(name, default(Types.Inputs.ApiRegistration.V1Beta1.APIServiceListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/ControllerRevision.cs
+++ b/sdk/dotnet/Apps/V1/ControllerRevision.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevision(string name, Types.Inputs.Apps.V1.ControllerRevisionArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:ControllerRevision", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:ControllerRevision", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -81,6 +81,20 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1beta1:ControllerRevision" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:ControllerRevision" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ControllerRevision resource's state with the given name and ID.
         /// </summary>
@@ -92,6 +106,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new ControllerRevision(name, default(Types.Inputs.Apps.V1.ControllerRevisionArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1/ControllerRevisionList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevisionList(string name, Types.Inputs.Apps.V1.ControllerRevisionListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:ControllerRevisionList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:ControllerRevisionList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ControllerRevisionList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new ControllerRevisionList(name, default(Types.Inputs.Apps.V1.ControllerRevisionListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/DaemonSet.cs
+++ b/sdk/dotnet/Apps/V1/DaemonSet.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSet(string name, Types.Inputs.Apps.V1.DaemonSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:DaemonSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:DaemonSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1beta2:DaemonSet" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:DaemonSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing DaemonSet resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new DaemonSet(name, default(Types.Inputs.Apps.V1.DaemonSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/DaemonSetList.cs
+++ b/sdk/dotnet/Apps/V1/DaemonSetList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSetList(string name, Types.Inputs.Apps.V1.DaemonSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:DaemonSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:DaemonSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DaemonSetList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new DaemonSetList(name, default(Types.Inputs.Apps.V1.DaemonSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/Deployment.cs
+++ b/sdk/dotnet/Apps/V1/Deployment.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Deployment(string name, Types.Inputs.Apps.V1.DeploymentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:Deployment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:Deployment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -97,6 +97,21 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1beta1:Deployment" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:Deployment" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:Deployment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Deployment resource's state with the given name and ID.
         /// </summary>
@@ -108,6 +123,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new Deployment(name, default(Types.Inputs.Apps.V1.DeploymentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1/DeploymentList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DeploymentList(string name, Types.Inputs.Apps.V1.DeploymentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:DeploymentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:DeploymentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DeploymentList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new DeploymentList(name, default(Types.Inputs.Apps.V1.DeploymentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/ReplicaSet.cs
+++ b/sdk/dotnet/Apps/V1/ReplicaSet.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSet(string name, Types.Inputs.Apps.V1.ReplicaSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:ReplicaSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:ReplicaSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,20 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1beta2:ReplicaSet" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:ReplicaSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ReplicaSet resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +103,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new ReplicaSet(name, default(Types.Inputs.Apps.V1.ReplicaSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/ReplicaSetList.cs
+++ b/sdk/dotnet/Apps/V1/ReplicaSetList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSetList(string name, Types.Inputs.Apps.V1.ReplicaSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:ReplicaSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:ReplicaSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ReplicaSetList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new ReplicaSetList(name, default(Types.Inputs.Apps.V1.ReplicaSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/StatefulSet.cs
+++ b/sdk/dotnet/Apps/V1/StatefulSet.cs
@@ -72,7 +72,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSet(string name, Types.Inputs.Apps.V1.StatefulSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:StatefulSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:StatefulSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -89,6 +89,20 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1beta1:StatefulSet" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:StatefulSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing StatefulSet resource's state with the given name and ID.
         /// </summary>
@@ -100,6 +114,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new StatefulSet(name, default(Types.Inputs.Apps.V1.StatefulSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1/StatefulSetList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Apps.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSetList(string name, Types.Inputs.Apps.V1.StatefulSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1:StatefulSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1:StatefulSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Apps.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing StatefulSetList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Apps.V1
             return new StatefulSetList(name, default(Types.Inputs.Apps.V1.StatefulSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/ControllerRevision.cs
+++ b/sdk/dotnet/Apps/V1Beta1/ControllerRevision.cs
@@ -67,7 +67,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevision(string name, Types.Inputs.Apps.V1Beta1.ControllerRevisionArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:ControllerRevision", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:ControllerRevision", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -84,6 +84,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:ControllerRevision" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:ControllerRevision" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ControllerRevision resource's state with the given name and ID.
         /// </summary>
@@ -95,6 +109,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new ControllerRevision(name, default(Types.Inputs.Apps.V1Beta1.ControllerRevisionArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/ControllerRevisionList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevisionList(string name, Types.Inputs.Apps.V1Beta1.ControllerRevisionListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:ControllerRevisionList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:ControllerRevisionList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ControllerRevisionList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new ControllerRevisionList(name, default(Types.Inputs.Apps.V1Beta1.ControllerRevisionListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/Deployment.cs
+++ b/sdk/dotnet/Apps/V1Beta1/Deployment.cs
@@ -83,7 +83,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Deployment(string name, Types.Inputs.Apps.V1Beta1.DeploymentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:Deployment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:Deployment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -100,6 +100,21 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:Deployment" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:Deployment" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:Deployment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Deployment resource's state with the given name and ID.
         /// </summary>
@@ -111,6 +126,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new Deployment(name, default(Types.Inputs.Apps.V1Beta1.DeploymentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/DeploymentList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DeploymentList(string name, Types.Inputs.Apps.V1Beta1.DeploymentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:DeploymentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:DeploymentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DeploymentList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new DeploymentList(name, default(Types.Inputs.Apps.V1Beta1.DeploymentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/StatefulSet.cs
+++ b/sdk/dotnet/Apps/V1Beta1/StatefulSet.cs
@@ -75,7 +75,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSet(string name, Types.Inputs.Apps.V1Beta1.StatefulSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:StatefulSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:StatefulSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -92,6 +92,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:StatefulSet" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:StatefulSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing StatefulSet resource's state with the given name and ID.
         /// </summary>
@@ -103,6 +117,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new StatefulSet(name, default(Types.Inputs.Apps.V1Beta1.StatefulSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta1/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta1/StatefulSetList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSetList(string name, Types.Inputs.Apps.V1Beta1.StatefulSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta1:StatefulSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta1:StatefulSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing StatefulSetList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
             return new StatefulSetList(name, default(Types.Inputs.Apps.V1Beta1.StatefulSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/ControllerRevision.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ControllerRevision.cs
@@ -67,7 +67,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevision(string name, Types.Inputs.Apps.V1Beta2.ControllerRevisionArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:ControllerRevision", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:ControllerRevision", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -84,6 +84,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:ControllerRevision" },
+                    new Alias { Type = "kubernetes:apps/v1beta1:ControllerRevision" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ControllerRevision resource's state with the given name and ID.
         /// </summary>
@@ -95,6 +109,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new ControllerRevision(name, default(Types.Inputs.Apps.V1Beta2.ControllerRevisionArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/ControllerRevisionList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ControllerRevisionList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ControllerRevisionList(string name, Types.Inputs.Apps.V1Beta2.ControllerRevisionListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:ControllerRevisionList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:ControllerRevisionList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ControllerRevisionList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new ControllerRevisionList(name, default(Types.Inputs.Apps.V1Beta2.ControllerRevisionListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/DaemonSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DaemonSet.cs
@@ -63,7 +63,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSet(string name, Types.Inputs.Apps.V1Beta2.DaemonSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:DaemonSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:DaemonSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -80,6 +80,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:DaemonSet" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:DaemonSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing DaemonSet resource's state with the given name and ID.
         /// </summary>
@@ -91,6 +105,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new DaemonSet(name, default(Types.Inputs.Apps.V1Beta2.DaemonSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/DaemonSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DaemonSetList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSetList(string name, Types.Inputs.Apps.V1Beta2.DaemonSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:DaemonSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:DaemonSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DaemonSetList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new DaemonSetList(name, default(Types.Inputs.Apps.V1Beta2.DaemonSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/Deployment.cs
+++ b/sdk/dotnet/Apps/V1Beta2/Deployment.cs
@@ -83,7 +83,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Deployment(string name, Types.Inputs.Apps.V1Beta2.DeploymentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:Deployment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:Deployment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -100,6 +100,21 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:Deployment" },
+                    new Alias { Type = "kubernetes:apps/v1beta1:Deployment" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:Deployment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Deployment resource's state with the given name and ID.
         /// </summary>
@@ -111,6 +126,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new Deployment(name, default(Types.Inputs.Apps.V1Beta2.DeploymentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/DeploymentList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DeploymentList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DeploymentList(string name, Types.Inputs.Apps.V1Beta2.DeploymentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:DeploymentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:DeploymentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DeploymentList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new DeploymentList(name, default(Types.Inputs.Apps.V1Beta2.DeploymentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/ReplicaSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ReplicaSet.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSet(string name, Types.Inputs.Apps.V1Beta2.ReplicaSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:ReplicaSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:ReplicaSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -81,6 +81,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:ReplicaSet" },
+                    new Alias { Type = "kubernetes:extensions/v1beta1:ReplicaSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ReplicaSet resource's state with the given name and ID.
         /// </summary>
@@ -92,6 +106,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new ReplicaSet(name, default(Types.Inputs.Apps.V1Beta2.ReplicaSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/ReplicaSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ReplicaSetList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSetList(string name, Types.Inputs.Apps.V1Beta2.ReplicaSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:ReplicaSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:ReplicaSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ReplicaSetList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new ReplicaSetList(name, default(Types.Inputs.Apps.V1Beta2.ReplicaSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/StatefulSet.cs
+++ b/sdk/dotnet/Apps/V1Beta2/StatefulSet.cs
@@ -75,7 +75,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSet(string name, Types.Inputs.Apps.V1Beta2.StatefulSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:StatefulSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:StatefulSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -92,6 +92,20 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:StatefulSet" },
+                    new Alias { Type = "kubernetes:apps/v1beta1:StatefulSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing StatefulSet resource's state with the given name and ID.
         /// </summary>
@@ -103,6 +117,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new StatefulSet(name, default(Types.Inputs.Apps.V1Beta2.StatefulSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Apps/V1Beta2/StatefulSetList.cs
+++ b/sdk/dotnet/Apps/V1Beta2/StatefulSetList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StatefulSetList(string name, Types.Inputs.Apps.V1Beta2.StatefulSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:apps/v1beta2:StatefulSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:apps/v1beta2:StatefulSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing StatefulSetList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
             return new StatefulSetList(name, default(Types.Inputs.Apps.V1Beta2.StatefulSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSink.cs
+++ b/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSink.cs
@@ -48,7 +48,7 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public AuditSink(string name, Types.Inputs.AuditRegistraion.V1Alpha1.AuditSinkArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSink", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSink", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -65,6 +65,11 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing AuditSink resource's state with the given name and ID.
         /// </summary>
@@ -76,6 +81,5 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
             return new AuditSink(name, default(Types.Inputs.AuditRegistraion.V1Alpha1.AuditSinkArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkList.cs
+++ b/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkList.cs
@@ -48,7 +48,7 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public AuditSinkList(string name, Types.Inputs.AuditRegistraion.V1Alpha1.AuditSinkListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSinkList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:auditregistration.k8s.io/v1alpha1:AuditSinkList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -65,6 +65,11 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing AuditSinkList resource's state with the given name and ID.
         /// </summary>
@@ -76,6 +81,5 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
             return new AuditSinkList(name, default(Types.Inputs.AuditRegistraion.V1Alpha1.AuditSinkListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authentication/V1/TokenRequest.cs
+++ b/sdk/dotnet/Authentication/V1/TokenRequest.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Authentication.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public TokenRequest(string name, Types.Inputs.Authentication.V1.TokenRequestArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authentication.k8s.io/v1:TokenRequest", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authentication.k8s.io/v1:TokenRequest", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Authentication.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing TokenRequest resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Authentication.V1
             return new TokenRequest(name, default(Types.Inputs.Authentication.V1.TokenRequestArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authentication/V1/TokenReview.cs
+++ b/sdk/dotnet/Authentication/V1/TokenReview.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes.Authentication.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public TokenReview(string name, Types.Inputs.Authentication.V1.TokenReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authentication.k8s.io/v1:TokenReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authentication.k8s.io/v1:TokenReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -73,6 +73,19 @@ namespace Pulumi.Kubernetes.Authentication.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authentication.k8s.io/v1beta1:TokenReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing TokenReview resource's state with the given name and ID.
         /// </summary>
@@ -84,6 +97,5 @@ namespace Pulumi.Kubernetes.Authentication.V1
             return new TokenReview(name, default(Types.Inputs.Authentication.V1.TokenReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authentication/V1Beta1/TokenReview.cs
+++ b/sdk/dotnet/Authentication/V1Beta1/TokenReview.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes.Authentication.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public TokenReview(string name, Types.Inputs.Authentication.V1Beta1.TokenReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authentication.k8s.io/v1beta1:TokenReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authentication.k8s.io/v1beta1:TokenReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -73,6 +73,19 @@ namespace Pulumi.Kubernetes.Authentication.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authentication.k8s.io/v1:TokenReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing TokenReview resource's state with the given name and ID.
         /// </summary>
@@ -84,6 +97,5 @@ namespace Pulumi.Kubernetes.Authentication.V1Beta1
             return new TokenReview(name, default(Types.Inputs.Authentication.V1Beta1.TokenReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1/LocalSubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1/LocalSubjectAccessReview.cs
@@ -57,7 +57,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LocalSubjectAccessReview(string name, Types.Inputs.Authorization.V1.LocalSubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -74,6 +74,19 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing LocalSubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -85,6 +98,5 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return new LocalSubjectAccessReview(name, default(Types.Inputs.Authorization.V1.LocalSubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1/SelfSubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1/SelfSubjectAccessReview.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SelfSubjectAccessReview(string name, Types.Inputs.Authorization.V1.SelfSubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -73,6 +73,19 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SelfSubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -84,6 +97,5 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return new SelfSubjectAccessReview(name, default(Types.Inputs.Authorization.V1.SelfSubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1/SelfSubjectRulesReview.cs
+++ b/sdk/dotnet/Authorization/V1/SelfSubjectRulesReview.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SelfSubjectRulesReview(string name, Types.Inputs.Authorization.V1.SelfSubjectRulesReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,19 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SelfSubjectRulesReview resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +102,5 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return new SelfSubjectRulesReview(name, default(Types.Inputs.Authorization.V1.SelfSubjectRulesReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1/SubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1/SubjectAccessReview.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SubjectAccessReview(string name, Types.Inputs.Authorization.V1.SubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1:SubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -71,6 +71,19 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -82,6 +95,5 @@ namespace Pulumi.Kubernetes.Authorization.V1
             return new SubjectAccessReview(name, default(Types.Inputs.Authorization.V1.SubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1Beta1/LocalSubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/LocalSubjectAccessReview.cs
@@ -57,7 +57,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LocalSubjectAccessReview(string name, Types.Inputs.Authorization.V1Beta1.LocalSubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1beta1:LocalSubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -74,6 +74,19 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1:LocalSubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing LocalSubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -85,6 +98,5 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return new LocalSubjectAccessReview(name, default(Types.Inputs.Authorization.V1Beta1.LocalSubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1Beta1/SelfSubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SelfSubjectAccessReview.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SelfSubjectAccessReview(string name, Types.Inputs.Authorization.V1Beta1.SelfSubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -73,6 +73,19 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1:SelfSubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SelfSubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -84,6 +97,5 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return new SelfSubjectAccessReview(name, default(Types.Inputs.Authorization.V1Beta1.SelfSubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1Beta1/SelfSubjectRulesReview.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SelfSubjectRulesReview.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SelfSubjectRulesReview(string name, Types.Inputs.Authorization.V1Beta1.SelfSubjectRulesReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1beta1:SelfSubjectRulesReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,19 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1:SelfSubjectRulesReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SelfSubjectRulesReview resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +102,5 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return new SelfSubjectRulesReview(name, default(Types.Inputs.Authorization.V1Beta1.SelfSubjectRulesReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Authorization/V1Beta1/SubjectAccessReview.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SubjectAccessReview.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SubjectAccessReview(string name, Types.Inputs.Authorization.V1Beta1.SubjectAccessReviewArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:authorization.k8s.io/v1beta1:SubjectAccessReview", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -71,6 +71,19 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:authorization.k8s.io/v1:SubjectAccessReview" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing SubjectAccessReview resource's state with the given name and ID.
         /// </summary>
@@ -82,6 +95,5 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
             return new SubjectAccessReview(name, default(Types.Inputs.Authorization.V1Beta1.SubjectAccessReviewArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscaler.cs
+++ b/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscaler.cs
@@ -58,7 +58,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscaler(string name, Types.Inputs.Autoscaling.V1.HorizontalPodAutoscalerArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v1:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -75,6 +75,20 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler" },
+                    new Alias { Type = "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscaler resource's state with the given name and ID.
         /// </summary>
@@ -86,6 +100,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
             return new HorizontalPodAutoscaler(name, default(Types.Inputs.Autoscaling.V1.HorizontalPodAutoscalerArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscalerList(string name, Types.Inputs.Autoscaling.V1.HorizontalPodAutoscalerListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v1:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v1:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscalerList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
             return new HorizontalPodAutoscalerList(name, default(Types.Inputs.Autoscaling.V1.HorizontalPodAutoscalerListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscaler.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscaler.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscaler(string name, Types.Inputs.Autoscaling.V2Beta1.HorizontalPodAutoscalerArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:autoscaling/v1:HorizontalPodAutoscaler" },
+                    new Alias { Type = "kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscaler resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
             return new HorizontalPodAutoscaler(name, default(Types.Inputs.Autoscaling.V2Beta1.HorizontalPodAutoscalerArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscalerList(string name, Types.Inputs.Autoscaling.V2Beta1.HorizontalPodAutoscalerListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v2beta1:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscalerList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
             return new HorizontalPodAutoscalerList(name, default(Types.Inputs.Autoscaling.V2Beta1.HorizontalPodAutoscalerListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscaler.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscaler.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscaler(string name, Types.Inputs.Autoscaling.V2Beta2.HorizontalPodAutoscalerArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscaler", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:autoscaling/v1:HorizontalPodAutoscaler" },
+                    new Alias { Type = "kubernetes:autoscaling/v2beta1:HorizontalPodAutoscaler" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscaler resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
             return new HorizontalPodAutoscaler(name, default(Types.Inputs.Autoscaling.V2Beta2.HorizontalPodAutoscalerArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerList.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public HorizontalPodAutoscalerList(string name, Types.Inputs.Autoscaling.V2Beta2.HorizontalPodAutoscalerListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:autoscaling/v2beta2:HorizontalPodAutoscalerList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing HorizontalPodAutoscalerList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
             return new HorizontalPodAutoscalerList(name, default(Types.Inputs.Autoscaling.V2Beta2.HorizontalPodAutoscalerListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V1/Job.cs
+++ b/sdk/dotnet/Batch/V1/Job.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Kubernetes.Batch.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Job(string name, Types.Inputs.Batch.V1.JobArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v1:Job", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v1:Job", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -91,6 +91,11 @@ namespace Pulumi.Kubernetes.Batch.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Job resource's state with the given name and ID.
         /// </summary>
@@ -102,6 +107,5 @@ namespace Pulumi.Kubernetes.Batch.V1
             return new Job(name, default(Types.Inputs.Batch.V1.JobArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V1/JobList.cs
+++ b/sdk/dotnet/Batch/V1/JobList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Batch.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public JobList(string name, Types.Inputs.Batch.V1.JobListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v1:JobList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v1:JobList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Batch.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing JobList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Batch.V1
             return new JobList(name, default(Types.Inputs.Batch.V1.JobListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V1Beta1/CronJob.cs
+++ b/sdk/dotnet/Batch/V1Beta1/CronJob.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CronJob(string name, Types.Inputs.Batch.V1Beta1.CronJobArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v1beta1:CronJob", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v1beta1:CronJob", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,19 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:batch/v2alpha1:CronJob" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CronJob resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +100,5 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
             return new CronJob(name, default(Types.Inputs.Batch.V1Beta1.CronJobArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V1Beta1/CronJobList.cs
+++ b/sdk/dotnet/Batch/V1Beta1/CronJobList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CronJobList(string name, Types.Inputs.Batch.V1Beta1.CronJobListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v1beta1:CronJobList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v1beta1:CronJobList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CronJobList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
             return new CronJobList(name, default(Types.Inputs.Batch.V1Beta1.CronJobListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V2Alpha1/CronJob.cs
+++ b/sdk/dotnet/Batch/V2Alpha1/CronJob.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CronJob(string name, Types.Inputs.Batch.V2Alpha1.CronJobArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v2alpha1:CronJob", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v2alpha1:CronJob", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,19 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:batch/v1beta1:CronJob" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CronJob resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +100,5 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
             return new CronJob(name, default(Types.Inputs.Batch.V2Alpha1.CronJobArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Batch/V2Alpha1/CronJobList.cs
+++ b/sdk/dotnet/Batch/V2Alpha1/CronJobList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CronJobList(string name, Types.Inputs.Batch.V2Alpha1.CronJobListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:batch/v2alpha1:CronJobList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:batch/v2alpha1:CronJobList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CronJobList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
             return new CronJobList(name, default(Types.Inputs.Batch.V2Alpha1.CronJobListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequest.cs
+++ b/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequest.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CertificateSigningRequest(string name, Types.Inputs.Certificates.V1Beta1.CertificateSigningRequestArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequest", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequest", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -71,6 +71,11 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CertificateSigningRequest resource's state with the given name and ID.
         /// </summary>
@@ -82,6 +87,5 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
             return new CertificateSigningRequest(name, default(Types.Inputs.Certificates.V1Beta1.CertificateSigningRequestArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestList.cs
+++ b/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CertificateSigningRequestList(string name, Types.Inputs.Certificates.V1Beta1.CertificateSigningRequestListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequestList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:certificates.k8s.io/v1beta1:CertificateSigningRequestList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CertificateSigningRequestList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
             return new CertificateSigningRequestList(name, default(Types.Inputs.Certificates.V1Beta1.CertificateSigningRequestListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Coordination/V1/Lease.cs
+++ b/sdk/dotnet/Coordination/V1/Lease.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Coordination.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Lease(string name, Types.Inputs.Coordination.V1.LeaseArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:coordination.k8s.io/v1:Lease", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:coordination.k8s.io/v1:Lease", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,19 @@ namespace Pulumi.Kubernetes.Coordination.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:coordination.k8s.io/v1beta1:Lease" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Lease resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +93,5 @@ namespace Pulumi.Kubernetes.Coordination.V1
             return new Lease(name, default(Types.Inputs.Coordination.V1.LeaseArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Coordination/V1/LeaseList.cs
+++ b/sdk/dotnet/Coordination/V1/LeaseList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Coordination.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LeaseList(string name, Types.Inputs.Coordination.V1.LeaseListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:coordination.k8s.io/v1:LeaseList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:coordination.k8s.io/v1:LeaseList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Coordination.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing LeaseList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Coordination.V1
             return new LeaseList(name, default(Types.Inputs.Coordination.V1.LeaseListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Coordination/V1Beta1/Lease.cs
+++ b/sdk/dotnet/Coordination/V1Beta1/Lease.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Lease(string name, Types.Inputs.Coordination.V1Beta1.LeaseArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:coordination.k8s.io/v1beta1:Lease", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:coordination.k8s.io/v1beta1:Lease", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,19 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:coordination.k8s.io/v1:Lease" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Lease resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +93,5 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
             return new Lease(name, default(Types.Inputs.Coordination.V1Beta1.LeaseArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Coordination/V1Beta1/LeaseList.cs
+++ b/sdk/dotnet/Coordination/V1Beta1/LeaseList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LeaseList(string name, Types.Inputs.Coordination.V1Beta1.LeaseListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:coordination.k8s.io/v1beta1:LeaseList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:coordination.k8s.io/v1beta1:LeaseList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing LeaseList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
             return new LeaseList(name, default(Types.Inputs.Coordination.V1Beta1.LeaseListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Binding.cs
+++ b/sdk/dotnet/Core/V1/Binding.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Binding(string name, Types.Inputs.Core.V1.BindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Binding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Binding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Binding resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Binding(name, default(Types.Inputs.Core.V1.BindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ComponentStatus.cs
+++ b/sdk/dotnet/Core/V1/ComponentStatus.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ComponentStatus(string name, Types.Inputs.Core.V1.ComponentStatusArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ComponentStatus", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ComponentStatus", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ComponentStatus resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ComponentStatus(name, default(Types.Inputs.Core.V1.ComponentStatusArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ComponentStatusList.cs
+++ b/sdk/dotnet/Core/V1/ComponentStatusList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ComponentStatusList(string name, Types.Inputs.Core.V1.ComponentStatusListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ComponentStatusList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ComponentStatusList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ComponentStatusList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ComponentStatusList(name, default(Types.Inputs.Core.V1.ComponentStatusListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ConfigMap.cs
+++ b/sdk/dotnet/Core/V1/ConfigMap.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ConfigMap(string name, Types.Inputs.Core.V1.ConfigMapArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ConfigMap", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ConfigMap", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -81,6 +81,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ConfigMap resource's state with the given name and ID.
         /// </summary>
@@ -92,6 +97,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ConfigMap(name, default(Types.Inputs.Core.V1.ConfigMapArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ConfigMapList.cs
+++ b/sdk/dotnet/Core/V1/ConfigMapList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ConfigMapList(string name, Types.Inputs.Core.V1.ConfigMapListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ConfigMapList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ConfigMapList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ConfigMapList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ConfigMapList(name, default(Types.Inputs.Core.V1.ConfigMapListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Endpoints.cs
+++ b/sdk/dotnet/Core/V1/Endpoints.cs
@@ -67,7 +67,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Endpoints(string name, Types.Inputs.Core.V1.EndpointsArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Endpoints", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Endpoints", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -84,6 +84,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Endpoints resource's state with the given name and ID.
         /// </summary>
@@ -95,6 +100,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Endpoints(name, default(Types.Inputs.Core.V1.EndpointsArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/EndpointsList.cs
+++ b/sdk/dotnet/Core/V1/EndpointsList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public EndpointsList(string name, Types.Inputs.Core.V1.EndpointsListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:EndpointsList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:EndpointsList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing EndpointsList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new EndpointsList(name, default(Types.Inputs.Core.V1.EndpointsListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Event.cs
+++ b/sdk/dotnet/Core/V1/Event.cs
@@ -130,7 +130,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Event(string name, Types.Inputs.Core.V1.EventArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Event", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Event", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -147,6 +147,19 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:events.k8s.io/v1beta1:Event" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Event resource's state with the given name and ID.
         /// </summary>
@@ -158,6 +171,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Event(name, default(Types.Inputs.Core.V1.EventArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/EventList.cs
+++ b/sdk/dotnet/Core/V1/EventList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public EventList(string name, Types.Inputs.Core.V1.EventListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:EventList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:EventList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing EventList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new EventList(name, default(Types.Inputs.Core.V1.EventListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/LimitRange.cs
+++ b/sdk/dotnet/Core/V1/LimitRange.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LimitRange(string name, Types.Inputs.Core.V1.LimitRangeArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:LimitRange", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:LimitRange", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing LimitRange resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new LimitRange(name, default(Types.Inputs.Core.V1.LimitRangeArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/LimitRangeList.cs
+++ b/sdk/dotnet/Core/V1/LimitRangeList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public LimitRangeList(string name, Types.Inputs.Core.V1.LimitRangeListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:LimitRangeList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:LimitRangeList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing LimitRangeList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new LimitRangeList(name, default(Types.Inputs.Core.V1.LimitRangeListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Namespace.cs
+++ b/sdk/dotnet/Core/V1/Namespace.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Namespace(string name, Types.Inputs.Core.V1.NamespaceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Namespace", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Namespace", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Namespace resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +92,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Namespace(name, default(Types.Inputs.Core.V1.NamespaceArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/NamespaceList.cs
+++ b/sdk/dotnet/Core/V1/NamespaceList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NamespaceList(string name, Types.Inputs.Core.V1.NamespaceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:NamespaceList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:NamespaceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing NamespaceList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new NamespaceList(name, default(Types.Inputs.Core.V1.NamespaceListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Node.cs
+++ b/sdk/dotnet/Core/V1/Node.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Node(string name, Types.Inputs.Core.V1.NodeArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Node", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Node", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Node resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +94,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Node(name, default(Types.Inputs.Core.V1.NodeArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/NodeList.cs
+++ b/sdk/dotnet/Core/V1/NodeList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NodeList(string name, Types.Inputs.Core.V1.NodeListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:NodeList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:NodeList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing NodeList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new NodeList(name, default(Types.Inputs.Core.V1.NodeListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PersistentVolume.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolume.cs
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PersistentVolume(string name, Types.Inputs.Core.V1.PersistentVolumeArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PersistentVolume", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PersistentVolume", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -79,6 +79,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PersistentVolume resource's state with the given name and ID.
         /// </summary>
@@ -90,6 +95,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PersistentVolume(name, default(Types.Inputs.Core.V1.PersistentVolumeArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PersistentVolumeClaim.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeClaim.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PersistentVolumeClaim(string name, Types.Inputs.Core.V1.PersistentVolumeClaimArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PersistentVolumeClaim", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PersistentVolumeClaim", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PersistentVolumeClaim resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +94,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PersistentVolumeClaim(name, default(Types.Inputs.Core.V1.PersistentVolumeClaimArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PersistentVolumeClaimList.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeClaimList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PersistentVolumeClaimList(string name, Types.Inputs.Core.V1.PersistentVolumeClaimListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PersistentVolumeClaimList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PersistentVolumeClaimList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PersistentVolumeClaimList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PersistentVolumeClaimList(name, default(Types.Inputs.Core.V1.PersistentVolumeClaimListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PersistentVolumeList.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PersistentVolumeList(string name, Types.Inputs.Core.V1.PersistentVolumeListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PersistentVolumeList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PersistentVolumeList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PersistentVolumeList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PersistentVolumeList(name, default(Types.Inputs.Core.V1.PersistentVolumeListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Pod.cs
+++ b/sdk/dotnet/Core/V1/Pod.cs
@@ -76,7 +76,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Pod(string name, Types.Inputs.Core.V1.PodArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Pod", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Pod", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -93,6 +93,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Pod resource's state with the given name and ID.
         /// </summary>
@@ -104,6 +109,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Pod(name, default(Types.Inputs.Core.V1.PodArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PodList.cs
+++ b/sdk/dotnet/Core/V1/PodList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodList(string name, Types.Inputs.Core.V1.PodListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PodList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PodList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PodList(name, default(Types.Inputs.Core.V1.PodListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PodTemplate.cs
+++ b/sdk/dotnet/Core/V1/PodTemplate.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodTemplate(string name, Types.Inputs.Core.V1.PodTemplateArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PodTemplate", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PodTemplate", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodTemplate resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PodTemplate(name, default(Types.Inputs.Core.V1.PodTemplateArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/PodTemplateList.cs
+++ b/sdk/dotnet/Core/V1/PodTemplateList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodTemplateList(string name, Types.Inputs.Core.V1.PodTemplateListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:PodTemplateList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:PodTemplateList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodTemplateList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new PodTemplateList(name, default(Types.Inputs.Core.V1.PodTemplateListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ReplicationController.cs
+++ b/sdk/dotnet/Core/V1/ReplicationController.cs
@@ -63,7 +63,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicationController(string name, Types.Inputs.Core.V1.ReplicationControllerArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ReplicationController", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ReplicationController", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -80,6 +80,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ReplicationController resource's state with the given name and ID.
         /// </summary>
@@ -91,6 +96,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ReplicationController(name, default(Types.Inputs.Core.V1.ReplicationControllerArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ReplicationControllerList.cs
+++ b/sdk/dotnet/Core/V1/ReplicationControllerList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicationControllerList(string name, Types.Inputs.Core.V1.ReplicationControllerListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ReplicationControllerList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ReplicationControllerList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ReplicationControllerList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ReplicationControllerList(name, default(Types.Inputs.Core.V1.ReplicationControllerListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ResourceQuota.cs
+++ b/sdk/dotnet/Core/V1/ResourceQuota.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ResourceQuota(string name, Types.Inputs.Core.V1.ResourceQuotaArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ResourceQuota", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ResourceQuota", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ResourceQuota resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +92,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ResourceQuota(name, default(Types.Inputs.Core.V1.ResourceQuotaArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ResourceQuotaList.cs
+++ b/sdk/dotnet/Core/V1/ResourceQuotaList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ResourceQuotaList(string name, Types.Inputs.Core.V1.ResourceQuotaListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ResourceQuotaList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ResourceQuotaList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ResourceQuotaList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ResourceQuotaList(name, default(Types.Inputs.Core.V1.ResourceQuotaListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Secret.cs
+++ b/sdk/dotnet/Core/V1/Secret.cs
@@ -79,7 +79,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Secret(string name, Types.Inputs.Core.V1.SecretArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Secret", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Secret", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -96,6 +96,20 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                AdditionalSecretOutputs =
+                {
+                    "data",
+                    "stringData",
+                },
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Secret resource's state with the given name and ID.
         /// </summary>
@@ -107,6 +121,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Secret(name, default(Types.Inputs.Core.V1.SecretArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/SecretList.cs
+++ b/sdk/dotnet/Core/V1/SecretList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public SecretList(string name, Types.Inputs.Core.V1.SecretListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:SecretList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:SecretList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing SecretList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new SecretList(name, default(Types.Inputs.Core.V1.SecretListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/Service.cs
+++ b/sdk/dotnet/Core/V1/Service.cs
@@ -87,7 +87,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Service(string name, Types.Inputs.Core.V1.ServiceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Service", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Service", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -104,6 +104,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Service resource's state with the given name and ID.
         /// </summary>
@@ -115,6 +120,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new Service(name, default(Types.Inputs.Core.V1.ServiceArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ServiceAccount.cs
+++ b/sdk/dotnet/Core/V1/ServiceAccount.cs
@@ -71,7 +71,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ServiceAccount(string name, Types.Inputs.Core.V1.ServiceAccountArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ServiceAccount", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ServiceAccount", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -88,6 +88,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ServiceAccount resource's state with the given name and ID.
         /// </summary>
@@ -99,6 +104,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ServiceAccount(name, default(Types.Inputs.Core.V1.ServiceAccountArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ServiceAccountList.cs
+++ b/sdk/dotnet/Core/V1/ServiceAccountList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ServiceAccountList(string name, Types.Inputs.Core.V1.ServiceAccountListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ServiceAccountList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ServiceAccountList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ServiceAccountList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ServiceAccountList(name, default(Types.Inputs.Core.V1.ServiceAccountListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Core/V1/ServiceList.cs
+++ b/sdk/dotnet/Core/V1/ServiceList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Core.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ServiceList(string name, Types.Inputs.Core.V1.ServiceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:ServiceList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:ServiceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Core.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ServiceList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Core.V1
             return new ServiceList(name, default(Types.Inputs.Core.V1.ServiceListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Discovery/V1Beta1/EndpointSlice.cs
+++ b/sdk/dotnet/Discovery/V1Beta1/EndpointSlice.cs
@@ -71,7 +71,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public EndpointSlice(string name, Types.Inputs.Discovery.V1Beta1.EndpointSliceArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:discovery.k8s.io/v1beta1:EndpointSlice", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:discovery.k8s.io/v1beta1:EndpointSlice", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -88,6 +88,11 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing EndpointSlice resource's state with the given name and ID.
         /// </summary>
@@ -99,6 +104,5 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
             return new EndpointSlice(name, default(Types.Inputs.Discovery.V1Beta1.EndpointSliceArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Discovery/V1Beta1/EndpointSliceList.cs
+++ b/sdk/dotnet/Discovery/V1Beta1/EndpointSliceList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public EndpointSliceList(string name, Types.Inputs.Discovery.V1Beta1.EndpointSliceListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:discovery.k8s.io/v1beta1:EndpointSliceList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:discovery.k8s.io/v1beta1:EndpointSliceList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing EndpointSliceList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
             return new EndpointSliceList(name, default(Types.Inputs.Discovery.V1Beta1.EndpointSliceListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Events/V1Beta1/Event.cs
+++ b/sdk/dotnet/Events/V1Beta1/Event.cs
@@ -131,7 +131,7 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Event(string name, Types.Inputs.Events.V1Beta1.EventArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:events.k8s.io/v1beta1:Event", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:events.k8s.io/v1beta1:Event", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -148,6 +148,19 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:core/v1:Event" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Event resource's state with the given name and ID.
         /// </summary>
@@ -159,6 +172,5 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
             return new Event(name, default(Types.Inputs.Events.V1Beta1.EventArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Events/V1Beta1/EventList.cs
+++ b/sdk/dotnet/Events/V1Beta1/EventList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public EventList(string name, Types.Inputs.Events.V1Beta1.EventListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:events.k8s.io/v1beta1:EventList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:events.k8s.io/v1beta1:EventList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing EventList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
             return new EventList(name, default(Types.Inputs.Events.V1Beta1.EventListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/DaemonSet.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DaemonSet.cs
@@ -63,7 +63,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSet(string name, Types.Inputs.Extensions.V1Beta1.DaemonSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:DaemonSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:DaemonSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -80,6 +80,20 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:DaemonSet" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:DaemonSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing DaemonSet resource's state with the given name and ID.
         /// </summary>
@@ -91,6 +105,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new DaemonSet(name, default(Types.Inputs.Extensions.V1Beta1.DaemonSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/DaemonSetList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DaemonSetList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DaemonSetList(string name, Types.Inputs.Extensions.V1Beta1.DaemonSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:DaemonSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:DaemonSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DaemonSetList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new DaemonSetList(name, default(Types.Inputs.Extensions.V1Beta1.DaemonSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/Deployment.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/Deployment.cs
@@ -83,7 +83,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Deployment(string name, Types.Inputs.Extensions.V1Beta1.DeploymentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:Deployment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:Deployment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -100,6 +100,21 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:Deployment" },
+                    new Alias { Type = "kubernetes:apps/v1beta1:Deployment" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:Deployment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Deployment resource's state with the given name and ID.
         /// </summary>
@@ -111,6 +126,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new Deployment(name, default(Types.Inputs.Extensions.V1Beta1.DeploymentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/DeploymentList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DeploymentList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public DeploymentList(string name, Types.Inputs.Extensions.V1Beta1.DeploymentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:DeploymentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:DeploymentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing DeploymentList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new DeploymentList(name, default(Types.Inputs.Extensions.V1Beta1.DeploymentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/Ingress.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/Ingress.cs
@@ -78,7 +78,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Ingress(string name, Types.Inputs.Extensions.V1Beta1.IngressArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:Ingress", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:Ingress", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -95,6 +95,19 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:networking.k8s.io/v1beta1:Ingress" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Ingress resource's state with the given name and ID.
         /// </summary>
@@ -106,6 +119,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new Ingress(name, default(Types.Inputs.Extensions.V1Beta1.IngressArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/IngressList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/IngressList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public IngressList(string name, Types.Inputs.Extensions.V1Beta1.IngressListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:IngressList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:IngressList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing IngressList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new IngressList(name, default(Types.Inputs.Extensions.V1Beta1.IngressListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/NetworkPolicy.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/NetworkPolicy.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NetworkPolicy(string name, Types.Inputs.Extensions.V1Beta1.NetworkPolicyArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:NetworkPolicy", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:NetworkPolicy", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -70,6 +70,19 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:networking.k8s.io/v1:NetworkPolicy" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing NetworkPolicy resource's state with the given name and ID.
         /// </summary>
@@ -81,6 +94,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new NetworkPolicy(name, default(Types.Inputs.Extensions.V1Beta1.NetworkPolicyArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NetworkPolicyList(string name, Types.Inputs.Extensions.V1Beta1.NetworkPolicyListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:NetworkPolicyList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:NetworkPolicyList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing NetworkPolicyList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new NetworkPolicyList(name, default(Types.Inputs.Extensions.V1Beta1.NetworkPolicyListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicy.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicy.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodSecurityPolicy(string name, Types.Inputs.Extensions.V1Beta1.PodSecurityPolicyArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:PodSecurityPolicy", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:PodSecurityPolicy", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -70,6 +70,19 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:policy/v1beta1:PodSecurityPolicy" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing PodSecurityPolicy resource's state with the given name and ID.
         /// </summary>
@@ -81,6 +94,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new PodSecurityPolicy(name, default(Types.Inputs.Extensions.V1Beta1.PodSecurityPolicyArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodSecurityPolicyList(string name, Types.Inputs.Extensions.V1Beta1.PodSecurityPolicyListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:PodSecurityPolicyList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:PodSecurityPolicyList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodSecurityPolicyList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new PodSecurityPolicyList(name, default(Types.Inputs.Extensions.V1Beta1.PodSecurityPolicyListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/ReplicaSet.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/ReplicaSet.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSet(string name, Types.Inputs.Extensions.V1Beta1.ReplicaSetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:ReplicaSet", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:ReplicaSet", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -81,6 +81,20 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:apps/v1:ReplicaSet" },
+                    new Alias { Type = "kubernetes:apps/v1beta2:ReplicaSet" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ReplicaSet resource's state with the given name and ID.
         /// </summary>
@@ -92,6 +106,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new ReplicaSet(name, default(Types.Inputs.Extensions.V1Beta1.ReplicaSetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Extensions/V1Beta1/ReplicaSetList.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/ReplicaSetList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ReplicaSetList(string name, Types.Inputs.Extensions.V1Beta1.ReplicaSetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:extensions/v1beta1:ReplicaSetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:extensions/v1beta1:ReplicaSetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ReplicaSetList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
             return new ReplicaSetList(name, default(Types.Inputs.Extensions.V1Beta1.ReplicaSetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/FlowControl/V1Alpha1/FlowSchema.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/FlowSchema.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public FlowSchema(string name, Types.Inputs.FlowControl.V1Alpha1.FlowSchemaArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:FlowSchema", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:FlowSchema", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,11 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing FlowSchema resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +94,5 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return new FlowSchema(name, default(Types.Inputs.FlowControl.V1Alpha1.FlowSchemaArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaList.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public FlowSchemaList(string name, Types.Inputs.FlowControl.V1Alpha1.FlowSchemaListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:FlowSchemaList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:FlowSchemaList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing FlowSchemaList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return new FlowSchemaList(name, default(Types.Inputs.FlowControl.V1Alpha1.FlowSchemaListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfiguration.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfiguration.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityLevelConfiguration(string name, Types.Inputs.FlowControl.V1Alpha1.PriorityLevelConfigurationArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:PriorityLevelConfiguration", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:PriorityLevelConfiguration", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,11 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PriorityLevelConfiguration resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +92,5 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return new PriorityLevelConfiguration(name, default(Types.Inputs.FlowControl.V1Alpha1.PriorityLevelConfigurationArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationList.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityLevelConfigurationList(string name, Types.Inputs.FlowControl.V1Alpha1.PriorityLevelConfigurationListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:PriorityLevelConfigurationList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:flowcontrol.apiserver.k8s.io/v1alpha1:PriorityLevelConfigurationList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PriorityLevelConfigurationList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
             return new PriorityLevelConfigurationList(name, default(Types.Inputs.FlowControl.V1Alpha1.PriorityLevelConfigurationListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Meta/V1/Status.cs
+++ b/sdk/dotnet/Meta/V1/Status.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Kubernetes.Meta.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Status(string name, Types.Inputs.Meta.V1.StatusArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:core/v1:Status", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:core/v1:Status", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -97,6 +97,11 @@ namespace Pulumi.Kubernetes.Meta.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing Status resource's state with the given name and ID.
         /// </summary>
@@ -108,6 +113,5 @@ namespace Pulumi.Kubernetes.Meta.V1
             return new Status(name, default(Types.Inputs.Meta.V1.StatusArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Networking/V1/NetworkPolicy.cs
+++ b/sdk/dotnet/Networking/V1/NetworkPolicy.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Networking.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NetworkPolicy(string name, Types.Inputs.Networking.V1.NetworkPolicyArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:networking.k8s.io/v1:NetworkPolicy", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:networking.k8s.io/v1:NetworkPolicy", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,19 @@ namespace Pulumi.Kubernetes.Networking.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:extensions/v1beta1:NetworkPolicy" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing NetworkPolicy resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +92,5 @@ namespace Pulumi.Kubernetes.Networking.V1
             return new NetworkPolicy(name, default(Types.Inputs.Networking.V1.NetworkPolicyArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Networking/V1/NetworkPolicyList.cs
+++ b/sdk/dotnet/Networking/V1/NetworkPolicyList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Networking.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public NetworkPolicyList(string name, Types.Inputs.Networking.V1.NetworkPolicyListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:networking.k8s.io/v1:NetworkPolicyList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:networking.k8s.io/v1:NetworkPolicyList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Networking.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing NetworkPolicyList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Networking.V1
             return new NetworkPolicyList(name, default(Types.Inputs.Networking.V1.NetworkPolicyListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Networking/V1Beta1/Ingress.cs
+++ b/sdk/dotnet/Networking/V1Beta1/Ingress.cs
@@ -75,7 +75,7 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Ingress(string name, Types.Inputs.Networking.V1Beta1.IngressArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:networking.k8s.io/v1beta1:Ingress", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:networking.k8s.io/v1beta1:Ingress", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -92,6 +92,19 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:extensions/v1beta1:Ingress" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Ingress resource's state with the given name and ID.
         /// </summary>
@@ -103,6 +116,5 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
             return new Ingress(name, default(Types.Inputs.Networking.V1Beta1.IngressArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Networking/V1Beta1/IngressList.cs
+++ b/sdk/dotnet/Networking/V1Beta1/IngressList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public IngressList(string name, Types.Inputs.Networking.V1Beta1.IngressListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:networking.k8s.io/v1beta1:IngressList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:networking.k8s.io/v1beta1:IngressList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing IngressList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
             return new IngressList(name, default(Types.Inputs.Networking.V1Beta1.IngressListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Node/V1Alpha1/RuntimeClass.cs
+++ b/sdk/dotnet/Node/V1Alpha1/RuntimeClass.cs
@@ -57,7 +57,7 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RuntimeClass(string name, Types.Inputs.Node.V1Alpha1.RuntimeClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:node.k8s.io/v1alpha1:RuntimeClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -74,6 +74,19 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:node.k8s.io/v1beta1:RuntimeClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing RuntimeClass resource's state with the given name and ID.
         /// </summary>
@@ -85,6 +98,5 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
             return new RuntimeClass(name, default(Types.Inputs.Node.V1Alpha1.RuntimeClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Node/V1Alpha1/RuntimeClassList.cs
+++ b/sdk/dotnet/Node/V1Alpha1/RuntimeClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RuntimeClassList(string name, Types.Inputs.Node.V1Alpha1.RuntimeClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:node.k8s.io/v1alpha1:RuntimeClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:node.k8s.io/v1alpha1:RuntimeClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RuntimeClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
             return new RuntimeClassList(name, default(Types.Inputs.Node.V1Alpha1.RuntimeClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Node/V1Beta1/RuntimeClass.cs
+++ b/sdk/dotnet/Node/V1Beta1/RuntimeClass.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RuntimeClass(string name, Types.Inputs.Node.V1Beta1.RuntimeClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:node.k8s.io/v1beta1:RuntimeClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:node.k8s.io/v1beta1:RuntimeClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -97,6 +97,19 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:node.k8s.io/v1alpha1:RuntimeClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing RuntimeClass resource's state with the given name and ID.
         /// </summary>
@@ -108,6 +121,5 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
             return new RuntimeClass(name, default(Types.Inputs.Node.V1Beta1.RuntimeClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Node/V1Beta1/RuntimeClassList.cs
+++ b/sdk/dotnet/Node/V1Beta1/RuntimeClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RuntimeClassList(string name, Types.Inputs.Node.V1Beta1.RuntimeClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:node.k8s.io/v1beta1:RuntimeClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:node.k8s.io/v1beta1:RuntimeClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RuntimeClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
             return new RuntimeClassList(name, default(Types.Inputs.Node.V1Beta1.RuntimeClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudget.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudget.cs
@@ -55,7 +55,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodDisruptionBudget(string name, Types.Inputs.Policy.V1Beta1.PodDisruptionBudgetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:policy/v1beta1:PodDisruptionBudget", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:policy/v1beta1:PodDisruptionBudget", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -72,6 +72,11 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodDisruptionBudget resource's state with the given name and ID.
         /// </summary>
@@ -83,6 +88,5 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return new PodDisruptionBudget(name, default(Types.Inputs.Policy.V1Beta1.PodDisruptionBudgetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetList.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetList.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodDisruptionBudgetList(string name, Types.Inputs.Policy.V1Beta1.PodDisruptionBudgetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:policy/v1beta1:PodDisruptionBudgetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:policy/v1beta1:PodDisruptionBudgetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodDisruptionBudgetList resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return new PodDisruptionBudgetList(name, default(Types.Inputs.Policy.V1Beta1.PodDisruptionBudgetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicy.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicy.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodSecurityPolicy(string name, Types.Inputs.Policy.V1Beta1.PodSecurityPolicyArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:policy/v1beta1:PodSecurityPolicy", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:policy/v1beta1:PodSecurityPolicy", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,19 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:extensions/v1beta1:PodSecurityPolicy" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing PodSecurityPolicy resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +93,5 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return new PodSecurityPolicy(name, default(Types.Inputs.Policy.V1Beta1.PodSecurityPolicyArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyList.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodSecurityPolicyList(string name, Types.Inputs.Policy.V1Beta1.PodSecurityPolicyListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:policy/v1beta1:PodSecurityPolicyList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:policy/v1beta1:PodSecurityPolicyList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodSecurityPolicyList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
             return new PodSecurityPolicyList(name, default(Types.Inputs.Policy.V1Beta1.PodSecurityPolicyListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRole.cs
@@ -59,7 +59,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRole(string name, Types.Inputs.Rbac.V1.ClusterRoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRole", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -76,6 +76,20 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRole resource's state with the given name and ID.
         /// </summary>
@@ -87,6 +101,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new ClusterRole(name, default(Types.Inputs.Rbac.V1.ClusterRoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleBinding.cs
@@ -58,7 +58,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBinding(string name, Types.Inputs.Rbac.V1.ClusterRoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -75,6 +75,20 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -86,6 +100,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new ClusterRoleBinding(name, default(Types.Inputs.Rbac.V1.ClusterRoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleBindingList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBindingList(string name, Types.Inputs.Rbac.V1.ClusterRoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new ClusterRoleBindingList(name, default(Types.Inputs.Rbac.V1.ClusterRoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleList(string name, Types.Inputs.Rbac.V1.ClusterRoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new ClusterRoleList(name, default(Types.Inputs.Rbac.V1.ClusterRoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/Role.cs
+++ b/sdk/dotnet/Rbac/V1/Role.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Role(string name, Types.Inputs.Rbac.V1.RoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:Role", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:Role", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,20 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:Role" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Role resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +93,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new Role(name, default(Types.Inputs.Rbac.V1.RoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1/RoleBinding.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBinding(string name, Types.Inputs.Rbac.V1.RoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing RoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new RoleBinding(name, default(Types.Inputs.Rbac.V1.RoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1/RoleBindingList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBindingList(string name, Types.Inputs.Rbac.V1.RoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new RoleBindingList(name, default(Types.Inputs.Rbac.V1.RoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1/RoleList.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleList(string name, Types.Inputs.Rbac.V1.RoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1:RoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -67,6 +67,11 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleList resource's state with the given name and ID.
         /// </summary>
@@ -78,6 +83,5 @@ namespace Pulumi.Kubernetes.Rbac.V1
             return new RoleList(name, default(Types.Inputs.Rbac.V1.RoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRole.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRole(string name, Types.Inputs.Rbac.V1Alpha1.ClusterRoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRole resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new ClusterRole(name, default(Types.Inputs.Rbac.V1Alpha1.ClusterRoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBinding.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBinding(string name, Types.Inputs.Rbac.V1Alpha1.ClusterRoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new ClusterRoleBinding(name, default(Types.Inputs.Rbac.V1Alpha1.ClusterRoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBindingList(string name, Types.Inputs.Rbac.V1Alpha1.ClusterRoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new ClusterRoleBindingList(name, default(Types.Inputs.Rbac.V1Alpha1.ClusterRoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleList(string name, Types.Inputs.Rbac.V1Alpha1.ClusterRoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new ClusterRoleList(name, default(Types.Inputs.Rbac.V1Alpha1.ClusterRoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/Role.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/Role.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Role(string name, Types.Inputs.Rbac.V1Alpha1.RoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:Role", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:Role" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:Role" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Role resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +94,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new Role(name, default(Types.Inputs.Rbac.V1Alpha1.RoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleBinding.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBinding(string name, Types.Inputs.Rbac.V1Alpha1.RoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing RoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +103,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new RoleBinding(name, default(Types.Inputs.Rbac.V1Alpha1.RoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleBindingList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBindingList(string name, Types.Inputs.Rbac.V1Alpha1.RoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new RoleBindingList(name, default(Types.Inputs.Rbac.V1Alpha1.RoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleList(string name, Types.Inputs.Rbac.V1Alpha1.RoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
             return new RoleList(name, default(Types.Inputs.Rbac.V1Alpha1.RoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRole.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRole.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRole(string name, Types.Inputs.Rbac.V1Beta1.ClusterRoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:ClusterRole" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRole" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRole resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new ClusterRole(name, default(Types.Inputs.Rbac.V1Beta1.ClusterRoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBinding.cs
@@ -60,7 +60,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBinding(string name, Types.Inputs.Rbac.V1Beta1.ClusterRoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -77,6 +77,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:ClusterRoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -88,6 +102,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new ClusterRoleBinding(name, default(Types.Inputs.Rbac.V1Beta1.ClusterRoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingList.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleBindingList(string name, Types.Inputs.Rbac.V1Beta1.ClusterRoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +85,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new ClusterRoleBindingList(name, default(Types.Inputs.Rbac.V1Beta1.ClusterRoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ClusterRoleList(string name, Types.Inputs.Rbac.V1Beta1.ClusterRoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing ClusterRoleList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new ClusterRoleList(name, default(Types.Inputs.Rbac.V1Beta1.ClusterRoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/Role.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/Role.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public Role(string name, Types.Inputs.Rbac.V1Beta1.RoleArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:Role", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -69,6 +69,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:Role" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:Role" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing Role resource's state with the given name and ID.
         /// </summary>
@@ -80,6 +94,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new Role(name, default(Types.Inputs.Rbac.V1Beta1.RoleArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/RoleBinding.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleBinding.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBinding(string name, Types.Inputs.Rbac.V1Beta1.RoleBindingArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBinding", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,20 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1:RoleBinding" },
+                    new Alias { Type = "kubernetes:rbac.authorization.k8s.io/v1alpha1:RoleBinding" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing RoleBinding resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +103,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new RoleBinding(name, default(Types.Inputs.Rbac.V1Beta1.RoleBindingArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/RoleBindingList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleBindingList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleBindingList(string name, Types.Inputs.Rbac.V1Beta1.RoleBindingListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBindingList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleBindingList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleBindingList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new RoleBindingList(name, default(Types.Inputs.Rbac.V1Beta1.RoleBindingListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Rbac/V1Beta1/RoleList.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public RoleList(string name, Types.Inputs.Rbac.V1Beta1.RoleListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:rbac.authorization.k8s.io/v1beta1:RoleList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing RoleList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
             return new RoleList(name, default(Types.Inputs.Rbac.V1Beta1.RoleListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1/PriorityClass.cs
+++ b/sdk/dotnet/Scheduling/V1/PriorityClass.cs
@@ -79,7 +79,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClass(string name, Types.Inputs.Scheduling.V1.PriorityClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1:PriorityClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1:PriorityClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -96,6 +96,20 @@ namespace Pulumi.Kubernetes.Scheduling.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass" },
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing PriorityClass resource's state with the given name and ID.
         /// </summary>
@@ -107,6 +121,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1
             return new PriorityClass(name, default(Types.Inputs.Scheduling.V1.PriorityClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1/PriorityClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClassList(string name, Types.Inputs.Scheduling.V1.PriorityClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1:PriorityClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1:PriorityClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Scheduling.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PriorityClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1
             return new PriorityClassList(name, default(Types.Inputs.Scheduling.V1.PriorityClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1Alpha1/PriorityClass.cs
+++ b/sdk/dotnet/Scheduling/V1Alpha1/PriorityClass.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClass(string name, Types.Inputs.Scheduling.V1Alpha1.PriorityClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -97,6 +97,20 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1:PriorityClass" },
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1beta1:PriorityClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing PriorityClass resource's state with the given name and ID.
         /// </summary>
@@ -108,6 +122,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
             return new PriorityClass(name, default(Types.Inputs.Scheduling.V1Alpha1.PriorityClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClassList(string name, Types.Inputs.Scheduling.V1Alpha1.PriorityClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1alpha1:PriorityClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PriorityClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
             return new PriorityClassList(name, default(Types.Inputs.Scheduling.V1Alpha1.PriorityClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1Beta1/PriorityClass.cs
+++ b/sdk/dotnet/Scheduling/V1Beta1/PriorityClass.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClass(string name, Types.Inputs.Scheduling.V1Beta1.PriorityClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1beta1:PriorityClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -97,6 +97,20 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1:PriorityClass" },
+                    new Alias { Type = "kubernetes:scheduling.k8s.io/v1alpha1:PriorityClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing PriorityClass resource's state with the given name and ID.
         /// </summary>
@@ -108,6 +122,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
             return new PriorityClass(name, default(Types.Inputs.Scheduling.V1Beta1.PriorityClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Scheduling/V1Beta1/PriorityClassList.cs
+++ b/sdk/dotnet/Scheduling/V1Beta1/PriorityClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PriorityClassList(string name, Types.Inputs.Scheduling.V1Beta1.PriorityClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:scheduling.k8s.io/v1beta1:PriorityClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:scheduling.k8s.io/v1beta1:PriorityClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PriorityClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
             return new PriorityClassList(name, default(Types.Inputs.Scheduling.V1Beta1.PriorityClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Settings/V1Alpha1/PodPreset.cs
+++ b/sdk/dotnet/Settings/V1Alpha1/PodPreset.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodPreset(string name, Types.Inputs.Settings.V1Alpha1.PodPresetArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:settings.k8s.io/v1alpha1:PodPreset", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:settings.k8s.io/v1alpha1:PodPreset", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -63,6 +63,11 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodPreset resource's state with the given name and ID.
         /// </summary>
@@ -74,6 +79,5 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
             return new PodPreset(name, default(Types.Inputs.Settings.V1Alpha1.PodPresetArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Settings/V1Alpha1/PodPresetList.cs
+++ b/sdk/dotnet/Settings/V1Alpha1/PodPresetList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public PodPresetList(string name, Types.Inputs.Settings.V1Alpha1.PodPresetListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:settings.k8s.io/v1alpha1:PodPresetList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:settings.k8s.io/v1alpha1:PodPresetList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing PodPresetList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
             return new PodPresetList(name, default(Types.Inputs.Settings.V1Alpha1.PodPresetListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/CSINode.cs
+++ b/sdk/dotnet/Storage/V1/CSINode.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSINode(string name, Types.Inputs.Storage.V1.CSINodeArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:CSINode", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:CSINode", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -73,6 +73,19 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1beta1:CSINode" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CSINode resource's state with the given name and ID.
         /// </summary>
@@ -84,6 +97,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new CSINode(name, default(Types.Inputs.Storage.V1.CSINodeArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/CSINodeList.cs
+++ b/sdk/dotnet/Storage/V1/CSINodeList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSINodeList(string name, Types.Inputs.Storage.V1.CSINodeListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:CSINodeList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:CSINodeList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CSINodeList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new CSINodeList(name, default(Types.Inputs.Storage.V1.CSINodeListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/StorageClass.cs
+++ b/sdk/dotnet/Storage/V1/StorageClass.cs
@@ -100,7 +100,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StorageClass(string name, Types.Inputs.Storage.V1.StorageClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:StorageClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:StorageClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -117,6 +117,19 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1beta1:StorageClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing StorageClass resource's state with the given name and ID.
         /// </summary>
@@ -128,6 +141,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new StorageClass(name, default(Types.Inputs.Storage.V1.StorageClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/StorageClassList.cs
+++ b/sdk/dotnet/Storage/V1/StorageClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StorageClassList(string name, Types.Inputs.Storage.V1.StorageClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:StorageClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:StorageClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing StorageClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new StorageClassList(name, default(Types.Inputs.Storage.V1.StorageClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/VolumeAttachment.cs
+++ b/sdk/dotnet/Storage/V1/VolumeAttachment.cs
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachment(string name, Types.Inputs.Storage.V1.VolumeAttachmentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:VolumeAttachment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:VolumeAttachment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -79,6 +79,20 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment" },
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachment resource's state with the given name and ID.
         /// </summary>
@@ -90,6 +104,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new VolumeAttachment(name, default(Types.Inputs.Storage.V1.VolumeAttachmentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1/VolumeAttachmentList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachmentList(string name, Types.Inputs.Storage.V1.VolumeAttachmentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachmentList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1
             return new VolumeAttachmentList(name, default(Types.Inputs.Storage.V1.VolumeAttachmentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Alpha1/VolumeAttachment.cs
+++ b/sdk/dotnet/Storage/V1Alpha1/VolumeAttachment.cs
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachment(string name, Types.Inputs.Storage.V1Alpha1.VolumeAttachmentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -79,6 +79,20 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1:VolumeAttachment" },
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1beta1:VolumeAttachment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachment resource's state with the given name and ID.
         /// </summary>
@@ -90,6 +104,5 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
             return new VolumeAttachment(name, default(Types.Inputs.Storage.V1Alpha1.VolumeAttachmentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachmentList(string name, Types.Inputs.Storage.V1Alpha1.VolumeAttachmentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1alpha1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachmentList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
             return new VolumeAttachmentList(name, default(Types.Inputs.Storage.V1Alpha1.VolumeAttachmentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/CSIDriver.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSIDriver.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSIDriver(string name, Types.Inputs.Storage.V1Beta1.CSIDriverArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:CSIDriver", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:CSIDriver", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -78,6 +78,11 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CSIDriver resource's state with the given name and ID.
         /// </summary>
@@ -89,6 +94,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new CSIDriver(name, default(Types.Inputs.Storage.V1Beta1.CSIDriverArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/CSIDriverList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSIDriverList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSIDriverList(string name, Types.Inputs.Storage.V1Beta1.CSIDriverListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:CSIDriverList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:CSIDriverList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CSIDriverList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new CSIDriverList(name, default(Types.Inputs.Storage.V1Beta1.CSIDriverListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/CSINode.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSINode.cs
@@ -58,7 +58,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSINode(string name, Types.Inputs.Storage.V1Beta1.CSINodeArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:CSINode", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:CSINode", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -75,6 +75,19 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1:CSINode" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing CSINode resource's state with the given name and ID.
         /// </summary>
@@ -86,6 +99,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new CSINode(name, default(Types.Inputs.Storage.V1Beta1.CSINodeArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/CSINodeList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSINodeList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public CSINodeList(string name, Types.Inputs.Storage.V1Beta1.CSINodeListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:CSINodeList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:CSINodeList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing CSINodeList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new CSINodeList(name, default(Types.Inputs.Storage.V1Beta1.CSINodeListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/StorageClass.cs
+++ b/sdk/dotnet/Storage/V1Beta1/StorageClass.cs
@@ -100,7 +100,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StorageClass(string name, Types.Inputs.Storage.V1Beta1.StorageClassArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:StorageClass", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:StorageClass", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -117,6 +117,19 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1:StorageClass" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing StorageClass resource's state with the given name and ID.
         /// </summary>
@@ -128,6 +141,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new StorageClass(name, default(Types.Inputs.Storage.V1Beta1.StorageClassArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/StorageClassList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/StorageClassList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public StorageClassList(string name, Types.Inputs.Storage.V1Beta1.StorageClassListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:StorageClassList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:StorageClassList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing StorageClassList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new StorageClassList(name, default(Types.Inputs.Storage.V1Beta1.StorageClassListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/VolumeAttachment.cs
+++ b/sdk/dotnet/Storage/V1Beta1/VolumeAttachment.cs
@@ -62,7 +62,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachment(string name, Types.Inputs.Storage.V1Beta1.VolumeAttachmentArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:VolumeAttachment", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -79,6 +79,20 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            var extraOptions = new CustomResourceOptions
+            {
+                Aliases =
+                {
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1:VolumeAttachment" },
+                    new Alias { Type = "kubernetes:storage.k8s.io/v1alpha1:VolumeAttachment" },
+                }
+            };
+
+            return CustomResourceOptions.Merge(options, extraOptions);
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachment resource's state with the given name and ID.
         /// </summary>
@@ -90,6 +104,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new VolumeAttachment(name, default(Types.Inputs.Storage.V1Beta1.VolumeAttachmentArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }

--- a/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentList.cs
+++ b/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentList.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public VolumeAttachmentList(string name, Types.Inputs.Storage.V1Beta1.VolumeAttachmentListArgs? args = null, CustomResourceOptions? options = null)
-            : base("kubernetes:storage.k8s.io/v1beta1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), options)
+            : base("kubernetes:storage.k8s.io/v1beta1:VolumeAttachmentList", name, SetAPIKindAndVersion(args), MakeOptions(options))
         {
         }
 
@@ -68,6 +68,11 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return args;
         }
 
+        private static CustomResourceOptions? MakeOptions(CustomResourceOptions? options)
+        {
+            return options;
+        }
+
         /// <summary>
         /// Get an existing VolumeAttachmentList resource's state with the given name and ID.
         /// </summary>
@@ -79,6 +84,5 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
             return new VolumeAttachmentList(name, default(Types.Inputs.Storage.V1Beta1.VolumeAttachmentListArgs),
                 CustomResourceOptions.Merge(options, new CustomResourceOptions {Id = id}));
         }
-
     }
 }


### PR DESCRIPTION
### Proposed changes

Automatically populate type aliases and additional secret outputs in the .NET SDK similar to Node.js.

### Related issues (optional)

Fixes #1022