### PR TITLE
Fix ci-cluster-destroy script to work with v2.0 CLI

### DIFF
--- a/scripts/ci-cluster-destroy.sh
+++ b/scripts/ci-cluster-destroy.sh
@@ -5,7 +5,7 @@ echo Deleting ephemeral Kubernetes cluster...
 
 pushd tests/ci-cluster
 pulumi stack select "${STACK}" && \
-  pulumi destroy --skip-preview && \
+  pulumi destroy --skip-preview --yes && \
   pulumi stack rm --yes
 
 popd


### PR DESCRIPTION
CI script was leaking clusters:
```
--yes must be passed in to proceed when running in non-interactive mode
```