### PR TITLE
Fix bool Python providers opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 -   Replace PersistentVolume if volume source changes. (https://github.com/pulumi/pulumi-kubernetes/pull/1015).
+-   Fix bool Python provider opts. (https://github.com/pulumi/pulumi-kubernetes/pull/1027).
 
 ## 1.5.6 (February 28, 2020)
 

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -54,10 +54,10 @@ class Provider(pulumi.ProviderResource):
         __props__ = {
             "cluster": cluster,
             "context": context,
-            "enableDryRun": "true" if enable_dry_run else "false",
+            "enableDryRun": enable_dry_run,
             "kubeconfig": kubeconfig,
             "namespace": namespace,
-            "suppress_deprecation_warnings": "true" if suppress_deprecation_warnings else "false",
-            "render_yaml_to_directory": render_yaml_to_directory,
+            "suppressDeprecationWarnings": suppress_deprecation_warnings,
+            "renderYamlToDirectory": render_yaml_to_directory,
         }
         super(Provider, self).__init__("kubernetes", __name__, __props__, __opts__)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Several Python Provider opts were not being handled correctly. This
fix maps all of the opts to the correct k8s provider config, and handles
the boolean values correctly.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1025 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
