### PR TITLE
Fix schema type for Fields and RawExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+-   Fix schema type for Fields and RawExtension. (https://github.com/pulumi/pulumi-kubernetes/pull/1086)
 -   Fix error parsing YAML in python 3.8 (https://github.com/pulumi/pulumi-kubernetes/pull/1079)
 -   Fix HELM_HOME handling for Helm v3. (https://github.com/pulumi/pulumi-kubernetes/pull/1076)
 

--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -808,8 +808,8 @@ func makeSchemaTypeSpec(prop map[string]interface{}, canonicalGroups map[string]
 		}}
 	case v1Fields, v1FieldsV1, rawExtension:
 		return pschema.TypeSpec{
-			Type:                 "object",
-			AdditionalProperties: &pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+			Type: "object",
+			Ref:  "pulumi.json#/Any",
 		}
 	case v1Time, v1MicroTime:
 		return pschema.TypeSpec{Type: "string"}

--- a/sdk/go/kubernetes/apps/v1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevision.go
@@ -18,7 +18,7 @@ type ControllerRevision struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapOutput `pulumi:"data"`
+	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -72,7 +72,7 @@ type controllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -85,7 +85,7 @@ type ControllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -102,7 +102,7 @@ type controllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -116,7 +116,7 @@ type ControllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/sdk/go/kubernetes/apps/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1/pulumiTypes.go
@@ -17,7 +17,7 @@ type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -43,7 +43,7 @@ type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput `pulumi:"data"`
+	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -111,8 +111,8 @@ func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Data is the serialized representation of the state.
-func (o ControllerRevisionTypeOutput) Data() pulumi.MapOutput {
-	return o.ApplyT(func(v ControllerRevisionType) map[string]interface{} { return v.Data }).(pulumi.MapOutput)
+func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
+	return o.ApplyT(func(v ControllerRevisionType) interface{} { return v.Data }).(pulumi.AnyOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
@@ -18,7 +18,7 @@ type ControllerRevision struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapOutput `pulumi:"data"`
+	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -72,7 +72,7 @@ type controllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -85,7 +85,7 @@ type ControllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -102,7 +102,7 @@ type controllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -116,7 +116,7 @@ type ControllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/sdk/go/kubernetes/apps/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1beta1/pulumiTypes.go
@@ -17,7 +17,7 @@ type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -43,7 +43,7 @@ type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput `pulumi:"data"`
+	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -111,8 +111,8 @@ func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Data is the serialized representation of the state.
-func (o ControllerRevisionTypeOutput) Data() pulumi.MapOutput {
-	return o.ApplyT(func(v ControllerRevisionType) map[string]interface{} { return v.Data }).(pulumi.MapOutput)
+func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
+	return o.ApplyT(func(v ControllerRevisionType) interface{} { return v.Data }).(pulumi.AnyOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
@@ -18,7 +18,7 @@ type ControllerRevision struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapOutput `pulumi:"data"`
+	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -72,7 +72,7 @@ type controllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -85,7 +85,7 @@ type ControllerRevisionState struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -102,7 +102,7 @@ type controllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -116,7 +116,7 @@ type ControllerRevisionArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput
+	Data pulumi.Input
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/sdk/go/kubernetes/apps/v1beta2/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1beta2/pulumiTypes.go
@@ -17,7 +17,7 @@ type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data map[string]interface{} `pulumi:"data"`
+	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -43,7 +43,7 @@ type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
-	Data pulumi.MapInput `pulumi:"data"`
+	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -111,8 +111,8 @@ func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Data is the serialized representation of the state.
-func (o ControllerRevisionTypeOutput) Data() pulumi.MapOutput {
-	return o.ApplyT(func(v ControllerRevisionType) map[string]interface{} { return v.Data }).(pulumi.MapOutput)
+func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
+	return o.ApplyT(func(v ControllerRevisionType) interface{} { return v.Data }).(pulumi.AnyOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/sdk/go/kubernetes/meta/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/meta/v1/pulumiTypes.go
@@ -1485,7 +1485,7 @@ type ManagedFieldsEntry struct {
 	// FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
 	FieldsType *string `pulumi:"fieldsType"`
 	// FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-	FieldsV1 map[string]interface{} `pulumi:"fieldsV1"`
+	FieldsV1 interface{} `pulumi:"fieldsV1"`
 	// Manager is an identifier of the workflow managing these fields.
 	Manager *string `pulumi:"manager"`
 	// Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
@@ -1513,7 +1513,7 @@ type ManagedFieldsEntryArgs struct {
 	// FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
 	FieldsType pulumi.StringPtrInput `pulumi:"fieldsType"`
 	// FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-	FieldsV1 pulumi.MapInput `pulumi:"fieldsV1"`
+	FieldsV1 pulumi.Input `pulumi:"fieldsV1"`
 	// Manager is an identifier of the workflow managing these fields.
 	Manager pulumi.StringPtrInput `pulumi:"manager"`
 	// Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
@@ -1586,8 +1586,8 @@ func (o ManagedFieldsEntryOutput) FieldsType() pulumi.StringPtrOutput {
 }
 
 // FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-func (o ManagedFieldsEntryOutput) FieldsV1() pulumi.MapOutput {
-	return o.ApplyT(func(v ManagedFieldsEntry) map[string]interface{} { return v.FieldsV1 }).(pulumi.MapOutput)
+func (o ManagedFieldsEntryOutput) FieldsV1() pulumi.AnyOutput {
+	return o.ApplyT(func(v ManagedFieldsEntry) interface{} { return v.FieldsV1 }).(pulumi.AnyOutput)
 }
 
 // Manager is an identifier of the workflow managing these fields.
@@ -2892,8 +2892,8 @@ type WatchEvent struct {
 	//  * If Type is Deleted: the state of the object immediately before deletion.
 	//  * If Type is Error: *Status is recommended; other types may make sense
 	//    depending on context.
-	Object map[string]interface{} `pulumi:"object"`
-	Type   *string                `pulumi:"type"`
+	Object interface{} `pulumi:"object"`
+	Type   *string     `pulumi:"type"`
 }
 
 // WatchEventInput is an input type that accepts WatchEventArgs and WatchEventOutput values.
@@ -2915,7 +2915,7 @@ type WatchEventArgs struct {
 	//  * If Type is Deleted: the state of the object immediately before deletion.
 	//  * If Type is Error: *Status is recommended; other types may make sense
 	//    depending on context.
-	Object pulumi.MapInput       `pulumi:"object"`
+	Object pulumi.Input          `pulumi:"object"`
 	Type   pulumi.StringPtrInput `pulumi:"type"`
 }
 
@@ -2951,8 +2951,8 @@ func (o WatchEventOutput) ToWatchEventOutputWithContext(ctx context.Context) Wat
 //  * If Type is Deleted: the state of the object immediately before deletion.
 //  * If Type is Error: *Status is recommended; other types may make sense
 //    depending on context.
-func (o WatchEventOutput) Object() pulumi.MapOutput {
-	return o.ApplyT(func(v WatchEvent) map[string]interface{} { return v.Object }).(pulumi.MapOutput)
+func (o WatchEventOutput) Object() pulumi.AnyOutput {
+	return o.ApplyT(func(v WatchEvent) interface{} { return v.Object }).(pulumi.AnyOutput)
 }
 
 func (o WatchEventOutput) Type() pulumi.StringPtrOutput {


### PR DESCRIPTION
Before:
```
"data": {
    "type": "object",
    "additionalProperties": {
        "$ref": "pulumi.json#/Any"
    },
    "description": "Data is the serialized representation of the state."
}
```

After:
```
"data": {
    "type": "object",
    "$ref": "pulumi.json#/Any",
    "description": "Data is the serialized representation of the state."
}
```
