### PR TITLE
Fix parse yaml error with python3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## HEAD (Unreleased)
 
+### Bug Fixes
+
+-   Fix error parsing YAML in python 3.8 (https://github.com/pulumi/pulumi-kubernetes/pull/1079)
+
 ## 2.0.0 (April 16, 2020)
 
 ### Improvements
 
 -   Add consts to Go SDK. (https://github.com/pulumi/pulumi-kubernetes/pull/1062).
 -   Add `CustomResource` to .NET SDK (https://github.com/pulumi/pulumi-kubernetes/pull/1067).
--   Upgrade to Pulumi v2.0.0 
+-   Upgrade to Pulumi v2.0.0
 
 ### Bug fixes
 
@@ -28,7 +32,7 @@
 
 ### Improvements
 
--   Automatically populate type aliases and additional secret outputs in the .NET SDK.  (https://github.com/pulumi/pulumi-kubernetes/pull/1026).  
+-   Automatically populate type aliases and additional secret outputs in the .NET SDK.  (https://github.com/pulumi/pulumi-kubernetes/pull/1026).
 -   Update to Pulumi NuGet 1.12.1 and .NET Core 3.1.  (https://github.com/pulumi/pulumi-kubernetes/pull/1030).
 
 ## 1.5.7 (March 10, 2020)

--- a/provider/pkg/gen/python-templates/yaml.py.mustache
+++ b/provider/pkg/gen/python-templates/yaml.py.mustache
@@ -174,7 +174,7 @@ def _parse_yaml_object(
             api_version, kind, json.dumps(obj)))
 
     # Convert obj keys to Python casing
-    for key in obj:
+    for key in list(obj.keys()):
         new_key = tables._CASING_FORWARD_TABLE.get(key) or key
         if new_key != key:
             obj[new_key] = obj.pop(key)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
In python 3.8 changing the keys of a dict during iteration of the dict itself can raise `RuntimeErrors`, specifically I got this error in plan while triying to add a Helm Chart:

```
  pulumi:pulumi:Stack (monitoring-staging):                                                                                                                                                                      
    error: Program failed with an unhandled exception:                                                                                                                                                           
    error: Traceback (most recent call last):                                                                                                                                                                    
      File "/home/charly/.pulumi/bin/pulumi-language-python-exec", line 85, in <module>                                                                                                                          
        loop.run_until_complete(coro)                                                                                                                                                                            
      File "/usr/lib/python3.8/asyncio/base_events.py", line 612, in run_until_complete                                                                                            
        return future.result()                                                                                                                                                     
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 155, in run                                                                                                   
        value = await self._future                                                                                                                                                 
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/stack.py", line 81, in run_in_stack                                                                                    
        await run_pulumi_func(lambda: Stack(func))                                                                                                                                 
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/stack.py", line 50, in run_pulumi_func                                                                                 
        await RPC_MANAGER.rpcs.pop()                                                                                                                                               
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/rpc_manager.py", line 67, in rpc_wrapper                                                                               
        result = await rpc                                                                                                                                                         
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/resource.py", line 440, in do_register_resource_outputs                                                                
        serialized_props = await rpc.serialize_properties(outputs, {})                                                                                                             
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/rpc.py", line 68, in serialize_properties                                                                              
        result = await serialize_property(v, deps, input_transformer)                                                                                                              
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/rpc.py", line 173, in serialize_property                                                                               
        value = await serialize_property(output.future(), deps, input_transformer)                                                                                                 
      File "/usr/lib/python3.8/site-packages/pulumi/runtime/rpc.py", line 159, in serialize_property                                                                               
        future_return = await asyncio.ensure_future(awaitable)                                                                                                                     
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 340, in gather_futures                                                                                        
        return await asyncio.gather(*value_futures)                                                                                                                                
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 114, in get_value                                                                                             
        val = await self._future                                                                                                                                                   
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 186, in run                                                                                                   
        return await transformed.future(with_unknowns=True)                                                                                                                        
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 114, in get_value                                                                                             
        val = await self._future                                                                                                                                                   
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 114, in get_value                                                                                             
        val = await self._future                                                                                                                                                   
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 155, in run                                                                                                   
        value = await self._future                                                                                                                                                 
      File "/usr/lib/python3.8/site-packages/pulumi/output.py", line 176, in run                                                                                                   
        transformed: Input[U] = func(value)                                                                                                                                        
      File "/usr/lib/python3.8/site-packages/pulumi_kubernetes/helm/v2/helm.py", line 362, in <lambda>                                                                             
        lambda objects: _parse_yaml_document(objects, opts, config.transformations))                                                                                               
      File "/usr/lib/python3.8/site-packages/pulumi_kubernetes/yaml.py", line 122, in _parse_yaml_document                                                                         
        file_objects = _parse_yaml_object(obj, opts, transformations, resource_prefix)                                                                                             
      File "/usr/lib/python3.8/site-packages/pulumi_kubernetes/yaml.py", line 177, in _parse_yaml_object
        for key in obj:
    RuntimeError: dictionary keys changed during iteration
```

A fix for this is iterate over a copy of the keys instead of iterate the dict itself.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
