### PR TITLE
Custom Resource for .NET SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 -   Add consts to Go SDK. (https://github.com/pulumi/pulumi-kubernetes/pull/1062).
+-   Add `CustomResource` to .NET SDK (https://github.com/pulumi/pulumi-kubernetes/pull/1067).
 
 ### Bug fixes
 

--- a/sdk/dotnet/ApiExtensions/CustomResource.cs
+++ b/sdk/dotnet/ApiExtensions/CustomResource.cs
@@ -1,0 +1,98 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+using Pulumi.Kubernetes.Types.Inputs.Meta.V1;
+using Pulumi.Kubernetes.Types.Outputs.Meta.V1;
+
+namespace Pulumi.Kubernetes.ApiExtensions
+{
+    /// <summary>
+    /// Represents an instance of a <see cref="V1.CustomResourceDefinition"/> (CRD). For example, the
+    /// CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to
+    /// instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the
+    /// `ServiceMonitor` resource definition as an argument.
+    /// </summary>
+    public class CustomResource : KubernetesResource
+    {
+        /// <summary>
+        /// APIVersion defines the versioned schema of this representation of an object. Servers
+        /// should convert recognized schemas to the latest internal value, and may reject
+        /// unrecognized values. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        /// </summary>
+        [Output("apiVersion")]
+        public Output<string> ApiVersion { get; private set; } = null!;
+
+        /// <summary>
+        /// Kind is a string value representing the REST resource this object represents. Servers
+        /// may infer this from the endpoint the client submits requests to. Cannot be updated. In
+        /// CamelCase. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        /// </summary>
+        [Output("kind")]
+        public Output<string> Kind { get; private set; } = null!;
+        
+        /// <summary>
+        /// Standard object metadata; More info:
+        /// https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
+        /// </summary>
+        [Output("metadata")]
+        public Output<ObjectMeta> Metadata { get; private set; } = null!;
+
+        public CustomResource(string name, CustomResourceArgs args, CustomResourceOptions? options = null)
+            : base(args.Type, name, args, options)
+        {
+        }
+    }
+    
+    /// <summary>
+    /// Represents a resource definition we'd use to create an instance of a Kubernetes
+    /// <see cref="V1.CustomResourceDefinition"/> (CRD). For example, the CoreOS Prometheus operator
+    /// exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to create a `ServiceMonitor`, we'd
+    /// pass a <see cref="CustomResourceArgs"/> containing the `ServiceMonitor` definition to
+    /// <see cref="CustomResource"/>.
+    ///
+    /// NOTE: This type is abstract. You need to inherit from it and define all the properties of
+    /// a specific custom resource in the derived class.
+    /// </summary>
+    public abstract class CustomResourceArgs : ResourceArgs
+    {
+        /// <summary>
+        /// APIVersion defines the versioned schema of this representation of an object. Servers should
+        /// convert recognized schemas to the latest internal value, and may reject unrecognized
+        /// values. More info:
+        /// https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+        /// </summary>
+        [Input("apiVersion")]
+        public Input<string> ApiVersion { get; }
+
+        /// <summary>
+        /// Kind is a string value representing the REST resource this object represents. Servers may
+        /// infer this from the endpoint the client submits requests to. Cannot be updated. In
+        /// CamelCase. More info:
+        /// https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+        /// </summary>
+        [Input("kind")]
+        public Input<string> Kind { get; }
+
+        /// <summary>
+        /// Standard object's metadata. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        /// </summary>
+        [Input("metadata")]
+        public Input<ObjectMetaArgs>? Metadata { get; set; }
+
+        /// <summary>
+        /// Resource type name, e.g. `kubernetes:stable.example.com:CronTab`.
+        /// We can't extract it from ApiVersion and Kind because they are Inputs, while we need
+        /// a plain string in the CustomResource constructor.
+        /// </summary>
+        internal string Type { get; }
+
+        protected CustomResourceArgs(string apiVersion, string kind)
+        {
+            this.ApiVersion = apiVersion;
+            this.Kind = kind;
+            this.Type = $"kubernetes:{apiVersion}:{kind}";
+        }
+    }
+}

--- a/tests/integration/dotnet/custom-resource/CustomResource.csproj
+++ b/tests/integration/dotnet/custom-resource/CustomResource.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/integration/dotnet/custom-resource/CustomResource.csproj
+++ b/tests/integration/dotnet/custom-resource/CustomResource.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/integration/dotnet/custom-resource/Program.cs
+++ b/tests/integration/dotnet/custom-resource/Program.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+using System.Threading.Tasks;
+using Pulumi;
+using Pulumi.Kubernetes.ApiExtensions;
+using Pulumi.Kubernetes.ApiExtensions.V1Beta1;
+using Pulumi.Kubernetes.Core.V1;
+using Pulumi.Kubernetes.Types.Inputs.ApiExtensions.V1Beta1;
+using Pulumi.Kubernetes.Types.Inputs.Meta.V1;
+
+/// <summary>
+/// Custom resource arguments for the `CronTab` custom resource.
+/// </summary>
+class CronTabArgs : CustomResourceArgs
+{
+    [Input("spec")]
+    public Input<CronTabSpecArgs>? Spec { get; set; }
+
+    public CronTabArgs() : base("stable.example.com/v1", "CronTab")
+    {
+    }
+}
+
+class CronTabSpecArgs : ResourceArgs
+{
+    [Input("cronSpec")]
+    public Input<string>? CronSpec { get; set; }
+        
+    [Input("image")]
+    public Input<string>? Image { get; set; }
+}
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var testNamespace = new Namespace("test-namespace");
+        
+        var ct = new CustomResourceDefinition("crontab", new CustomResourceDefinitionArgs
+        {
+            Metadata = new ObjectMetaArgs { Name = "crontabs.stable.example.com" },
+            Spec = new CustomResourceDefinitionSpecArgs
+            {
+                Group = "stable.example.com",
+                Version = "v1",
+                Scope = "Namespaced",
+                Names = new CustomResourceDefinitionNamesArgs
+                {
+                    Plural = "crontabs",
+                    Singular = "crontab",
+                    Kind = "CronTab",
+                    ShortNames = { { "ct" } }
+                }
+            }
+        });
+        
+        new Pulumi.Kubernetes.ApiExtensions.CustomResource("my-new-cron-object", new CronTabArgs
+        {
+            Metadata = new ObjectMetaArgs
+            {
+                Namespace = testNamespace.Metadata.Apply(m => m.Name),
+                Name = "my-new-cron-object2"
+            },
+            Spec = new CronTabSpecArgs
+            {
+                CronSpec = "* * * * */5", 
+                Image = "my-awesome-cron-image"
+            }
+        }, new CustomResourceOptions { DependsOn = { ct } });
+    }
+}
+
+class Program
+{
+    static Task<int> Main(string[] args) => Deployment.RunAsync<MyStack>();
+}

--- a/tests/integration/dotnet/custom-resource/Program.cs
+++ b/tests/integration/dotnet/custom-resource/Program.cs
@@ -16,7 +16,7 @@ class CronTabArgs : CustomResourceArgs
     [Input("spec")]
     public Input<CronTabSpecArgs>? Spec { get; set; }
 
-    public CronTabArgs() : base("stable.example.com/v1", "CronTab")
+    public CronTabArgs() : base("dotnet.example.com/v1", "CronTab")
     {
     }
 }
@@ -38,10 +38,10 @@ class MyStack : Stack
         
         var ct = new CustomResourceDefinition("crontab", new CustomResourceDefinitionArgs
         {
-            Metadata = new ObjectMetaArgs { Name = "crontabs.stable.example.com" },
+            Metadata = new ObjectMetaArgs { Name = "crontabs.dotnet.example.com" },
             Spec = new CustomResourceDefinitionSpecArgs
             {
-                Group = "stable.example.com",
+                Group = "dotnet.example.com",
                 Version = "v1",
                 Scope = "Namespaced",
                 Names = new CustomResourceDefinitionNamesArgs

--- a/tests/integration/dotnet/custom-resource/Pulumi.yaml
+++ b/tests/integration/dotnet/custom-resource/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: cr_dotnet_kubernetes
+description: An example of CRD and CR usage.
+runtime: dotnet

--- a/tests/integration/dotnet/dotnet_test.go
+++ b/tests/integration/dotnet/dotnet_test.go
@@ -158,3 +158,17 @@ func TestDotnet_HelmApiVersions(t *testing.T) {
 		},
 	})
 }
+
+func TestDotnet_CustomResource(t *testing.T) {
+	kubectx := os.Getenv("KUBERNETES_CONTEXT")
+
+	if kubectx == "" {
+		t.Skipf("Skipping test due to missing KUBERNETES_CONTEXT variable")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "custom-resource",
+		Dependencies: []string{"Pulumi.Kubernetes"},
+		Quick:        true,
+	})
+}


### PR DESCRIPTION
Introduces `CustomResource` class for the .NET SDK.

Important design decisions:

1. `CustomResourceArgs` argument type is abstract. Users are expected to derive from it and provide additional inputs for their own custom resource. See the example.
2. `apiVersion` and `kind` must be provided as plain strings to the `CustomResourceArgs` constructor, although later they are assigned to corresponding input properties. That's because the type string has to be immediately resolved.

Resolves #1038