### PR TITLE
Fix HELM_HOME handling for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 -   Fix error parsing YAML in python 3.8 (https://github.com/pulumi/pulumi-kubernetes/pull/1079)
+-   Fix HELM_HOME handling for Helm v3. (https://github.com/pulumi/pulumi-kubernetes/pull/1076)
 
 ## 2.0.0 (April 16, 2020)
 

--- a/provider/pkg/gen/dotnet-templates/Utilities.cs
+++ b/provider/pkg/gen/dotnet-templates/Utilities.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes
 
             foreach (KeyValuePair<string, string> value in env)
             {
-                process.StartInfo.EnvironmentVariables.Add(value.Key, value.Value);
+                process.StartInfo.EnvironmentVariables[value.Key] = value.Value;
             }
 
             process.Start();
@@ -148,23 +148,6 @@ namespace Pulumi.Kubernetes
             escapedArgument.Append('\"');
 
             return escapedArgument.ToString();
-        }
-
-        /// <summary>
-        /// Get ambient environment variables as a IDictionary.
-        /// </summary>
-        public static IDictionary<string, string> GetEnvironmentVariables()
-        {
-            var result = new Dictionary<string, string>();
-            foreach (var variable in Environment.GetEnvironmentVariables())
-            {
-                if (variable == null) continue;
-
-                var entry = (DictionaryEntry)variable;
-                if (entry.Key is string key && entry.Value is string value)
-                    result.Add(key, value);
-            }
-            return result;
         }
     }
 }

--- a/provider/pkg/gen/dotnet-templates/Utilities.cs
+++ b/provider/pkg/gen/dotnet-templates/Utilities.cs
@@ -3,6 +3,7 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace Pulumi.Kubernetes
             };
         }
 
-        public static string ExecuteCommand(string command, string[] flags)
+        public static string ExecuteCommand(string command, string[] flags, IDictionary<string, string>? env)
         {
             using var process = new Process
             {
@@ -51,6 +52,13 @@ namespace Pulumi.Kubernetes
                     RedirectStandardError = true
                 }
             };
+            if (env != null)
+            {
+                foreach (KeyValuePair<string, string> value in env)
+                {
+                    process.StartInfo.EnvironmentVariables.Add(value.Key, value.Value);
+                }
+            }
             process.Start();
             string output = process.StandardOutput.ReadToEnd();
             process.WaitForExit();

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -345,9 +345,8 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         // Untar by default.
         if(opts.untar !== false) { flags.push(`--untar`); }
 
-        // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        const home = opts.home ?? process.env?.HELM_HOME;
-        if (home) { env['HELM_HOME'] = path.quotePath(home) } // Helm v3 removed the `--home` flag, so use an env var.
+        // Helm v3 removed the `--home` flag, so we must use an env var instead.
+        if (opts.home) { env['HELM_HOME'] = path.quotePath(opts.home) }
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
         // However, for arguments that are actual paths to files we use path.quotePath (note that path here is

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -205,15 +205,10 @@ export class Chart extends yaml.CollectionComponentResource {
                     : "";
                 let cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
 
-                // Use the HELM_HOME environment variable value if set.
-                const home = process.env.HELM_HOME || undefined;
-                if (home !== undefined) {
-                    cmd += ` --home ${path.quotePath(home)}`;
-                }
-
                 const yamlStream = execSync(
                     cmd,
                     {
+                        env: {...process.env},
                         maxBuffer: 512 * 1024 * 1024 // 512 MB
                     },
                 ).toString();
@@ -345,14 +340,14 @@ interface ResolvedFetchOpts {
  */
 export function fetch(chart: string, opts?: ResolvedFetchOpts) {
     const flags: string[] = [];
+    const env: { [key: string]: string | undefined } = {...process.env};
     if (opts !== undefined) {
         // Untar by default.
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        if (!opts.home) {
-            opts.home = process.env.HELM_HOME || undefined;
-        }
+        const home = opts.home ?? process.env?.HELM_HOME;
+        if (home) { env['HELM_HOME'] = path.quotePath(home) } // Helm v3 removed the `--home` flag, so use an env var.
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
         // However, for arguments that are actual paths to files we use path.quotePath (note that path here is
@@ -367,10 +362,9 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if (opts.repo !== undefined)        { flags.push(`--repo ${path.quotePath(opts.repo)}`);               }
         if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);  }
-        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                           }
         if (opts.prov === true)             { flags.push(`--prov`);                                            }
         if (opts.verify === true)           { flags.push(`--verify`);                                          }
     }
-    execSync(`helm fetch ${shell.quote([chart])} ${flags.join(" ")}`);
+    execSync(`helm fetch ${shell.quote([chart])} ${flags.join(" ")}`, { env });
 }

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -275,8 +275,7 @@ class LocalChartOpts(BaseChartOpts):
 def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     cmd, _ = all_config
 
-    output = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=os.environ)
+    output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
     yaml_str: str = output.stdout
     return yaml_str
 

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -276,7 +276,7 @@ def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     cmd, _ = all_config
 
     output = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=os.environ)
     yaml_str: str = output.stdout
     return yaml_str
 
@@ -339,14 +339,10 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
-    home = os.environ.get('HELM_HOME')
-    home_arg = ['--home', home] if home else []
-
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
-    cmd.extend(home_arg)
 
     chart_resources = pulumi.Output.all(cmd, data).apply(_run_helm_cmd)
 
@@ -373,10 +369,10 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     if opts.untar is not False:
         cmd.append('--untar')
 
+    env = os.environ
+    # Helm v3 removed the `--home` flag, so we must use an env var instead.
     if opts.home:
-        cmd.extend(['--home', opts.home])
-    elif os.environ.get('HELM_HOME'):
-        cmd.extend(['--home', os.environ.get('HELM_HOME')])
+        env['HELM_HOME'] = opts.home
 
     if opts.version:
         cmd.extend(['--version', opts.version])
@@ -405,7 +401,7 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     if opts.verify:
         cmd.append('--verify')
 
-    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=env)
 
 
 class Chart(pulumi.ComponentResource):

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -111,7 +111,7 @@ namespace Pulumi.Kubernetes.Helm
                         flags.Add(cfgBase.Namespace);
                     }
 
-                    var yaml = Utilities.ExecuteCommand("helm", flags.ToArray(), Utilities.GetEnvironmentVariables());
+                    var yaml = Utilities.ExecuteCommand("helm", flags.ToArray(), new Dictionary<string, string>());
                     return ParseTemplate(
                         yaml, cfgBase.Transformations, cfgBase.ResourcePrefix, dependencies, cfgBase.Namespace);
                 }
@@ -144,7 +144,7 @@ namespace Pulumi.Kubernetes.Helm
                 flags.Add("--untar");
             }
 
-            var env = Utilities.GetEnvironmentVariables();
+            var env = new Dictionary<string, string>();
 
             // Helm v3 removed the `--home` flag, so we must use an env var instead.
             if (!string.IsNullOrEmpty(opts.Home))

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -56,7 +56,7 @@ namespace Pulumi.Kubernetes
 
             foreach (KeyValuePair<string, string> value in env)
             {
-                process.StartInfo.EnvironmentVariables.Add(value.Key, value.Value);
+                process.StartInfo.EnvironmentVariables[value.Key] = value.Value;
             }
 
             process.Start();
@@ -148,23 +148,6 @@ namespace Pulumi.Kubernetes
             escapedArgument.Append('\"');
 
             return escapedArgument.ToString();
-        }
-
-        /// <summary>
-        /// Get ambient environment variables as a IDictionary.
-        /// </summary>
-        public static IDictionary<string, string> GetEnvironmentVariables()
-        {
-            var result = new Dictionary<string, string>();
-            foreach (var variable in Environment.GetEnvironmentVariables())
-            {
-                if (variable == null) continue;
-
-                var entry = (DictionaryEntry)variable;
-                if (entry.Key is string key && entry.Value is string value)
-                    result.Add(key, value);
-            }
-            return result;
         }
     }
 }

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -3,6 +3,7 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace Pulumi.Kubernetes
             };
         }
 
-        public static string ExecuteCommand(string command, string[] flags)
+        public static string ExecuteCommand(string command, string[] flags, IDictionary<string, string>? env)
         {
             using var process = new Process
             {
@@ -51,6 +52,13 @@ namespace Pulumi.Kubernetes
                     RedirectStandardError = true
                 }
             };
+            if (env != null)
+            {
+                foreach (KeyValuePair<string, string> value in env)
+                {
+                    process.StartInfo.EnvironmentVariables.Add(value.Key, value.Value);
+                }
+            }
             process.Start();
             string output = process.StandardOutput.ReadToEnd();
             process.WaitForExit();

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -345,9 +345,8 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         // Untar by default.
         if(opts.untar !== false) { flags.push(`--untar`); }
 
-        // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        const home = opts.home ?? process.env?.HELM_HOME;
-        if (home) { env['HELM_HOME'] = path.quotePath(home) } // Helm v3 removed the `--home` flag, so use an env var.
+        // Helm v3 removed the `--home` flag, so we must use an env var instead.
+        if (opts.home) { env['HELM_HOME'] = path.quotePath(opts.home) }
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
         // However, for arguments that are actual paths to files we use path.quotePath (note that path here is

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -205,15 +205,10 @@ export class Chart extends yaml.CollectionComponentResource {
                     : "";
                 let cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
 
-                // Use the HELM_HOME environment variable value if set.
-                const home = process.env.HELM_HOME || undefined;
-                if (home !== undefined) {
-                    cmd += ` --home ${path.quotePath(home)}`;
-                }
-
                 const yamlStream = execSync(
                     cmd,
                     {
+                        env: {...process.env},
                         maxBuffer: 512 * 1024 * 1024 // 512 MB
                     },
                 ).toString();
@@ -345,14 +340,14 @@ interface ResolvedFetchOpts {
  */
 export function fetch(chart: string, opts?: ResolvedFetchOpts) {
     const flags: string[] = [];
+    const env: { [key: string]: string | undefined } = {...process.env};
     if (opts !== undefined) {
         // Untar by default.
         if(opts.untar !== false) { flags.push(`--untar`); }
 
         // Fallback to using the HELM_HOME environment variable if opts.home is not set.
-        if (!opts.home) {
-            opts.home = process.env.HELM_HOME || undefined;
-        }
+        const home = opts.home ?? process.env?.HELM_HOME;
+        if (home) { env['HELM_HOME'] = path.quotePath(home) } // Helm v3 removed the `--home` flag, so use an env var.
 
         // For arguments that are not paths to files, it is sufficient to use shell.quote to quote the arguments.
         // However, for arguments that are actual paths to files we use path.quotePath (note that path here is
@@ -367,10 +362,9 @@ export function fetch(chart: string, opts?: ResolvedFetchOpts) {
         if (opts.repo !== undefined)        { flags.push(`--repo ${path.quotePath(opts.repo)}`);               }
         if (opts.untardir !== undefined)    { flags.push(`--untardir ${path.quotePath(opts.untardir)}`);       }
         if (opts.username !== undefined)    { flags.push(`--username ${shell.quote([opts.username])}`);  }
-        if (opts.home !== undefined)        { flags.push(`--home ${path.quotePath(opts.home)}`);               }
         if (opts.devel === true)            { flags.push(`--devel`);                                           }
         if (opts.prov === true)             { flags.push(`--prov`);                                            }
         if (opts.verify === true)           { flags.push(`--verify`);                                          }
     }
-    execSync(`helm fetch ${shell.quote([chart])} ${flags.join(" ")}`);
+    execSync(`helm fetch ${shell.quote([chart])} ${flags.join(" ")}`, { env });
 }

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -275,8 +275,7 @@ class LocalChartOpts(BaseChartOpts):
 def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     cmd, _ = all_config
 
-    output = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=os.environ)
+    output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
     yaml_str: str = output.stdout
     return yaml_str
 

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -276,7 +276,7 @@ def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     cmd, _ = all_config
 
     output = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=os.environ)
     yaml_str: str = output.stdout
     return yaml_str
 
@@ -339,14 +339,10 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
 
-    home = os.environ.get('HELM_HOME')
-    home_arg = ['--home', home] if home else []
-
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,
            '--values', default_values, '--values', overrides_filename]
     cmd.extend(namespace_arg)
-    cmd.extend(home_arg)
 
     chart_resources = pulumi.Output.all(cmd, data).apply(_run_helm_cmd)
 
@@ -373,10 +369,10 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     if opts.untar is not False:
         cmd.append('--untar')
 
+    env = os.environ
+    # Helm v3 removed the `--home` flag, so we must use an env var instead.
     if opts.home:
-        cmd.extend(['--home', opts.home])
-    elif os.environ.get('HELM_HOME'):
-        cmd.extend(['--home', os.environ.get('HELM_HOME')])
+        env['HELM_HOME'] = opts.home
 
     if opts.version:
         cmd.extend(['--version', opts.version])
@@ -405,7 +401,7 @@ def _fetch(chart: str, opts: FetchOpts) -> None:
     if opts.verify:
         cmd.append('--verify')
 
-    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, env=env)
 
 
 class Chart(pulumi.ComponentResource):

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -174,7 +174,7 @@ def _parse_yaml_object(
             api_version, kind, json.dumps(obj)))
 
     # Convert obj keys to Python casing
-    for key in obj:
+    for key in list(obj.keys()):
         new_key = tables._CASING_FORWARD_TABLE.get(key) or key
         if new_key != key:
             obj[new_key] = obj.pop(key)

--- a/tests/examples/helm/index.ts
+++ b/tests/examples/helm/index.ts
@@ -13,17 +13,21 @@
 // limitations under the License.
 
 import * as k8s from "@pulumi/kubernetes";
+import * as os from "os";
 import * as pulumi from "@pulumi/pulumi";
 
 const namespace = new k8s.core.v1.Namespace("test");
 const namespaceName = namespace.metadata.name;
 
-const nginx = new k8s.helm.v2.Chart("simple-nginx", {
+const nginx = new k8s.helm.v3.Chart("simple-nginx", {
     // Represents chart `stable/nginx-lego@v0.3.1`.
     repo: "stable",
     chart: "nginx-lego",
     version: "0.3.1",
     namespace: namespaceName,
+    fetchOpts: {
+        home: os.homedir(),
+    },
     values: {
         // Override for the Chart's `values.yml` file. Use `null` to zero out resource requests so it
         // can be scheduled on our (wimpy) CI cluster. (Setting these values to `null` is the "normal"

--- a/tests/examples/helm/package.json
+++ b/tests/examples/helm/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@pulumi/pulumi": "latest",
-    "@types/js-yaml": "^3.11.2",
-    "js-yaml": "^3.12.0"
+    "os": "^0.1.1"
   },
   "devDependencies": {
     "@types/node": "^9.3.0"

--- a/tests/examples/python/helm/__main__.py
+++ b/tests/examples/python/helm/__main__.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pulumi_kubernetes.core.v1 import Namespace
-from pulumi_kubernetes.helm.v2 import Chart, ChartOpts
+from pulumi_kubernetes.helm.v2 import Chart, ChartOpts, FetchOpts
 from pulumi_random import RandomString
+from os.path import expanduser
 
 namespace = Namespace("test")
 
@@ -29,10 +30,11 @@ values = {
 }
 
 Chart("unbound", ChartOpts(
-    "stable/unbound", values=values, namespace=namespace.metadata["name"], version="1.1.0"))
+    "stable/unbound", values=values, namespace=namespace.metadata["name"], version="1.1.0",
+    fetch_opts=FetchOpts(home=expanduser("~"))))
 
 # Deploy a duplicate chart with a different resource prefix to verify that multiple instances of the Chart
 # can be managed in the same stack.
 Chart("unbound", ChartOpts(
     "stable/unbound", resource_prefix="dup", values=values, namespace=namespace.metadata["name"],
-    version="1.1.0"))
+    version="1.1.0", fetch_opts=FetchOpts(home=expanduser("~"))))

--- a/tests/integration/dotnet/helm/Program.cs
+++ b/tests/integration/dotnet/helm/Program.cs
@@ -58,7 +58,8 @@ class HelmStack : Stack
             Version = "0.1.0",
             FetchOptions = new ChartFetchArgs
             {
-                Repo = "https://kubernetes-charts-incubator.storage.googleapis.com/"
+                Home = Environment.GetEnvironmentVariable("HOME"),
+                Repo = "https://kubernetes-charts-incubator.storage.googleapis.com/",
             }
         });
         


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Helm v3 removed the `--home` parameter, but still supports the `HELM_HOME` env var for backward compatibility. Pass ambient env vars to the `helm` binary so this works properly.

TODO:

- [x] NodeJS
- [x] Python
- [x] C#

### Related issues (optional)
Fix #1070 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
