### PR TITLE
Fix python Helm test

### DIFF
--- a/tests/examples/python/helm/requirements.txt
+++ b/tests/examples/python/helm/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=1.8.1,<2.0.0
-pulumi_random>==1.0.1a1566600005
+pulumi_random>=1.6.0


### PR DESCRIPTION
Set pulumi-random version requirement to a stable release
to avoid pulling in 2.0 beta packages

Fix #1057