### PR TITLE
Adjust schema for C# codegen

### DIFF
--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -803,7 +803,7 @@ func makeSchemaTypeSpec(prop map[string]interface{}, canonicalGroups map[string]
 		return pschema.TypeSpec{Type: "string"}
 	case intOrString:
 		return pschema.TypeSpec{OneOf: []pschema.TypeSpec{
-			{Type: "number"},
+			{Type: "integer"},
 			{Type: "string"},
 		}}
 	case v1Fields, v1FieldsV1, rawExtension:

--- a/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfiguration.go
@@ -15,11 +15,11 @@ type MutatingWebhookConfiguration struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks MutatingWebhookArrayOutput `pulumi:"webhooks"`
 }

--- a/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationList.go
@@ -16,13 +16,13 @@ type MutatingWebhookConfigurationList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items MutatingWebhookConfigurationTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewMutatingWebhookConfigurationList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/admissionregistration/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/pulumiTypes.go
@@ -16,7 +16,7 @@ type MutatingWebhook struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
 	AdmissionReviewVersions []string `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig *WebhookClientConfig `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfig `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
 	FailurePolicy *string `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -28,7 +28,7 @@ type MutatingWebhook struct {
 	// Defaults to "Equivalent"
 	MatchPolicy *string `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -74,7 +74,7 @@ type MutatingWebhook struct {
 	// Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	Rules []RuleWithOperations `pulumi:"rules"`
 	// SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-	SideEffects *string `pulumi:"sideEffects"`
+	SideEffects string `pulumi:"sideEffects"`
 	// TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 	TimeoutSeconds *int `pulumi:"timeoutSeconds"`
 }
@@ -96,7 +96,7 @@ type MutatingWebhookArgs struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
 	AdmissionReviewVersions pulumi.StringArrayInput `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig WebhookClientConfigPtrInput `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfigInput `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
 	FailurePolicy pulumi.StringPtrInput `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -108,7 +108,7 @@ type MutatingWebhookArgs struct {
 	// Defaults to "Equivalent"
 	MatchPolicy pulumi.StringPtrInput `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -154,7 +154,7 @@ type MutatingWebhookArgs struct {
 	// Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	Rules RuleWithOperationsArrayInput `pulumi:"rules"`
 	// SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-	SideEffects pulumi.StringPtrInput `pulumi:"sideEffects"`
+	SideEffects pulumi.StringInput `pulumi:"sideEffects"`
 	// TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 	TimeoutSeconds pulumi.IntPtrInput `pulumi:"timeoutSeconds"`
 }
@@ -218,8 +218,8 @@ func (o MutatingWebhookOutput) AdmissionReviewVersions() pulumi.StringArrayOutpu
 }
 
 // ClientConfig defines how to communicate with the hook. Required
-func (o MutatingWebhookOutput) ClientConfig() WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v MutatingWebhook) *WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigPtrOutput)
+func (o MutatingWebhookOutput) ClientConfig() WebhookClientConfigOutput {
+	return o.ApplyT(func(v MutatingWebhook) WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigOutput)
 }
 
 // FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
@@ -239,8 +239,8 @@ func (o MutatingWebhookOutput) MatchPolicy() pulumi.StringPtrOutput {
 }
 
 // The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-func (o MutatingWebhookOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhook) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhook) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
@@ -300,8 +300,8 @@ func (o MutatingWebhookOutput) Rules() RuleWithOperationsArrayOutput {
 }
 
 // SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-func (o MutatingWebhookOutput) SideEffects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhook) *string { return v.SideEffects }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookOutput) SideEffects() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhook) string { return v.SideEffects }).(pulumi.StringOutput)
 }
 
 // TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
@@ -332,11 +332,11 @@ func (o MutatingWebhookArrayOutput) Index(i pulumi.IntInput) MutatingWebhookOutp
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 type MutatingWebhookConfigurationType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks []MutatingWebhook `pulumi:"webhooks"`
 }
@@ -356,11 +356,11 @@ type MutatingWebhookConfigurationTypeInput interface {
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 type MutatingWebhookConfigurationTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks MutatingWebhookArrayInput `pulumi:"webhooks"`
 }
@@ -419,18 +419,18 @@ func (o MutatingWebhookConfigurationTypeOutput) ToMutatingWebhookConfigurationTy
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o MutatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-func (o MutatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Webhooks is a list of webhooks and the affected resources and operations.
@@ -461,13 +461,13 @@ func (o MutatingWebhookConfigurationTypeArrayOutput) Index(i pulumi.IntInput) Mu
 // MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
 type MutatingWebhookConfigurationListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items []MutatingWebhookConfigurationType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // MutatingWebhookConfigurationListTypeInput is an input type that accepts MutatingWebhookConfigurationListTypeArgs and MutatingWebhookConfigurationListTypeOutput values.
@@ -485,13 +485,13 @@ type MutatingWebhookConfigurationListTypeInput interface {
 // MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
 type MutatingWebhookConfigurationListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items MutatingWebhookConfigurationTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (MutatingWebhookConfigurationListTypeArgs) ElementType() reflect.Type {
@@ -522,8 +522,8 @@ func (o MutatingWebhookConfigurationListTypeOutput) ToMutatingWebhookConfigurati
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o MutatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of MutatingWebhookConfiguration.
@@ -532,13 +532,13 @@ func (o MutatingWebhookConfigurationListTypeOutput) Items() MutatingWebhookConfi
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
@@ -700,9 +700,9 @@ func (o RuleWithOperationsArrayOutput) Index(i pulumi.IntInput) RuleWithOperatio
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
 	// `name` is the name of the service. Required
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path *string `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -724,9 +724,9 @@ type ServiceReferenceInput interface {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReferenceArgs struct {
 	// `name` is the name of the service. Required
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -813,13 +813,13 @@ func (o ServiceReferenceOutput) ToServiceReferencePtrOutputWithContext(ctx conte
 }
 
 // `name` is the name of the service. Required
-func (o ServiceReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // `namespace` is the namespace of the service. Required
-func (o ServiceReferenceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // `path` is an optional URL path which will be sent in any request to this service.
@@ -856,7 +856,7 @@ func (o ServiceReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -866,7 +866,7 @@ func (o ServiceReferencePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -895,7 +895,7 @@ type ValidatingWebhook struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
 	AdmissionReviewVersions []string `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig *WebhookClientConfig `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfig `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
 	FailurePolicy *string `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -907,7 +907,7 @@ type ValidatingWebhook struct {
 	// Defaults to "Equivalent"
 	MatchPolicy *string `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -945,7 +945,7 @@ type ValidatingWebhook struct {
 	// Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	Rules []RuleWithOperations `pulumi:"rules"`
 	// SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-	SideEffects *string `pulumi:"sideEffects"`
+	SideEffects string `pulumi:"sideEffects"`
 	// TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 	TimeoutSeconds *int `pulumi:"timeoutSeconds"`
 }
@@ -967,7 +967,7 @@ type ValidatingWebhookArgs struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
 	AdmissionReviewVersions pulumi.StringArrayInput `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig WebhookClientConfigPtrInput `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfigInput `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
 	FailurePolicy pulumi.StringPtrInput `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -979,7 +979,7 @@ type ValidatingWebhookArgs struct {
 	// Defaults to "Equivalent"
 	MatchPolicy pulumi.StringPtrInput `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -1017,7 +1017,7 @@ type ValidatingWebhookArgs struct {
 	// Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	Rules RuleWithOperationsArrayInput `pulumi:"rules"`
 	// SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-	SideEffects pulumi.StringPtrInput `pulumi:"sideEffects"`
+	SideEffects pulumi.StringInput `pulumi:"sideEffects"`
 	// TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 	TimeoutSeconds pulumi.IntPtrInput `pulumi:"timeoutSeconds"`
 }
@@ -1081,8 +1081,8 @@ func (o ValidatingWebhookOutput) AdmissionReviewVersions() pulumi.StringArrayOut
 }
 
 // ClientConfig defines how to communicate with the hook. Required
-func (o ValidatingWebhookOutput) ClientConfig() WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhook) *WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigPtrOutput)
+func (o ValidatingWebhookOutput) ClientConfig() WebhookClientConfigOutput {
+	return o.ApplyT(func(v ValidatingWebhook) WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigOutput)
 }
 
 // FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
@@ -1102,8 +1102,8 @@ func (o ValidatingWebhookOutput) MatchPolicy() pulumi.StringPtrOutput {
 }
 
 // The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-func (o ValidatingWebhookOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhook) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhook) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
@@ -1152,8 +1152,8 @@ func (o ValidatingWebhookOutput) Rules() RuleWithOperationsArrayOutput {
 }
 
 // SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-func (o ValidatingWebhookOutput) SideEffects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhook) *string { return v.SideEffects }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookOutput) SideEffects() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhook) string { return v.SideEffects }).(pulumi.StringOutput)
 }
 
 // TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
@@ -1184,11 +1184,11 @@ func (o ValidatingWebhookArrayOutput) Index(i pulumi.IntInput) ValidatingWebhook
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 type ValidatingWebhookConfigurationType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks []ValidatingWebhook `pulumi:"webhooks"`
 }
@@ -1208,11 +1208,11 @@ type ValidatingWebhookConfigurationTypeInput interface {
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 type ValidatingWebhookConfigurationTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks ValidatingWebhookArrayInput `pulumi:"webhooks"`
 }
@@ -1271,18 +1271,18 @@ func (o ValidatingWebhookConfigurationTypeOutput) ToValidatingWebhookConfigurati
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ValidatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-func (o ValidatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Webhooks is a list of webhooks and the affected resources and operations.
@@ -1313,13 +1313,13 @@ func (o ValidatingWebhookConfigurationTypeArrayOutput) Index(i pulumi.IntInput) 
 // ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
 type ValidatingWebhookConfigurationListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items []ValidatingWebhookConfigurationType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ValidatingWebhookConfigurationListTypeInput is an input type that accepts ValidatingWebhookConfigurationListTypeArgs and ValidatingWebhookConfigurationListTypeOutput values.
@@ -1337,13 +1337,13 @@ type ValidatingWebhookConfigurationListTypeInput interface {
 // ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
 type ValidatingWebhookConfigurationListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items ValidatingWebhookConfigurationTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ValidatingWebhookConfigurationListTypeArgs) ElementType() reflect.Type {
@@ -1374,8 +1374,8 @@ func (o ValidatingWebhookConfigurationListTypeOutput) ToValidatingWebhookConfigu
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ValidatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ValidatingWebhookConfiguration.
@@ -1384,13 +1384,13 @@ func (o ValidatingWebhookConfigurationListTypeOutput) Items() ValidatingWebhookC
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // WebhookClientConfig contains the information to make a TLS connection with the webhook
@@ -1461,48 +1461,6 @@ func (i WebhookClientConfigArgs) ToWebhookClientConfigOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigOutput)
 }
 
-func (i WebhookClientConfigArgs) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return i.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (i WebhookClientConfigArgs) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigOutput).ToWebhookClientConfigPtrOutputWithContext(ctx)
-}
-
-// WebhookClientConfigPtrInput is an input type that accepts WebhookClientConfigArgs, WebhookClientConfigPtr and WebhookClientConfigPtrOutput values.
-// You can construct a concrete instance of `WebhookClientConfigPtrInput` via:
-//
-// 		 WebhookClientConfigArgs{...}
-//
-//  or:
-//
-// 		 nil
-//
-type WebhookClientConfigPtrInput interface {
-	pulumi.Input
-
-	ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput
-	ToWebhookClientConfigPtrOutputWithContext(context.Context) WebhookClientConfigPtrOutput
-}
-
-type webhookClientConfigPtrType WebhookClientConfigArgs
-
-func WebhookClientConfigPtr(v *WebhookClientConfigArgs) WebhookClientConfigPtrInput {
-	return (*webhookClientConfigPtrType)(v)
-}
-
-func (*webhookClientConfigPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**WebhookClientConfig)(nil)).Elem()
-}
-
-func (i *webhookClientConfigPtrType) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return i.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (i *webhookClientConfigPtrType) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigPtrOutput)
-}
-
 // WebhookClientConfig contains the information to make a TLS connection with the webhook
 type WebhookClientConfigOutput struct{ *pulumi.OutputState }
 
@@ -1516,16 +1474,6 @@ func (o WebhookClientConfigOutput) ToWebhookClientConfigOutput() WebhookClientCo
 
 func (o WebhookClientConfigOutput) ToWebhookClientConfigOutputWithContext(ctx context.Context) WebhookClientConfigOutput {
 	return o
-}
-
-func (o WebhookClientConfigOutput) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return o.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (o WebhookClientConfigOutput) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v WebhookClientConfig) *WebhookClientConfig {
-		return &v
-	}).(WebhookClientConfigPtrOutput)
 }
 
 // `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
@@ -1555,66 +1503,6 @@ func (o WebhookClientConfigOutput) Url() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WebhookClientConfig) *string { return v.Url }).(pulumi.StringPtrOutput)
 }
 
-type WebhookClientConfigPtrOutput struct{ *pulumi.OutputState }
-
-func (WebhookClientConfigPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**WebhookClientConfig)(nil)).Elem()
-}
-
-func (o WebhookClientConfigPtrOutput) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return o
-}
-
-func (o WebhookClientConfigPtrOutput) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return o
-}
-
-func (o WebhookClientConfigPtrOutput) Elem() WebhookClientConfigOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) WebhookClientConfig { return *v }).(WebhookClientConfigOutput)
-}
-
-// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
-func (o WebhookClientConfigPtrOutput) CaBundle() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *string {
-		if v == nil {
-			return nil
-		}
-		return v.CaBundle
-	}).(pulumi.StringPtrOutput)
-}
-
-// `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
-//
-// If the webhook is running within the cluster, then you should use `service`.
-func (o WebhookClientConfigPtrOutput) Service() ServiceReferencePtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *ServiceReference {
-		if v == nil {
-			return nil
-		}
-		return v.Service
-	}).(ServiceReferencePtrOutput)
-}
-
-// `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
-//
-// The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
-//
-// Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
-//
-// The scheme must be "https"; the URL must begin with "https://".
-//
-// A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
-//
-// Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
-func (o WebhookClientConfigPtrOutput) Url() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *string {
-		if v == nil {
-			return nil
-		}
-		return v.Url
-	}).(pulumi.StringPtrOutput)
-}
-
 func init() {
 	pulumi.RegisterOutputType(MutatingWebhookOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookArrayOutput{})
@@ -1631,5 +1519,4 @@ func init() {
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationTypeArrayOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListTypeOutput{})
 	pulumi.RegisterOutputType(WebhookClientConfigOutput{})
-	pulumi.RegisterOutputType(WebhookClientConfigPtrOutput{})
 }

--- a/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfiguration.go
@@ -15,11 +15,11 @@ type ValidatingWebhookConfiguration struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks ValidatingWebhookArrayOutput `pulumi:"webhooks"`
 }

--- a/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationList.go
@@ -16,13 +16,13 @@ type ValidatingWebhookConfigurationList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items ValidatingWebhookConfigurationTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewValidatingWebhookConfigurationList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfiguration.go
@@ -15,11 +15,11 @@ type MutatingWebhookConfiguration struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks MutatingWebhookArrayOutput `pulumi:"webhooks"`
 }

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationList.go
@@ -16,13 +16,13 @@ type MutatingWebhookConfigurationList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items MutatingWebhookConfigurationTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewMutatingWebhookConfigurationList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/pulumiTypes.go
@@ -16,7 +16,7 @@ type MutatingWebhook struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
 	AdmissionReviewVersions []string `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig *WebhookClientConfig `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfig `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
 	FailurePolicy *string `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -28,7 +28,7 @@ type MutatingWebhook struct {
 	// Defaults to "Exact"
 	MatchPolicy *string `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -96,7 +96,7 @@ type MutatingWebhookArgs struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
 	AdmissionReviewVersions pulumi.StringArrayInput `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig WebhookClientConfigPtrInput `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfigInput `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
 	FailurePolicy pulumi.StringPtrInput `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -108,7 +108,7 @@ type MutatingWebhookArgs struct {
 	// Defaults to "Exact"
 	MatchPolicy pulumi.StringPtrInput `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -218,8 +218,8 @@ func (o MutatingWebhookOutput) AdmissionReviewVersions() pulumi.StringArrayOutpu
 }
 
 // ClientConfig defines how to communicate with the hook. Required
-func (o MutatingWebhookOutput) ClientConfig() WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v MutatingWebhook) *WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigPtrOutput)
+func (o MutatingWebhookOutput) ClientConfig() WebhookClientConfigOutput {
+	return o.ApplyT(func(v MutatingWebhook) WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigOutput)
 }
 
 // FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
@@ -239,8 +239,8 @@ func (o MutatingWebhookOutput) MatchPolicy() pulumi.StringPtrOutput {
 }
 
 // The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-func (o MutatingWebhookOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhook) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhook) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
@@ -332,11 +332,11 @@ func (o MutatingWebhookArrayOutput) Index(i pulumi.IntInput) MutatingWebhookOutp
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
 type MutatingWebhookConfigurationType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks []MutatingWebhook `pulumi:"webhooks"`
 }
@@ -356,11 +356,11 @@ type MutatingWebhookConfigurationTypeInput interface {
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
 type MutatingWebhookConfigurationTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks MutatingWebhookArrayInput `pulumi:"webhooks"`
 }
@@ -419,18 +419,18 @@ func (o MutatingWebhookConfigurationTypeOutput) ToMutatingWebhookConfigurationTy
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o MutatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-func (o MutatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o MutatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Webhooks is a list of webhooks and the affected resources and operations.
@@ -461,13 +461,13 @@ func (o MutatingWebhookConfigurationTypeArrayOutput) Index(i pulumi.IntInput) Mu
 // MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
 type MutatingWebhookConfigurationListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items []MutatingWebhookConfigurationType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // MutatingWebhookConfigurationListTypeInput is an input type that accepts MutatingWebhookConfigurationListTypeArgs and MutatingWebhookConfigurationListTypeOutput values.
@@ -485,13 +485,13 @@ type MutatingWebhookConfigurationListTypeInput interface {
 // MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
 type MutatingWebhookConfigurationListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of MutatingWebhookConfiguration.
 	Items MutatingWebhookConfigurationTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (MutatingWebhookConfigurationListTypeArgs) ElementType() reflect.Type {
@@ -522,8 +522,8 @@ func (o MutatingWebhookConfigurationListTypeOutput) ToMutatingWebhookConfigurati
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o MutatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of MutatingWebhookConfiguration.
@@ -532,13 +532,13 @@ func (o MutatingWebhookConfigurationListTypeOutput) Items() MutatingWebhookConfi
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o MutatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v MutatingWebhookConfigurationListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o MutatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v MutatingWebhookConfigurationListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
@@ -700,9 +700,9 @@ func (o RuleWithOperationsArrayOutput) Index(i pulumi.IntInput) RuleWithOperatio
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
 	// `name` is the name of the service. Required
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path *string `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -724,9 +724,9 @@ type ServiceReferenceInput interface {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReferenceArgs struct {
 	// `name` is the name of the service. Required
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -813,13 +813,13 @@ func (o ServiceReferenceOutput) ToServiceReferencePtrOutputWithContext(ctx conte
 }
 
 // `name` is the name of the service. Required
-func (o ServiceReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // `namespace` is the namespace of the service. Required
-func (o ServiceReferenceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // `path` is an optional URL path which will be sent in any request to this service.
@@ -856,7 +856,7 @@ func (o ServiceReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -866,7 +866,7 @@ func (o ServiceReferencePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -895,7 +895,7 @@ type ValidatingWebhook struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
 	AdmissionReviewVersions []string `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig *WebhookClientConfig `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfig `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
 	FailurePolicy *string `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -907,7 +907,7 @@ type ValidatingWebhook struct {
 	// Defaults to "Exact"
 	MatchPolicy *string `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -967,7 +967,7 @@ type ValidatingWebhookArgs struct {
 	// AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
 	AdmissionReviewVersions pulumi.StringArrayInput `pulumi:"admissionReviewVersions"`
 	// ClientConfig defines how to communicate with the hook. Required
-	ClientConfig WebhookClientConfigPtrInput `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfigInput `pulumi:"clientConfig"`
 	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
 	FailurePolicy pulumi.StringPtrInput `pulumi:"failurePolicy"`
 	// matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
@@ -979,7 +979,7 @@ type ValidatingWebhookArgs struct {
 	// Defaults to "Exact"
 	MatchPolicy pulumi.StringPtrInput `pulumi:"matchPolicy"`
 	// The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
 	//
 	// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
@@ -1081,8 +1081,8 @@ func (o ValidatingWebhookOutput) AdmissionReviewVersions() pulumi.StringArrayOut
 }
 
 // ClientConfig defines how to communicate with the hook. Required
-func (o ValidatingWebhookOutput) ClientConfig() WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhook) *WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigPtrOutput)
+func (o ValidatingWebhookOutput) ClientConfig() WebhookClientConfigOutput {
+	return o.ApplyT(func(v ValidatingWebhook) WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigOutput)
 }
 
 // FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
@@ -1102,8 +1102,8 @@ func (o ValidatingWebhookOutput) MatchPolicy() pulumi.StringPtrOutput {
 }
 
 // The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
-func (o ValidatingWebhookOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhook) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhook) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
@@ -1184,11 +1184,11 @@ func (o ValidatingWebhookArrayOutput) Index(i pulumi.IntInput) ValidatingWebhook
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
 type ValidatingWebhookConfigurationType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks []ValidatingWebhook `pulumi:"webhooks"`
 }
@@ -1208,11 +1208,11 @@ type ValidatingWebhookConfigurationTypeInput interface {
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
 type ValidatingWebhookConfigurationTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks ValidatingWebhookArrayInput `pulumi:"webhooks"`
 }
@@ -1271,18 +1271,18 @@ func (o ValidatingWebhookConfigurationTypeOutput) ToValidatingWebhookConfigurati
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ValidatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-func (o ValidatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ValidatingWebhookConfigurationTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Webhooks is a list of webhooks and the affected resources and operations.
@@ -1313,13 +1313,13 @@ func (o ValidatingWebhookConfigurationTypeArrayOutput) Index(i pulumi.IntInput) 
 // ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
 type ValidatingWebhookConfigurationListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items []ValidatingWebhookConfigurationType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ValidatingWebhookConfigurationListTypeInput is an input type that accepts ValidatingWebhookConfigurationListTypeArgs and ValidatingWebhookConfigurationListTypeOutput values.
@@ -1337,13 +1337,13 @@ type ValidatingWebhookConfigurationListTypeInput interface {
 // ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
 type ValidatingWebhookConfigurationListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items ValidatingWebhookConfigurationTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ValidatingWebhookConfigurationListTypeArgs) ElementType() reflect.Type {
@@ -1374,8 +1374,8 @@ func (o ValidatingWebhookConfigurationListTypeOutput) ToValidatingWebhookConfigu
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ValidatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ValidatingWebhookConfiguration.
@@ -1384,13 +1384,13 @@ func (o ValidatingWebhookConfigurationListTypeOutput) Items() ValidatingWebhookC
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ValidatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ValidatingWebhookConfigurationListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ValidatingWebhookConfigurationListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // WebhookClientConfig contains the information to make a TLS connection with the webhook
@@ -1461,48 +1461,6 @@ func (i WebhookClientConfigArgs) ToWebhookClientConfigOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigOutput)
 }
 
-func (i WebhookClientConfigArgs) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return i.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (i WebhookClientConfigArgs) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigOutput).ToWebhookClientConfigPtrOutputWithContext(ctx)
-}
-
-// WebhookClientConfigPtrInput is an input type that accepts WebhookClientConfigArgs, WebhookClientConfigPtr and WebhookClientConfigPtrOutput values.
-// You can construct a concrete instance of `WebhookClientConfigPtrInput` via:
-//
-// 		 WebhookClientConfigArgs{...}
-//
-//  or:
-//
-// 		 nil
-//
-type WebhookClientConfigPtrInput interface {
-	pulumi.Input
-
-	ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput
-	ToWebhookClientConfigPtrOutputWithContext(context.Context) WebhookClientConfigPtrOutput
-}
-
-type webhookClientConfigPtrType WebhookClientConfigArgs
-
-func WebhookClientConfigPtr(v *WebhookClientConfigArgs) WebhookClientConfigPtrInput {
-	return (*webhookClientConfigPtrType)(v)
-}
-
-func (*webhookClientConfigPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**WebhookClientConfig)(nil)).Elem()
-}
-
-func (i *webhookClientConfigPtrType) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return i.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (i *webhookClientConfigPtrType) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WebhookClientConfigPtrOutput)
-}
-
 // WebhookClientConfig contains the information to make a TLS connection with the webhook
 type WebhookClientConfigOutput struct{ *pulumi.OutputState }
 
@@ -1516,16 +1474,6 @@ func (o WebhookClientConfigOutput) ToWebhookClientConfigOutput() WebhookClientCo
 
 func (o WebhookClientConfigOutput) ToWebhookClientConfigOutputWithContext(ctx context.Context) WebhookClientConfigOutput {
 	return o
-}
-
-func (o WebhookClientConfigOutput) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return o.ToWebhookClientConfigPtrOutputWithContext(context.Background())
-}
-
-func (o WebhookClientConfigOutput) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v WebhookClientConfig) *WebhookClientConfig {
-		return &v
-	}).(WebhookClientConfigPtrOutput)
 }
 
 // `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
@@ -1555,66 +1503,6 @@ func (o WebhookClientConfigOutput) Url() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WebhookClientConfig) *string { return v.Url }).(pulumi.StringPtrOutput)
 }
 
-type WebhookClientConfigPtrOutput struct{ *pulumi.OutputState }
-
-func (WebhookClientConfigPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**WebhookClientConfig)(nil)).Elem()
-}
-
-func (o WebhookClientConfigPtrOutput) ToWebhookClientConfigPtrOutput() WebhookClientConfigPtrOutput {
-	return o
-}
-
-func (o WebhookClientConfigPtrOutput) ToWebhookClientConfigPtrOutputWithContext(ctx context.Context) WebhookClientConfigPtrOutput {
-	return o
-}
-
-func (o WebhookClientConfigPtrOutput) Elem() WebhookClientConfigOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) WebhookClientConfig { return *v }).(WebhookClientConfigOutput)
-}
-
-// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
-func (o WebhookClientConfigPtrOutput) CaBundle() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *string {
-		if v == nil {
-			return nil
-		}
-		return v.CaBundle
-	}).(pulumi.StringPtrOutput)
-}
-
-// `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
-//
-// If the webhook is running within the cluster, then you should use `service`.
-func (o WebhookClientConfigPtrOutput) Service() ServiceReferencePtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *ServiceReference {
-		if v == nil {
-			return nil
-		}
-		return v.Service
-	}).(ServiceReferencePtrOutput)
-}
-
-// `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
-//
-// The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
-//
-// Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
-//
-// The scheme must be "https"; the URL must begin with "https://".
-//
-// A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
-//
-// Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
-func (o WebhookClientConfigPtrOutput) Url() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *WebhookClientConfig) *string {
-		if v == nil {
-			return nil
-		}
-		return v.Url
-	}).(pulumi.StringPtrOutput)
-}
-
 func init() {
 	pulumi.RegisterOutputType(MutatingWebhookOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookArrayOutput{})
@@ -1631,5 +1519,4 @@ func init() {
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationTypeArrayOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListTypeOutput{})
 	pulumi.RegisterOutputType(WebhookClientConfigOutput{})
-	pulumi.RegisterOutputType(WebhookClientConfigPtrOutput{})
 }

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfiguration.go
@@ -15,11 +15,11 @@ type ValidatingWebhookConfiguration struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Webhooks is a list of webhooks and the affected resources and operations.
 	Webhooks ValidatingWebhookArrayOutput `pulumi:"webhooks"`
 }

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationList.go
@@ -16,13 +16,13 @@ type ValidatingWebhookConfigurationList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ValidatingWebhookConfiguration.
 	Items ValidatingWebhookConfigurationTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewValidatingWebhookConfigurationList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiextensions/v1/customResourceDefinition.go
+++ b/sdk/go/kubernetes/apiextensions/v1/customResourceDefinition.go
@@ -16,14 +16,14 @@ type CustomResourceDefinition struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec CustomResourceDefinitionSpecPtrOutput `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpecOutput `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status CustomResourceDefinitionStatusPtrOutput `pulumi:"status"`
+	Status CustomResourceDefinitionStatusOutput `pulumi:"status"`
 }
 
 // NewCustomResourceDefinition registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionList.go
+++ b/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionList.go
@@ -16,12 +16,12 @@ type CustomResourceDefinitionList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items CustomResourceDefinitionTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCustomResourceDefinitionList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiextensions/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiextensions/v1/pulumiTypes.go
@@ -18,13 +18,13 @@ type CustomResourceColumnDefinition struct {
 	// format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
 	Format *string `pulumi:"format"`
 	// jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-	JsonPath *string `pulumi:"jsonPath"`
+	JsonPath string `pulumi:"jsonPath"`
 	// name is a human readable name for the column.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
 	Priority *int `pulumi:"priority"`
 	// type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // CustomResourceColumnDefinitionInput is an input type that accepts CustomResourceColumnDefinitionArgs and CustomResourceColumnDefinitionOutput values.
@@ -46,13 +46,13 @@ type CustomResourceColumnDefinitionArgs struct {
 	// format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
 	Format pulumi.StringPtrInput `pulumi:"format"`
 	// jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-	JsonPath pulumi.StringPtrInput `pulumi:"jsonPath"`
+	JsonPath pulumi.StringInput `pulumi:"jsonPath"`
 	// name is a human readable name for the column.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
 	Priority pulumi.IntPtrInput `pulumi:"priority"`
 	// type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (CustomResourceColumnDefinitionArgs) ElementType() reflect.Type {
@@ -119,13 +119,13 @@ func (o CustomResourceColumnDefinitionOutput) Format() pulumi.StringPtrOutput {
 }
 
 // jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-func (o CustomResourceColumnDefinitionOutput) JsonPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.JsonPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) JsonPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.JsonPath }).(pulumi.StringOutput)
 }
 
 // name is a human readable name for the column.
-func (o CustomResourceColumnDefinitionOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
@@ -134,8 +134,8 @@ func (o CustomResourceColumnDefinitionOutput) Priority() pulumi.IntPtrOutput {
 }
 
 // type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-func (o CustomResourceColumnDefinitionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type CustomResourceColumnDefinitionArrayOutput struct{ *pulumi.OutputState }
@@ -162,7 +162,7 @@ func (o CustomResourceColumnDefinitionArrayOutput) Index(i pulumi.IntInput) Cust
 type CustomResourceConversion struct {
 	// strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 	//   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
-	Strategy *string `pulumi:"strategy"`
+	Strategy string `pulumi:"strategy"`
 	// webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.
 	Webhook *WebhookConversion `pulumi:"webhook"`
 }
@@ -183,7 +183,7 @@ type CustomResourceConversionInput interface {
 type CustomResourceConversionArgs struct {
 	// strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 	//   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
-	Strategy pulumi.StringPtrInput `pulumi:"strategy"`
+	Strategy pulumi.StringInput `pulumi:"strategy"`
 	// webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.
 	Webhook WebhookConversionPtrInput `pulumi:"webhook"`
 }
@@ -269,8 +269,8 @@ func (o CustomResourceConversionOutput) ToCustomResourceConversionPtrOutputWithC
 
 // strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 //   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
-func (o CustomResourceConversionOutput) Strategy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceConversion) *string { return v.Strategy }).(pulumi.StringPtrOutput)
+func (o CustomResourceConversionOutput) Strategy() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceConversion) string { return v.Strategy }).(pulumi.StringOutput)
 }
 
 // webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.
@@ -303,7 +303,7 @@ func (o CustomResourceConversionPtrOutput) Strategy() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Strategy
+		return &v.Strategy
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -320,14 +320,14 @@ func (o CustomResourceConversionPtrOutput) Webhook() WebhookConversionPtrOutput 
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
 type CustomResourceDefinitionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec *CustomResourceDefinitionSpec `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpec `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status *CustomResourceDefinitionStatus `pulumi:"status"`
+	Status CustomResourceDefinitionStatus `pulumi:"status"`
 }
 
 // CustomResourceDefinitionTypeInput is an input type that accepts CustomResourceDefinitionTypeArgs and CustomResourceDefinitionTypeOutput values.
@@ -345,14 +345,14 @@ type CustomResourceDefinitionTypeInput interface {
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
 type CustomResourceDefinitionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec CustomResourceDefinitionSpecPtrInput `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpecInput `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status CustomResourceDefinitionStatusPtrInput `pulumi:"status"`
+	Status CustomResourceDefinitionStatusInput `pulumi:"status"`
 }
 
 func (CustomResourceDefinitionTypeArgs) ElementType() reflect.Type {
@@ -409,27 +409,27 @@ func (o CustomResourceDefinitionTypeOutput) ToCustomResourceDefinitionTypeOutput
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CustomResourceDefinitionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CustomResourceDefinitionTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CustomResourceDefinitionTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec describes how the user wants the resources to appear
-func (o CustomResourceDefinitionTypeOutput) Spec() CustomResourceDefinitionSpecPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *CustomResourceDefinitionSpec { return v.Spec }).(CustomResourceDefinitionSpecPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Spec() CustomResourceDefinitionSpecOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) CustomResourceDefinitionSpec { return v.Spec }).(CustomResourceDefinitionSpecOutput)
 }
 
 // status indicates the actual state of the CustomResourceDefinition
-func (o CustomResourceDefinitionTypeOutput) Status() CustomResourceDefinitionStatusPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *CustomResourceDefinitionStatus { return v.Status }).(CustomResourceDefinitionStatusPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Status() CustomResourceDefinitionStatusOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) CustomResourceDefinitionStatus { return v.Status }).(CustomResourceDefinitionStatusOutput)
 }
 
 type CustomResourceDefinitionTypeArrayOutput struct{ *pulumi.OutputState }
@@ -461,9 +461,9 @@ type CustomResourceDefinitionCondition struct {
 	// reason is a unique, one-word, CamelCase reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// status is the status of the condition. Can be True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // CustomResourceDefinitionConditionInput is an input type that accepts CustomResourceDefinitionConditionArgs and CustomResourceDefinitionConditionOutput values.
@@ -487,9 +487,9 @@ type CustomResourceDefinitionConditionArgs struct {
 	// reason is a unique, one-word, CamelCase reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// status is the status of the condition. Can be True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (CustomResourceDefinitionConditionArgs) ElementType() reflect.Type {
@@ -561,13 +561,13 @@ func (o CustomResourceDefinitionConditionOutput) Reason() pulumi.StringPtrOutput
 }
 
 // status is the status of the condition. Can be True, False, Unknown.
-func (o CustomResourceDefinitionConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-func (o CustomResourceDefinitionConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type CustomResourceDefinitionConditionArrayOutput struct{ *pulumi.OutputState }
@@ -593,12 +593,12 @@ func (o CustomResourceDefinitionConditionArrayOutput) Index(i pulumi.IntInput) C
 // CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
 type CustomResourceDefinitionListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items []CustomResourceDefinitionType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CustomResourceDefinitionListTypeInput is an input type that accepts CustomResourceDefinitionListTypeArgs and CustomResourceDefinitionListTypeOutput values.
@@ -616,12 +616,12 @@ type CustomResourceDefinitionListTypeInput interface {
 // CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
 type CustomResourceDefinitionListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items CustomResourceDefinitionTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CustomResourceDefinitionListTypeArgs) ElementType() reflect.Type {
@@ -652,8 +652,8 @@ func (o CustomResourceDefinitionListTypeOutput) ToCustomResourceDefinitionListTy
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CustomResourceDefinitionListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items list individual CustomResourceDefinition objects
@@ -662,12 +662,12 @@ func (o CustomResourceDefinitionListTypeOutput) Items() CustomResourceDefinition
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CustomResourceDefinitionListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CustomResourceDefinitionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
@@ -675,11 +675,11 @@ type CustomResourceDefinitionNames struct {
 	// categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
 	Categories []string `pulumi:"categories"`
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
 	ListKind *string `pulumi:"listKind"`
 	// plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-	Plural *string `pulumi:"plural"`
+	Plural string `pulumi:"plural"`
 	// shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
 	ShortNames []string `pulumi:"shortNames"`
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
@@ -703,11 +703,11 @@ type CustomResourceDefinitionNamesArgs struct {
 	// categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
 	Categories pulumi.StringArrayInput `pulumi:"categories"`
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
 	ListKind pulumi.StringPtrInput `pulumi:"listKind"`
 	// plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-	Plural pulumi.StringPtrInput `pulumi:"plural"`
+	Plural pulumi.StringInput `pulumi:"plural"`
 	// shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
 	ShortNames pulumi.StringArrayInput `pulumi:"shortNames"`
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
@@ -799,8 +799,8 @@ func (o CustomResourceDefinitionNamesOutput) Categories() pulumi.StringArrayOutp
 }
 
 // kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-func (o CustomResourceDefinitionNamesOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionNames) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionNamesOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionNames) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
@@ -809,8 +809,8 @@ func (o CustomResourceDefinitionNamesOutput) ListKind() pulumi.StringPtrOutput {
 }
 
 // plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-func (o CustomResourceDefinitionNamesOutput) Plural() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionNames) *string { return v.Plural }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionNamesOutput) Plural() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionNames) string { return v.Plural }).(pulumi.StringOutput)
 }
 
 // shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
@@ -857,7 +857,7 @@ func (o CustomResourceDefinitionNamesPtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -877,7 +877,7 @@ func (o CustomResourceDefinitionNamesPtrOutput) Plural() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Plural
+		return &v.Plural
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -906,13 +906,13 @@ type CustomResourceDefinitionSpec struct {
 	// conversion defines conversion settings for the CRD.
 	Conversion *CustomResourceConversion `pulumi:"conversion"`
 	// group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	Group *string `pulumi:"group"`
+	Group string `pulumi:"group"`
 	// names specify the resource and kind names for the custom resource.
-	Names *CustomResourceDefinitionNames `pulumi:"names"`
+	Names CustomResourceDefinitionNames `pulumi:"names"`
 	// preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
 	PreserveUnknownFields *bool `pulumi:"preserveUnknownFields"`
 	// scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
-	Scope *string `pulumi:"scope"`
+	Scope string `pulumi:"scope"`
 	// versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	Versions []CustomResourceDefinitionVersion `pulumi:"versions"`
 }
@@ -934,13 +934,13 @@ type CustomResourceDefinitionSpecArgs struct {
 	// conversion defines conversion settings for the CRD.
 	Conversion CustomResourceConversionPtrInput `pulumi:"conversion"`
 	// group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	Group pulumi.StringPtrInput `pulumi:"group"`
+	Group pulumi.StringInput `pulumi:"group"`
 	// names specify the resource and kind names for the custom resource.
-	Names CustomResourceDefinitionNamesPtrInput `pulumi:"names"`
+	Names CustomResourceDefinitionNamesInput `pulumi:"names"`
 	// preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
 	PreserveUnknownFields pulumi.BoolPtrInput `pulumi:"preserveUnknownFields"`
 	// scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
-	Scope pulumi.StringPtrInput `pulumi:"scope"`
+	Scope pulumi.StringInput `pulumi:"scope"`
 	// versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	Versions CustomResourceDefinitionVersionArrayInput `pulumi:"versions"`
 }
@@ -1030,13 +1030,13 @@ func (o CustomResourceDefinitionSpecOutput) Conversion() CustomResourceConversio
 }
 
 // group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-func (o CustomResourceDefinitionSpecOutput) Group() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *string { return v.Group }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Group() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) string { return v.Group }).(pulumi.StringOutput)
 }
 
 // names specify the resource and kind names for the custom resource.
-func (o CustomResourceDefinitionSpecOutput) Names() CustomResourceDefinitionNamesPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *CustomResourceDefinitionNames { return v.Names }).(CustomResourceDefinitionNamesPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Names() CustomResourceDefinitionNamesOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) CustomResourceDefinitionNames { return v.Names }).(CustomResourceDefinitionNamesOutput)
 }
 
 // preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
@@ -1045,8 +1045,8 @@ func (o CustomResourceDefinitionSpecOutput) PreserveUnknownFields() pulumi.BoolP
 }
 
 // scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
-func (o CustomResourceDefinitionSpecOutput) Scope() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *string { return v.Scope }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Scope() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) string { return v.Scope }).(pulumi.StringOutput)
 }
 
 // versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
@@ -1088,7 +1088,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Group() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Group
+		return &v.Group
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1098,7 +1098,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Names() CustomResourceDefinitionN
 		if v == nil {
 			return nil
 		}
-		return v.Names
+		return &v.Names
 	}).(CustomResourceDefinitionNamesPtrOutput)
 }
 
@@ -1118,7 +1118,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Scope() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Scope
+		return &v.Scope
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1135,7 +1135,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Versions() CustomResourceDefiniti
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatus struct {
 	// acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-	AcceptedNames *CustomResourceDefinitionNames `pulumi:"acceptedNames"`
+	AcceptedNames CustomResourceDefinitionNames `pulumi:"acceptedNames"`
 	// conditions indicate state for particular aspects of a CustomResourceDefinition
 	Conditions []CustomResourceDefinitionCondition `pulumi:"conditions"`
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
@@ -1157,7 +1157,7 @@ type CustomResourceDefinitionStatusInput interface {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatusArgs struct {
 	// acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-	AcceptedNames CustomResourceDefinitionNamesPtrInput `pulumi:"acceptedNames"`
+	AcceptedNames CustomResourceDefinitionNamesInput `pulumi:"acceptedNames"`
 	// conditions indicate state for particular aspects of a CustomResourceDefinition
 	Conditions CustomResourceDefinitionConditionArrayInput `pulumi:"conditions"`
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
@@ -1244,8 +1244,8 @@ func (o CustomResourceDefinitionStatusOutput) ToCustomResourceDefinitionStatusPt
 }
 
 // acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-func (o CustomResourceDefinitionStatusOutput) AcceptedNames() CustomResourceDefinitionNamesPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionStatus) *CustomResourceDefinitionNames { return v.AcceptedNames }).(CustomResourceDefinitionNamesPtrOutput)
+func (o CustomResourceDefinitionStatusOutput) AcceptedNames() CustomResourceDefinitionNamesOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionStatus) CustomResourceDefinitionNames { return v.AcceptedNames }).(CustomResourceDefinitionNamesOutput)
 }
 
 // conditions indicate state for particular aspects of a CustomResourceDefinition
@@ -1282,7 +1282,7 @@ func (o CustomResourceDefinitionStatusPtrOutput) AcceptedNames() CustomResourceD
 		if v == nil {
 			return nil
 		}
-		return v.AcceptedNames
+		return &v.AcceptedNames
 	}).(CustomResourceDefinitionNamesPtrOutput)
 }
 
@@ -1311,13 +1311,13 @@ type CustomResourceDefinitionVersion struct {
 	// additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.
 	AdditionalPrinterColumns []CustomResourceColumnDefinition `pulumi:"additionalPrinterColumns"`
 	// name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
 	Schema *CustomResourceValidation `pulumi:"schema"`
 	// served is a flag enabling/disabling this version from being served via REST APIs
-	Served *bool `pulumi:"served"`
+	Served bool `pulumi:"served"`
 	// storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-	Storage *bool `pulumi:"storage"`
+	Storage bool `pulumi:"storage"`
 	// subresources specify what subresources this version of the defined custom resource have.
 	Subresources *CustomResourceSubresources `pulumi:"subresources"`
 }
@@ -1339,13 +1339,13 @@ type CustomResourceDefinitionVersionArgs struct {
 	// additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.
 	AdditionalPrinterColumns CustomResourceColumnDefinitionArrayInput `pulumi:"additionalPrinterColumns"`
 	// name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
 	Schema CustomResourceValidationPtrInput `pulumi:"schema"`
 	// served is a flag enabling/disabling this version from being served via REST APIs
-	Served pulumi.BoolPtrInput `pulumi:"served"`
+	Served pulumi.BoolInput `pulumi:"served"`
 	// storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-	Storage pulumi.BoolPtrInput `pulumi:"storage"`
+	Storage pulumi.BoolInput `pulumi:"storage"`
 	// subresources specify what subresources this version of the defined custom resource have.
 	Subresources CustomResourceSubresourcesPtrInput `pulumi:"subresources"`
 }
@@ -1411,8 +1411,8 @@ func (o CustomResourceDefinitionVersionOutput) AdditionalPrinterColumns() Custom
 }
 
 // name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-func (o CustomResourceDefinitionVersionOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
@@ -1421,13 +1421,13 @@ func (o CustomResourceDefinitionVersionOutput) Schema() CustomResourceValidation
 }
 
 // served is a flag enabling/disabling this version from being served via REST APIs
-func (o CustomResourceDefinitionVersionOutput) Served() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *bool { return v.Served }).(pulumi.BoolPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Served() pulumi.BoolOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) bool { return v.Served }).(pulumi.BoolOutput)
 }
 
 // storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-func (o CustomResourceDefinitionVersionOutput) Storage() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *bool { return v.Storage }).(pulumi.BoolPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Storage() pulumi.BoolOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) bool { return v.Storage }).(pulumi.BoolOutput)
 }
 
 // subresources specify what subresources this version of the defined custom resource have.
@@ -1460,9 +1460,9 @@ type CustomResourceSubresourceScale struct {
 	// labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
 	LabelSelectorPath *string `pulumi:"labelSelectorPath"`
 	// specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-	SpecReplicasPath *string `pulumi:"specReplicasPath"`
+	SpecReplicasPath string `pulumi:"specReplicasPath"`
 	// statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-	StatusReplicasPath *string `pulumi:"statusReplicasPath"`
+	StatusReplicasPath string `pulumi:"statusReplicasPath"`
 }
 
 // CustomResourceSubresourceScaleInput is an input type that accepts CustomResourceSubresourceScaleArgs and CustomResourceSubresourceScaleOutput values.
@@ -1482,9 +1482,9 @@ type CustomResourceSubresourceScaleArgs struct {
 	// labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
 	LabelSelectorPath pulumi.StringPtrInput `pulumi:"labelSelectorPath"`
 	// specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-	SpecReplicasPath pulumi.StringPtrInput `pulumi:"specReplicasPath"`
+	SpecReplicasPath pulumi.StringInput `pulumi:"specReplicasPath"`
 	// statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-	StatusReplicasPath pulumi.StringPtrInput `pulumi:"statusReplicasPath"`
+	StatusReplicasPath pulumi.StringInput `pulumi:"statusReplicasPath"`
 }
 
 func (CustomResourceSubresourceScaleArgs) ElementType() reflect.Type {
@@ -1572,13 +1572,13 @@ func (o CustomResourceSubresourceScaleOutput) LabelSelectorPath() pulumi.StringP
 }
 
 // specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-func (o CustomResourceSubresourceScaleOutput) SpecReplicasPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceSubresourceScale) *string { return v.SpecReplicasPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceSubresourceScaleOutput) SpecReplicasPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceSubresourceScale) string { return v.SpecReplicasPath }).(pulumi.StringOutput)
 }
 
 // statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-func (o CustomResourceSubresourceScaleOutput) StatusReplicasPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceSubresourceScale) *string { return v.StatusReplicasPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceSubresourceScaleOutput) StatusReplicasPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceSubresourceScale) string { return v.StatusReplicasPath }).(pulumi.StringOutput)
 }
 
 type CustomResourceSubresourceScalePtrOutput struct{ *pulumi.OutputState }
@@ -1615,7 +1615,7 @@ func (o CustomResourceSubresourceScalePtrOutput) SpecReplicasPath() pulumi.Strin
 		if v == nil {
 			return nil
 		}
-		return v.SpecReplicasPath
+		return &v.SpecReplicasPath
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1625,7 +1625,7 @@ func (o CustomResourceSubresourceScalePtrOutput) StatusReplicasPath() pulumi.Str
 		if v == nil {
 			return nil
 		}
-		return v.StatusReplicasPath
+		return &v.StatusReplicasPath
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3094,9 +3094,9 @@ func (o JSONSchemaPropsMapOutput) MapIndex(k pulumi.StringInput) JSONSchemaProps
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
 	// name is the name of the service. Required
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// namespace is the namespace of the service. Required
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// path is an optional URL path at which the webhook will be contacted.
 	Path *string `pulumi:"path"`
 	// port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
@@ -3118,9 +3118,9 @@ type ServiceReferenceInput interface {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReferenceArgs struct {
 	// name is the name of the service. Required
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// namespace is the namespace of the service. Required
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// path is an optional URL path at which the webhook will be contacted.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
@@ -3207,13 +3207,13 @@ func (o ServiceReferenceOutput) ToServiceReferencePtrOutputWithContext(ctx conte
 }
 
 // name is the name of the service. Required
-func (o ServiceReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // namespace is the namespace of the service. Required
-func (o ServiceReferenceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // path is an optional URL path at which the webhook will be contacted.
@@ -3250,7 +3250,7 @@ func (o ServiceReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3260,7 +3260,7 @@ func (o ServiceReferencePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinition.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinition.go
@@ -16,14 +16,14 @@ type CustomResourceDefinition struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec CustomResourceDefinitionSpecPtrOutput `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpecOutput `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status CustomResourceDefinitionStatusPtrOutput `pulumi:"status"`
+	Status CustomResourceDefinitionStatusOutput `pulumi:"status"`
 }
 
 // NewCustomResourceDefinition registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionList.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionList.go
@@ -16,12 +16,12 @@ type CustomResourceDefinitionList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items CustomResourceDefinitionTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCustomResourceDefinitionList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiextensions/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/pulumiTypes.go
@@ -14,17 +14,17 @@ import (
 // CustomResourceColumnDefinition specifies a column for server side printing.
 type CustomResourceColumnDefinition struct {
 	// JSONPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-	JSONPath *string `pulumi:"JSONPath"`
+	JSONPath string `pulumi:"JSONPath"`
 	// description is a human readable description of this column.
 	Description *string `pulumi:"description"`
 	// format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
 	Format *string `pulumi:"format"`
 	// name is a human readable name for the column.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
 	Priority *int `pulumi:"priority"`
 	// type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // CustomResourceColumnDefinitionInput is an input type that accepts CustomResourceColumnDefinitionArgs and CustomResourceColumnDefinitionOutput values.
@@ -42,17 +42,17 @@ type CustomResourceColumnDefinitionInput interface {
 // CustomResourceColumnDefinition specifies a column for server side printing.
 type CustomResourceColumnDefinitionArgs struct {
 	// JSONPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-	JSONPath pulumi.StringPtrInput `pulumi:"JSONPath"`
+	JSONPath pulumi.StringInput `pulumi:"JSONPath"`
 	// description is a human readable description of this column.
 	Description pulumi.StringPtrInput `pulumi:"description"`
 	// format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
 	Format pulumi.StringPtrInput `pulumi:"format"`
 	// name is a human readable name for the column.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
 	Priority pulumi.IntPtrInput `pulumi:"priority"`
 	// type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (CustomResourceColumnDefinitionArgs) ElementType() reflect.Type {
@@ -109,8 +109,8 @@ func (o CustomResourceColumnDefinitionOutput) ToCustomResourceColumnDefinitionOu
 }
 
 // JSONPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
-func (o CustomResourceColumnDefinitionOutput) JSONPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.JSONPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) JSONPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.JSONPath }).(pulumi.StringOutput)
 }
 
 // description is a human readable description of this column.
@@ -124,8 +124,8 @@ func (o CustomResourceColumnDefinitionOutput) Format() pulumi.StringPtrOutput {
 }
 
 // name is a human readable name for the column.
-func (o CustomResourceColumnDefinitionOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
@@ -134,8 +134,8 @@ func (o CustomResourceColumnDefinitionOutput) Priority() pulumi.IntPtrOutput {
 }
 
 // type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
-func (o CustomResourceColumnDefinitionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceColumnDefinition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o CustomResourceColumnDefinitionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceColumnDefinition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type CustomResourceColumnDefinitionArrayOutput struct{ *pulumi.OutputState }
@@ -164,7 +164,7 @@ type CustomResourceConversion struct {
 	ConversionReviewVersions []string `pulumi:"conversionReviewVersions"`
 	// strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 	//   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhookClientConfig to be set.
-	Strategy *string `pulumi:"strategy"`
+	Strategy string `pulumi:"strategy"`
 	// webhookClientConfig is the instructions for how to call the webhook if strategy is `Webhook`. Required when `strategy` is set to `Webhook`.
 	WebhookClientConfig *WebhookClientConfig `pulumi:"webhookClientConfig"`
 }
@@ -187,7 +187,7 @@ type CustomResourceConversionArgs struct {
 	ConversionReviewVersions pulumi.StringArrayInput `pulumi:"conversionReviewVersions"`
 	// strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 	//   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhookClientConfig to be set.
-	Strategy pulumi.StringPtrInput `pulumi:"strategy"`
+	Strategy pulumi.StringInput `pulumi:"strategy"`
 	// webhookClientConfig is the instructions for how to call the webhook if strategy is `Webhook`. Required when `strategy` is set to `Webhook`.
 	WebhookClientConfig WebhookClientConfigPtrInput `pulumi:"webhookClientConfig"`
 }
@@ -278,8 +278,8 @@ func (o CustomResourceConversionOutput) ConversionReviewVersions() pulumi.String
 
 // strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
 //   is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhookClientConfig to be set.
-func (o CustomResourceConversionOutput) Strategy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceConversion) *string { return v.Strategy }).(pulumi.StringPtrOutput)
+func (o CustomResourceConversionOutput) Strategy() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceConversion) string { return v.Strategy }).(pulumi.StringOutput)
 }
 
 // webhookClientConfig is the instructions for how to call the webhook if strategy is `Webhook`. Required when `strategy` is set to `Webhook`.
@@ -322,7 +322,7 @@ func (o CustomResourceConversionPtrOutput) Strategy() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Strategy
+		return &v.Strategy
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -339,14 +339,14 @@ func (o CustomResourceConversionPtrOutput) WebhookClientConfig() WebhookClientCo
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
 type CustomResourceDefinitionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec *CustomResourceDefinitionSpec `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpec `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status *CustomResourceDefinitionStatus `pulumi:"status"`
+	Status CustomResourceDefinitionStatus `pulumi:"status"`
 }
 
 // CustomResourceDefinitionTypeInput is an input type that accepts CustomResourceDefinitionTypeArgs and CustomResourceDefinitionTypeOutput values.
@@ -364,14 +364,14 @@ type CustomResourceDefinitionTypeInput interface {
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
 type CustomResourceDefinitionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec describes how the user wants the resources to appear
-	Spec CustomResourceDefinitionSpecPtrInput `pulumi:"spec"`
+	Spec CustomResourceDefinitionSpecInput `pulumi:"spec"`
 	// status indicates the actual state of the CustomResourceDefinition
-	Status CustomResourceDefinitionStatusPtrInput `pulumi:"status"`
+	Status CustomResourceDefinitionStatusInput `pulumi:"status"`
 }
 
 func (CustomResourceDefinitionTypeArgs) ElementType() reflect.Type {
@@ -428,27 +428,27 @@ func (o CustomResourceDefinitionTypeOutput) ToCustomResourceDefinitionTypeOutput
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CustomResourceDefinitionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CustomResourceDefinitionTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CustomResourceDefinitionTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec describes how the user wants the resources to appear
-func (o CustomResourceDefinitionTypeOutput) Spec() CustomResourceDefinitionSpecPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *CustomResourceDefinitionSpec { return v.Spec }).(CustomResourceDefinitionSpecPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Spec() CustomResourceDefinitionSpecOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) CustomResourceDefinitionSpec { return v.Spec }).(CustomResourceDefinitionSpecOutput)
 }
 
 // status indicates the actual state of the CustomResourceDefinition
-func (o CustomResourceDefinitionTypeOutput) Status() CustomResourceDefinitionStatusPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionType) *CustomResourceDefinitionStatus { return v.Status }).(CustomResourceDefinitionStatusPtrOutput)
+func (o CustomResourceDefinitionTypeOutput) Status() CustomResourceDefinitionStatusOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionType) CustomResourceDefinitionStatus { return v.Status }).(CustomResourceDefinitionStatusOutput)
 }
 
 type CustomResourceDefinitionTypeArrayOutput struct{ *pulumi.OutputState }
@@ -480,9 +480,9 @@ type CustomResourceDefinitionCondition struct {
 	// reason is a unique, one-word, CamelCase reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// status is the status of the condition. Can be True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // CustomResourceDefinitionConditionInput is an input type that accepts CustomResourceDefinitionConditionArgs and CustomResourceDefinitionConditionOutput values.
@@ -506,9 +506,9 @@ type CustomResourceDefinitionConditionArgs struct {
 	// reason is a unique, one-word, CamelCase reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// status is the status of the condition. Can be True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (CustomResourceDefinitionConditionArgs) ElementType() reflect.Type {
@@ -580,13 +580,13 @@ func (o CustomResourceDefinitionConditionOutput) Reason() pulumi.StringPtrOutput
 }
 
 // status is the status of the condition. Can be True, False, Unknown.
-func (o CustomResourceDefinitionConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // type is the type of the condition. Types include Established, NamesAccepted and Terminating.
-func (o CustomResourceDefinitionConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type CustomResourceDefinitionConditionArrayOutput struct{ *pulumi.OutputState }
@@ -612,12 +612,12 @@ func (o CustomResourceDefinitionConditionArrayOutput) Index(i pulumi.IntInput) C
 // CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
 type CustomResourceDefinitionListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items []CustomResourceDefinitionType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CustomResourceDefinitionListTypeInput is an input type that accepts CustomResourceDefinitionListTypeArgs and CustomResourceDefinitionListTypeOutput values.
@@ -635,12 +635,12 @@ type CustomResourceDefinitionListTypeInput interface {
 // CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
 type CustomResourceDefinitionListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items list individual CustomResourceDefinition objects
 	Items CustomResourceDefinitionTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CustomResourceDefinitionListTypeArgs) ElementType() reflect.Type {
@@ -671,8 +671,8 @@ func (o CustomResourceDefinitionListTypeOutput) ToCustomResourceDefinitionListTy
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CustomResourceDefinitionListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items list individual CustomResourceDefinition objects
@@ -681,12 +681,12 @@ func (o CustomResourceDefinitionListTypeOutput) Items() CustomResourceDefinition
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CustomResourceDefinitionListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CustomResourceDefinitionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CustomResourceDefinitionListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
@@ -694,11 +694,11 @@ type CustomResourceDefinitionNames struct {
 	// categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
 	Categories []string `pulumi:"categories"`
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
 	ListKind *string `pulumi:"listKind"`
 	// plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-	Plural *string `pulumi:"plural"`
+	Plural string `pulumi:"plural"`
 	// shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
 	ShortNames []string `pulumi:"shortNames"`
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
@@ -722,11 +722,11 @@ type CustomResourceDefinitionNamesArgs struct {
 	// categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
 	Categories pulumi.StringArrayInput `pulumi:"categories"`
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
 	ListKind pulumi.StringPtrInput `pulumi:"listKind"`
 	// plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-	Plural pulumi.StringPtrInput `pulumi:"plural"`
+	Plural pulumi.StringInput `pulumi:"plural"`
 	// shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
 	ShortNames pulumi.StringArrayInput `pulumi:"shortNames"`
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
@@ -818,8 +818,8 @@ func (o CustomResourceDefinitionNamesOutput) Categories() pulumi.StringArrayOutp
 }
 
 // kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
-func (o CustomResourceDefinitionNamesOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionNames) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionNamesOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionNames) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
@@ -828,8 +828,8 @@ func (o CustomResourceDefinitionNamesOutput) ListKind() pulumi.StringPtrOutput {
 }
 
 // plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
-func (o CustomResourceDefinitionNamesOutput) Plural() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionNames) *string { return v.Plural }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionNamesOutput) Plural() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionNames) string { return v.Plural }).(pulumi.StringOutput)
 }
 
 // shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
@@ -876,7 +876,7 @@ func (o CustomResourceDefinitionNamesPtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -896,7 +896,7 @@ func (o CustomResourceDefinitionNamesPtrOutput) Plural() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Plural
+		return &v.Plural
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -927,13 +927,13 @@ type CustomResourceDefinitionSpec struct {
 	// conversion defines conversion settings for the CRD.
 	Conversion *CustomResourceConversion `pulumi:"conversion"`
 	// group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	Group *string `pulumi:"group"`
+	Group string `pulumi:"group"`
 	// names specify the resource and kind names for the custom resource.
-	Names *CustomResourceDefinitionNames `pulumi:"names"`
+	Names CustomResourceDefinitionNames `pulumi:"names"`
 	// preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. If false, schemas must be defined for all versions. Defaults to true in v1beta for backwards compatibility. Deprecated: will be required to be false in v1. Preservation of unknown fields can be specified in the validation schema using the `x-kubernetes-preserve-unknown-fields: true` extension. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
 	PreserveUnknownFields *bool `pulumi:"preserveUnknownFields"`
 	// scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`. Default is `Namespaced`.
-	Scope *string `pulumi:"scope"`
+	Scope string `pulumi:"scope"`
 	// subresources specify what subresources the defined custom resource has. If present, this field configures subresources for all versions. Top-level and per-version subresources are mutually exclusive.
 	Subresources *CustomResourceSubresources `pulumi:"subresources"`
 	// validation describes the schema used for validation and pruning of the custom resource. If present, this validation schema is used to validate all versions. Top-level and per-version schemas are mutually exclusive.
@@ -963,13 +963,13 @@ type CustomResourceDefinitionSpecArgs struct {
 	// conversion defines conversion settings for the CRD.
 	Conversion CustomResourceConversionPtrInput `pulumi:"conversion"`
 	// group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	Group pulumi.StringPtrInput `pulumi:"group"`
+	Group pulumi.StringInput `pulumi:"group"`
 	// names specify the resource and kind names for the custom resource.
-	Names CustomResourceDefinitionNamesPtrInput `pulumi:"names"`
+	Names CustomResourceDefinitionNamesInput `pulumi:"names"`
 	// preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. If false, schemas must be defined for all versions. Defaults to true in v1beta for backwards compatibility. Deprecated: will be required to be false in v1. Preservation of unknown fields can be specified in the validation schema using the `x-kubernetes-preserve-unknown-fields: true` extension. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
 	PreserveUnknownFields pulumi.BoolPtrInput `pulumi:"preserveUnknownFields"`
 	// scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`. Default is `Namespaced`.
-	Scope pulumi.StringPtrInput `pulumi:"scope"`
+	Scope pulumi.StringInput `pulumi:"scope"`
 	// subresources specify what subresources the defined custom resource has. If present, this field configures subresources for all versions. Top-level and per-version subresources are mutually exclusive.
 	Subresources CustomResourceSubresourcesPtrInput `pulumi:"subresources"`
 	// validation describes the schema used for validation and pruning of the custom resource. If present, this validation schema is used to validate all versions. Top-level and per-version schemas are mutually exclusive.
@@ -1072,13 +1072,13 @@ func (o CustomResourceDefinitionSpecOutput) Conversion() CustomResourceConversio
 }
 
 // group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-func (o CustomResourceDefinitionSpecOutput) Group() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *string { return v.Group }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Group() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) string { return v.Group }).(pulumi.StringOutput)
 }
 
 // names specify the resource and kind names for the custom resource.
-func (o CustomResourceDefinitionSpecOutput) Names() CustomResourceDefinitionNamesPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *CustomResourceDefinitionNames { return v.Names }).(CustomResourceDefinitionNamesPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Names() CustomResourceDefinitionNamesOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) CustomResourceDefinitionNames { return v.Names }).(CustomResourceDefinitionNamesOutput)
 }
 
 // preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. If false, schemas must be defined for all versions. Defaults to true in v1beta for backwards compatibility. Deprecated: will be required to be false in v1. Preservation of unknown fields can be specified in the validation schema using the `x-kubernetes-preserve-unknown-fields: true` extension. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
@@ -1087,8 +1087,8 @@ func (o CustomResourceDefinitionSpecOutput) PreserveUnknownFields() pulumi.BoolP
 }
 
 // scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`. Default is `Namespaced`.
-func (o CustomResourceDefinitionSpecOutput) Scope() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionSpec) *string { return v.Scope }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionSpecOutput) Scope() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionSpec) string { return v.Scope }).(pulumi.StringOutput)
 }
 
 // subresources specify what subresources the defined custom resource has. If present, this field configures subresources for all versions. Top-level and per-version subresources are mutually exclusive.
@@ -1155,7 +1155,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Group() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Group
+		return &v.Group
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1165,7 +1165,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Names() CustomResourceDefinitionN
 		if v == nil {
 			return nil
 		}
-		return v.Names
+		return &v.Names
 	}).(CustomResourceDefinitionNamesPtrOutput)
 }
 
@@ -1185,7 +1185,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Scope() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Scope
+		return &v.Scope
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1232,7 +1232,7 @@ func (o CustomResourceDefinitionSpecPtrOutput) Versions() CustomResourceDefiniti
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatus struct {
 	// acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-	AcceptedNames *CustomResourceDefinitionNames `pulumi:"acceptedNames"`
+	AcceptedNames CustomResourceDefinitionNames `pulumi:"acceptedNames"`
 	// conditions indicate state for particular aspects of a CustomResourceDefinition
 	Conditions []CustomResourceDefinitionCondition `pulumi:"conditions"`
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
@@ -1254,7 +1254,7 @@ type CustomResourceDefinitionStatusInput interface {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatusArgs struct {
 	// acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-	AcceptedNames CustomResourceDefinitionNamesPtrInput `pulumi:"acceptedNames"`
+	AcceptedNames CustomResourceDefinitionNamesInput `pulumi:"acceptedNames"`
 	// conditions indicate state for particular aspects of a CustomResourceDefinition
 	Conditions CustomResourceDefinitionConditionArrayInput `pulumi:"conditions"`
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
@@ -1341,8 +1341,8 @@ func (o CustomResourceDefinitionStatusOutput) ToCustomResourceDefinitionStatusPt
 }
 
 // acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
-func (o CustomResourceDefinitionStatusOutput) AcceptedNames() CustomResourceDefinitionNamesPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionStatus) *CustomResourceDefinitionNames { return v.AcceptedNames }).(CustomResourceDefinitionNamesPtrOutput)
+func (o CustomResourceDefinitionStatusOutput) AcceptedNames() CustomResourceDefinitionNamesOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionStatus) CustomResourceDefinitionNames { return v.AcceptedNames }).(CustomResourceDefinitionNamesOutput)
 }
 
 // conditions indicate state for particular aspects of a CustomResourceDefinition
@@ -1379,7 +1379,7 @@ func (o CustomResourceDefinitionStatusPtrOutput) AcceptedNames() CustomResourceD
 		if v == nil {
 			return nil
 		}
-		return v.AcceptedNames
+		return &v.AcceptedNames
 	}).(CustomResourceDefinitionNamesPtrOutput)
 }
 
@@ -1408,13 +1408,13 @@ type CustomResourceDefinitionVersion struct {
 	// additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
 	AdditionalPrinterColumns []CustomResourceColumnDefinition `pulumi:"additionalPrinterColumns"`
 	// name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// schema describes the schema used for validation and pruning of this version of the custom resource. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead).
 	Schema *CustomResourceValidation `pulumi:"schema"`
 	// served is a flag enabling/disabling this version from being served via REST APIs
-	Served *bool `pulumi:"served"`
+	Served bool `pulumi:"served"`
 	// storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-	Storage *bool `pulumi:"storage"`
+	Storage bool `pulumi:"storage"`
 	// subresources specify what subresources this version of the defined custom resource have. Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead).
 	Subresources *CustomResourceSubresources `pulumi:"subresources"`
 }
@@ -1436,13 +1436,13 @@ type CustomResourceDefinitionVersionArgs struct {
 	// additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
 	AdditionalPrinterColumns CustomResourceColumnDefinitionArrayInput `pulumi:"additionalPrinterColumns"`
 	// name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// schema describes the schema used for validation and pruning of this version of the custom resource. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead).
 	Schema CustomResourceValidationPtrInput `pulumi:"schema"`
 	// served is a flag enabling/disabling this version from being served via REST APIs
-	Served pulumi.BoolPtrInput `pulumi:"served"`
+	Served pulumi.BoolInput `pulumi:"served"`
 	// storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-	Storage pulumi.BoolPtrInput `pulumi:"storage"`
+	Storage pulumi.BoolInput `pulumi:"storage"`
 	// subresources specify what subresources this version of the defined custom resource have. Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead).
 	Subresources CustomResourceSubresourcesPtrInput `pulumi:"subresources"`
 }
@@ -1508,8 +1508,8 @@ func (o CustomResourceDefinitionVersionOutput) AdditionalPrinterColumns() Custom
 }
 
 // name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
-func (o CustomResourceDefinitionVersionOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // schema describes the schema used for validation and pruning of this version of the custom resource. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead).
@@ -1518,13 +1518,13 @@ func (o CustomResourceDefinitionVersionOutput) Schema() CustomResourceValidation
 }
 
 // served is a flag enabling/disabling this version from being served via REST APIs
-func (o CustomResourceDefinitionVersionOutput) Served() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *bool { return v.Served }).(pulumi.BoolPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Served() pulumi.BoolOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) bool { return v.Served }).(pulumi.BoolOutput)
 }
 
 // storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
-func (o CustomResourceDefinitionVersionOutput) Storage() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v CustomResourceDefinitionVersion) *bool { return v.Storage }).(pulumi.BoolPtrOutput)
+func (o CustomResourceDefinitionVersionOutput) Storage() pulumi.BoolOutput {
+	return o.ApplyT(func(v CustomResourceDefinitionVersion) bool { return v.Storage }).(pulumi.BoolOutput)
 }
 
 // subresources specify what subresources this version of the defined custom resource have. Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead).
@@ -1557,9 +1557,9 @@ type CustomResourceSubresourceScale struct {
 	// labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
 	LabelSelectorPath *string `pulumi:"labelSelectorPath"`
 	// specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-	SpecReplicasPath *string `pulumi:"specReplicasPath"`
+	SpecReplicasPath string `pulumi:"specReplicasPath"`
 	// statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-	StatusReplicasPath *string `pulumi:"statusReplicasPath"`
+	StatusReplicasPath string `pulumi:"statusReplicasPath"`
 }
 
 // CustomResourceSubresourceScaleInput is an input type that accepts CustomResourceSubresourceScaleArgs and CustomResourceSubresourceScaleOutput values.
@@ -1579,9 +1579,9 @@ type CustomResourceSubresourceScaleArgs struct {
 	// labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
 	LabelSelectorPath pulumi.StringPtrInput `pulumi:"labelSelectorPath"`
 	// specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-	SpecReplicasPath pulumi.StringPtrInput `pulumi:"specReplicasPath"`
+	SpecReplicasPath pulumi.StringInput `pulumi:"specReplicasPath"`
 	// statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-	StatusReplicasPath pulumi.StringPtrInput `pulumi:"statusReplicasPath"`
+	StatusReplicasPath pulumi.StringInput `pulumi:"statusReplicasPath"`
 }
 
 func (CustomResourceSubresourceScaleArgs) ElementType() reflect.Type {
@@ -1669,13 +1669,13 @@ func (o CustomResourceSubresourceScaleOutput) LabelSelectorPath() pulumi.StringP
 }
 
 // specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
-func (o CustomResourceSubresourceScaleOutput) SpecReplicasPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceSubresourceScale) *string { return v.SpecReplicasPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceSubresourceScaleOutput) SpecReplicasPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceSubresourceScale) string { return v.SpecReplicasPath }).(pulumi.StringOutput)
 }
 
 // statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
-func (o CustomResourceSubresourceScaleOutput) StatusReplicasPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CustomResourceSubresourceScale) *string { return v.StatusReplicasPath }).(pulumi.StringPtrOutput)
+func (o CustomResourceSubresourceScaleOutput) StatusReplicasPath() pulumi.StringOutput {
+	return o.ApplyT(func(v CustomResourceSubresourceScale) string { return v.StatusReplicasPath }).(pulumi.StringOutput)
 }
 
 type CustomResourceSubresourceScalePtrOutput struct{ *pulumi.OutputState }
@@ -1712,7 +1712,7 @@ func (o CustomResourceSubresourceScalePtrOutput) SpecReplicasPath() pulumi.Strin
 		if v == nil {
 			return nil
 		}
-		return v.SpecReplicasPath
+		return &v.SpecReplicasPath
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1722,7 +1722,7 @@ func (o CustomResourceSubresourceScalePtrOutput) StatusReplicasPath() pulumi.Str
 		if v == nil {
 			return nil
 		}
-		return v.StatusReplicasPath
+		return &v.StatusReplicasPath
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3191,9 +3191,9 @@ func (o JSONSchemaPropsMapOutput) MapIndex(k pulumi.StringInput) JSONSchemaProps
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
 	// name is the name of the service. Required
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// namespace is the namespace of the service. Required
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// path is an optional URL path at which the webhook will be contacted.
 	Path *string `pulumi:"path"`
 	// port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
@@ -3215,9 +3215,9 @@ type ServiceReferenceInput interface {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReferenceArgs struct {
 	// name is the name of the service. Required
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// namespace is the namespace of the service. Required
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// path is an optional URL path at which the webhook will be contacted.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
@@ -3304,13 +3304,13 @@ func (o ServiceReferenceOutput) ToServiceReferencePtrOutputWithContext(ctx conte
 }
 
 // name is the name of the service. Required
-func (o ServiceReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // namespace is the namespace of the service. Required
-func (o ServiceReferenceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // path is an optional URL path at which the webhook will be contacted.
@@ -3347,7 +3347,7 @@ func (o ServiceReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3357,7 +3357,7 @@ func (o ServiceReferencePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apiregistration/v1/apiservice.go
+++ b/sdk/go/kubernetes/apiregistration/v1/apiservice.go
@@ -15,14 +15,14 @@ type APIService struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec APIServiceSpecPtrOutput `pulumi:"spec"`
+	Spec APIServiceSpecOutput `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status APIServiceStatusPtrOutput `pulumi:"status"`
+	Status APIServiceStatusOutput `pulumi:"status"`
 }
 
 // NewAPIService registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiregistration/v1/apiserviceList.go
+++ b/sdk/go/kubernetes/apiregistration/v1/apiserviceList.go
@@ -16,11 +16,11 @@ type APIServiceList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput    `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput       `pulumi:"apiVersion"`
 	Items      APIServiceTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewAPIServiceList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiregistration/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiregistration/v1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServiceType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec *APIServiceSpec `pulumi:"spec"`
+	Spec APIServiceSpec `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status *APIServiceStatus `pulumi:"status"`
+	Status APIServiceStatus `pulumi:"status"`
 }
 
 // APIServiceTypeInput is an input type that accepts APIServiceTypeArgs and APIServiceTypeOutput values.
@@ -39,14 +39,14 @@ type APIServiceTypeInput interface {
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServiceTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec APIServiceSpecPtrInput `pulumi:"spec"`
+	Spec APIServiceSpecInput `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status APIServiceStatusPtrInput `pulumi:"status"`
+	Status APIServiceStatusInput `pulumi:"status"`
 }
 
 func (APIServiceTypeArgs) ElementType() reflect.Type {
@@ -103,27 +103,27 @@ func (o APIServiceTypeOutput) ToAPIServiceTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o APIServiceTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o APIServiceTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o APIServiceTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o APIServiceTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o APIServiceTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o APIServiceTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v APIServiceType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec contains information for locating and communicating with a server
-func (o APIServiceTypeOutput) Spec() APIServiceSpecPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *APIServiceSpec { return v.Spec }).(APIServiceSpecPtrOutput)
+func (o APIServiceTypeOutput) Spec() APIServiceSpecOutput {
+	return o.ApplyT(func(v APIServiceType) APIServiceSpec { return v.Spec }).(APIServiceSpecOutput)
 }
 
 // Status contains derived information about an API server
-func (o APIServiceTypeOutput) Status() APIServiceStatusPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *APIServiceStatus { return v.Status }).(APIServiceStatusPtrOutput)
+func (o APIServiceTypeOutput) Status() APIServiceStatusOutput {
+	return o.ApplyT(func(v APIServiceType) APIServiceStatus { return v.Status }).(APIServiceStatusOutput)
 }
 
 type APIServiceTypeArrayOutput struct{ *pulumi.OutputState }
@@ -155,9 +155,9 @@ type APIServiceCondition struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type is the type of the condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // APIServiceConditionInput is an input type that accepts APIServiceConditionArgs and APIServiceConditionOutput values.
@@ -181,9 +181,9 @@ type APIServiceConditionArgs struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type is the type of the condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (APIServiceConditionArgs) ElementType() reflect.Type {
@@ -255,13 +255,13 @@ func (o APIServiceConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status is the status of the condition. Can be True, False, Unknown.
-func (o APIServiceConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o APIServiceConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type is the type of the condition.
-func (o APIServiceConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o APIServiceConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type APIServiceConditionArrayOutput struct{ *pulumi.OutputState }
@@ -287,11 +287,11 @@ func (o APIServiceConditionArrayOutput) Index(i pulumi.IntInput) APIServiceCondi
 // APIServiceList is a list of APIService objects.
 type APIServiceListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string          `pulumi:"apiVersion"`
+	ApiVersion string           `pulumi:"apiVersion"`
 	Items      []APIServiceType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // APIServiceListTypeInput is an input type that accepts APIServiceListTypeArgs and APIServiceListTypeOutput values.
@@ -309,11 +309,11 @@ type APIServiceListTypeInput interface {
 // APIServiceList is a list of APIService objects.
 type APIServiceListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput    `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput       `pulumi:"apiVersion"`
 	Items      APIServiceTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (APIServiceListTypeArgs) ElementType() reflect.Type {
@@ -344,8 +344,8 @@ func (o APIServiceListTypeOutput) ToAPIServiceListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o APIServiceListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o APIServiceListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o APIServiceListTypeOutput) Items() APIServiceTypeArrayOutput {
@@ -353,12 +353,12 @@ func (o APIServiceListTypeOutput) Items() APIServiceTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o APIServiceListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o APIServiceListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o APIServiceListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o APIServiceListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v APIServiceListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
@@ -368,7 +368,7 @@ type APIServiceSpec struct {
 	// Group is the API group name this server hosts
 	Group *string `pulumi:"group"`
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-	GroupPriorityMinimum *int `pulumi:"groupPriorityMinimum"`
+	GroupPriorityMinimum int `pulumi:"groupPriorityMinimum"`
 	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify *bool `pulumi:"insecureSkipTLSVerify"`
 	// Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
@@ -376,7 +376,7 @@ type APIServiceSpec struct {
 	// Version is the API version this server hosts.  For example, "v1"
 	Version *string `pulumi:"version"`
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-	VersionPriority *int `pulumi:"versionPriority"`
+	VersionPriority int `pulumi:"versionPriority"`
 }
 
 // APIServiceSpecInput is an input type that accepts APIServiceSpecArgs and APIServiceSpecOutput values.
@@ -398,7 +398,7 @@ type APIServiceSpecArgs struct {
 	// Group is the API group name this server hosts
 	Group pulumi.StringPtrInput `pulumi:"group"`
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-	GroupPriorityMinimum pulumi.IntPtrInput `pulumi:"groupPriorityMinimum"`
+	GroupPriorityMinimum pulumi.IntInput `pulumi:"groupPriorityMinimum"`
 	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify pulumi.BoolPtrInput `pulumi:"insecureSkipTLSVerify"`
 	// Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
@@ -406,7 +406,7 @@ type APIServiceSpecArgs struct {
 	// Version is the API version this server hosts.  For example, "v1"
 	Version pulumi.StringPtrInput `pulumi:"version"`
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-	VersionPriority pulumi.IntPtrInput `pulumi:"versionPriority"`
+	VersionPriority pulumi.IntInput `pulumi:"versionPriority"`
 }
 
 func (APIServiceSpecArgs) ElementType() reflect.Type {
@@ -499,8 +499,8 @@ func (o APIServiceSpecOutput) Group() pulumi.StringPtrOutput {
 }
 
 // GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-func (o APIServiceSpecOutput) GroupPriorityMinimum() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v APIServiceSpec) *int { return v.GroupPriorityMinimum }).(pulumi.IntPtrOutput)
+func (o APIServiceSpecOutput) GroupPriorityMinimum() pulumi.IntOutput {
+	return o.ApplyT(func(v APIServiceSpec) int { return v.GroupPriorityMinimum }).(pulumi.IntOutput)
 }
 
 // InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
@@ -519,8 +519,8 @@ func (o APIServiceSpecOutput) Version() pulumi.StringPtrOutput {
 }
 
 // VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-func (o APIServiceSpecOutput) VersionPriority() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v APIServiceSpec) *int { return v.VersionPriority }).(pulumi.IntPtrOutput)
+func (o APIServiceSpecOutput) VersionPriority() pulumi.IntOutput {
+	return o.ApplyT(func(v APIServiceSpec) int { return v.VersionPriority }).(pulumi.IntOutput)
 }
 
 type APIServiceSpecPtrOutput struct{ *pulumi.OutputState }
@@ -567,7 +567,7 @@ func (o APIServiceSpecPtrOutput) GroupPriorityMinimum() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.GroupPriorityMinimum
+		return &v.GroupPriorityMinimum
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -607,7 +607,7 @@ func (o APIServiceSpecPtrOutput) VersionPriority() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.VersionPriority
+		return &v.VersionPriority
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apiregistration/v1beta1/apiservice.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/apiservice.go
@@ -15,14 +15,14 @@ type APIService struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec APIServiceSpecPtrOutput `pulumi:"spec"`
+	Spec APIServiceSpecOutput `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status APIServiceStatusPtrOutput `pulumi:"status"`
+	Status APIServiceStatusOutput `pulumi:"status"`
 }
 
 // NewAPIService registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiregistration/v1beta1/apiserviceList.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/apiserviceList.go
@@ -16,11 +16,11 @@ type APIServiceList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput    `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput       `pulumi:"apiVersion"`
 	Items      APIServiceTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewAPIServiceList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apiregistration/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServiceType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec *APIServiceSpec `pulumi:"spec"`
+	Spec APIServiceSpec `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status *APIServiceStatus `pulumi:"status"`
+	Status APIServiceStatus `pulumi:"status"`
 }
 
 // APIServiceTypeInput is an input type that accepts APIServiceTypeArgs and APIServiceTypeOutput values.
@@ -39,14 +39,14 @@ type APIServiceTypeInput interface {
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServiceTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec contains information for locating and communicating with a server
-	Spec APIServiceSpecPtrInput `pulumi:"spec"`
+	Spec APIServiceSpecInput `pulumi:"spec"`
 	// Status contains derived information about an API server
-	Status APIServiceStatusPtrInput `pulumi:"status"`
+	Status APIServiceStatusInput `pulumi:"status"`
 }
 
 func (APIServiceTypeArgs) ElementType() reflect.Type {
@@ -103,27 +103,27 @@ func (o APIServiceTypeOutput) ToAPIServiceTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o APIServiceTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o APIServiceTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o APIServiceTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o APIServiceTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o APIServiceTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o APIServiceTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v APIServiceType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec contains information for locating and communicating with a server
-func (o APIServiceTypeOutput) Spec() APIServiceSpecPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *APIServiceSpec { return v.Spec }).(APIServiceSpecPtrOutput)
+func (o APIServiceTypeOutput) Spec() APIServiceSpecOutput {
+	return o.ApplyT(func(v APIServiceType) APIServiceSpec { return v.Spec }).(APIServiceSpecOutput)
 }
 
 // Status contains derived information about an API server
-func (o APIServiceTypeOutput) Status() APIServiceStatusPtrOutput {
-	return o.ApplyT(func(v APIServiceType) *APIServiceStatus { return v.Status }).(APIServiceStatusPtrOutput)
+func (o APIServiceTypeOutput) Status() APIServiceStatusOutput {
+	return o.ApplyT(func(v APIServiceType) APIServiceStatus { return v.Status }).(APIServiceStatusOutput)
 }
 
 type APIServiceTypeArrayOutput struct{ *pulumi.OutputState }
@@ -155,9 +155,9 @@ type APIServiceCondition struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type is the type of the condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // APIServiceConditionInput is an input type that accepts APIServiceConditionArgs and APIServiceConditionOutput values.
@@ -181,9 +181,9 @@ type APIServiceConditionArgs struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type is the type of the condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (APIServiceConditionArgs) ElementType() reflect.Type {
@@ -255,13 +255,13 @@ func (o APIServiceConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status is the status of the condition. Can be True, False, Unknown.
-func (o APIServiceConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o APIServiceConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type is the type of the condition.
-func (o APIServiceConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o APIServiceConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type APIServiceConditionArrayOutput struct{ *pulumi.OutputState }
@@ -287,11 +287,11 @@ func (o APIServiceConditionArrayOutput) Index(i pulumi.IntInput) APIServiceCondi
 // APIServiceList is a list of APIService objects.
 type APIServiceListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string          `pulumi:"apiVersion"`
+	ApiVersion string           `pulumi:"apiVersion"`
 	Items      []APIServiceType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // APIServiceListTypeInput is an input type that accepts APIServiceListTypeArgs and APIServiceListTypeOutput values.
@@ -309,11 +309,11 @@ type APIServiceListTypeInput interface {
 // APIServiceList is a list of APIService objects.
 type APIServiceListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput    `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput       `pulumi:"apiVersion"`
 	Items      APIServiceTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (APIServiceListTypeArgs) ElementType() reflect.Type {
@@ -344,8 +344,8 @@ func (o APIServiceListTypeOutput) ToAPIServiceListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o APIServiceListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o APIServiceListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o APIServiceListTypeOutput) Items() APIServiceTypeArrayOutput {
@@ -353,12 +353,12 @@ func (o APIServiceListTypeOutput) Items() APIServiceTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o APIServiceListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o APIServiceListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v APIServiceListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o APIServiceListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v APIServiceListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o APIServiceListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v APIServiceListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
@@ -368,7 +368,7 @@ type APIServiceSpec struct {
 	// Group is the API group name this server hosts
 	Group *string `pulumi:"group"`
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-	GroupPriorityMinimum *int `pulumi:"groupPriorityMinimum"`
+	GroupPriorityMinimum int `pulumi:"groupPriorityMinimum"`
 	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify *bool `pulumi:"insecureSkipTLSVerify"`
 	// Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
@@ -376,7 +376,7 @@ type APIServiceSpec struct {
 	// Version is the API version this server hosts.  For example, "v1"
 	Version *string `pulumi:"version"`
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-	VersionPriority *int `pulumi:"versionPriority"`
+	VersionPriority int `pulumi:"versionPriority"`
 }
 
 // APIServiceSpecInput is an input type that accepts APIServiceSpecArgs and APIServiceSpecOutput values.
@@ -398,7 +398,7 @@ type APIServiceSpecArgs struct {
 	// Group is the API group name this server hosts
 	Group pulumi.StringPtrInput `pulumi:"group"`
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-	GroupPriorityMinimum pulumi.IntPtrInput `pulumi:"groupPriorityMinimum"`
+	GroupPriorityMinimum pulumi.IntInput `pulumi:"groupPriorityMinimum"`
 	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify pulumi.BoolPtrInput `pulumi:"insecureSkipTLSVerify"`
 	// Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
@@ -406,7 +406,7 @@ type APIServiceSpecArgs struct {
 	// Version is the API version this server hosts.  For example, "v1"
 	Version pulumi.StringPtrInput `pulumi:"version"`
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-	VersionPriority pulumi.IntPtrInput `pulumi:"versionPriority"`
+	VersionPriority pulumi.IntInput `pulumi:"versionPriority"`
 }
 
 func (APIServiceSpecArgs) ElementType() reflect.Type {
@@ -499,8 +499,8 @@ func (o APIServiceSpecOutput) Group() pulumi.StringPtrOutput {
 }
 
 // GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
-func (o APIServiceSpecOutput) GroupPriorityMinimum() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v APIServiceSpec) *int { return v.GroupPriorityMinimum }).(pulumi.IntPtrOutput)
+func (o APIServiceSpecOutput) GroupPriorityMinimum() pulumi.IntOutput {
+	return o.ApplyT(func(v APIServiceSpec) int { return v.GroupPriorityMinimum }).(pulumi.IntOutput)
 }
 
 // InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
@@ -519,8 +519,8 @@ func (o APIServiceSpecOutput) Version() pulumi.StringPtrOutput {
 }
 
 // VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-func (o APIServiceSpecOutput) VersionPriority() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v APIServiceSpec) *int { return v.VersionPriority }).(pulumi.IntPtrOutput)
+func (o APIServiceSpecOutput) VersionPriority() pulumi.IntOutput {
+	return o.ApplyT(func(v APIServiceSpec) int { return v.VersionPriority }).(pulumi.IntOutput)
 }
 
 type APIServiceSpecPtrOutput struct{ *pulumi.OutputState }
@@ -567,7 +567,7 @@ func (o APIServiceSpecPtrOutput) GroupPriorityMinimum() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.GroupPriorityMinimum
+		return &v.GroupPriorityMinimum
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -607,7 +607,7 @@ func (o APIServiceSpecPtrOutput) VersionPriority() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.VersionPriority
+		return &v.VersionPriority
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apps/v1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevision.go
@@ -16,15 +16,15 @@ type ControllerRevision struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrOutput `pulumi:"revision"`
+	Revision pulumi.IntOutput `pulumi:"revision"`
 }
 
 // NewControllerRevision registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevisionList.go
@@ -16,13 +16,13 @@ type ControllerRevisionList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewControllerRevisionList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/daemonSet.go
+++ b/sdk/go/kubernetes/apps/v1/daemonSet.go
@@ -15,15 +15,15 @@ type DaemonSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrOutput `pulumi:"spec"`
+	Spec DaemonSetSpecOutput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrOutput `pulumi:"status"`
+	Status DaemonSetStatusOutput `pulumi:"status"`
 }
 
 // NewDaemonSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/daemonSetList.go
+++ b/sdk/go/kubernetes/apps/v1/daemonSetList.go
@@ -16,13 +16,13 @@ type DaemonSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDaemonSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/deployment.go
+++ b/sdk/go/kubernetes/apps/v1/deployment.go
@@ -37,15 +37,15 @@ type Deployment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrOutput `pulumi:"spec"`
+	Spec DeploymentSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrOutput `pulumi:"status"`
+	Status DeploymentStatusOutput `pulumi:"status"`
 }
 
 // NewDeployment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1/deploymentList.go
@@ -16,13 +16,13 @@ type DeploymentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDeploymentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1/pulumiTypes.go
@@ -15,15 +15,15 @@ import (
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision *int `pulumi:"revision"`
+	Revision int `pulumi:"revision"`
 }
 
 // ControllerRevisionTypeInput is an input type that accepts ControllerRevisionTypeArgs and ControllerRevisionTypeOutput values.
@@ -41,15 +41,15 @@ type ControllerRevisionTypeInput interface {
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrInput `pulumi:"revision"`
+	Revision pulumi.IntInput `pulumi:"revision"`
 }
 
 func (ControllerRevisionTypeArgs) ElementType() reflect.Type {
@@ -106,8 +106,8 @@ func (o ControllerRevisionTypeOutput) ToControllerRevisionTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Data is the serialized representation of the state.
@@ -116,18 +116,18 @@ func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Revision indicates the revision of the state represented by Data.
-func (o ControllerRevisionTypeOutput) Revision() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *int { return v.Revision }).(pulumi.IntPtrOutput)
+func (o ControllerRevisionTypeOutput) Revision() pulumi.IntOutput {
+	return o.ApplyT(func(v ControllerRevisionType) int { return v.Revision }).(pulumi.IntOutput)
 }
 
 type ControllerRevisionTypeArrayOutput struct{ *pulumi.OutputState }
@@ -153,13 +153,13 @@ func (o ControllerRevisionTypeArrayOutput) Index(i pulumi.IntInput) ControllerRe
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items []ControllerRevisionType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ControllerRevisionListTypeInput is an input type that accepts ControllerRevisionListTypeArgs and ControllerRevisionListTypeOutput values.
@@ -177,13 +177,13 @@ type ControllerRevisionListTypeInput interface {
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ControllerRevisionListTypeArgs) ElementType() reflect.Type {
@@ -214,8 +214,8 @@ func (o ControllerRevisionListTypeOutput) ToControllerRevisionListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of ControllerRevisions
@@ -224,27 +224,27 @@ func (o ControllerRevisionListTypeOutput) Items() ControllerRevisionTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *DaemonSetSpec `pulumi:"spec"`
+	Spec DaemonSetSpec `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *DaemonSetStatus `pulumi:"status"`
+	Status DaemonSetStatus `pulumi:"status"`
 }
 
 // DaemonSetTypeInput is an input type that accepts DaemonSetTypeArgs and DaemonSetTypeOutput values.
@@ -262,15 +262,15 @@ type DaemonSetTypeInput interface {
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrInput `pulumi:"spec"`
+	Spec DaemonSetSpecInput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrInput `pulumi:"status"`
+	Status DaemonSetStatusInput `pulumi:"status"`
 }
 
 func (DaemonSetTypeArgs) ElementType() reflect.Type {
@@ -327,28 +327,28 @@ func (o DaemonSetTypeOutput) ToDaemonSetTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DaemonSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Spec() DaemonSetSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetSpec { return v.Spec }).(DaemonSetSpecPtrOutput)
+func (o DaemonSetTypeOutput) Spec() DaemonSetSpecOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetSpec { return v.Spec }).(DaemonSetSpecOutput)
 }
 
 // The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Status() DaemonSetStatusPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetStatus { return v.Status }).(DaemonSetStatusPtrOutput)
+func (o DaemonSetTypeOutput) Status() DaemonSetStatusOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetStatus { return v.Status }).(DaemonSetStatusOutput)
 }
 
 type DaemonSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -380,9 +380,9 @@ type DaemonSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DaemonSetConditionInput is an input type that accepts DaemonSetConditionArgs and DaemonSetConditionOutput values.
@@ -406,9 +406,9 @@ type DaemonSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DaemonSetConditionArgs) ElementType() reflect.Type {
@@ -480,13 +480,13 @@ func (o DaemonSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DaemonSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of DaemonSet condition.
-func (o DaemonSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DaemonSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -512,13 +512,13 @@ func (o DaemonSetConditionArrayOutput) Index(i pulumi.IntInput) DaemonSetConditi
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items []DaemonSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DaemonSetListTypeInput is an input type that accepts DaemonSetListTypeArgs and DaemonSetListTypeOutput values.
@@ -536,13 +536,13 @@ type DaemonSetListTypeInput interface {
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DaemonSetListTypeArgs) ElementType() reflect.Type {
@@ -573,8 +573,8 @@ func (o DaemonSetListTypeOutput) ToDaemonSetListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // A list of daemon sets.
@@ -583,13 +583,13 @@ func (o DaemonSetListTypeOutput) Items() DaemonSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DaemonSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DaemonSetSpec is the specification of a daemon set.
@@ -599,9 +599,9 @@ type DaemonSetSpec struct {
 	// The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy *DaemonSetUpdateStrategy `pulumi:"updateStrategy"`
 }
@@ -625,9 +625,9 @@ type DaemonSetSpecArgs struct {
 	// The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy DaemonSetUpdateStrategyPtrInput `pulumi:"updateStrategy"`
 }
@@ -722,13 +722,13 @@ func (o DaemonSetSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o DaemonSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v DaemonSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o DaemonSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v DaemonSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DaemonSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // An update strategy to replace existing DaemonSet pods with new pods.
@@ -780,7 +780,7 @@ func (o DaemonSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -790,7 +790,7 @@ func (o DaemonSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -811,15 +811,15 @@ type DaemonSetStatus struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions []DaemonSetCondition `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled *int `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled int `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled *int `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled int `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable *int `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled *int `pulumi:"numberMisscheduled"`
+	NumberMisscheduled int `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady *int `pulumi:"numberReady"`
+	NumberReady int `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable *int `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -847,15 +847,15 @@ type DaemonSetStatusArgs struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions DaemonSetConditionArrayInput `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled pulumi.IntPtrInput `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled pulumi.IntInput `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled pulumi.IntPtrInput `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled pulumi.IntInput `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable pulumi.IntPtrInput `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled pulumi.IntPtrInput `pulumi:"numberMisscheduled"`
+	NumberMisscheduled pulumi.IntInput `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady pulumi.IntPtrInput `pulumi:"numberReady"`
+	NumberReady pulumi.IntInput `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable pulumi.IntPtrInput `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -954,13 +954,13 @@ func (o DaemonSetStatusOutput) Conditions() DaemonSetConditionArrayOutput {
 }
 
 // The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.CurrentNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.CurrentNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.DesiredNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.DesiredNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -969,13 +969,13 @@ func (o DaemonSetStatusOutput) NumberAvailable() pulumi.IntPtrOutput {
 }
 
 // The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberMisscheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberMisscheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-func (o DaemonSetStatusOutput) NumberReady() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberReady }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberReady() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberReady }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -1037,7 +1037,7 @@ func (o DaemonSetStatusPtrOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.CurrentNumberScheduled
+		return &v.CurrentNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1047,7 +1047,7 @@ func (o DaemonSetStatusPtrOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.DesiredNumberScheduled
+		return &v.DesiredNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1067,7 +1067,7 @@ func (o DaemonSetStatusPtrOutput) NumberMisscheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberMisscheduled
+		return &v.NumberMisscheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1077,7 +1077,7 @@ func (o DaemonSetStatusPtrOutput) NumberReady() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberReady
+		return &v.NumberReady
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1291,15 +1291,15 @@ func (o DaemonSetUpdateStrategyPtrOutput) Type() pulumi.StringPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec *DeploymentSpec `pulumi:"spec"`
+	Spec DeploymentSpec `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status *DeploymentStatus `pulumi:"status"`
+	Status DeploymentStatus `pulumi:"status"`
 }
 
 // DeploymentTypeInput is an input type that accepts DeploymentTypeArgs and DeploymentTypeOutput values.
@@ -1339,15 +1339,15 @@ type DeploymentTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrInput `pulumi:"spec"`
+	Spec DeploymentSpecInput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrInput `pulumi:"status"`
+	Status DeploymentStatusInput `pulumi:"status"`
 }
 
 func (DeploymentTypeArgs) ElementType() reflect.Type {
@@ -1426,28 +1426,28 @@ func (o DeploymentTypeOutput) ToDeploymentTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata.
-func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DeploymentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the Deployment.
-func (o DeploymentTypeOutput) Spec() DeploymentSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentSpec { return v.Spec }).(DeploymentSpecPtrOutput)
+func (o DeploymentTypeOutput) Spec() DeploymentSpecOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentSpec { return v.Spec }).(DeploymentSpecOutput)
 }
 
 // Most recently observed status of the Deployment.
-func (o DeploymentTypeOutput) Status() DeploymentStatusPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentStatus { return v.Status }).(DeploymentStatusPtrOutput)
+func (o DeploymentTypeOutput) Status() DeploymentStatusOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentStatus { return v.Status }).(DeploymentStatusOutput)
 }
 
 type DeploymentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1481,9 +1481,9 @@ type DeploymentCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of deployment condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DeploymentConditionInput is an input type that accepts DeploymentConditionArgs and DeploymentConditionOutput values.
@@ -1509,9 +1509,9 @@ type DeploymentConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of deployment condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DeploymentConditionArgs) ElementType() reflect.Type {
@@ -1588,13 +1588,13 @@ func (o DeploymentConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DeploymentConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of deployment condition.
-func (o DeploymentConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DeploymentConditionArrayOutput struct{ *pulumi.OutputState }
@@ -1620,13 +1620,13 @@ func (o DeploymentConditionArrayOutput) Index(i pulumi.IntInput) DeploymentCondi
 // DeploymentList is a list of Deployments.
 type DeploymentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items []DeploymentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DeploymentListTypeInput is an input type that accepts DeploymentListTypeArgs and DeploymentListTypeOutput values.
@@ -1644,13 +1644,13 @@ type DeploymentListTypeInput interface {
 // DeploymentList is a list of Deployments.
 type DeploymentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DeploymentListTypeArgs) ElementType() reflect.Type {
@@ -1681,8 +1681,8 @@ func (o DeploymentListTypeOutput) ToDeploymentListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Deployments.
@@ -1691,13 +1691,13 @@ func (o DeploymentListTypeOutput) Items() DeploymentTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DeploymentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
@@ -1713,11 +1713,11 @@ type DeploymentSpec struct {
 	// The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy *DeploymentStrategy `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 }
 
 // DeploymentSpecInput is an input type that accepts DeploymentSpecArgs and DeploymentSpecOutput values.
@@ -1745,11 +1745,11 @@ type DeploymentSpecArgs struct {
 	// The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy DeploymentStrategyPtrInput `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 }
 
 func (DeploymentSpecArgs) ElementType() reflect.Type {
@@ -1857,8 +1857,8 @@ func (o DeploymentSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-func (o DeploymentSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o DeploymentSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v DeploymentSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // The deployment strategy to use to replace existing pods with new ones.
@@ -1867,8 +1867,8 @@ func (o DeploymentSpecOutput) Strategy() DeploymentStrategyPtrOutput {
 }
 
 // Template describes the pods that will be created.
-func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DeploymentSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 type DeploymentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1945,7 +1945,7 @@ func (o DeploymentSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -1965,7 +1965,7 @@ func (o DeploymentSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -2396,15 +2396,15 @@ func (o DeploymentStrategyPtrOutput) Type() pulumi.StringPtrOutput {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ReplicaSetSpec `pulumi:"spec"`
+	Spec ReplicaSetSpec `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ReplicaSetStatus `pulumi:"status"`
+	Status ReplicaSetStatus `pulumi:"status"`
 }
 
 // ReplicaSetTypeInput is an input type that accepts ReplicaSetTypeArgs and ReplicaSetTypeOutput values.
@@ -2422,15 +2422,15 @@ type ReplicaSetTypeInput interface {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrInput `pulumi:"spec"`
+	Spec ReplicaSetSpecInput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrInput `pulumi:"status"`
+	Status ReplicaSetStatusInput `pulumi:"status"`
 }
 
 func (ReplicaSetTypeArgs) ElementType() reflect.Type {
@@ -2487,28 +2487,28 @@ func (o ReplicaSetTypeOutput) ToReplicaSetTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ReplicaSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecPtrOutput)
+func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecOutput)
 }
 
 // Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetStatus { return v.Status }).(ReplicaSetStatusPtrOutput)
+func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetStatus { return v.Status }).(ReplicaSetStatusOutput)
 }
 
 type ReplicaSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -2540,9 +2540,9 @@ type ReplicaSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of replica set condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // ReplicaSetConditionInput is an input type that accepts ReplicaSetConditionArgs and ReplicaSetConditionOutput values.
@@ -2566,9 +2566,9 @@ type ReplicaSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of replica set condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (ReplicaSetConditionArgs) ElementType() reflect.Type {
@@ -2640,13 +2640,13 @@ func (o ReplicaSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o ReplicaSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of replica set condition.
-func (o ReplicaSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type ReplicaSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -2672,13 +2672,13 @@ func (o ReplicaSetConditionArrayOutput) Index(i pulumi.IntInput) ReplicaSetCondi
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items []ReplicaSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ReplicaSetListTypeInput is an input type that accepts ReplicaSetListTypeArgs and ReplicaSetListTypeOutput values.
@@ -2696,13 +2696,13 @@ type ReplicaSetListTypeInput interface {
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ReplicaSetListTypeArgs) ElementType() reflect.Type {
@@ -2733,8 +2733,8 @@ func (o ReplicaSetListTypeOutput) ToReplicaSetListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -2743,13 +2743,13 @@ func (o ReplicaSetListTypeOutput) Items() ReplicaSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ReplicaSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ReplicaSetSpec is the specification of a ReplicaSet.
@@ -2759,7 +2759,7 @@ type ReplicaSetSpec struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
 	Replicas *int `pulumi:"replicas"`
 	// Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
 	Template *corev1.PodTemplateSpec `pulumi:"template"`
 }
@@ -2783,7 +2783,7 @@ type ReplicaSetSpecArgs struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
 	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
 	// Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
 	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
 }
@@ -2878,8 +2878,8 @@ func (o ReplicaSetSpecOutput) Replicas() pulumi.IntPtrOutput {
 }
 
 // Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o ReplicaSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v ReplicaSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o ReplicaSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v ReplicaSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
@@ -2931,7 +2931,7 @@ func (o ReplicaSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -2958,7 +2958,7 @@ type ReplicaSetStatus struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 }
 
 // ReplicaSetStatusInput is an input type that accepts ReplicaSetStatusArgs and ReplicaSetStatusOutput values.
@@ -2986,7 +2986,7 @@ type ReplicaSetStatusArgs struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 }
 
 func (ReplicaSetStatusArgs) ElementType() reflect.Type {
@@ -3094,8 +3094,8 @@ func (o ReplicaSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-func (o ReplicaSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ReplicaSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ReplicaSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ReplicaSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 type ReplicaSetStatusPtrOutput struct{ *pulumi.OutputState }
@@ -3172,7 +3172,7 @@ func (o ReplicaSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -3622,14 +3622,14 @@ func (o RollingUpdateStatefulSetStrategyPtrOutput) Partition() pulumi.IntPtrOutp
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec *StatefulSetSpec `pulumi:"spec"`
+	Spec StatefulSetSpec `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status *StatefulSetStatus `pulumi:"status"`
+	Status StatefulSetStatus `pulumi:"status"`
 }
 
 // StatefulSetTypeInput is an input type that accepts StatefulSetTypeArgs and StatefulSetTypeOutput values.
@@ -3663,14 +3663,14 @@ type StatefulSetTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrInput `pulumi:"spec"`
+	Spec StatefulSetSpecInput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrInput `pulumi:"status"`
+	Status StatefulSetStatusInput `pulumi:"status"`
 }
 
 func (StatefulSetTypeArgs) ElementType() reflect.Type {
@@ -3743,27 +3743,27 @@ func (o StatefulSetTypeOutput) ToStatefulSetTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v StatefulSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the desired identities of pods in this set.
-func (o StatefulSetTypeOutput) Spec() StatefulSetSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetSpec { return v.Spec }).(StatefulSetSpecPtrOutput)
+func (o StatefulSetTypeOutput) Spec() StatefulSetSpecOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetSpec { return v.Spec }).(StatefulSetSpecOutput)
 }
 
 // Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-func (o StatefulSetTypeOutput) Status() StatefulSetStatusPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetStatus { return v.Status }).(StatefulSetStatusPtrOutput)
+func (o StatefulSetTypeOutput) Status() StatefulSetStatusOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetStatus { return v.Status }).(StatefulSetStatusOutput)
 }
 
 type StatefulSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -3795,9 +3795,9 @@ type StatefulSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of statefulset condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // StatefulSetConditionInput is an input type that accepts StatefulSetConditionArgs and StatefulSetConditionOutput values.
@@ -3821,9 +3821,9 @@ type StatefulSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of statefulset condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (StatefulSetConditionArgs) ElementType() reflect.Type {
@@ -3895,13 +3895,13 @@ func (o StatefulSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o StatefulSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of statefulset condition.
-func (o StatefulSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type StatefulSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -3927,11 +3927,11 @@ func (o StatefulSetConditionArrayOutput) Index(i pulumi.IntInput) StatefulSetCon
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string           `pulumi:"apiVersion"`
+	ApiVersion string            `pulumi:"apiVersion"`
 	Items      []StatefulSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // StatefulSetListTypeInput is an input type that accepts StatefulSetListTypeArgs and StatefulSetListTypeOutput values.
@@ -3949,11 +3949,11 @@ type StatefulSetListTypeInput interface {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (StatefulSetListTypeArgs) ElementType() reflect.Type {
@@ -3984,8 +3984,8 @@ func (o StatefulSetListTypeOutput) ToStatefulSetListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
@@ -3993,12 +3993,12 @@ func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v StatefulSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // A StatefulSetSpec is the specification of a StatefulSet.
@@ -4010,11 +4010,11 @@ type StatefulSetSpec struct {
 	// revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName *string `pulumi:"serviceName"`
+	ServiceName string `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy *StatefulSetUpdateStrategy `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -4042,11 +4042,11 @@ type StatefulSetSpecArgs struct {
 	// revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName pulumi.StringPtrInput `pulumi:"serviceName"`
+	ServiceName pulumi.StringInput `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy StatefulSetUpdateStrategyPtrInput `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -4148,18 +4148,18 @@ func (o StatefulSetSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o StatefulSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o StatefulSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v StatefulSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-func (o StatefulSetSpecOutput) ServiceName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *string { return v.ServiceName }).(pulumi.StringPtrOutput)
+func (o StatefulSetSpecOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetSpec) string { return v.ServiceName }).(pulumi.StringOutput)
 }
 
 // template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v StatefulSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
@@ -4226,7 +4226,7 @@ func (o StatefulSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -4236,7 +4236,7 @@ func (o StatefulSetSpecPtrOutput) ServiceName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ServiceName
+		return &v.ServiceName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -4246,7 +4246,7 @@ func (o StatefulSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -4285,7 +4285,7 @@ type StatefulSetStatus struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision *string `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -4319,7 +4319,7 @@ type StatefulSetStatusArgs struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision pulumi.StringPtrInput `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -4436,8 +4436,8 @@ func (o StatefulSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // replicas is the number of Pods created by the StatefulSet controller.
-func (o StatefulSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v StatefulSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o StatefulSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v StatefulSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
@@ -4534,7 +4534,7 @@ func (o StatefulSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apps/v1/replicaSet.go
+++ b/sdk/go/kubernetes/apps/v1/replicaSet.go
@@ -15,15 +15,15 @@ type ReplicaSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrOutput `pulumi:"spec"`
+	Spec ReplicaSetSpecOutput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrOutput `pulumi:"status"`
+	Status ReplicaSetStatusOutput `pulumi:"status"`
 }
 
 // NewReplicaSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/replicaSetList.go
+++ b/sdk/go/kubernetes/apps/v1/replicaSetList.go
@@ -16,13 +16,13 @@ type ReplicaSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewReplicaSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1/statefulSet.go
@@ -31,14 +31,14 @@ type StatefulSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrOutput `pulumi:"spec"`
+	Spec StatefulSetSpecOutput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrOutput `pulumi:"status"`
+	Status StatefulSetStatusOutput `pulumi:"status"`
 }
 
 // NewStatefulSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1/statefulSetList.go
@@ -16,11 +16,11 @@ type StatefulSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewStatefulSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
@@ -16,15 +16,15 @@ type ControllerRevision struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrOutput `pulumi:"revision"`
+	Revision pulumi.IntOutput `pulumi:"revision"`
 }
 
 // NewControllerRevision registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevisionList.go
@@ -16,13 +16,13 @@ type ControllerRevisionList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewControllerRevisionList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/deployment.go
+++ b/sdk/go/kubernetes/apps/v1beta1/deployment.go
@@ -37,15 +37,15 @@ type Deployment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrOutput `pulumi:"spec"`
+	Spec DeploymentSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrOutput `pulumi:"status"`
+	Status DeploymentStatusOutput `pulumi:"status"`
 }
 
 // NewDeployment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/deploymentList.go
@@ -16,13 +16,13 @@ type DeploymentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDeploymentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1beta1/pulumiTypes.go
@@ -15,15 +15,15 @@ import (
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision *int `pulumi:"revision"`
+	Revision int `pulumi:"revision"`
 }
 
 // ControllerRevisionTypeInput is an input type that accepts ControllerRevisionTypeArgs and ControllerRevisionTypeOutput values.
@@ -41,15 +41,15 @@ type ControllerRevisionTypeInput interface {
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrInput `pulumi:"revision"`
+	Revision pulumi.IntInput `pulumi:"revision"`
 }
 
 func (ControllerRevisionTypeArgs) ElementType() reflect.Type {
@@ -106,8 +106,8 @@ func (o ControllerRevisionTypeOutput) ToControllerRevisionTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Data is the serialized representation of the state.
@@ -116,18 +116,18 @@ func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Revision indicates the revision of the state represented by Data.
-func (o ControllerRevisionTypeOutput) Revision() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *int { return v.Revision }).(pulumi.IntPtrOutput)
+func (o ControllerRevisionTypeOutput) Revision() pulumi.IntOutput {
+	return o.ApplyT(func(v ControllerRevisionType) int { return v.Revision }).(pulumi.IntOutput)
 }
 
 type ControllerRevisionTypeArrayOutput struct{ *pulumi.OutputState }
@@ -153,13 +153,13 @@ func (o ControllerRevisionTypeArrayOutput) Index(i pulumi.IntInput) ControllerRe
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items []ControllerRevisionType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ControllerRevisionListTypeInput is an input type that accepts ControllerRevisionListTypeArgs and ControllerRevisionListTypeOutput values.
@@ -177,13 +177,13 @@ type ControllerRevisionListTypeInput interface {
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ControllerRevisionListTypeArgs) ElementType() reflect.Type {
@@ -214,8 +214,8 @@ func (o ControllerRevisionListTypeOutput) ToControllerRevisionListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of ControllerRevisions
@@ -224,13 +224,13 @@ func (o ControllerRevisionListTypeOutput) Items() ControllerRevisionTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
@@ -258,15 +258,15 @@ func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec *DeploymentSpec `pulumi:"spec"`
+	Spec DeploymentSpec `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status *DeploymentStatus `pulumi:"status"`
+	Status DeploymentStatus `pulumi:"status"`
 }
 
 // DeploymentTypeInput is an input type that accepts DeploymentTypeArgs and DeploymentTypeOutput values.
@@ -306,15 +306,15 @@ type DeploymentTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrInput `pulumi:"spec"`
+	Spec DeploymentSpecInput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrInput `pulumi:"status"`
+	Status DeploymentStatusInput `pulumi:"status"`
 }
 
 func (DeploymentTypeArgs) ElementType() reflect.Type {
@@ -393,28 +393,28 @@ func (o DeploymentTypeOutput) ToDeploymentTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata.
-func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DeploymentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the Deployment.
-func (o DeploymentTypeOutput) Spec() DeploymentSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentSpec { return v.Spec }).(DeploymentSpecPtrOutput)
+func (o DeploymentTypeOutput) Spec() DeploymentSpecOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentSpec { return v.Spec }).(DeploymentSpecOutput)
 }
 
 // Most recently observed status of the Deployment.
-func (o DeploymentTypeOutput) Status() DeploymentStatusPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentStatus { return v.Status }).(DeploymentStatusPtrOutput)
+func (o DeploymentTypeOutput) Status() DeploymentStatusOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentStatus { return v.Status }).(DeploymentStatusOutput)
 }
 
 type DeploymentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -448,9 +448,9 @@ type DeploymentCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of deployment condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DeploymentConditionInput is an input type that accepts DeploymentConditionArgs and DeploymentConditionOutput values.
@@ -476,9 +476,9 @@ type DeploymentConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of deployment condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DeploymentConditionArgs) ElementType() reflect.Type {
@@ -555,13 +555,13 @@ func (o DeploymentConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DeploymentConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of deployment condition.
-func (o DeploymentConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DeploymentConditionArrayOutput struct{ *pulumi.OutputState }
@@ -587,13 +587,13 @@ func (o DeploymentConditionArrayOutput) Index(i pulumi.IntInput) DeploymentCondi
 // DeploymentList is a list of Deployments.
 type DeploymentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items []DeploymentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DeploymentListTypeInput is an input type that accepts DeploymentListTypeArgs and DeploymentListTypeOutput values.
@@ -611,13 +611,13 @@ type DeploymentListTypeInput interface {
 // DeploymentList is a list of Deployments.
 type DeploymentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DeploymentListTypeArgs) ElementType() reflect.Type {
@@ -648,8 +648,8 @@ func (o DeploymentListTypeOutput) ToDeploymentListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Deployments.
@@ -658,13 +658,13 @@ func (o DeploymentListTypeOutput) Items() DeploymentTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DeploymentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.
@@ -674,9 +674,9 @@ type DeploymentRollback struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Required: This must match the Name of a deployment.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The config of this deployment rollback.
-	RollbackTo *RollbackConfig `pulumi:"rollbackTo"`
+	RollbackTo RollbackConfig `pulumi:"rollbackTo"`
 	// The annotations to be updated to a deployment
 	UpdatedAnnotations map[string]string `pulumi:"updatedAnnotations"`
 }
@@ -700,9 +700,9 @@ type DeploymentRollbackArgs struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// Required: This must match the Name of a deployment.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// The config of this deployment rollback.
-	RollbackTo RollbackConfigPtrInput `pulumi:"rollbackTo"`
+	RollbackTo RollbackConfigInput `pulumi:"rollbackTo"`
 	// The annotations to be updated to a deployment
 	UpdatedAnnotations pulumi.StringMapInput `pulumi:"updatedAnnotations"`
 }
@@ -745,13 +745,13 @@ func (o DeploymentRollbackOutput) Kind() pulumi.StringPtrOutput {
 }
 
 // Required: This must match the Name of a deployment.
-func (o DeploymentRollbackOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentRollback) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o DeploymentRollbackOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentRollback) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // The config of this deployment rollback.
-func (o DeploymentRollbackOutput) RollbackTo() RollbackConfigPtrOutput {
-	return o.ApplyT(func(v DeploymentRollback) *RollbackConfig { return v.RollbackTo }).(RollbackConfigPtrOutput)
+func (o DeploymentRollbackOutput) RollbackTo() RollbackConfigOutput {
+	return o.ApplyT(func(v DeploymentRollback) RollbackConfig { return v.RollbackTo }).(RollbackConfigOutput)
 }
 
 // The annotations to be updated to a deployment
@@ -778,7 +778,7 @@ type DeploymentSpec struct {
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy *DeploymentStrategy `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 }
 
 // DeploymentSpecInput is an input type that accepts DeploymentSpecArgs and DeploymentSpecOutput values.
@@ -812,7 +812,7 @@ type DeploymentSpecArgs struct {
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy DeploymentStrategyPtrInput `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 }
 
 func (DeploymentSpecArgs) ElementType() reflect.Type {
@@ -935,8 +935,8 @@ func (o DeploymentSpecOutput) Strategy() DeploymentStrategyPtrOutput {
 }
 
 // Template describes the pods that will be created.
-func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DeploymentSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 type DeploymentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1043,7 +1043,7 @@ func (o DeploymentSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -2129,7 +2129,7 @@ func (o ScaleSpecPtrOutput) Replicas() pulumi.IntPtrOutput {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector map[string]string `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -2151,7 +2151,7 @@ type ScaleStatusInput interface {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatusArgs struct {
 	// actual number of observed instances of the scaled object.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector pulumi.StringMapInput `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -2238,8 +2238,8 @@ func (o ScaleStatusOutput) ToScaleStatusPtrOutputWithContext(ctx context.Context
 }
 
 // actual number of observed instances of the scaled object.
-func (o ScaleStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ScaleStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ScaleStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ScaleStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
@@ -2276,7 +2276,7 @@ func (o ScaleStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -2319,14 +2319,14 @@ func (o ScaleStatusPtrOutput) TargetSelector() pulumi.StringPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec *StatefulSetSpec `pulumi:"spec"`
+	Spec StatefulSetSpec `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status *StatefulSetStatus `pulumi:"status"`
+	Status StatefulSetStatus `pulumi:"status"`
 }
 
 // StatefulSetTypeInput is an input type that accepts StatefulSetTypeArgs and StatefulSetTypeOutput values.
@@ -2360,14 +2360,14 @@ type StatefulSetTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrInput `pulumi:"spec"`
+	Spec StatefulSetSpecInput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrInput `pulumi:"status"`
+	Status StatefulSetStatusInput `pulumi:"status"`
 }
 
 func (StatefulSetTypeArgs) ElementType() reflect.Type {
@@ -2440,27 +2440,27 @@ func (o StatefulSetTypeOutput) ToStatefulSetTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v StatefulSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the desired identities of pods in this set.
-func (o StatefulSetTypeOutput) Spec() StatefulSetSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetSpec { return v.Spec }).(StatefulSetSpecPtrOutput)
+func (o StatefulSetTypeOutput) Spec() StatefulSetSpecOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetSpec { return v.Spec }).(StatefulSetSpecOutput)
 }
 
 // Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-func (o StatefulSetTypeOutput) Status() StatefulSetStatusPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetStatus { return v.Status }).(StatefulSetStatusPtrOutput)
+func (o StatefulSetTypeOutput) Status() StatefulSetStatusOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetStatus { return v.Status }).(StatefulSetStatusOutput)
 }
 
 type StatefulSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -2492,9 +2492,9 @@ type StatefulSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of statefulset condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // StatefulSetConditionInput is an input type that accepts StatefulSetConditionArgs and StatefulSetConditionOutput values.
@@ -2518,9 +2518,9 @@ type StatefulSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of statefulset condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (StatefulSetConditionArgs) ElementType() reflect.Type {
@@ -2592,13 +2592,13 @@ func (o StatefulSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o StatefulSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of statefulset condition.
-func (o StatefulSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type StatefulSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -2624,11 +2624,11 @@ func (o StatefulSetConditionArrayOutput) Index(i pulumi.IntInput) StatefulSetCon
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string           `pulumi:"apiVersion"`
+	ApiVersion string            `pulumi:"apiVersion"`
 	Items      []StatefulSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // StatefulSetListTypeInput is an input type that accepts StatefulSetListTypeArgs and StatefulSetListTypeOutput values.
@@ -2646,11 +2646,11 @@ type StatefulSetListTypeInput interface {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (StatefulSetListTypeArgs) ElementType() reflect.Type {
@@ -2681,8 +2681,8 @@ func (o StatefulSetListTypeOutput) ToStatefulSetListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
@@ -2690,12 +2690,12 @@ func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v StatefulSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // A StatefulSetSpec is the specification of a StatefulSet.
@@ -2709,9 +2709,9 @@ type StatefulSetSpec struct {
 	// selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName *string `pulumi:"serviceName"`
+	ServiceName string `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy *StatefulSetUpdateStrategy `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -2741,9 +2741,9 @@ type StatefulSetSpecArgs struct {
 	// selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName pulumi.StringPtrInput `pulumi:"serviceName"`
+	ServiceName pulumi.StringInput `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy StatefulSetUpdateStrategyPtrInput `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -2850,13 +2850,13 @@ func (o StatefulSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-func (o StatefulSetSpecOutput) ServiceName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *string { return v.ServiceName }).(pulumi.StringPtrOutput)
+func (o StatefulSetSpecOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetSpec) string { return v.ServiceName }).(pulumi.StringOutput)
 }
 
 // template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v StatefulSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
@@ -2933,7 +2933,7 @@ func (o StatefulSetSpecPtrOutput) ServiceName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ServiceName
+		return &v.ServiceName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2943,7 +2943,7 @@ func (o StatefulSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -2982,7 +2982,7 @@ type StatefulSetStatus struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision *string `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -3016,7 +3016,7 @@ type StatefulSetStatusArgs struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision pulumi.StringPtrInput `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -3133,8 +3133,8 @@ func (o StatefulSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // replicas is the number of Pods created by the StatefulSet controller.
-func (o StatefulSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v StatefulSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o StatefulSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v StatefulSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
@@ -3231,7 +3231,7 @@ func (o StatefulSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apps/v1beta1/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1beta1/statefulSet.go
@@ -31,14 +31,14 @@ type StatefulSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrOutput `pulumi:"spec"`
+	Spec StatefulSetSpecOutput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrOutput `pulumi:"status"`
+	Status StatefulSetStatusOutput `pulumi:"status"`
 }
 
 // NewStatefulSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta1/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/statefulSetList.go
@@ -16,11 +16,11 @@ type StatefulSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewStatefulSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
@@ -16,15 +16,15 @@ type ControllerRevision struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.AnyOutput `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrOutput `pulumi:"revision"`
+	Revision pulumi.IntOutput `pulumi:"revision"`
 }
 
 // NewControllerRevision registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevisionList.go
@@ -16,13 +16,13 @@ type ControllerRevisionList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewControllerRevisionList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/daemonSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/daemonSet.go
@@ -15,15 +15,15 @@ type DaemonSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrOutput `pulumi:"spec"`
+	Spec DaemonSetSpecOutput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrOutput `pulumi:"status"`
+	Status DaemonSetStatusOutput `pulumi:"status"`
 }
 
 // NewDaemonSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/daemonSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/daemonSetList.go
@@ -16,13 +16,13 @@ type DaemonSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDaemonSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/deployment.go
+++ b/sdk/go/kubernetes/apps/v1beta2/deployment.go
@@ -37,15 +37,15 @@ type Deployment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrOutput `pulumi:"spec"`
+	Spec DeploymentSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrOutput `pulumi:"status"`
+	Status DeploymentStatusOutput `pulumi:"status"`
 }
 
 // NewDeployment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/deploymentList.go
@@ -16,13 +16,13 @@ type DeploymentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDeploymentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/pulumiTypes.go
+++ b/sdk/go/kubernetes/apps/v1beta2/pulumiTypes.go
@@ -15,15 +15,15 @@ import (
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data interface{} `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision *int `pulumi:"revision"`
+	Revision int `pulumi:"revision"`
 }
 
 // ControllerRevisionTypeInput is an input type that accepts ControllerRevisionTypeArgs and ControllerRevisionTypeOutput values.
@@ -41,15 +41,15 @@ type ControllerRevisionTypeInput interface {
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Data is the serialized representation of the state.
 	Data pulumi.Input `pulumi:"data"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Revision indicates the revision of the state represented by Data.
-	Revision pulumi.IntPtrInput `pulumi:"revision"`
+	Revision pulumi.IntInput `pulumi:"revision"`
 }
 
 func (ControllerRevisionTypeArgs) ElementType() reflect.Type {
@@ -106,8 +106,8 @@ func (o ControllerRevisionTypeOutput) ToControllerRevisionTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Data is the serialized representation of the state.
@@ -116,18 +116,18 @@ func (o ControllerRevisionTypeOutput) Data() pulumi.AnyOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ControllerRevisionTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Revision indicates the revision of the state represented by Data.
-func (o ControllerRevisionTypeOutput) Revision() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionType) *int { return v.Revision }).(pulumi.IntPtrOutput)
+func (o ControllerRevisionTypeOutput) Revision() pulumi.IntOutput {
+	return o.ApplyT(func(v ControllerRevisionType) int { return v.Revision }).(pulumi.IntOutput)
 }
 
 type ControllerRevisionTypeArrayOutput struct{ *pulumi.OutputState }
@@ -153,13 +153,13 @@ func (o ControllerRevisionTypeArrayOutput) Index(i pulumi.IntInput) ControllerRe
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items []ControllerRevisionType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ControllerRevisionListTypeInput is an input type that accepts ControllerRevisionListTypeArgs and ControllerRevisionListTypeOutput values.
@@ -177,13 +177,13 @@ type ControllerRevisionListTypeInput interface {
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of ControllerRevisions
 	Items ControllerRevisionTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ControllerRevisionListTypeArgs) ElementType() reflect.Type {
@@ -214,8 +214,8 @@ func (o ControllerRevisionListTypeOutput) ToControllerRevisionListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of ControllerRevisions
@@ -224,27 +224,27 @@ func (o ControllerRevisionListTypeOutput) Items() ControllerRevisionTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ControllerRevisionListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ControllerRevisionListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ControllerRevisionListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ControllerRevisionListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *DaemonSetSpec `pulumi:"spec"`
+	Spec DaemonSetSpec `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *DaemonSetStatus `pulumi:"status"`
+	Status DaemonSetStatus `pulumi:"status"`
 }
 
 // DaemonSetTypeInput is an input type that accepts DaemonSetTypeArgs and DaemonSetTypeOutput values.
@@ -262,15 +262,15 @@ type DaemonSetTypeInput interface {
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrInput `pulumi:"spec"`
+	Spec DaemonSetSpecInput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrInput `pulumi:"status"`
+	Status DaemonSetStatusInput `pulumi:"status"`
 }
 
 func (DaemonSetTypeArgs) ElementType() reflect.Type {
@@ -327,28 +327,28 @@ func (o DaemonSetTypeOutput) ToDaemonSetTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DaemonSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Spec() DaemonSetSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetSpec { return v.Spec }).(DaemonSetSpecPtrOutput)
+func (o DaemonSetTypeOutput) Spec() DaemonSetSpecOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetSpec { return v.Spec }).(DaemonSetSpecOutput)
 }
 
 // The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Status() DaemonSetStatusPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetStatus { return v.Status }).(DaemonSetStatusPtrOutput)
+func (o DaemonSetTypeOutput) Status() DaemonSetStatusOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetStatus { return v.Status }).(DaemonSetStatusOutput)
 }
 
 type DaemonSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -380,9 +380,9 @@ type DaemonSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DaemonSetConditionInput is an input type that accepts DaemonSetConditionArgs and DaemonSetConditionOutput values.
@@ -406,9 +406,9 @@ type DaemonSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DaemonSetConditionArgs) ElementType() reflect.Type {
@@ -480,13 +480,13 @@ func (o DaemonSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DaemonSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of DaemonSet condition.
-func (o DaemonSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DaemonSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -512,13 +512,13 @@ func (o DaemonSetConditionArrayOutput) Index(i pulumi.IntInput) DaemonSetConditi
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items []DaemonSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DaemonSetListTypeInput is an input type that accepts DaemonSetListTypeArgs and DaemonSetListTypeOutput values.
@@ -536,13 +536,13 @@ type DaemonSetListTypeInput interface {
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DaemonSetListTypeArgs) ElementType() reflect.Type {
@@ -573,8 +573,8 @@ func (o DaemonSetListTypeOutput) ToDaemonSetListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // A list of daemon sets.
@@ -583,13 +583,13 @@ func (o DaemonSetListTypeOutput) Items() DaemonSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DaemonSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DaemonSetSpec is the specification of a daemon set.
@@ -599,9 +599,9 @@ type DaemonSetSpec struct {
 	// The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy *DaemonSetUpdateStrategy `pulumi:"updateStrategy"`
 }
@@ -625,9 +625,9 @@ type DaemonSetSpecArgs struct {
 	// The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy DaemonSetUpdateStrategyPtrInput `pulumi:"updateStrategy"`
 }
@@ -722,13 +722,13 @@ func (o DaemonSetSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o DaemonSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v DaemonSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o DaemonSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v DaemonSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DaemonSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // An update strategy to replace existing DaemonSet pods with new pods.
@@ -780,7 +780,7 @@ func (o DaemonSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -790,7 +790,7 @@ func (o DaemonSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -811,15 +811,15 @@ type DaemonSetStatus struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions []DaemonSetCondition `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled *int `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled int `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled *int `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled int `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable *int `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled *int `pulumi:"numberMisscheduled"`
+	NumberMisscheduled int `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady *int `pulumi:"numberReady"`
+	NumberReady int `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable *int `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -847,15 +847,15 @@ type DaemonSetStatusArgs struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions DaemonSetConditionArrayInput `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled pulumi.IntPtrInput `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled pulumi.IntInput `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled pulumi.IntPtrInput `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled pulumi.IntInput `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable pulumi.IntPtrInput `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled pulumi.IntPtrInput `pulumi:"numberMisscheduled"`
+	NumberMisscheduled pulumi.IntInput `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady pulumi.IntPtrInput `pulumi:"numberReady"`
+	NumberReady pulumi.IntInput `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable pulumi.IntPtrInput `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -954,13 +954,13 @@ func (o DaemonSetStatusOutput) Conditions() DaemonSetConditionArrayOutput {
 }
 
 // The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.CurrentNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.CurrentNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.DesiredNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.DesiredNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -969,13 +969,13 @@ func (o DaemonSetStatusOutput) NumberAvailable() pulumi.IntPtrOutput {
 }
 
 // The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberMisscheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberMisscheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-func (o DaemonSetStatusOutput) NumberReady() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberReady }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberReady() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberReady }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -1037,7 +1037,7 @@ func (o DaemonSetStatusPtrOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.CurrentNumberScheduled
+		return &v.CurrentNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1047,7 +1047,7 @@ func (o DaemonSetStatusPtrOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.DesiredNumberScheduled
+		return &v.DesiredNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1067,7 +1067,7 @@ func (o DaemonSetStatusPtrOutput) NumberMisscheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberMisscheduled
+		return &v.NumberMisscheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1077,7 +1077,7 @@ func (o DaemonSetStatusPtrOutput) NumberReady() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberReady
+		return &v.NumberReady
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1291,15 +1291,15 @@ func (o DaemonSetUpdateStrategyPtrOutput) Type() pulumi.StringPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec *DeploymentSpec `pulumi:"spec"`
+	Spec DeploymentSpec `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status *DeploymentStatus `pulumi:"status"`
+	Status DeploymentStatus `pulumi:"status"`
 }
 
 // DeploymentTypeInput is an input type that accepts DeploymentTypeArgs and DeploymentTypeOutput values.
@@ -1339,15 +1339,15 @@ type DeploymentTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrInput `pulumi:"spec"`
+	Spec DeploymentSpecInput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrInput `pulumi:"status"`
+	Status DeploymentStatusInput `pulumi:"status"`
 }
 
 func (DeploymentTypeArgs) ElementType() reflect.Type {
@@ -1426,28 +1426,28 @@ func (o DeploymentTypeOutput) ToDeploymentTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata.
-func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DeploymentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the Deployment.
-func (o DeploymentTypeOutput) Spec() DeploymentSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentSpec { return v.Spec }).(DeploymentSpecPtrOutput)
+func (o DeploymentTypeOutput) Spec() DeploymentSpecOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentSpec { return v.Spec }).(DeploymentSpecOutput)
 }
 
 // Most recently observed status of the Deployment.
-func (o DeploymentTypeOutput) Status() DeploymentStatusPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentStatus { return v.Status }).(DeploymentStatusPtrOutput)
+func (o DeploymentTypeOutput) Status() DeploymentStatusOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentStatus { return v.Status }).(DeploymentStatusOutput)
 }
 
 type DeploymentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1481,9 +1481,9 @@ type DeploymentCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of deployment condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DeploymentConditionInput is an input type that accepts DeploymentConditionArgs and DeploymentConditionOutput values.
@@ -1509,9 +1509,9 @@ type DeploymentConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of deployment condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DeploymentConditionArgs) ElementType() reflect.Type {
@@ -1588,13 +1588,13 @@ func (o DeploymentConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DeploymentConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of deployment condition.
-func (o DeploymentConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DeploymentConditionArrayOutput struct{ *pulumi.OutputState }
@@ -1620,13 +1620,13 @@ func (o DeploymentConditionArrayOutput) Index(i pulumi.IntInput) DeploymentCondi
 // DeploymentList is a list of Deployments.
 type DeploymentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items []DeploymentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DeploymentListTypeInput is an input type that accepts DeploymentListTypeArgs and DeploymentListTypeOutput values.
@@ -1644,13 +1644,13 @@ type DeploymentListTypeInput interface {
 // DeploymentList is a list of Deployments.
 type DeploymentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DeploymentListTypeArgs) ElementType() reflect.Type {
@@ -1681,8 +1681,8 @@ func (o DeploymentListTypeOutput) ToDeploymentListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Deployments.
@@ -1691,13 +1691,13 @@ func (o DeploymentListTypeOutput) Items() DeploymentTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DeploymentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
@@ -1713,11 +1713,11 @@ type DeploymentSpec struct {
 	// The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy *DeploymentStrategy `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 }
 
 // DeploymentSpecInput is an input type that accepts DeploymentSpecArgs and DeploymentSpecOutput values.
@@ -1745,11 +1745,11 @@ type DeploymentSpecArgs struct {
 	// The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy DeploymentStrategyPtrInput `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 }
 
 func (DeploymentSpecArgs) ElementType() reflect.Type {
@@ -1857,8 +1857,8 @@ func (o DeploymentSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
-func (o DeploymentSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o DeploymentSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v DeploymentSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // The deployment strategy to use to replace existing pods with new ones.
@@ -1867,8 +1867,8 @@ func (o DeploymentSpecOutput) Strategy() DeploymentStrategyPtrOutput {
 }
 
 // Template describes the pods that will be created.
-func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DeploymentSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 type DeploymentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1945,7 +1945,7 @@ func (o DeploymentSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -1965,7 +1965,7 @@ func (o DeploymentSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -2396,15 +2396,15 @@ func (o DeploymentStrategyPtrOutput) Type() pulumi.StringPtrOutput {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ReplicaSetSpec `pulumi:"spec"`
+	Spec ReplicaSetSpec `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ReplicaSetStatus `pulumi:"status"`
+	Status ReplicaSetStatus `pulumi:"status"`
 }
 
 // ReplicaSetTypeInput is an input type that accepts ReplicaSetTypeArgs and ReplicaSetTypeOutput values.
@@ -2422,15 +2422,15 @@ type ReplicaSetTypeInput interface {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrInput `pulumi:"spec"`
+	Spec ReplicaSetSpecInput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrInput `pulumi:"status"`
+	Status ReplicaSetStatusInput `pulumi:"status"`
 }
 
 func (ReplicaSetTypeArgs) ElementType() reflect.Type {
@@ -2487,28 +2487,28 @@ func (o ReplicaSetTypeOutput) ToReplicaSetTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ReplicaSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecPtrOutput)
+func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecOutput)
 }
 
 // Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetStatus { return v.Status }).(ReplicaSetStatusPtrOutput)
+func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetStatus { return v.Status }).(ReplicaSetStatusOutput)
 }
 
 type ReplicaSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -2540,9 +2540,9 @@ type ReplicaSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of replica set condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // ReplicaSetConditionInput is an input type that accepts ReplicaSetConditionArgs and ReplicaSetConditionOutput values.
@@ -2566,9 +2566,9 @@ type ReplicaSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of replica set condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (ReplicaSetConditionArgs) ElementType() reflect.Type {
@@ -2640,13 +2640,13 @@ func (o ReplicaSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o ReplicaSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of replica set condition.
-func (o ReplicaSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type ReplicaSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -2672,13 +2672,13 @@ func (o ReplicaSetConditionArrayOutput) Index(i pulumi.IntInput) ReplicaSetCondi
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items []ReplicaSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ReplicaSetListTypeInput is an input type that accepts ReplicaSetListTypeArgs and ReplicaSetListTypeOutput values.
@@ -2696,13 +2696,13 @@ type ReplicaSetListTypeInput interface {
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ReplicaSetListTypeArgs) ElementType() reflect.Type {
@@ -2733,8 +2733,8 @@ func (o ReplicaSetListTypeOutput) ToReplicaSetListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -2743,13 +2743,13 @@ func (o ReplicaSetListTypeOutput) Items() ReplicaSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ReplicaSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ReplicaSetSpec is the specification of a ReplicaSet.
@@ -2759,7 +2759,7 @@ type ReplicaSetSpec struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
 	Replicas *int `pulumi:"replicas"`
 	// Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
 	Template *corev1.PodTemplateSpec `pulumi:"template"`
 }
@@ -2783,7 +2783,7 @@ type ReplicaSetSpecArgs struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
 	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
 	// Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
 	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
 }
@@ -2878,8 +2878,8 @@ func (o ReplicaSetSpecOutput) Replicas() pulumi.IntPtrOutput {
 }
 
 // Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o ReplicaSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v ReplicaSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o ReplicaSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v ReplicaSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
@@ -2931,7 +2931,7 @@ func (o ReplicaSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -2958,7 +2958,7 @@ type ReplicaSetStatus struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 }
 
 // ReplicaSetStatusInput is an input type that accepts ReplicaSetStatusArgs and ReplicaSetStatusOutput values.
@@ -2986,7 +2986,7 @@ type ReplicaSetStatusArgs struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 }
 
 func (ReplicaSetStatusArgs) ElementType() reflect.Type {
@@ -3094,8 +3094,8 @@ func (o ReplicaSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-func (o ReplicaSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ReplicaSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ReplicaSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ReplicaSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 type ReplicaSetStatusPtrOutput struct{ *pulumi.OutputState }
@@ -3172,7 +3172,7 @@ func (o ReplicaSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -3834,7 +3834,7 @@ func (o ScaleSpecPtrOutput) Replicas() pulumi.IntPtrOutput {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector map[string]string `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -3856,7 +3856,7 @@ type ScaleStatusInput interface {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatusArgs struct {
 	// actual number of observed instances of the scaled object.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector pulumi.StringMapInput `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -3943,8 +3943,8 @@ func (o ScaleStatusOutput) ToScaleStatusPtrOutputWithContext(ctx context.Context
 }
 
 // actual number of observed instances of the scaled object.
-func (o ScaleStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ScaleStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ScaleStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ScaleStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
@@ -3981,7 +3981,7 @@ func (o ScaleStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -4024,14 +4024,14 @@ func (o ScaleStatusPtrOutput) TargetSelector() pulumi.StringPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec *StatefulSetSpec `pulumi:"spec"`
+	Spec StatefulSetSpec `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status *StatefulSetStatus `pulumi:"status"`
+	Status StatefulSetStatus `pulumi:"status"`
 }
 
 // StatefulSetTypeInput is an input type that accepts StatefulSetTypeArgs and StatefulSetTypeOutput values.
@@ -4065,14 +4065,14 @@ type StatefulSetTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type StatefulSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrInput `pulumi:"spec"`
+	Spec StatefulSetSpecInput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrInput `pulumi:"status"`
+	Status StatefulSetStatusInput `pulumi:"status"`
 }
 
 func (StatefulSetTypeArgs) ElementType() reflect.Type {
@@ -4145,27 +4145,27 @@ func (o StatefulSetTypeOutput) ToStatefulSetTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o StatefulSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v StatefulSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the desired identities of pods in this set.
-func (o StatefulSetTypeOutput) Spec() StatefulSetSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetSpec { return v.Spec }).(StatefulSetSpecPtrOutput)
+func (o StatefulSetTypeOutput) Spec() StatefulSetSpecOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetSpec { return v.Spec }).(StatefulSetSpecOutput)
 }
 
 // Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-func (o StatefulSetTypeOutput) Status() StatefulSetStatusPtrOutput {
-	return o.ApplyT(func(v StatefulSetType) *StatefulSetStatus { return v.Status }).(StatefulSetStatusPtrOutput)
+func (o StatefulSetTypeOutput) Status() StatefulSetStatusOutput {
+	return o.ApplyT(func(v StatefulSetType) StatefulSetStatus { return v.Status }).(StatefulSetStatusOutput)
 }
 
 type StatefulSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -4197,9 +4197,9 @@ type StatefulSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of statefulset condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // StatefulSetConditionInput is an input type that accepts StatefulSetConditionArgs and StatefulSetConditionOutput values.
@@ -4223,9 +4223,9 @@ type StatefulSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of statefulset condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (StatefulSetConditionArgs) ElementType() reflect.Type {
@@ -4297,13 +4297,13 @@ func (o StatefulSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o StatefulSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of statefulset condition.
-func (o StatefulSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o StatefulSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type StatefulSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -4329,11 +4329,11 @@ func (o StatefulSetConditionArrayOutput) Index(i pulumi.IntInput) StatefulSetCon
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string           `pulumi:"apiVersion"`
+	ApiVersion string            `pulumi:"apiVersion"`
 	Items      []StatefulSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // StatefulSetListTypeInput is an input type that accepts StatefulSetListTypeArgs and StatefulSetListTypeOutput values.
@@ -4351,11 +4351,11 @@ type StatefulSetListTypeInput interface {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (StatefulSetListTypeArgs) ElementType() reflect.Type {
@@ -4386,8 +4386,8 @@ func (o StatefulSetListTypeOutput) ToStatefulSetListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
@@ -4395,12 +4395,12 @@ func (o StatefulSetListTypeOutput) Items() StatefulSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatefulSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatefulSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v StatefulSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o StatefulSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v StatefulSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // A StatefulSetSpec is the specification of a StatefulSet.
@@ -4412,11 +4412,11 @@ type StatefulSetSpec struct {
 	// revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
 	RevisionHistoryLimit *int `pulumi:"revisionHistoryLimit"`
 	// selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector *metav1.LabelSelector `pulumi:"selector"`
+	Selector metav1.LabelSelector `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName *string `pulumi:"serviceName"`
+	ServiceName string `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy *StatefulSetUpdateStrategy `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -4444,11 +4444,11 @@ type StatefulSetSpecArgs struct {
 	// revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
 	RevisionHistoryLimit pulumi.IntPtrInput `pulumi:"revisionHistoryLimit"`
 	// selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
+	Selector metav1.LabelSelectorInput `pulumi:"selector"`
 	// serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-	ServiceName pulumi.StringPtrInput `pulumi:"serviceName"`
+	ServiceName pulumi.StringInput `pulumi:"serviceName"`
 	// template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 	UpdateStrategy StatefulSetUpdateStrategyPtrInput `pulumi:"updateStrategy"`
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
@@ -4550,18 +4550,18 @@ func (o StatefulSetSpecOutput) RevisionHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-func (o StatefulSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorPtrOutput)
+func (o StatefulSetSpecOutput) Selector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v StatefulSetSpec) metav1.LabelSelector { return v.Selector }).(metav1.LabelSelectorOutput)
 }
 
 // serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
-func (o StatefulSetSpecOutput) ServiceName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *string { return v.ServiceName }).(pulumi.StringPtrOutput)
+func (o StatefulSetSpecOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v StatefulSetSpec) string { return v.ServiceName }).(pulumi.StringOutput)
 }
 
 // template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v StatefulSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o StatefulSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v StatefulSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
@@ -4628,7 +4628,7 @@ func (o StatefulSetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Selector
+		return &v.Selector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -4638,7 +4638,7 @@ func (o StatefulSetSpecPtrOutput) ServiceName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ServiceName
+		return &v.ServiceName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -4648,7 +4648,7 @@ func (o StatefulSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -4687,7 +4687,7 @@ type StatefulSetStatus struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision *string `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -4721,7 +4721,7 @@ type StatefulSetStatusArgs struct {
 	// readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// replicas is the number of Pods created by the StatefulSet controller.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 	UpdateRevision pulumi.StringPtrInput `pulumi:"updateRevision"`
 	// updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
@@ -4838,8 +4838,8 @@ func (o StatefulSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // replicas is the number of Pods created by the StatefulSet controller.
-func (o StatefulSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v StatefulSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o StatefulSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v StatefulSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
@@ -4936,7 +4936,7 @@ func (o StatefulSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/apps/v1beta2/replicaSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/replicaSet.go
@@ -15,15 +15,15 @@ type ReplicaSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrOutput `pulumi:"spec"`
+	Spec ReplicaSetSpecOutput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrOutput `pulumi:"status"`
+	Status ReplicaSetStatusOutput `pulumi:"status"`
 }
 
 // NewReplicaSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/replicaSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/replicaSetList.go
@@ -16,13 +16,13 @@ type ReplicaSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewReplicaSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/statefulSet.go
@@ -31,14 +31,14 @@ type StatefulSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the desired identities of pods in this set.
-	Spec StatefulSetSpecPtrOutput `pulumi:"spec"`
+	Spec StatefulSetSpecOutput `pulumi:"spec"`
 	// Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
-	Status StatefulSetStatusPtrOutput `pulumi:"status"`
+	Status StatefulSetStatusOutput `pulumi:"status"`
 }
 
 // NewStatefulSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/apps/v1beta2/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/statefulSetList.go
@@ -16,11 +16,11 @@ type StatefulSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput     `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput        `pulumi:"apiVersion"`
 	Items      StatefulSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewStatefulSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/auditSink.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/auditSink.go
@@ -15,12 +15,12 @@ type AuditSink struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the audit configuration spec
-	Spec AuditSinkSpecPtrOutput `pulumi:"spec"`
+	Spec AuditSinkSpecOutput `pulumi:"spec"`
 }
 
 // NewAuditSink registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkList.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkList.go
@@ -16,12 +16,12 @@ type AuditSinkList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of audit configurations.
 	Items AuditSinkTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewAuditSinkList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/pulumiTypes.go
@@ -14,12 +14,12 @@ import (
 // AuditSink represents a cluster level audit sink
 type AuditSinkType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the audit configuration spec
-	Spec *AuditSinkSpec `pulumi:"spec"`
+	Spec AuditSinkSpec `pulumi:"spec"`
 }
 
 // AuditSinkTypeInput is an input type that accepts AuditSinkTypeArgs and AuditSinkTypeOutput values.
@@ -37,12 +37,12 @@ type AuditSinkTypeInput interface {
 // AuditSink represents a cluster level audit sink
 type AuditSinkTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the audit configuration spec
-	Spec AuditSinkSpecPtrInput `pulumi:"spec"`
+	Spec AuditSinkSpecInput `pulumi:"spec"`
 }
 
 func (AuditSinkTypeArgs) ElementType() reflect.Type {
@@ -99,22 +99,22 @@ func (o AuditSinkTypeOutput) ToAuditSinkTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o AuditSinkTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AuditSinkType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o AuditSinkTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v AuditSinkType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o AuditSinkTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AuditSinkType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o AuditSinkTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v AuditSinkType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o AuditSinkTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v AuditSinkType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o AuditSinkTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v AuditSinkType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the audit configuration spec
-func (o AuditSinkTypeOutput) Spec() AuditSinkSpecPtrOutput {
-	return o.ApplyT(func(v AuditSinkType) *AuditSinkSpec { return v.Spec }).(AuditSinkSpecPtrOutput)
+func (o AuditSinkTypeOutput) Spec() AuditSinkSpecOutput {
+	return o.ApplyT(func(v AuditSinkType) AuditSinkSpec { return v.Spec }).(AuditSinkSpecOutput)
 }
 
 type AuditSinkTypeArrayOutput struct{ *pulumi.OutputState }
@@ -140,12 +140,12 @@ func (o AuditSinkTypeArrayOutput) Index(i pulumi.IntInput) AuditSinkTypeOutput {
 // AuditSinkList is a list of AuditSink items.
 type AuditSinkListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of audit configurations.
 	Items []AuditSinkType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // AuditSinkListTypeInput is an input type that accepts AuditSinkListTypeArgs and AuditSinkListTypeOutput values.
@@ -163,12 +163,12 @@ type AuditSinkListTypeInput interface {
 // AuditSinkList is a list of AuditSink items.
 type AuditSinkListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of audit configurations.
 	Items AuditSinkTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (AuditSinkListTypeArgs) ElementType() reflect.Type {
@@ -199,8 +199,8 @@ func (o AuditSinkListTypeOutput) ToAuditSinkListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o AuditSinkListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AuditSinkListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o AuditSinkListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v AuditSinkListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of audit configurations.
@@ -209,20 +209,20 @@ func (o AuditSinkListTypeOutput) Items() AuditSinkTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o AuditSinkListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AuditSinkListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o AuditSinkListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v AuditSinkListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o AuditSinkListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v AuditSinkListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o AuditSinkListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v AuditSinkListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // AuditSinkSpec holds the spec for the audit sink
 type AuditSinkSpec struct {
 	// Policy defines the policy for selecting which events should be sent to the webhook required
-	Policy *Policy `pulumi:"policy"`
+	Policy Policy `pulumi:"policy"`
 	// Webhook to send events required
-	Webhook *Webhook `pulumi:"webhook"`
+	Webhook Webhook `pulumi:"webhook"`
 }
 
 // AuditSinkSpecInput is an input type that accepts AuditSinkSpecArgs and AuditSinkSpecOutput values.
@@ -240,9 +240,9 @@ type AuditSinkSpecInput interface {
 // AuditSinkSpec holds the spec for the audit sink
 type AuditSinkSpecArgs struct {
 	// Policy defines the policy for selecting which events should be sent to the webhook required
-	Policy PolicyPtrInput `pulumi:"policy"`
+	Policy PolicyInput `pulumi:"policy"`
 	// Webhook to send events required
-	Webhook WebhookPtrInput `pulumi:"webhook"`
+	Webhook WebhookInput `pulumi:"webhook"`
 }
 
 func (AuditSinkSpecArgs) ElementType() reflect.Type {
@@ -325,13 +325,13 @@ func (o AuditSinkSpecOutput) ToAuditSinkSpecPtrOutputWithContext(ctx context.Con
 }
 
 // Policy defines the policy for selecting which events should be sent to the webhook required
-func (o AuditSinkSpecOutput) Policy() PolicyPtrOutput {
-	return o.ApplyT(func(v AuditSinkSpec) *Policy { return v.Policy }).(PolicyPtrOutput)
+func (o AuditSinkSpecOutput) Policy() PolicyOutput {
+	return o.ApplyT(func(v AuditSinkSpec) Policy { return v.Policy }).(PolicyOutput)
 }
 
 // Webhook to send events required
-func (o AuditSinkSpecOutput) Webhook() WebhookPtrOutput {
-	return o.ApplyT(func(v AuditSinkSpec) *Webhook { return v.Webhook }).(WebhookPtrOutput)
+func (o AuditSinkSpecOutput) Webhook() WebhookOutput {
+	return o.ApplyT(func(v AuditSinkSpec) Webhook { return v.Webhook }).(WebhookOutput)
 }
 
 type AuditSinkSpecPtrOutput struct{ *pulumi.OutputState }
@@ -358,7 +358,7 @@ func (o AuditSinkSpecPtrOutput) Policy() PolicyPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Policy
+		return &v.Policy
 	}).(PolicyPtrOutput)
 }
 
@@ -368,14 +368,14 @@ func (o AuditSinkSpecPtrOutput) Webhook() WebhookPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Webhook
+		return &v.Webhook
 	}).(WebhookPtrOutput)
 }
 
 // Policy defines the configuration of how audit events are logged
 type Policy struct {
 	// The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required
-	Level *string `pulumi:"level"`
+	Level string `pulumi:"level"`
 	// Stages is a list of stages for which events are created.
 	Stages []string `pulumi:"stages"`
 }
@@ -395,7 +395,7 @@ type PolicyInput interface {
 // Policy defines the configuration of how audit events are logged
 type PolicyArgs struct {
 	// The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required
-	Level pulumi.StringPtrInput `pulumi:"level"`
+	Level pulumi.StringInput `pulumi:"level"`
 	// Stages is a list of stages for which events are created.
 	Stages pulumi.StringArrayInput `pulumi:"stages"`
 }
@@ -480,8 +480,8 @@ func (o PolicyOutput) ToPolicyPtrOutputWithContext(ctx context.Context) PolicyPt
 }
 
 // The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required
-func (o PolicyOutput) Level() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Policy) *string { return v.Level }).(pulumi.StringPtrOutput)
+func (o PolicyOutput) Level() pulumi.StringOutput {
+	return o.ApplyT(func(v Policy) string { return v.Level }).(pulumi.StringOutput)
 }
 
 // Stages is a list of stages for which events are created.
@@ -513,7 +513,7 @@ func (o PolicyPtrOutput) Level() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Level
+		return &v.Level
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -530,9 +530,9 @@ func (o PolicyPtrOutput) Stages() pulumi.StringArrayOutput {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
 	// `name` is the name of the service. Required
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path *string `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -554,9 +554,9 @@ type ServiceReferenceInput interface {
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReferenceArgs struct {
 	// `name` is the name of the service. Required
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// `namespace` is the namespace of the service. Required
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// `path` is an optional URL path which will be sent in any request to this service.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
@@ -643,13 +643,13 @@ func (o ServiceReferenceOutput) ToServiceReferencePtrOutputWithContext(ctx conte
 }
 
 // `name` is the name of the service. Required
-func (o ServiceReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // `namespace` is the namespace of the service. Required
-func (o ServiceReferenceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceReference) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceReferenceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceReference) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // `path` is an optional URL path which will be sent in any request to this service.
@@ -686,7 +686,7 @@ func (o ServiceReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -696,7 +696,7 @@ func (o ServiceReferencePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -723,7 +723,7 @@ func (o ServiceReferencePtrOutput) Port() pulumi.IntPtrOutput {
 // Webhook holds the configuration of the webhook
 type Webhook struct {
 	// ClientConfig holds the connection parameters for the webhook required
-	ClientConfig *WebhookClientConfig `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfig `pulumi:"clientConfig"`
 	// Throttle holds the options for throttling the webhook
 	Throttle *WebhookThrottleConfig `pulumi:"throttle"`
 }
@@ -743,7 +743,7 @@ type WebhookInput interface {
 // Webhook holds the configuration of the webhook
 type WebhookArgs struct {
 	// ClientConfig holds the connection parameters for the webhook required
-	ClientConfig WebhookClientConfigPtrInput `pulumi:"clientConfig"`
+	ClientConfig WebhookClientConfigInput `pulumi:"clientConfig"`
 	// Throttle holds the options for throttling the webhook
 	Throttle WebhookThrottleConfigPtrInput `pulumi:"throttle"`
 }
@@ -828,8 +828,8 @@ func (o WebhookOutput) ToWebhookPtrOutputWithContext(ctx context.Context) Webhoo
 }
 
 // ClientConfig holds the connection parameters for the webhook required
-func (o WebhookOutput) ClientConfig() WebhookClientConfigPtrOutput {
-	return o.ApplyT(func(v Webhook) *WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigPtrOutput)
+func (o WebhookOutput) ClientConfig() WebhookClientConfigOutput {
+	return o.ApplyT(func(v Webhook) WebhookClientConfig { return v.ClientConfig }).(WebhookClientConfigOutput)
 }
 
 // Throttle holds the options for throttling the webhook
@@ -861,7 +861,7 @@ func (o WebhookPtrOutput) ClientConfig() WebhookClientConfigPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ClientConfig
+		return &v.ClientConfig
 	}).(WebhookClientConfigPtrOutput)
 }
 

--- a/sdk/go/kubernetes/authentication/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/authentication/v1/pulumiTypes.go
@@ -207,12 +207,12 @@ func (o BoundObjectReferencePtrOutput) Uid() pulumi.StringPtrOutput {
 // TokenRequest requests a token for a given service account.
 type TokenRequestType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string             `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta  `pulumi:"metadata"`
-	Spec     *TokenRequestSpec   `pulumi:"spec"`
-	Status   *TokenRequestStatus `pulumi:"status"`
+	Kind     string             `pulumi:"kind"`
+	Metadata metav1.ObjectMeta  `pulumi:"metadata"`
+	Spec     TokenRequestSpec   `pulumi:"spec"`
+	Status   TokenRequestStatus `pulumi:"status"`
 }
 
 // TokenRequestTypeInput is an input type that accepts TokenRequestTypeArgs and TokenRequestTypeOutput values.
@@ -230,12 +230,12 @@ type TokenRequestTypeInput interface {
 // TokenRequest requests a token for a given service account.
 type TokenRequestTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput      `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput  `pulumi:"metadata"`
-	Spec     TokenRequestSpecPtrInput   `pulumi:"spec"`
-	Status   TokenRequestStatusPtrInput `pulumi:"status"`
+	Kind     pulumi.StringInput      `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput  `pulumi:"metadata"`
+	Spec     TokenRequestSpecInput   `pulumi:"spec"`
+	Status   TokenRequestStatusInput `pulumi:"status"`
 }
 
 func (TokenRequestTypeArgs) ElementType() reflect.Type {
@@ -266,25 +266,25 @@ func (o TokenRequestTypeOutput) ToTokenRequestTypeOutputWithContext(ctx context.
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o TokenRequestTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenRequestType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o TokenRequestTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenRequestType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o TokenRequestTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenRequestType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o TokenRequestTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenRequestType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o TokenRequestTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v TokenRequestType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o TokenRequestTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v TokenRequestType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
-func (o TokenRequestTypeOutput) Spec() TokenRequestSpecPtrOutput {
-	return o.ApplyT(func(v TokenRequestType) *TokenRequestSpec { return v.Spec }).(TokenRequestSpecPtrOutput)
+func (o TokenRequestTypeOutput) Spec() TokenRequestSpecOutput {
+	return o.ApplyT(func(v TokenRequestType) TokenRequestSpec { return v.Spec }).(TokenRequestSpecOutput)
 }
 
-func (o TokenRequestTypeOutput) Status() TokenRequestStatusPtrOutput {
-	return o.ApplyT(func(v TokenRequestType) *TokenRequestStatus { return v.Status }).(TokenRequestStatusPtrOutput)
+func (o TokenRequestTypeOutput) Status() TokenRequestStatusOutput {
+	return o.ApplyT(func(v TokenRequestType) TokenRequestStatus { return v.Status }).(TokenRequestStatusOutput)
 }
 
 // TokenRequestSpec contains client provided parameters of a token request.
@@ -464,9 +464,9 @@ func (o TokenRequestSpecPtrOutput) ExpirationSeconds() pulumi.IntPtrOutput {
 // TokenRequestStatus is the result of a token request.
 type TokenRequestStatus struct {
 	// ExpirationTimestamp is the time of expiration of the returned token.
-	ExpirationTimestamp *string `pulumi:"expirationTimestamp"`
+	ExpirationTimestamp string `pulumi:"expirationTimestamp"`
 	// Token is the opaque bearer token.
-	Token *string `pulumi:"token"`
+	Token string `pulumi:"token"`
 }
 
 // TokenRequestStatusInput is an input type that accepts TokenRequestStatusArgs and TokenRequestStatusOutput values.
@@ -484,9 +484,9 @@ type TokenRequestStatusInput interface {
 // TokenRequestStatus is the result of a token request.
 type TokenRequestStatusArgs struct {
 	// ExpirationTimestamp is the time of expiration of the returned token.
-	ExpirationTimestamp pulumi.StringPtrInput `pulumi:"expirationTimestamp"`
+	ExpirationTimestamp pulumi.StringInput `pulumi:"expirationTimestamp"`
 	// Token is the opaque bearer token.
-	Token pulumi.StringPtrInput `pulumi:"token"`
+	Token pulumi.StringInput `pulumi:"token"`
 }
 
 func (TokenRequestStatusArgs) ElementType() reflect.Type {
@@ -569,13 +569,13 @@ func (o TokenRequestStatusOutput) ToTokenRequestStatusPtrOutputWithContext(ctx c
 }
 
 // ExpirationTimestamp is the time of expiration of the returned token.
-func (o TokenRequestStatusOutput) ExpirationTimestamp() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenRequestStatus) *string { return v.ExpirationTimestamp }).(pulumi.StringPtrOutput)
+func (o TokenRequestStatusOutput) ExpirationTimestamp() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenRequestStatus) string { return v.ExpirationTimestamp }).(pulumi.StringOutput)
 }
 
 // Token is the opaque bearer token.
-func (o TokenRequestStatusOutput) Token() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenRequestStatus) *string { return v.Token }).(pulumi.StringPtrOutput)
+func (o TokenRequestStatusOutput) Token() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenRequestStatus) string { return v.Token }).(pulumi.StringOutput)
 }
 
 type TokenRequestStatusPtrOutput struct{ *pulumi.OutputState }
@@ -602,7 +602,7 @@ func (o TokenRequestStatusPtrOutput) ExpirationTimestamp() pulumi.StringPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.ExpirationTimestamp
+		return &v.ExpirationTimestamp
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -612,21 +612,21 @@ func (o TokenRequestStatusPtrOutput) Token() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Token
+		return &v.Token
 	}).(pulumi.StringPtrOutput)
 }
 
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec *TokenReviewSpec `pulumi:"spec"`
+	Spec TokenReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status *TokenReviewStatus `pulumi:"status"`
+	Status TokenReviewStatus `pulumi:"status"`
 }
 
 // TokenReviewTypeInput is an input type that accepts TokenReviewTypeArgs and TokenReviewTypeOutput values.
@@ -644,14 +644,14 @@ type TokenReviewTypeInput interface {
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec TokenReviewSpecPtrInput `pulumi:"spec"`
+	Spec TokenReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status TokenReviewStatusPtrInput `pulumi:"status"`
+	Status TokenReviewStatusInput `pulumi:"status"`
 }
 
 func (TokenReviewTypeArgs) ElementType() reflect.Type {
@@ -682,27 +682,27 @@ func (o TokenReviewTypeOutput) ToTokenReviewTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o TokenReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o TokenReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o TokenReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o TokenReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o TokenReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o TokenReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v TokenReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated
-func (o TokenReviewTypeOutput) Spec() TokenReviewSpecPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *TokenReviewSpec { return v.Spec }).(TokenReviewSpecPtrOutput)
+func (o TokenReviewTypeOutput) Spec() TokenReviewSpecOutput {
+	return o.ApplyT(func(v TokenReviewType) TokenReviewSpec { return v.Spec }).(TokenReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request can be authenticated.
-func (o TokenReviewTypeOutput) Status() TokenReviewStatusPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *TokenReviewStatus { return v.Status }).(TokenReviewStatusPtrOutput)
+func (o TokenReviewTypeOutput) Status() TokenReviewStatusOutput {
+	return o.ApplyT(func(v TokenReviewType) TokenReviewStatus { return v.Status }).(TokenReviewStatusOutput)
 }
 
 // TokenReviewSpec is a description of the token authentication request.

--- a/sdk/go/kubernetes/authentication/v1/tokenRequest.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenRequest.go
@@ -16,12 +16,12 @@ type TokenRequest struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput      `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput  `pulumi:"metadata"`
-	Spec     TokenRequestSpecPtrOutput   `pulumi:"spec"`
-	Status   TokenRequestStatusPtrOutput `pulumi:"status"`
+	Kind     pulumi.StringOutput      `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput  `pulumi:"metadata"`
+	Spec     TokenRequestSpecOutput   `pulumi:"spec"`
+	Status   TokenRequestStatusOutput `pulumi:"status"`
 }
 
 // NewTokenRequest registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authentication/v1/tokenReview.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenReview.go
@@ -16,14 +16,14 @@ type TokenReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec TokenReviewSpecPtrOutput `pulumi:"spec"`
+	Spec TokenReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status TokenReviewStatusPtrOutput `pulumi:"status"`
+	Status TokenReviewStatusOutput `pulumi:"status"`
 }
 
 // NewTokenReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authentication/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/authentication/v1beta1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec *TokenReviewSpec `pulumi:"spec"`
+	Spec TokenReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status *TokenReviewStatus `pulumi:"status"`
+	Status TokenReviewStatus `pulumi:"status"`
 }
 
 // TokenReviewTypeInput is an input type that accepts TokenReviewTypeArgs and TokenReviewTypeOutput values.
@@ -39,14 +39,14 @@ type TokenReviewTypeInput interface {
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec TokenReviewSpecPtrInput `pulumi:"spec"`
+	Spec TokenReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status TokenReviewStatusPtrInput `pulumi:"status"`
+	Status TokenReviewStatusInput `pulumi:"status"`
 }
 
 func (TokenReviewTypeArgs) ElementType() reflect.Type {
@@ -77,27 +77,27 @@ func (o TokenReviewTypeOutput) ToTokenReviewTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o TokenReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o TokenReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o TokenReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o TokenReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v TokenReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o TokenReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o TokenReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v TokenReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated
-func (o TokenReviewTypeOutput) Spec() TokenReviewSpecPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *TokenReviewSpec { return v.Spec }).(TokenReviewSpecPtrOutput)
+func (o TokenReviewTypeOutput) Spec() TokenReviewSpecOutput {
+	return o.ApplyT(func(v TokenReviewType) TokenReviewSpec { return v.Spec }).(TokenReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request can be authenticated.
-func (o TokenReviewTypeOutput) Status() TokenReviewStatusPtrOutput {
-	return o.ApplyT(func(v TokenReviewType) *TokenReviewStatus { return v.Status }).(TokenReviewStatusPtrOutput)
+func (o TokenReviewTypeOutput) Status() TokenReviewStatusOutput {
+	return o.ApplyT(func(v TokenReviewType) TokenReviewStatus { return v.Status }).(TokenReviewStatusOutput)
 }
 
 // TokenReviewSpec is a description of the token authentication request.

--- a/sdk/go/kubernetes/authentication/v1beta1/tokenReview.go
+++ b/sdk/go/kubernetes/authentication/v1beta1/tokenReview.go
@@ -16,14 +16,14 @@ type TokenReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec TokenReviewSpecPtrOutput `pulumi:"spec"`
+	Spec TokenReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request can be authenticated.
-	Status TokenReviewStatusPtrOutput `pulumi:"status"`
+	Status TokenReviewStatusOutput `pulumi:"status"`
 }
 
 // NewTokenReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1/localSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/localSubjectAccessReview.go
@@ -16,14 +16,14 @@ type LocalSubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec SubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewLocalSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/authorization/v1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec *SubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // LocalSubjectAccessReviewTypeInput is an input type that accepts LocalSubjectAccessReviewTypeArgs and LocalSubjectAccessReviewTypeOutput values.
@@ -39,14 +39,14 @@ type LocalSubjectAccessReviewTypeInput interface {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec SubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (LocalSubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -77,27 +77,27 @@ func (o LocalSubjectAccessReviewTypeOutput) ToLocalSubjectAccessReviewTypeOutput
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LocalSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LocalSubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o LocalSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-func (o LocalSubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o LocalSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface
@@ -751,14 +751,14 @@ func (o ResourceRuleArrayOutput) Index(i pulumi.IntInput) ResourceRuleOutput {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec *SelfSubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // SelfSubjectAccessReviewTypeInput is an input type that accepts SelfSubjectAccessReviewTypeArgs and SelfSubjectAccessReviewTypeOutput values.
@@ -776,14 +776,14 @@ type SelfSubjectAccessReviewTypeInput interface {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec SelfSubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (SelfSubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -814,27 +814,27 @@ func (o SelfSubjectAccessReviewTypeOutput) ToSelfSubjectAccessReviewTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SelfSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SelfSubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SelfSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.  user and groups must be empty
-func (o SelfSubjectAccessReviewTypeOutput) Spec() SelfSubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *SelfSubjectAccessReviewSpec { return v.Spec }).(SelfSubjectAccessReviewSpecPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Spec() SelfSubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) SelfSubjectAccessReviewSpec { return v.Spec }).(SelfSubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o SelfSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
@@ -995,14 +995,14 @@ func (o SelfSubjectAccessReviewSpecPtrOutput) ResourceAttributes() ResourceAttri
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec *SelfSubjectRulesReviewSpec `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status *SubjectRulesReviewStatus `pulumi:"status"`
+	Status SubjectRulesReviewStatus `pulumi:"status"`
 }
 
 // SelfSubjectRulesReviewTypeInput is an input type that accepts SelfSubjectRulesReviewTypeArgs and SelfSubjectRulesReviewTypeOutput values.
@@ -1020,14 +1020,14 @@ type SelfSubjectRulesReviewTypeInput interface {
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec SelfSubjectRulesReviewSpecPtrInput `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status SubjectRulesReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectRulesReviewStatusInput `pulumi:"status"`
 }
 
 func (SelfSubjectRulesReviewTypeArgs) ElementType() reflect.Type {
@@ -1058,27 +1058,27 @@ func (o SelfSubjectRulesReviewTypeOutput) ToSelfSubjectRulesReviewTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SelfSubjectRulesReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SelfSubjectRulesReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SelfSubjectRulesReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.
-func (o SelfSubjectRulesReviewTypeOutput) Spec() SelfSubjectRulesReviewSpecPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *SelfSubjectRulesReviewSpec { return v.Spec }).(SelfSubjectRulesReviewSpecPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Spec() SelfSubjectRulesReviewSpecOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) SelfSubjectRulesReviewSpec { return v.Spec }).(SelfSubjectRulesReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates the set of actions a user can perform.
-func (o SelfSubjectRulesReviewTypeOutput) Status() SubjectRulesReviewStatusPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *SubjectRulesReviewStatus { return v.Status }).(SubjectRulesReviewStatusPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Status() SubjectRulesReviewStatusOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) SubjectRulesReviewStatus { return v.Status }).(SubjectRulesReviewStatusOutput)
 }
 
 type SelfSubjectRulesReviewSpec struct {
@@ -1217,14 +1217,14 @@ func (o SelfSubjectRulesReviewSpecPtrOutput) Namespace() pulumi.StringPtrOutput 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec *SubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // SubjectAccessReviewTypeInput is an input type that accepts SubjectAccessReviewTypeArgs and SubjectAccessReviewTypeOutput values.
@@ -1242,14 +1242,14 @@ type SubjectAccessReviewTypeInput interface {
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec SubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (SubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -1280,27 +1280,27 @@ func (o SubjectAccessReviewTypeOutput) ToSubjectAccessReviewTypeOutputWithContex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated
-func (o SubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o SubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
@@ -1537,7 +1537,7 @@ func (o SubjectAccessReviewSpecPtrOutput) User() pulumi.StringPtrOutput {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
 	// Allowed is required. True if the action would be allowed, false otherwise.
-	Allowed *bool `pulumi:"allowed"`
+	Allowed bool `pulumi:"allowed"`
 	// Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
 	Denied *bool `pulumi:"denied"`
 	// EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.
@@ -1561,7 +1561,7 @@ type SubjectAccessReviewStatusInput interface {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatusArgs struct {
 	// Allowed is required. True if the action would be allowed, false otherwise.
-	Allowed pulumi.BoolPtrInput `pulumi:"allowed"`
+	Allowed pulumi.BoolInput `pulumi:"allowed"`
 	// Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
 	Denied pulumi.BoolPtrInput `pulumi:"denied"`
 	// EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.
@@ -1650,8 +1650,8 @@ func (o SubjectAccessReviewStatusOutput) ToSubjectAccessReviewStatusPtrOutputWit
 }
 
 // Allowed is required. True if the action would be allowed, false otherwise.
-func (o SubjectAccessReviewStatusOutput) Allowed() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewStatus) *bool { return v.Allowed }).(pulumi.BoolPtrOutput)
+func (o SubjectAccessReviewStatusOutput) Allowed() pulumi.BoolOutput {
+	return o.ApplyT(func(v SubjectAccessReviewStatus) bool { return v.Allowed }).(pulumi.BoolOutput)
 }
 
 // Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
@@ -1693,7 +1693,7 @@ func (o SubjectAccessReviewStatusPtrOutput) Allowed() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Allowed
+		return &v.Allowed
 	}).(pulumi.BoolPtrOutput)
 }
 
@@ -1732,7 +1732,7 @@ type SubjectRulesReviewStatus struct {
 	// EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
 	EvaluationError *string `pulumi:"evaluationError"`
 	// Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-	Incomplete *bool `pulumi:"incomplete"`
+	Incomplete bool `pulumi:"incomplete"`
 	// NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
 	NonResourceRules []NonResourceRule `pulumi:"nonResourceRules"`
 	// ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1756,7 +1756,7 @@ type SubjectRulesReviewStatusArgs struct {
 	// EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
 	EvaluationError pulumi.StringPtrInput `pulumi:"evaluationError"`
 	// Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-	Incomplete pulumi.BoolPtrInput `pulumi:"incomplete"`
+	Incomplete pulumi.BoolInput `pulumi:"incomplete"`
 	// NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
 	NonResourceRules NonResourceRuleArrayInput `pulumi:"nonResourceRules"`
 	// ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1848,8 +1848,8 @@ func (o SubjectRulesReviewStatusOutput) EvaluationError() pulumi.StringPtrOutput
 }
 
 // Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-func (o SubjectRulesReviewStatusOutput) Incomplete() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v SubjectRulesReviewStatus) *bool { return v.Incomplete }).(pulumi.BoolPtrOutput)
+func (o SubjectRulesReviewStatusOutput) Incomplete() pulumi.BoolOutput {
+	return o.ApplyT(func(v SubjectRulesReviewStatus) bool { return v.Incomplete }).(pulumi.BoolOutput)
 }
 
 // NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1896,7 +1896,7 @@ func (o SubjectRulesReviewStatusPtrOutput) Incomplete() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Incomplete
+		return &v.Incomplete
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReview.go
@@ -16,14 +16,14 @@ type SelfSubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec SelfSubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSelfSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReview.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReview.go
@@ -16,14 +16,14 @@ type SelfSubjectRulesReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec SelfSubjectRulesReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status SubjectRulesReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectRulesReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSelfSubjectRulesReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1/subjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/subjectAccessReview.go
@@ -16,14 +16,14 @@ type SubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec SubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReview.go
@@ -16,14 +16,14 @@ type LocalSubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec SubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewLocalSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec *SubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // LocalSubjectAccessReviewTypeInput is an input type that accepts LocalSubjectAccessReviewTypeArgs and LocalSubjectAccessReviewTypeOutput values.
@@ -39,14 +39,14 @@ type LocalSubjectAccessReviewTypeInput interface {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-	Spec SubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (LocalSubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -77,27 +77,27 @@ func (o LocalSubjectAccessReviewTypeOutput) ToLocalSubjectAccessReviewTypeOutput
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LocalSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LocalSubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o LocalSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
-func (o LocalSubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o LocalSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v LocalSubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o LocalSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v LocalSubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface
@@ -751,14 +751,14 @@ func (o ResourceRuleArrayOutput) Index(i pulumi.IntInput) ResourceRuleOutput {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec *SelfSubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // SelfSubjectAccessReviewTypeInput is an input type that accepts SelfSubjectAccessReviewTypeArgs and SelfSubjectAccessReviewTypeOutput values.
@@ -776,14 +776,14 @@ type SelfSubjectAccessReviewTypeInput interface {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec SelfSubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (SelfSubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -814,27 +814,27 @@ func (o SelfSubjectAccessReviewTypeOutput) ToSelfSubjectAccessReviewTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SelfSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SelfSubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SelfSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.  user and groups must be empty
-func (o SelfSubjectAccessReviewTypeOutput) Spec() SelfSubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *SelfSubjectAccessReviewSpec { return v.Spec }).(SelfSubjectAccessReviewSpecPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Spec() SelfSubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) SelfSubjectAccessReviewSpec { return v.Spec }).(SelfSubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o SelfSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v SelfSubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o SelfSubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v SelfSubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
@@ -995,14 +995,14 @@ func (o SelfSubjectAccessReviewSpecPtrOutput) ResourceAttributes() ResourceAttri
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec *SelfSubjectRulesReviewSpec `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status *SubjectRulesReviewStatus `pulumi:"status"`
+	Status SubjectRulesReviewStatus `pulumi:"status"`
 }
 
 // SelfSubjectRulesReviewTypeInput is an input type that accepts SelfSubjectRulesReviewTypeArgs and SelfSubjectRulesReviewTypeOutput values.
@@ -1020,14 +1020,14 @@ type SelfSubjectRulesReviewTypeInput interface {
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec SelfSubjectRulesReviewSpecPtrInput `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status SubjectRulesReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectRulesReviewStatusInput `pulumi:"status"`
 }
 
 func (SelfSubjectRulesReviewTypeArgs) ElementType() reflect.Type {
@@ -1058,27 +1058,27 @@ func (o SelfSubjectRulesReviewTypeOutput) ToSelfSubjectRulesReviewTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SelfSubjectRulesReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SelfSubjectRulesReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SelfSubjectRulesReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated.
-func (o SelfSubjectRulesReviewTypeOutput) Spec() SelfSubjectRulesReviewSpecPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *SelfSubjectRulesReviewSpec { return v.Spec }).(SelfSubjectRulesReviewSpecPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Spec() SelfSubjectRulesReviewSpecOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) SelfSubjectRulesReviewSpec { return v.Spec }).(SelfSubjectRulesReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates the set of actions a user can perform.
-func (o SelfSubjectRulesReviewTypeOutput) Status() SubjectRulesReviewStatusPtrOutput {
-	return o.ApplyT(func(v SelfSubjectRulesReviewType) *SubjectRulesReviewStatus { return v.Status }).(SubjectRulesReviewStatusPtrOutput)
+func (o SelfSubjectRulesReviewTypeOutput) Status() SubjectRulesReviewStatusOutput {
+	return o.ApplyT(func(v SelfSubjectRulesReviewType) SubjectRulesReviewStatus { return v.Status }).(SubjectRulesReviewStatusOutput)
 }
 
 type SelfSubjectRulesReviewSpec struct {
@@ -1217,14 +1217,14 @@ func (o SelfSubjectRulesReviewSpecPtrOutput) Namespace() pulumi.StringPtrOutput 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec *SubjectAccessReviewSpec `pulumi:"spec"`
+	Spec SubjectAccessReviewSpec `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status *SubjectAccessReviewStatus `pulumi:"status"`
+	Status SubjectAccessReviewStatus `pulumi:"status"`
 }
 
 // SubjectAccessReviewTypeInput is an input type that accepts SubjectAccessReviewTypeArgs and SubjectAccessReviewTypeOutput values.
@@ -1242,14 +1242,14 @@ type SubjectAccessReviewTypeInput interface {
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec SubjectAccessReviewSpecPtrInput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecInput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrInput `pulumi:"status"`
+	Status SubjectAccessReviewStatusInput `pulumi:"status"`
 }
 
 func (SubjectAccessReviewTypeArgs) ElementType() reflect.Type {
@@ -1280,27 +1280,27 @@ func (o SubjectAccessReviewTypeOutput) ToSubjectAccessReviewTypeOutputWithContex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SubjectAccessReviewTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SubjectAccessReviewTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o SubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec holds information about the request being evaluated
-func (o SubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Spec() SubjectAccessReviewSpecOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) SubjectAccessReviewSpec { return v.Spec }).(SubjectAccessReviewSpecOutput)
 }
 
 // Status is filled in by the server and indicates whether the request is allowed or not
-func (o SubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewType) *SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusPtrOutput)
+func (o SubjectAccessReviewTypeOutput) Status() SubjectAccessReviewStatusOutput {
+	return o.ApplyT(func(v SubjectAccessReviewType) SubjectAccessReviewStatus { return v.Status }).(SubjectAccessReviewStatusOutput)
 }
 
 // SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
@@ -1537,7 +1537,7 @@ func (o SubjectAccessReviewSpecPtrOutput) User() pulumi.StringPtrOutput {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
 	// Allowed is required. True if the action would be allowed, false otherwise.
-	Allowed *bool `pulumi:"allowed"`
+	Allowed bool `pulumi:"allowed"`
 	// Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
 	Denied *bool `pulumi:"denied"`
 	// EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.
@@ -1561,7 +1561,7 @@ type SubjectAccessReviewStatusInput interface {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatusArgs struct {
 	// Allowed is required. True if the action would be allowed, false otherwise.
-	Allowed pulumi.BoolPtrInput `pulumi:"allowed"`
+	Allowed pulumi.BoolInput `pulumi:"allowed"`
 	// Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
 	Denied pulumi.BoolPtrInput `pulumi:"denied"`
 	// EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.
@@ -1650,8 +1650,8 @@ func (o SubjectAccessReviewStatusOutput) ToSubjectAccessReviewStatusPtrOutputWit
 }
 
 // Allowed is required. True if the action would be allowed, false otherwise.
-func (o SubjectAccessReviewStatusOutput) Allowed() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v SubjectAccessReviewStatus) *bool { return v.Allowed }).(pulumi.BoolPtrOutput)
+func (o SubjectAccessReviewStatusOutput) Allowed() pulumi.BoolOutput {
+	return o.ApplyT(func(v SubjectAccessReviewStatus) bool { return v.Allowed }).(pulumi.BoolOutput)
 }
 
 // Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
@@ -1693,7 +1693,7 @@ func (o SubjectAccessReviewStatusPtrOutput) Allowed() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Allowed
+		return &v.Allowed
 	}).(pulumi.BoolPtrOutput)
 }
 
@@ -1732,7 +1732,7 @@ type SubjectRulesReviewStatus struct {
 	// EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
 	EvaluationError *string `pulumi:"evaluationError"`
 	// Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-	Incomplete *bool `pulumi:"incomplete"`
+	Incomplete bool `pulumi:"incomplete"`
 	// NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
 	NonResourceRules []NonResourceRule `pulumi:"nonResourceRules"`
 	// ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1756,7 +1756,7 @@ type SubjectRulesReviewStatusArgs struct {
 	// EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
 	EvaluationError pulumi.StringPtrInput `pulumi:"evaluationError"`
 	// Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-	Incomplete pulumi.BoolPtrInput `pulumi:"incomplete"`
+	Incomplete pulumi.BoolInput `pulumi:"incomplete"`
 	// NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
 	NonResourceRules NonResourceRuleArrayInput `pulumi:"nonResourceRules"`
 	// ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1848,8 +1848,8 @@ func (o SubjectRulesReviewStatusOutput) EvaluationError() pulumi.StringPtrOutput
 }
 
 // Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-func (o SubjectRulesReviewStatusOutput) Incomplete() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v SubjectRulesReviewStatus) *bool { return v.Incomplete }).(pulumi.BoolPtrOutput)
+func (o SubjectRulesReviewStatusOutput) Incomplete() pulumi.BoolOutput {
+	return o.ApplyT(func(v SubjectRulesReviewStatus) bool { return v.Incomplete }).(pulumi.BoolOutput)
 }
 
 // NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
@@ -1896,7 +1896,7 @@ func (o SubjectRulesReviewStatusPtrOutput) Incomplete() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Incomplete
+		return &v.Incomplete
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReview.go
@@ -16,14 +16,14 @@ type SelfSubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.  user and groups must be empty
-	Spec SelfSubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SelfSubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSelfSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReview.go
@@ -16,14 +16,14 @@ type SelfSubjectRulesReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated.
-	Spec SelfSubjectRulesReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SelfSubjectRulesReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates the set of actions a user can perform.
-	Status SubjectRulesReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectRulesReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSelfSubjectRulesReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReview.go
@@ -16,14 +16,14 @@ type SubjectAccessReview struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec holds information about the request being evaluated
-	Spec SubjectAccessReviewSpecPtrOutput `pulumi:"spec"`
+	Spec SubjectAccessReviewSpecOutput `pulumi:"spec"`
 	// Status is filled in by the server and indicates whether the request is allowed or not
-	Status SubjectAccessReviewStatusPtrOutput `pulumi:"status"`
+	Status SubjectAccessReviewStatusOutput `pulumi:"status"`
 }
 
 // NewSubjectAccessReview registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscaler.go
@@ -15,15 +15,15 @@ type HorizontalPodAutoscaler struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrOutput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecOutput `pulumi:"spec"`
 	// current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrOutput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusOutput `pulumi:"status"`
 }
 
 // NewHorizontalPodAutoscaler registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerList.go
@@ -16,13 +16,13 @@ type HorizontalPodAutoscalerList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewHorizontalPodAutoscalerList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/autoscaling/v1/pulumiTypes.go
@@ -16,9 +16,9 @@ type CrossVersionObjectReference struct {
 	// API version of the referent
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // CrossVersionObjectReferenceInput is an input type that accepts CrossVersionObjectReferenceArgs and CrossVersionObjectReferenceOutput values.
@@ -38,9 +38,9 @@ type CrossVersionObjectReferenceArgs struct {
 	// API version of the referent
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (CrossVersionObjectReferenceArgs) ElementType() reflect.Type {
@@ -128,13 +128,13 @@ func (o CrossVersionObjectReferenceOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type CrossVersionObjectReferencePtrOutput struct{ *pulumi.OutputState }
@@ -171,7 +171,7 @@ func (o CrossVersionObjectReferencePtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -181,22 +181,22 @@ func (o CrossVersionObjectReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
 // configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec *HorizontalPodAutoscalerSpec `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpec `pulumi:"spec"`
 	// current information about the autoscaler.
-	Status *HorizontalPodAutoscalerStatus `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatus `pulumi:"status"`
 }
 
 // HorizontalPodAutoscalerTypeInput is an input type that accepts HorizontalPodAutoscalerTypeArgs and HorizontalPodAutoscalerTypeOutput values.
@@ -214,15 +214,15 @@ type HorizontalPodAutoscalerTypeInput interface {
 // configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrInput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecInput `pulumi:"spec"`
 	// current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrInput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusInput `pulumi:"status"`
 }
 
 func (HorizontalPodAutoscalerTypeArgs) ElementType() reflect.Type {
@@ -279,28 +279,28 @@ func (o HorizontalPodAutoscalerTypeOutput) ToHorizontalPodAutoscalerTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecOutput)
 }
 
 // current information about the autoscaler.
-func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusOutput)
 }
 
 type HorizontalPodAutoscalerTypeArrayOutput struct{ *pulumi.OutputState }
@@ -326,13 +326,13 @@ func (o HorizontalPodAutoscalerTypeArrayOutput) Index(i pulumi.IntInput) Horizon
 // list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscalerType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // HorizontalPodAutoscalerListTypeInput is an input type that accepts HorizontalPodAutoscalerListTypeArgs and HorizontalPodAutoscalerListTypeOutput values.
@@ -350,13 +350,13 @@ type HorizontalPodAutoscalerListTypeInput interface {
 // list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (HorizontalPodAutoscalerListTypeArgs) ElementType() reflect.Type {
@@ -387,8 +387,8 @@ func (o HorizontalPodAutoscalerListTypeOutput) ToHorizontalPodAutoscalerListType
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // list of horizontal pod autoscaler objects.
@@ -397,23 +397,23 @@ func (o HorizontalPodAutoscalerListTypeOutput) Items() HorizontalPodAutoscalerTy
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // specification of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerSpec struct {
 	// upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-	MaxReplicas *int `pulumi:"maxReplicas"`
+	MaxReplicas int `pulumi:"maxReplicas"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas *int `pulumi:"minReplicas"`
 	// reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
-	ScaleTargetRef *CrossVersionObjectReference `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReference `pulumi:"scaleTargetRef"`
 	// target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
 	TargetCPUUtilizationPercentage *int `pulumi:"targetCPUUtilizationPercentage"`
 }
@@ -433,11 +433,11 @@ type HorizontalPodAutoscalerSpecInput interface {
 // specification of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerSpecArgs struct {
 	// upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-	MaxReplicas pulumi.IntPtrInput `pulumi:"maxReplicas"`
+	MaxReplicas pulumi.IntInput `pulumi:"maxReplicas"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas pulumi.IntPtrInput `pulumi:"minReplicas"`
 	// reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
-	ScaleTargetRef CrossVersionObjectReferencePtrInput `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReferenceInput `pulumi:"scaleTargetRef"`
 	// target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
 	TargetCPUUtilizationPercentage pulumi.IntPtrInput `pulumi:"targetCPUUtilizationPercentage"`
 }
@@ -522,8 +522,8 @@ func (o HorizontalPodAutoscalerSpecOutput) ToHorizontalPodAutoscalerSpecPtrOutpu
 }
 
 // upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *int { return v.MaxReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) int { return v.MaxReplicas }).(pulumi.IntOutput)
 }
 
 // minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
@@ -532,8 +532,8 @@ func (o HorizontalPodAutoscalerSpecOutput) MinReplicas() pulumi.IntPtrOutput {
 }
 
 // reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
-func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferencePtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferenceOutput)
 }
 
 // target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
@@ -565,7 +565,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) MaxReplicas() pulumi.IntPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.MaxReplicas
+		return &v.MaxReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -585,7 +585,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) ScaleTargetRef() CrossVersionObjec
 		if v == nil {
 			return nil
 		}
-		return v.ScaleTargetRef
+		return &v.ScaleTargetRef
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -604,9 +604,9 @@ type HorizontalPodAutoscalerStatus struct {
 	// current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
 	CurrentCPUUtilizationPercentage *int `pulumi:"currentCPUUtilizationPercentage"`
 	// current number of replicas of pods managed by this autoscaler.
-	CurrentReplicas *int `pulumi:"currentReplicas"`
+	CurrentReplicas int `pulumi:"currentReplicas"`
 	// desired number of replicas of pods managed by this autoscaler.
-	DesiredReplicas *int `pulumi:"desiredReplicas"`
+	DesiredReplicas int `pulumi:"desiredReplicas"`
 	// last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime *string `pulumi:"lastScaleTime"`
 	// most recent generation observed by this autoscaler.
@@ -630,9 +630,9 @@ type HorizontalPodAutoscalerStatusArgs struct {
 	// current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
 	CurrentCPUUtilizationPercentage pulumi.IntPtrInput `pulumi:"currentCPUUtilizationPercentage"`
 	// current number of replicas of pods managed by this autoscaler.
-	CurrentReplicas pulumi.IntPtrInput `pulumi:"currentReplicas"`
+	CurrentReplicas pulumi.IntInput `pulumi:"currentReplicas"`
 	// desired number of replicas of pods managed by this autoscaler.
-	DesiredReplicas pulumi.IntPtrInput `pulumi:"desiredReplicas"`
+	DesiredReplicas pulumi.IntInput `pulumi:"desiredReplicas"`
 	// last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime pulumi.StringPtrInput `pulumi:"lastScaleTime"`
 	// most recent generation observed by this autoscaler.
@@ -724,13 +724,13 @@ func (o HorizontalPodAutoscalerStatusOutput) CurrentCPUUtilizationPercentage() p
 }
 
 // current number of replicas of pods managed by this autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.CurrentReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.CurrentReplicas }).(pulumi.IntOutput)
 }
 
 // desired number of replicas of pods managed by this autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.DesiredReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.DesiredReplicas }).(pulumi.IntOutput)
 }
 
 // last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
@@ -777,7 +777,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) CurrentReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.CurrentReplicas
+		return &v.CurrentReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -787,7 +787,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) DesiredReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.DesiredReplicas
+		return &v.DesiredReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1042,7 +1042,7 @@ func (o ScaleSpecPtrOutput) Replicas() pulumi.IntPtrOutput {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector *string `pulumi:"selector"`
 }
@@ -1062,7 +1062,7 @@ type ScaleStatusInput interface {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatusArgs struct {
 	// actual number of observed instances of the scaled object.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector pulumi.StringPtrInput `pulumi:"selector"`
 }
@@ -1147,8 +1147,8 @@ func (o ScaleStatusOutput) ToScaleStatusPtrOutputWithContext(ctx context.Context
 }
 
 // actual number of observed instances of the scaled object.
-func (o ScaleStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ScaleStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ScaleStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ScaleStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
@@ -1180,7 +1180,7 @@ func (o ScaleStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscaler.go
@@ -15,15 +15,15 @@ type HorizontalPodAutoscaler struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrOutput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecOutput `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrOutput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusOutput `pulumi:"status"`
 }
 
 // NewHorizontalPodAutoscaler registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerList.go
@@ -16,13 +16,13 @@ type HorizontalPodAutoscalerList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewHorizontalPodAutoscalerList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v2beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/pulumiTypes.go
@@ -16,9 +16,9 @@ type CrossVersionObjectReference struct {
 	// API version of the referent
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // CrossVersionObjectReferenceInput is an input type that accepts CrossVersionObjectReferenceArgs and CrossVersionObjectReferenceOutput values.
@@ -38,9 +38,9 @@ type CrossVersionObjectReferenceArgs struct {
 	// API version of the referent
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (CrossVersionObjectReferenceArgs) ElementType() reflect.Type {
@@ -128,13 +128,13 @@ func (o CrossVersionObjectReferenceOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type CrossVersionObjectReferencePtrOutput struct{ *pulumi.OutputState }
@@ -171,7 +171,7 @@ func (o CrossVersionObjectReferencePtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -181,14 +181,14 @@ func (o CrossVersionObjectReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
 // ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one "target" type should be set.
 type ExternalMetricSource struct {
 	// metricName is the name of the metric in question.
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// metricSelector is used to identify a specific time series within a given metric.
 	MetricSelector *metav1.LabelSelector `pulumi:"metricSelector"`
 	// targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
@@ -212,7 +212,7 @@ type ExternalMetricSourceInput interface {
 // ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one "target" type should be set.
 type ExternalMetricSourceArgs struct {
 	// metricName is the name of the metric in question.
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// metricSelector is used to identify a specific time series within a given metric.
 	MetricSelector metav1.LabelSelectorPtrInput `pulumi:"metricSelector"`
 	// targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
@@ -301,8 +301,8 @@ func (o ExternalMetricSourceOutput) ToExternalMetricSourcePtrOutputWithContext(c
 }
 
 // metricName is the name of the metric in question.
-func (o ExternalMetricSourceOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ExternalMetricSource) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o ExternalMetricSourceOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v ExternalMetricSource) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // metricSelector is used to identify a specific time series within a given metric.
@@ -344,7 +344,7 @@ func (o ExternalMetricSourcePtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -383,9 +383,9 @@ type ExternalMetricStatus struct {
 	// currentAverageValue is the current value of metric averaged over autoscaled pods.
 	CurrentAverageValue *string `pulumi:"currentAverageValue"`
 	// currentValue is the current value of the metric (as a quantity)
-	CurrentValue *string `pulumi:"currentValue"`
+	CurrentValue string `pulumi:"currentValue"`
 	// metricName is the name of a metric used for autoscaling in metric system.
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// metricSelector is used to identify a specific time series within a given metric.
 	MetricSelector *metav1.LabelSelector `pulumi:"metricSelector"`
 }
@@ -407,9 +407,9 @@ type ExternalMetricStatusArgs struct {
 	// currentAverageValue is the current value of metric averaged over autoscaled pods.
 	CurrentAverageValue pulumi.StringPtrInput `pulumi:"currentAverageValue"`
 	// currentValue is the current value of the metric (as a quantity)
-	CurrentValue pulumi.StringPtrInput `pulumi:"currentValue"`
+	CurrentValue pulumi.StringInput `pulumi:"currentValue"`
 	// metricName is the name of a metric used for autoscaling in metric system.
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// metricSelector is used to identify a specific time series within a given metric.
 	MetricSelector metav1.LabelSelectorPtrInput `pulumi:"metricSelector"`
 }
@@ -499,13 +499,13 @@ func (o ExternalMetricStatusOutput) CurrentAverageValue() pulumi.StringPtrOutput
 }
 
 // currentValue is the current value of the metric (as a quantity)
-func (o ExternalMetricStatusOutput) CurrentValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ExternalMetricStatus) *string { return v.CurrentValue }).(pulumi.StringPtrOutput)
+func (o ExternalMetricStatusOutput) CurrentValue() pulumi.StringOutput {
+	return o.ApplyT(func(v ExternalMetricStatus) string { return v.CurrentValue }).(pulumi.StringOutput)
 }
 
 // metricName is the name of a metric used for autoscaling in metric system.
-func (o ExternalMetricStatusOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ExternalMetricStatus) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o ExternalMetricStatusOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v ExternalMetricStatus) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // metricSelector is used to identify a specific time series within a given metric.
@@ -547,7 +547,7 @@ func (o ExternalMetricStatusPtrOutput) CurrentValue() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.CurrentValue
+		return &v.CurrentValue
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -557,7 +557,7 @@ func (o ExternalMetricStatusPtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -574,15 +574,15 @@ func (o ExternalMetricStatusPtrOutput) MetricSelector() metav1.LabelSelectorPtrO
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec *HorizontalPodAutoscalerSpec `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpec `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status *HorizontalPodAutoscalerStatus `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatus `pulumi:"status"`
 }
 
 // HorizontalPodAutoscalerTypeInput is an input type that accepts HorizontalPodAutoscalerTypeArgs and HorizontalPodAutoscalerTypeOutput values.
@@ -600,15 +600,15 @@ type HorizontalPodAutoscalerTypeInput interface {
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrInput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecInput `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrInput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusInput `pulumi:"status"`
 }
 
 func (HorizontalPodAutoscalerTypeArgs) ElementType() reflect.Type {
@@ -665,28 +665,28 @@ func (o HorizontalPodAutoscalerTypeOutput) ToHorizontalPodAutoscalerTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecOutput)
 }
 
 // status is the current information about the autoscaler.
-func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusOutput)
 }
 
 type HorizontalPodAutoscalerTypeArrayOutput struct{ *pulumi.OutputState }
@@ -718,9 +718,9 @@ type HorizontalPodAutoscalerCondition struct {
 	// reason is the reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// status is the status of the condition (True, False, Unknown)
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// type describes the current condition
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // HorizontalPodAutoscalerConditionInput is an input type that accepts HorizontalPodAutoscalerConditionArgs and HorizontalPodAutoscalerConditionOutput values.
@@ -744,9 +744,9 @@ type HorizontalPodAutoscalerConditionArgs struct {
 	// reason is the reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// status is the status of the condition (True, False, Unknown)
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// type describes the current condition
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (HorizontalPodAutoscalerConditionArgs) ElementType() reflect.Type {
@@ -818,13 +818,13 @@ func (o HorizontalPodAutoscalerConditionOutput) Reason() pulumi.StringPtrOutput 
 }
 
 // status is the status of the condition (True, False, Unknown)
-func (o HorizontalPodAutoscalerConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // type describes the current condition
-func (o HorizontalPodAutoscalerConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type HorizontalPodAutoscalerConditionArrayOutput struct{ *pulumi.OutputState }
@@ -850,13 +850,13 @@ func (o HorizontalPodAutoscalerConditionArrayOutput) Index(i pulumi.IntInput) Ho
 // HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscalerType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // HorizontalPodAutoscalerListTypeInput is an input type that accepts HorizontalPodAutoscalerListTypeArgs and HorizontalPodAutoscalerListTypeOutput values.
@@ -874,13 +874,13 @@ type HorizontalPodAutoscalerListTypeInput interface {
 // HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (HorizontalPodAutoscalerListTypeArgs) ElementType() reflect.Type {
@@ -911,8 +911,8 @@ func (o HorizontalPodAutoscalerListTypeOutput) ToHorizontalPodAutoscalerListType
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of horizontal pod autoscaler objects.
@@ -921,25 +921,25 @@ func (o HorizontalPodAutoscalerListTypeOutput) Items() HorizontalPodAutoscalerTy
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata is the standard list metadata.
-func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
 type HorizontalPodAutoscalerSpec struct {
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-	MaxReplicas *int `pulumi:"maxReplicas"`
+	MaxReplicas int `pulumi:"maxReplicas"`
 	// metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.
 	Metrics []MetricSpec `pulumi:"metrics"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas *int `pulumi:"minReplicas"`
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-	ScaleTargetRef *CrossVersionObjectReference `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReference `pulumi:"scaleTargetRef"`
 }
 
 // HorizontalPodAutoscalerSpecInput is an input type that accepts HorizontalPodAutoscalerSpecArgs and HorizontalPodAutoscalerSpecOutput values.
@@ -957,13 +957,13 @@ type HorizontalPodAutoscalerSpecInput interface {
 // HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
 type HorizontalPodAutoscalerSpecArgs struct {
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-	MaxReplicas pulumi.IntPtrInput `pulumi:"maxReplicas"`
+	MaxReplicas pulumi.IntInput `pulumi:"maxReplicas"`
 	// metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.
 	Metrics MetricSpecArrayInput `pulumi:"metrics"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas pulumi.IntPtrInput `pulumi:"minReplicas"`
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-	ScaleTargetRef CrossVersionObjectReferencePtrInput `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReferenceInput `pulumi:"scaleTargetRef"`
 }
 
 func (HorizontalPodAutoscalerSpecArgs) ElementType() reflect.Type {
@@ -1046,8 +1046,8 @@ func (o HorizontalPodAutoscalerSpecOutput) ToHorizontalPodAutoscalerSpecPtrOutpu
 }
 
 // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *int { return v.MaxReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) int { return v.MaxReplicas }).(pulumi.IntOutput)
 }
 
 // metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.
@@ -1061,8 +1061,8 @@ func (o HorizontalPodAutoscalerSpecOutput) MinReplicas() pulumi.IntPtrOutput {
 }
 
 // scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferencePtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferenceOutput)
 }
 
 type HorizontalPodAutoscalerSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1089,7 +1089,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) MaxReplicas() pulumi.IntPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.MaxReplicas
+		return &v.MaxReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1119,7 +1119,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) ScaleTargetRef() CrossVersionObjec
 		if v == nil {
 			return nil
 		}
-		return v.ScaleTargetRef
+		return &v.ScaleTargetRef
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -1130,9 +1130,9 @@ type HorizontalPodAutoscalerStatus struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	CurrentMetrics []MetricStatus `pulumi:"currentMetrics"`
 	// currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-	CurrentReplicas *int `pulumi:"currentReplicas"`
+	CurrentReplicas int `pulumi:"currentReplicas"`
 	// desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-	DesiredReplicas *int `pulumi:"desiredReplicas"`
+	DesiredReplicas int `pulumi:"desiredReplicas"`
 	// lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime *string `pulumi:"lastScaleTime"`
 	// observedGeneration is the most recent generation observed by this autoscaler.
@@ -1158,9 +1158,9 @@ type HorizontalPodAutoscalerStatusArgs struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	CurrentMetrics MetricStatusArrayInput `pulumi:"currentMetrics"`
 	// currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-	CurrentReplicas pulumi.IntPtrInput `pulumi:"currentReplicas"`
+	CurrentReplicas pulumi.IntInput `pulumi:"currentReplicas"`
 	// desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-	DesiredReplicas pulumi.IntPtrInput `pulumi:"desiredReplicas"`
+	DesiredReplicas pulumi.IntInput `pulumi:"desiredReplicas"`
 	// lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime pulumi.StringPtrInput `pulumi:"lastScaleTime"`
 	// observedGeneration is the most recent generation observed by this autoscaler.
@@ -1257,13 +1257,13 @@ func (o HorizontalPodAutoscalerStatusOutput) CurrentMetrics() MetricStatusArrayO
 }
 
 // currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.CurrentReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.CurrentReplicas }).(pulumi.IntOutput)
 }
 
 // desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.DesiredReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.DesiredReplicas }).(pulumi.IntOutput)
 }
 
 // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
@@ -1320,7 +1320,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) CurrentReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.CurrentReplicas
+		return &v.CurrentReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1330,7 +1330,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) DesiredReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.DesiredReplicas
+		return &v.DesiredReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1365,7 +1365,7 @@ type MetricSpec struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource *ResourceMetricSource `pulumi:"resource"`
 	// type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // MetricSpecInput is an input type that accepts MetricSpecArgs and MetricSpecOutput values.
@@ -1391,7 +1391,7 @@ type MetricSpecArgs struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource ResourceMetricSourcePtrInput `pulumi:"resource"`
 	// type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (MetricSpecArgs) ElementType() reflect.Type {
@@ -1468,8 +1468,8 @@ func (o MetricSpecOutput) Resource() ResourceMetricSourcePtrOutput {
 }
 
 // type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-func (o MetricSpecOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricSpec) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o MetricSpecOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricSpec) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type MetricSpecArrayOutput struct{ *pulumi.OutputState }
@@ -1503,7 +1503,7 @@ type MetricStatus struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource *ResourceMetricStatus `pulumi:"resource"`
 	// type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // MetricStatusInput is an input type that accepts MetricStatusArgs and MetricStatusOutput values.
@@ -1529,7 +1529,7 @@ type MetricStatusArgs struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource ResourceMetricStatusPtrInput `pulumi:"resource"`
 	// type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (MetricStatusArgs) ElementType() reflect.Type {
@@ -1606,8 +1606,8 @@ func (o MetricStatusOutput) Resource() ResourceMetricStatusPtrOutput {
 }
 
 // type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-func (o MetricStatusOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricStatus) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o MetricStatusOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricStatus) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type MetricStatusArrayOutput struct{ *pulumi.OutputState }
@@ -1635,13 +1635,13 @@ type ObjectMetricSource struct {
 	// averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue *string `pulumi:"averageValue"`
 	// metricName is the name of the metric in question.
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// target is the described Kubernetes object.
-	Target *CrossVersionObjectReference `pulumi:"target"`
+	Target CrossVersionObjectReference `pulumi:"target"`
 	// targetValue is the target value of the metric (as a quantity).
-	TargetValue *string `pulumi:"targetValue"`
+	TargetValue string `pulumi:"targetValue"`
 }
 
 // ObjectMetricSourceInput is an input type that accepts ObjectMetricSourceArgs and ObjectMetricSourceOutput values.
@@ -1661,13 +1661,13 @@ type ObjectMetricSourceArgs struct {
 	// averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue pulumi.StringPtrInput `pulumi:"averageValue"`
 	// metricName is the name of the metric in question.
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// target is the described Kubernetes object.
-	Target CrossVersionObjectReferencePtrInput `pulumi:"target"`
+	Target CrossVersionObjectReferenceInput `pulumi:"target"`
 	// targetValue is the target value of the metric (as a quantity).
-	TargetValue pulumi.StringPtrInput `pulumi:"targetValue"`
+	TargetValue pulumi.StringInput `pulumi:"targetValue"`
 }
 
 func (ObjectMetricSourceArgs) ElementType() reflect.Type {
@@ -1755,8 +1755,8 @@ func (o ObjectMetricSourceOutput) AverageValue() pulumi.StringPtrOutput {
 }
 
 // metricName is the name of the metric in question.
-func (o ObjectMetricSourceOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o ObjectMetricSourceOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v ObjectMetricSource) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
@@ -1765,13 +1765,13 @@ func (o ObjectMetricSourceOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // target is the described Kubernetes object.
-func (o ObjectMetricSourceOutput) Target() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *CrossVersionObjectReference { return v.Target }).(CrossVersionObjectReferencePtrOutput)
+func (o ObjectMetricSourceOutput) Target() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v ObjectMetricSource) CrossVersionObjectReference { return v.Target }).(CrossVersionObjectReferenceOutput)
 }
 
 // targetValue is the target value of the metric (as a quantity).
-func (o ObjectMetricSourceOutput) TargetValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *string { return v.TargetValue }).(pulumi.StringPtrOutput)
+func (o ObjectMetricSourceOutput) TargetValue() pulumi.StringOutput {
+	return o.ApplyT(func(v ObjectMetricSource) string { return v.TargetValue }).(pulumi.StringOutput)
 }
 
 type ObjectMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -1808,7 +1808,7 @@ func (o ObjectMetricSourcePtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1828,7 +1828,7 @@ func (o ObjectMetricSourcePtrOutput) Target() CrossVersionObjectReferencePtrOutp
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -1838,7 +1838,7 @@ func (o ObjectMetricSourcePtrOutput) TargetValue() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.TargetValue
+		return &v.TargetValue
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1847,13 +1847,13 @@ type ObjectMetricStatus struct {
 	// averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue *string `pulumi:"averageValue"`
 	// currentValue is the current value of the metric (as a quantity).
-	CurrentValue *string `pulumi:"currentValue"`
+	CurrentValue string `pulumi:"currentValue"`
 	// metricName is the name of the metric in question.
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// target is the described Kubernetes object.
-	Target *CrossVersionObjectReference `pulumi:"target"`
+	Target CrossVersionObjectReference `pulumi:"target"`
 }
 
 // ObjectMetricStatusInput is an input type that accepts ObjectMetricStatusArgs and ObjectMetricStatusOutput values.
@@ -1873,13 +1873,13 @@ type ObjectMetricStatusArgs struct {
 	// averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue pulumi.StringPtrInput `pulumi:"averageValue"`
 	// currentValue is the current value of the metric (as a quantity).
-	CurrentValue pulumi.StringPtrInput `pulumi:"currentValue"`
+	CurrentValue pulumi.StringInput `pulumi:"currentValue"`
 	// metricName is the name of the metric in question.
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// target is the described Kubernetes object.
-	Target CrossVersionObjectReferencePtrInput `pulumi:"target"`
+	Target CrossVersionObjectReferenceInput `pulumi:"target"`
 }
 
 func (ObjectMetricStatusArgs) ElementType() reflect.Type {
@@ -1967,13 +1967,13 @@ func (o ObjectMetricStatusOutput) AverageValue() pulumi.StringPtrOutput {
 }
 
 // currentValue is the current value of the metric (as a quantity).
-func (o ObjectMetricStatusOutput) CurrentValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *string { return v.CurrentValue }).(pulumi.StringPtrOutput)
+func (o ObjectMetricStatusOutput) CurrentValue() pulumi.StringOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) string { return v.CurrentValue }).(pulumi.StringOutput)
 }
 
 // metricName is the name of the metric in question.
-func (o ObjectMetricStatusOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o ObjectMetricStatusOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
@@ -1982,8 +1982,8 @@ func (o ObjectMetricStatusOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // target is the described Kubernetes object.
-func (o ObjectMetricStatusOutput) Target() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *CrossVersionObjectReference { return v.Target }).(CrossVersionObjectReferencePtrOutput)
+func (o ObjectMetricStatusOutput) Target() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) CrossVersionObjectReference { return v.Target }).(CrossVersionObjectReferenceOutput)
 }
 
 type ObjectMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -2020,7 +2020,7 @@ func (o ObjectMetricStatusPtrOutput) CurrentValue() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.CurrentValue
+		return &v.CurrentValue
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2030,7 +2030,7 @@ func (o ObjectMetricStatusPtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2050,18 +2050,18 @@ func (o ObjectMetricStatusPtrOutput) Target() CrossVersionObjectReferencePtrOutp
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
 // PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
 type PodsMetricSource struct {
 	// metricName is the name of the metric in question
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-	TargetAverageValue *string `pulumi:"targetAverageValue"`
+	TargetAverageValue string `pulumi:"targetAverageValue"`
 }
 
 // PodsMetricSourceInput is an input type that accepts PodsMetricSourceArgs and PodsMetricSourceOutput values.
@@ -2079,11 +2079,11 @@ type PodsMetricSourceInput interface {
 // PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
 type PodsMetricSourceArgs struct {
 	// metricName is the name of the metric in question
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-	TargetAverageValue pulumi.StringPtrInput `pulumi:"targetAverageValue"`
+	TargetAverageValue pulumi.StringInput `pulumi:"targetAverageValue"`
 }
 
 func (PodsMetricSourceArgs) ElementType() reflect.Type {
@@ -2166,8 +2166,8 @@ func (o PodsMetricSourceOutput) ToPodsMetricSourcePtrOutputWithContext(ctx conte
 }
 
 // metricName is the name of the metric in question
-func (o PodsMetricSourceOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodsMetricSource) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o PodsMetricSourceOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v PodsMetricSource) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
@@ -2176,8 +2176,8 @@ func (o PodsMetricSourceOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-func (o PodsMetricSourceOutput) TargetAverageValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodsMetricSource) *string { return v.TargetAverageValue }).(pulumi.StringPtrOutput)
+func (o PodsMetricSourceOutput) TargetAverageValue() pulumi.StringOutput {
+	return o.ApplyT(func(v PodsMetricSource) string { return v.TargetAverageValue }).(pulumi.StringOutput)
 }
 
 type PodsMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -2204,7 +2204,7 @@ func (o PodsMetricSourcePtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2224,16 +2224,16 @@ func (o PodsMetricSourcePtrOutput) TargetAverageValue() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.TargetAverageValue
+		return &v.TargetAverageValue
 	}).(pulumi.StringPtrOutput)
 }
 
 // PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatus struct {
 	// currentAverageValue is the current value of the average of the metric across all relevant pods (as a quantity)
-	CurrentAverageValue *string `pulumi:"currentAverageValue"`
+	CurrentAverageValue string `pulumi:"currentAverageValue"`
 	// metricName is the name of the metric in question
-	MetricName *string `pulumi:"metricName"`
+	MetricName string `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 }
@@ -2253,9 +2253,9 @@ type PodsMetricStatusInput interface {
 // PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatusArgs struct {
 	// currentAverageValue is the current value of the average of the metric across all relevant pods (as a quantity)
-	CurrentAverageValue pulumi.StringPtrInput `pulumi:"currentAverageValue"`
+	CurrentAverageValue pulumi.StringInput `pulumi:"currentAverageValue"`
 	// metricName is the name of the metric in question
-	MetricName pulumi.StringPtrInput `pulumi:"metricName"`
+	MetricName pulumi.StringInput `pulumi:"metricName"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 }
@@ -2340,13 +2340,13 @@ func (o PodsMetricStatusOutput) ToPodsMetricStatusPtrOutputWithContext(ctx conte
 }
 
 // currentAverageValue is the current value of the average of the metric across all relevant pods (as a quantity)
-func (o PodsMetricStatusOutput) CurrentAverageValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodsMetricStatus) *string { return v.CurrentAverageValue }).(pulumi.StringPtrOutput)
+func (o PodsMetricStatusOutput) CurrentAverageValue() pulumi.StringOutput {
+	return o.ApplyT(func(v PodsMetricStatus) string { return v.CurrentAverageValue }).(pulumi.StringOutput)
 }
 
 // metricName is the name of the metric in question
-func (o PodsMetricStatusOutput) MetricName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodsMetricStatus) *string { return v.MetricName }).(pulumi.StringPtrOutput)
+func (o PodsMetricStatusOutput) MetricName() pulumi.StringOutput {
+	return o.ApplyT(func(v PodsMetricStatus) string { return v.MetricName }).(pulumi.StringOutput)
 }
 
 // selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
@@ -2378,7 +2378,7 @@ func (o PodsMetricStatusPtrOutput) CurrentAverageValue() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.CurrentAverageValue
+		return &v.CurrentAverageValue
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2388,7 +2388,7 @@ func (o PodsMetricStatusPtrOutput) MetricName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MetricName
+		return &v.MetricName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2405,7 +2405,7 @@ func (o PodsMetricStatusPtrOutput) Selector() metav1.LabelSelectorPtrOutput {
 // ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	TargetAverageUtilization *int `pulumi:"targetAverageUtilization"`
 	// targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
@@ -2427,7 +2427,7 @@ type ResourceMetricSourceInput interface {
 // ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
 type ResourceMetricSourceArgs struct {
 	// name is the name of the resource in question.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	TargetAverageUtilization pulumi.IntPtrInput `pulumi:"targetAverageUtilization"`
 	// targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
@@ -2514,8 +2514,8 @@ func (o ResourceMetricSourceOutput) ToResourceMetricSourcePtrOutputWithContext(c
 }
 
 // name is the name of the resource in question.
-func (o ResourceMetricSourceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceMetricSource) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ResourceMetricSourceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceMetricSource) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
@@ -2552,7 +2552,7 @@ func (o ResourceMetricSourcePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2581,9 +2581,9 @@ type ResourceMetricStatus struct {
 	// currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.  It will only be present if `targetAverageValue` was set in the corresponding metric specification.
 	CurrentAverageUtilization *int `pulumi:"currentAverageUtilization"`
 	// currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type. It will always be set, regardless of the corresponding metric specification.
-	CurrentAverageValue *string `pulumi:"currentAverageValue"`
+	CurrentAverageValue string `pulumi:"currentAverageValue"`
 	// name is the name of the resource in question.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // ResourceMetricStatusInput is an input type that accepts ResourceMetricStatusArgs and ResourceMetricStatusOutput values.
@@ -2603,9 +2603,9 @@ type ResourceMetricStatusArgs struct {
 	// currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.  It will only be present if `targetAverageValue` was set in the corresponding metric specification.
 	CurrentAverageUtilization pulumi.IntPtrInput `pulumi:"currentAverageUtilization"`
 	// currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type. It will always be set, regardless of the corresponding metric specification.
-	CurrentAverageValue pulumi.StringPtrInput `pulumi:"currentAverageValue"`
+	CurrentAverageValue pulumi.StringInput `pulumi:"currentAverageValue"`
 	// name is the name of the resource in question.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (ResourceMetricStatusArgs) ElementType() reflect.Type {
@@ -2693,13 +2693,13 @@ func (o ResourceMetricStatusOutput) CurrentAverageUtilization() pulumi.IntPtrOut
 }
 
 // currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type. It will always be set, regardless of the corresponding metric specification.
-func (o ResourceMetricStatusOutput) CurrentAverageValue() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceMetricStatus) *string { return v.CurrentAverageValue }).(pulumi.StringPtrOutput)
+func (o ResourceMetricStatusOutput) CurrentAverageValue() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceMetricStatus) string { return v.CurrentAverageValue }).(pulumi.StringOutput)
 }
 
 // name is the name of the resource in question.
-func (o ResourceMetricStatusOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceMetricStatus) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ResourceMetricStatusOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceMetricStatus) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type ResourceMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -2736,7 +2736,7 @@ func (o ResourceMetricStatusPtrOutput) CurrentAverageValue() pulumi.StringPtrOut
 		if v == nil {
 			return nil
 		}
-		return v.CurrentAverageValue
+		return &v.CurrentAverageValue
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2746,7 +2746,7 @@ func (o ResourceMetricStatusPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscaler.go
@@ -15,15 +15,15 @@ type HorizontalPodAutoscaler struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrOutput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecOutput `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrOutput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusOutput `pulumi:"status"`
 }
 
 // NewHorizontalPodAutoscaler registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerList.go
@@ -16,13 +16,13 @@ type HorizontalPodAutoscalerList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewHorizontalPodAutoscalerList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/autoscaling/v2beta2/pulumiTypes.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/pulumiTypes.go
@@ -16,9 +16,9 @@ type CrossVersionObjectReference struct {
 	// API version of the referent
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // CrossVersionObjectReferenceInput is an input type that accepts CrossVersionObjectReferenceArgs and CrossVersionObjectReferenceOutput values.
@@ -38,9 +38,9 @@ type CrossVersionObjectReferenceArgs struct {
 	// API version of the referent
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (CrossVersionObjectReferenceArgs) ElementType() reflect.Type {
@@ -128,13 +128,13 @@ func (o CrossVersionObjectReferenceOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CrossVersionObjectReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CrossVersionObjectReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CrossVersionObjectReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type CrossVersionObjectReferencePtrOutput struct{ *pulumi.OutputState }
@@ -171,7 +171,7 @@ func (o CrossVersionObjectReferencePtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -181,16 +181,16 @@ func (o CrossVersionObjectReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
 // ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
 type ExternalMetricSource struct {
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target *MetricTarget `pulumi:"target"`
+	Target MetricTarget `pulumi:"target"`
 }
 
 // ExternalMetricSourceInput is an input type that accepts ExternalMetricSourceArgs and ExternalMetricSourceOutput values.
@@ -208,9 +208,9 @@ type ExternalMetricSourceInput interface {
 // ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
 type ExternalMetricSourceArgs struct {
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target MetricTargetPtrInput `pulumi:"target"`
+	Target MetricTargetInput `pulumi:"target"`
 }
 
 func (ExternalMetricSourceArgs) ElementType() reflect.Type {
@@ -293,13 +293,13 @@ func (o ExternalMetricSourceOutput) ToExternalMetricSourcePtrOutputWithContext(c
 }
 
 // metric identifies the target metric by name and selector
-func (o ExternalMetricSourceOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v ExternalMetricSource) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o ExternalMetricSourceOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v ExternalMetricSource) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 // target specifies the target value for the given metric
-func (o ExternalMetricSourceOutput) Target() MetricTargetPtrOutput {
-	return o.ApplyT(func(v ExternalMetricSource) *MetricTarget { return v.Target }).(MetricTargetPtrOutput)
+func (o ExternalMetricSourceOutput) Target() MetricTargetOutput {
+	return o.ApplyT(func(v ExternalMetricSource) MetricTarget { return v.Target }).(MetricTargetOutput)
 }
 
 type ExternalMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -326,7 +326,7 @@ func (o ExternalMetricSourcePtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
@@ -336,16 +336,16 @@ func (o ExternalMetricSourcePtrOutput) Target() MetricTargetPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(MetricTargetPtrOutput)
 }
 
 // ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.
 type ExternalMetricStatus struct {
 	// current contains the current value for the given metric
-	Current *MetricValueStatus `pulumi:"current"`
+	Current MetricValueStatus `pulumi:"current"`
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 }
 
 // ExternalMetricStatusInput is an input type that accepts ExternalMetricStatusArgs and ExternalMetricStatusOutput values.
@@ -363,9 +363,9 @@ type ExternalMetricStatusInput interface {
 // ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.
 type ExternalMetricStatusArgs struct {
 	// current contains the current value for the given metric
-	Current MetricValueStatusPtrInput `pulumi:"current"`
+	Current MetricValueStatusInput `pulumi:"current"`
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 }
 
 func (ExternalMetricStatusArgs) ElementType() reflect.Type {
@@ -448,13 +448,13 @@ func (o ExternalMetricStatusOutput) ToExternalMetricStatusPtrOutputWithContext(c
 }
 
 // current contains the current value for the given metric
-func (o ExternalMetricStatusOutput) Current() MetricValueStatusPtrOutput {
-	return o.ApplyT(func(v ExternalMetricStatus) *MetricValueStatus { return v.Current }).(MetricValueStatusPtrOutput)
+func (o ExternalMetricStatusOutput) Current() MetricValueStatusOutput {
+	return o.ApplyT(func(v ExternalMetricStatus) MetricValueStatus { return v.Current }).(MetricValueStatusOutput)
 }
 
 // metric identifies the target metric by name and selector
-func (o ExternalMetricStatusOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v ExternalMetricStatus) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o ExternalMetricStatusOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v ExternalMetricStatus) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 type ExternalMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -481,7 +481,7 @@ func (o ExternalMetricStatusPtrOutput) Current() MetricValueStatusPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Current
+		return &v.Current
 	}).(MetricValueStatusPtrOutput)
 }
 
@@ -491,18 +491,18 @@ func (o ExternalMetricStatusPtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type HPAScalingPolicy struct {
 	// PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
-	PeriodSeconds *int `pulumi:"periodSeconds"`
+	PeriodSeconds int `pulumi:"periodSeconds"`
 	// Type is used to specify the scaling policy.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 	// Value contains the amount of change which is permitted by the policy. It must be greater than zero
-	Value *int `pulumi:"value"`
+	Value int `pulumi:"value"`
 }
 
 // HPAScalingPolicyInput is an input type that accepts HPAScalingPolicyArgs and HPAScalingPolicyOutput values.
@@ -520,11 +520,11 @@ type HPAScalingPolicyInput interface {
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type HPAScalingPolicyArgs struct {
 	// PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
-	PeriodSeconds pulumi.IntPtrInput `pulumi:"periodSeconds"`
+	PeriodSeconds pulumi.IntInput `pulumi:"periodSeconds"`
 	// Type is used to specify the scaling policy.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 	// Value contains the amount of change which is permitted by the policy. It must be greater than zero
-	Value pulumi.IntPtrInput `pulumi:"value"`
+	Value pulumi.IntInput `pulumi:"value"`
 }
 
 func (HPAScalingPolicyArgs) ElementType() reflect.Type {
@@ -581,18 +581,18 @@ func (o HPAScalingPolicyOutput) ToHPAScalingPolicyOutputWithContext(ctx context.
 }
 
 // PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
-func (o HPAScalingPolicyOutput) PeriodSeconds() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HPAScalingPolicy) *int { return v.PeriodSeconds }).(pulumi.IntPtrOutput)
+func (o HPAScalingPolicyOutput) PeriodSeconds() pulumi.IntOutput {
+	return o.ApplyT(func(v HPAScalingPolicy) int { return v.PeriodSeconds }).(pulumi.IntOutput)
 }
 
 // Type is used to specify the scaling policy.
-func (o HPAScalingPolicyOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HPAScalingPolicy) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o HPAScalingPolicyOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v HPAScalingPolicy) string { return v.Type }).(pulumi.StringOutput)
 }
 
 // Value contains the amount of change which is permitted by the policy. It must be greater than zero
-func (o HPAScalingPolicyOutput) Value() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HPAScalingPolicy) *int { return v.Value }).(pulumi.IntPtrOutput)
+func (o HPAScalingPolicyOutput) Value() pulumi.IntOutput {
+	return o.ApplyT(func(v HPAScalingPolicy) int { return v.Value }).(pulumi.IntOutput)
 }
 
 type HPAScalingPolicyArrayOutput struct{ *pulumi.OutputState }
@@ -792,15 +792,15 @@ func (o HPAScalingRulesPtrOutput) StabilizationWindowSeconds() pulumi.IntPtrOutp
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec *HorizontalPodAutoscalerSpec `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpec `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status *HorizontalPodAutoscalerStatus `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatus `pulumi:"status"`
 }
 
 // HorizontalPodAutoscalerTypeInput is an input type that accepts HorizontalPodAutoscalerTypeArgs and HorizontalPodAutoscalerTypeOutput values.
@@ -818,15 +818,15 @@ type HorizontalPodAutoscalerTypeInput interface {
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	Spec HorizontalPodAutoscalerSpecPtrInput `pulumi:"spec"`
+	Spec HorizontalPodAutoscalerSpecInput `pulumi:"spec"`
 	// status is the current information about the autoscaler.
-	Status HorizontalPodAutoscalerStatusPtrInput `pulumi:"status"`
+	Status HorizontalPodAutoscalerStatusInput `pulumi:"status"`
 }
 
 func (HorizontalPodAutoscalerTypeArgs) ElementType() reflect.Type {
@@ -883,28 +883,28 @@ func (o HorizontalPodAutoscalerTypeOutput) ToHorizontalPodAutoscalerTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Spec() HorizontalPodAutoscalerSpecOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerSpec { return v.Spec }).(HorizontalPodAutoscalerSpecOutput)
 }
 
 // status is the current information about the autoscaler.
-func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerType) *HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusPtrOutput)
+func (o HorizontalPodAutoscalerTypeOutput) Status() HorizontalPodAutoscalerStatusOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerType) HorizontalPodAutoscalerStatus { return v.Status }).(HorizontalPodAutoscalerStatusOutput)
 }
 
 type HorizontalPodAutoscalerTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1103,9 +1103,9 @@ type HorizontalPodAutoscalerCondition struct {
 	// reason is the reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// status is the status of the condition (True, False, Unknown)
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// type describes the current condition
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // HorizontalPodAutoscalerConditionInput is an input type that accepts HorizontalPodAutoscalerConditionArgs and HorizontalPodAutoscalerConditionOutput values.
@@ -1129,9 +1129,9 @@ type HorizontalPodAutoscalerConditionArgs struct {
 	// reason is the reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// status is the status of the condition (True, False, Unknown)
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// type describes the current condition
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (HorizontalPodAutoscalerConditionArgs) ElementType() reflect.Type {
@@ -1203,13 +1203,13 @@ func (o HorizontalPodAutoscalerConditionOutput) Reason() pulumi.StringPtrOutput 
 }
 
 // status is the status of the condition (True, False, Unknown)
-func (o HorizontalPodAutoscalerConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // type describes the current condition
-func (o HorizontalPodAutoscalerConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type HorizontalPodAutoscalerConditionArrayOutput struct{ *pulumi.OutputState }
@@ -1235,13 +1235,13 @@ func (o HorizontalPodAutoscalerConditionArrayOutput) Index(i pulumi.IntInput) Ho
 // HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscalerType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // HorizontalPodAutoscalerListTypeInput is an input type that accepts HorizontalPodAutoscalerListTypeArgs and HorizontalPodAutoscalerListTypeOutput values.
@@ -1259,13 +1259,13 @@ type HorizontalPodAutoscalerListTypeInput interface {
 // HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of horizontal pod autoscaler objects.
 	Items HorizontalPodAutoscalerTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata is the standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (HorizontalPodAutoscalerListTypeArgs) ElementType() reflect.Type {
@@ -1296,8 +1296,8 @@ func (o HorizontalPodAutoscalerListTypeOutput) ToHorizontalPodAutoscalerListType
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of horizontal pod autoscaler objects.
@@ -1306,13 +1306,13 @@ func (o HorizontalPodAutoscalerListTypeOutput) Items() HorizontalPodAutoscalerTy
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata is the standard list metadata.
-func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o HorizontalPodAutoscalerListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
@@ -1320,13 +1320,13 @@ type HorizontalPodAutoscalerSpec struct {
 	// behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
 	Behavior *HorizontalPodAutoscalerBehavior `pulumi:"behavior"`
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-	MaxReplicas *int `pulumi:"maxReplicas"`
+	MaxReplicas int `pulumi:"maxReplicas"`
 	// metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
 	Metrics []MetricSpec `pulumi:"metrics"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas *int `pulumi:"minReplicas"`
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-	ScaleTargetRef *CrossVersionObjectReference `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReference `pulumi:"scaleTargetRef"`
 }
 
 // HorizontalPodAutoscalerSpecInput is an input type that accepts HorizontalPodAutoscalerSpecArgs and HorizontalPodAutoscalerSpecOutput values.
@@ -1346,13 +1346,13 @@ type HorizontalPodAutoscalerSpecArgs struct {
 	// behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
 	Behavior HorizontalPodAutoscalerBehaviorPtrInput `pulumi:"behavior"`
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-	MaxReplicas pulumi.IntPtrInput `pulumi:"maxReplicas"`
+	MaxReplicas pulumi.IntInput `pulumi:"maxReplicas"`
 	// metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
 	Metrics MetricSpecArrayInput `pulumi:"metrics"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 	MinReplicas pulumi.IntPtrInput `pulumi:"minReplicas"`
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-	ScaleTargetRef CrossVersionObjectReferencePtrInput `pulumi:"scaleTargetRef"`
+	ScaleTargetRef CrossVersionObjectReferenceInput `pulumi:"scaleTargetRef"`
 }
 
 func (HorizontalPodAutoscalerSpecArgs) ElementType() reflect.Type {
@@ -1440,8 +1440,8 @@ func (o HorizontalPodAutoscalerSpecOutput) Behavior() HorizontalPodAutoscalerBeh
 }
 
 // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
-func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *int { return v.MaxReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) MaxReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) int { return v.MaxReplicas }).(pulumi.IntOutput)
 }
 
 // metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
@@ -1455,8 +1455,8 @@ func (o HorizontalPodAutoscalerSpecOutput) MinReplicas() pulumi.IntPtrOutput {
 }
 
 // scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
-func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) *CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferencePtrOutput)
+func (o HorizontalPodAutoscalerSpecOutput) ScaleTargetRef() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerSpec) CrossVersionObjectReference { return v.ScaleTargetRef }).(CrossVersionObjectReferenceOutput)
 }
 
 type HorizontalPodAutoscalerSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1493,7 +1493,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) MaxReplicas() pulumi.IntPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.MaxReplicas
+		return &v.MaxReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1523,7 +1523,7 @@ func (o HorizontalPodAutoscalerSpecPtrOutput) ScaleTargetRef() CrossVersionObjec
 		if v == nil {
 			return nil
 		}
-		return v.ScaleTargetRef
+		return &v.ScaleTargetRef
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -1534,9 +1534,9 @@ type HorizontalPodAutoscalerStatus struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	CurrentMetrics []MetricStatus `pulumi:"currentMetrics"`
 	// currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-	CurrentReplicas *int `pulumi:"currentReplicas"`
+	CurrentReplicas int `pulumi:"currentReplicas"`
 	// desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-	DesiredReplicas *int `pulumi:"desiredReplicas"`
+	DesiredReplicas int `pulumi:"desiredReplicas"`
 	// lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime *string `pulumi:"lastScaleTime"`
 	// observedGeneration is the most recent generation observed by this autoscaler.
@@ -1562,9 +1562,9 @@ type HorizontalPodAutoscalerStatusArgs struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	CurrentMetrics MetricStatusArrayInput `pulumi:"currentMetrics"`
 	// currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-	CurrentReplicas pulumi.IntPtrInput `pulumi:"currentReplicas"`
+	CurrentReplicas pulumi.IntInput `pulumi:"currentReplicas"`
 	// desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-	DesiredReplicas pulumi.IntPtrInput `pulumi:"desiredReplicas"`
+	DesiredReplicas pulumi.IntInput `pulumi:"desiredReplicas"`
 	// lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
 	LastScaleTime pulumi.StringPtrInput `pulumi:"lastScaleTime"`
 	// observedGeneration is the most recent generation observed by this autoscaler.
@@ -1661,13 +1661,13 @@ func (o HorizontalPodAutoscalerStatusOutput) CurrentMetrics() MetricStatusArrayO
 }
 
 // currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.CurrentReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) CurrentReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.CurrentReplicas }).(pulumi.IntOutput)
 }
 
 // desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
-func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) *int { return v.DesiredReplicas }).(pulumi.IntPtrOutput)
+func (o HorizontalPodAutoscalerStatusOutput) DesiredReplicas() pulumi.IntOutput {
+	return o.ApplyT(func(v HorizontalPodAutoscalerStatus) int { return v.DesiredReplicas }).(pulumi.IntOutput)
 }
 
 // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
@@ -1724,7 +1724,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) CurrentReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.CurrentReplicas
+		return &v.CurrentReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1734,7 +1734,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) DesiredReplicas() pulumi.IntPtrO
 		if v == nil {
 			return nil
 		}
-		return v.DesiredReplicas
+		return &v.DesiredReplicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1761,7 +1761,7 @@ func (o HorizontalPodAutoscalerStatusPtrOutput) ObservedGeneration() pulumi.IntP
 // MetricIdentifier defines the name and optionally selector for a metric
 type MetricIdentifier struct {
 	// name is the name of the given metric
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 }
@@ -1781,7 +1781,7 @@ type MetricIdentifierInput interface {
 // MetricIdentifier defines the name and optionally selector for a metric
 type MetricIdentifierArgs struct {
 	// name is the name of the given metric
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 }
@@ -1866,8 +1866,8 @@ func (o MetricIdentifierOutput) ToMetricIdentifierPtrOutputWithContext(ctx conte
 }
 
 // name is the name of the given metric
-func (o MetricIdentifierOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricIdentifier) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o MetricIdentifierOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricIdentifier) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
@@ -1899,7 +1899,7 @@ func (o MetricIdentifierPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1924,7 +1924,7 @@ type MetricSpec struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource *ResourceMetricSource `pulumi:"resource"`
 	// type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // MetricSpecInput is an input type that accepts MetricSpecArgs and MetricSpecOutput values.
@@ -1950,7 +1950,7 @@ type MetricSpecArgs struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource ResourceMetricSourcePtrInput `pulumi:"resource"`
 	// type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (MetricSpecArgs) ElementType() reflect.Type {
@@ -2027,8 +2027,8 @@ func (o MetricSpecOutput) Resource() ResourceMetricSourcePtrOutput {
 }
 
 // type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
-func (o MetricSpecOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricSpec) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o MetricSpecOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricSpec) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type MetricSpecArrayOutput struct{ *pulumi.OutputState }
@@ -2062,7 +2062,7 @@ type MetricStatus struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource *ResourceMetricStatus `pulumi:"resource"`
 	// type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // MetricStatusInput is an input type that accepts MetricStatusArgs and MetricStatusOutput values.
@@ -2088,7 +2088,7 @@ type MetricStatusArgs struct {
 	// resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 	Resource ResourceMetricStatusPtrInput `pulumi:"resource"`
 	// type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (MetricStatusArgs) ElementType() reflect.Type {
@@ -2165,8 +2165,8 @@ func (o MetricStatusOutput) Resource() ResourceMetricStatusPtrOutput {
 }
 
 // type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
-func (o MetricStatusOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricStatus) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o MetricStatusOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricStatus) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type MetricStatusArrayOutput struct{ *pulumi.OutputState }
@@ -2196,7 +2196,7 @@ type MetricTarget struct {
 	// averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue *string `pulumi:"averageValue"`
 	// type represents whether the metric type is Utilization, Value, or AverageValue
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 	// value is the target value of the metric (as a quantity).
 	Value *string `pulumi:"value"`
 }
@@ -2220,7 +2220,7 @@ type MetricTargetArgs struct {
 	// averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
 	AverageValue pulumi.StringPtrInput `pulumi:"averageValue"`
 	// type represents whether the metric type is Utilization, Value, or AverageValue
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 	// value is the target value of the metric (as a quantity).
 	Value pulumi.StringPtrInput `pulumi:"value"`
 }
@@ -2315,8 +2315,8 @@ func (o MetricTargetOutput) AverageValue() pulumi.StringPtrOutput {
 }
 
 // type represents whether the metric type is Utilization, Value, or AverageValue
-func (o MetricTargetOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v MetricTarget) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o MetricTargetOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v MetricTarget) string { return v.Type }).(pulumi.StringOutput)
 }
 
 // value is the target value of the metric (as a quantity).
@@ -2368,7 +2368,7 @@ func (o MetricTargetPtrOutput) Type() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Type
+		return &v.Type
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2558,11 +2558,11 @@ func (o MetricValueStatusPtrOutput) Value() pulumi.StringPtrOutput {
 
 // ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricSource struct {
-	DescribedObject *CrossVersionObjectReference `pulumi:"describedObject"`
+	DescribedObject CrossVersionObjectReference `pulumi:"describedObject"`
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target *MetricTarget `pulumi:"target"`
+	Target MetricTarget `pulumi:"target"`
 }
 
 // ObjectMetricSourceInput is an input type that accepts ObjectMetricSourceArgs and ObjectMetricSourceOutput values.
@@ -2579,11 +2579,11 @@ type ObjectMetricSourceInput interface {
 
 // ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricSourceArgs struct {
-	DescribedObject CrossVersionObjectReferencePtrInput `pulumi:"describedObject"`
+	DescribedObject CrossVersionObjectReferenceInput `pulumi:"describedObject"`
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target MetricTargetPtrInput `pulumi:"target"`
+	Target MetricTargetInput `pulumi:"target"`
 }
 
 func (ObjectMetricSourceArgs) ElementType() reflect.Type {
@@ -2664,18 +2664,18 @@ func (o ObjectMetricSourceOutput) ToObjectMetricSourcePtrOutputWithContext(ctx c
 		return &v
 	}).(ObjectMetricSourcePtrOutput)
 }
-func (o ObjectMetricSourceOutput) DescribedObject() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *CrossVersionObjectReference { return v.DescribedObject }).(CrossVersionObjectReferencePtrOutput)
+func (o ObjectMetricSourceOutput) DescribedObject() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v ObjectMetricSource) CrossVersionObjectReference { return v.DescribedObject }).(CrossVersionObjectReferenceOutput)
 }
 
 // metric identifies the target metric by name and selector
-func (o ObjectMetricSourceOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o ObjectMetricSourceOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v ObjectMetricSource) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 // target specifies the target value for the given metric
-func (o ObjectMetricSourceOutput) Target() MetricTargetPtrOutput {
-	return o.ApplyT(func(v ObjectMetricSource) *MetricTarget { return v.Target }).(MetricTargetPtrOutput)
+func (o ObjectMetricSourceOutput) Target() MetricTargetOutput {
+	return o.ApplyT(func(v ObjectMetricSource) MetricTarget { return v.Target }).(MetricTargetOutput)
 }
 
 type ObjectMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -2701,7 +2701,7 @@ func (o ObjectMetricSourcePtrOutput) DescribedObject() CrossVersionObjectReferen
 		if v == nil {
 			return nil
 		}
-		return v.DescribedObject
+		return &v.DescribedObject
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -2711,7 +2711,7 @@ func (o ObjectMetricSourcePtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
@@ -2721,17 +2721,17 @@ func (o ObjectMetricSourcePtrOutput) Target() MetricTargetPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(MetricTargetPtrOutput)
 }
 
 // ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricStatus struct {
 	// current contains the current value for the given metric
-	Current         *MetricValueStatus           `pulumi:"current"`
-	DescribedObject *CrossVersionObjectReference `pulumi:"describedObject"`
+	Current         MetricValueStatus           `pulumi:"current"`
+	DescribedObject CrossVersionObjectReference `pulumi:"describedObject"`
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 }
 
 // ObjectMetricStatusInput is an input type that accepts ObjectMetricStatusArgs and ObjectMetricStatusOutput values.
@@ -2749,10 +2749,10 @@ type ObjectMetricStatusInput interface {
 // ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricStatusArgs struct {
 	// current contains the current value for the given metric
-	Current         MetricValueStatusPtrInput           `pulumi:"current"`
-	DescribedObject CrossVersionObjectReferencePtrInput `pulumi:"describedObject"`
+	Current         MetricValueStatusInput           `pulumi:"current"`
+	DescribedObject CrossVersionObjectReferenceInput `pulumi:"describedObject"`
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 }
 
 func (ObjectMetricStatusArgs) ElementType() reflect.Type {
@@ -2835,17 +2835,17 @@ func (o ObjectMetricStatusOutput) ToObjectMetricStatusPtrOutputWithContext(ctx c
 }
 
 // current contains the current value for the given metric
-func (o ObjectMetricStatusOutput) Current() MetricValueStatusPtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *MetricValueStatus { return v.Current }).(MetricValueStatusPtrOutput)
+func (o ObjectMetricStatusOutput) Current() MetricValueStatusOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) MetricValueStatus { return v.Current }).(MetricValueStatusOutput)
 }
 
-func (o ObjectMetricStatusOutput) DescribedObject() CrossVersionObjectReferencePtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *CrossVersionObjectReference { return v.DescribedObject }).(CrossVersionObjectReferencePtrOutput)
+func (o ObjectMetricStatusOutput) DescribedObject() CrossVersionObjectReferenceOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) CrossVersionObjectReference { return v.DescribedObject }).(CrossVersionObjectReferenceOutput)
 }
 
 // metric identifies the target metric by name and selector
-func (o ObjectMetricStatusOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v ObjectMetricStatus) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o ObjectMetricStatusOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v ObjectMetricStatus) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 type ObjectMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -2872,7 +2872,7 @@ func (o ObjectMetricStatusPtrOutput) Current() MetricValueStatusPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Current
+		return &v.Current
 	}).(MetricValueStatusPtrOutput)
 }
 
@@ -2881,7 +2881,7 @@ func (o ObjectMetricStatusPtrOutput) DescribedObject() CrossVersionObjectReferen
 		if v == nil {
 			return nil
 		}
-		return v.DescribedObject
+		return &v.DescribedObject
 	}).(CrossVersionObjectReferencePtrOutput)
 }
 
@@ -2891,16 +2891,16 @@ func (o ObjectMetricStatusPtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
 // PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
 type PodsMetricSource struct {
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target *MetricTarget `pulumi:"target"`
+	Target MetricTarget `pulumi:"target"`
 }
 
 // PodsMetricSourceInput is an input type that accepts PodsMetricSourceArgs and PodsMetricSourceOutput values.
@@ -2918,9 +2918,9 @@ type PodsMetricSourceInput interface {
 // PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
 type PodsMetricSourceArgs struct {
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 	// target specifies the target value for the given metric
-	Target MetricTargetPtrInput `pulumi:"target"`
+	Target MetricTargetInput `pulumi:"target"`
 }
 
 func (PodsMetricSourceArgs) ElementType() reflect.Type {
@@ -3003,13 +3003,13 @@ func (o PodsMetricSourceOutput) ToPodsMetricSourcePtrOutputWithContext(ctx conte
 }
 
 // metric identifies the target metric by name and selector
-func (o PodsMetricSourceOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v PodsMetricSource) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o PodsMetricSourceOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v PodsMetricSource) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 // target specifies the target value for the given metric
-func (o PodsMetricSourceOutput) Target() MetricTargetPtrOutput {
-	return o.ApplyT(func(v PodsMetricSource) *MetricTarget { return v.Target }).(MetricTargetPtrOutput)
+func (o PodsMetricSourceOutput) Target() MetricTargetOutput {
+	return o.ApplyT(func(v PodsMetricSource) MetricTarget { return v.Target }).(MetricTargetOutput)
 }
 
 type PodsMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -3036,7 +3036,7 @@ func (o PodsMetricSourcePtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
@@ -3046,16 +3046,16 @@ func (o PodsMetricSourcePtrOutput) Target() MetricTargetPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(MetricTargetPtrOutput)
 }
 
 // PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatus struct {
 	// current contains the current value for the given metric
-	Current *MetricValueStatus `pulumi:"current"`
+	Current MetricValueStatus `pulumi:"current"`
 	// metric identifies the target metric by name and selector
-	Metric *MetricIdentifier `pulumi:"metric"`
+	Metric MetricIdentifier `pulumi:"metric"`
 }
 
 // PodsMetricStatusInput is an input type that accepts PodsMetricStatusArgs and PodsMetricStatusOutput values.
@@ -3073,9 +3073,9 @@ type PodsMetricStatusInput interface {
 // PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatusArgs struct {
 	// current contains the current value for the given metric
-	Current MetricValueStatusPtrInput `pulumi:"current"`
+	Current MetricValueStatusInput `pulumi:"current"`
 	// metric identifies the target metric by name and selector
-	Metric MetricIdentifierPtrInput `pulumi:"metric"`
+	Metric MetricIdentifierInput `pulumi:"metric"`
 }
 
 func (PodsMetricStatusArgs) ElementType() reflect.Type {
@@ -3158,13 +3158,13 @@ func (o PodsMetricStatusOutput) ToPodsMetricStatusPtrOutputWithContext(ctx conte
 }
 
 // current contains the current value for the given metric
-func (o PodsMetricStatusOutput) Current() MetricValueStatusPtrOutput {
-	return o.ApplyT(func(v PodsMetricStatus) *MetricValueStatus { return v.Current }).(MetricValueStatusPtrOutput)
+func (o PodsMetricStatusOutput) Current() MetricValueStatusOutput {
+	return o.ApplyT(func(v PodsMetricStatus) MetricValueStatus { return v.Current }).(MetricValueStatusOutput)
 }
 
 // metric identifies the target metric by name and selector
-func (o PodsMetricStatusOutput) Metric() MetricIdentifierPtrOutput {
-	return o.ApplyT(func(v PodsMetricStatus) *MetricIdentifier { return v.Metric }).(MetricIdentifierPtrOutput)
+func (o PodsMetricStatusOutput) Metric() MetricIdentifierOutput {
+	return o.ApplyT(func(v PodsMetricStatus) MetricIdentifier { return v.Metric }).(MetricIdentifierOutput)
 }
 
 type PodsMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -3191,7 +3191,7 @@ func (o PodsMetricStatusPtrOutput) Current() MetricValueStatusPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Current
+		return &v.Current
 	}).(MetricValueStatusPtrOutput)
 }
 
@@ -3201,16 +3201,16 @@ func (o PodsMetricStatusPtrOutput) Metric() MetricIdentifierPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Metric
+		return &v.Metric
 	}).(MetricIdentifierPtrOutput)
 }
 
 // ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// target specifies the target value for the given metric
-	Target *MetricTarget `pulumi:"target"`
+	Target MetricTarget `pulumi:"target"`
 }
 
 // ResourceMetricSourceInput is an input type that accepts ResourceMetricSourceArgs and ResourceMetricSourceOutput values.
@@ -3228,9 +3228,9 @@ type ResourceMetricSourceInput interface {
 // ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
 type ResourceMetricSourceArgs struct {
 	// name is the name of the resource in question.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// target specifies the target value for the given metric
-	Target MetricTargetPtrInput `pulumi:"target"`
+	Target MetricTargetInput `pulumi:"target"`
 }
 
 func (ResourceMetricSourceArgs) ElementType() reflect.Type {
@@ -3313,13 +3313,13 @@ func (o ResourceMetricSourceOutput) ToResourceMetricSourcePtrOutputWithContext(c
 }
 
 // name is the name of the resource in question.
-func (o ResourceMetricSourceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceMetricSource) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ResourceMetricSourceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceMetricSource) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // target specifies the target value for the given metric
-func (o ResourceMetricSourceOutput) Target() MetricTargetPtrOutput {
-	return o.ApplyT(func(v ResourceMetricSource) *MetricTarget { return v.Target }).(MetricTargetPtrOutput)
+func (o ResourceMetricSourceOutput) Target() MetricTargetOutput {
+	return o.ApplyT(func(v ResourceMetricSource) MetricTarget { return v.Target }).(MetricTargetOutput)
 }
 
 type ResourceMetricSourcePtrOutput struct{ *pulumi.OutputState }
@@ -3346,7 +3346,7 @@ func (o ResourceMetricSourcePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3356,16 +3356,16 @@ func (o ResourceMetricSourcePtrOutput) Target() MetricTargetPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Target
+		return &v.Target
 	}).(MetricTargetPtrOutput)
 }
 
 // ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
 	// current contains the current value for the given metric
-	Current *MetricValueStatus `pulumi:"current"`
+	Current MetricValueStatus `pulumi:"current"`
 	// Name is the name of the resource in question.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // ResourceMetricStatusInput is an input type that accepts ResourceMetricStatusArgs and ResourceMetricStatusOutput values.
@@ -3383,9 +3383,9 @@ type ResourceMetricStatusInput interface {
 // ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
 type ResourceMetricStatusArgs struct {
 	// current contains the current value for the given metric
-	Current MetricValueStatusPtrInput `pulumi:"current"`
+	Current MetricValueStatusInput `pulumi:"current"`
 	// Name is the name of the resource in question.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (ResourceMetricStatusArgs) ElementType() reflect.Type {
@@ -3468,13 +3468,13 @@ func (o ResourceMetricStatusOutput) ToResourceMetricStatusPtrOutputWithContext(c
 }
 
 // current contains the current value for the given metric
-func (o ResourceMetricStatusOutput) Current() MetricValueStatusPtrOutput {
-	return o.ApplyT(func(v ResourceMetricStatus) *MetricValueStatus { return v.Current }).(MetricValueStatusPtrOutput)
+func (o ResourceMetricStatusOutput) Current() MetricValueStatusOutput {
+	return o.ApplyT(func(v ResourceMetricStatus) MetricValueStatus { return v.Current }).(MetricValueStatusOutput)
 }
 
 // Name is the name of the resource in question.
-func (o ResourceMetricStatusOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceMetricStatus) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ResourceMetricStatusOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceMetricStatus) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type ResourceMetricStatusPtrOutput struct{ *pulumi.OutputState }
@@ -3501,7 +3501,7 @@ func (o ResourceMetricStatusPtrOutput) Current() MetricValueStatusPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Current
+		return &v.Current
 	}).(MetricValueStatusPtrOutput)
 }
 
@@ -3511,7 +3511,7 @@ func (o ResourceMetricStatusPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/batch/v1/job.go
+++ b/sdk/go/kubernetes/batch/v1/job.go
@@ -30,15 +30,15 @@ type Job struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec JobSpecPtrOutput `pulumi:"spec"`
+	Spec JobSpecOutput `pulumi:"spec"`
 	// Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status JobStatusPtrOutput `pulumi:"status"`
+	Status JobStatusOutput `pulumi:"status"`
 }
 
 // NewJob registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v1/jobList.go
+++ b/sdk/go/kubernetes/batch/v1/jobList.go
@@ -16,13 +16,13 @@ type JobList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of Jobs.
 	Items JobTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewJobList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/batch/v1/pulumiTypes.go
@@ -30,15 +30,15 @@ import (
 // by setting the 'customTimeouts' option on the resource.
 type JobType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *JobSpec `pulumi:"spec"`
+	Spec JobSpec `pulumi:"spec"`
 	// Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *JobStatus `pulumi:"status"`
+	Status JobStatus `pulumi:"status"`
 }
 
 // JobTypeInput is an input type that accepts JobTypeArgs and JobTypeOutput values.
@@ -71,15 +71,15 @@ type JobTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type JobTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec JobSpecPtrInput `pulumi:"spec"`
+	Spec JobSpecInput `pulumi:"spec"`
 	// Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status JobStatusPtrInput `pulumi:"status"`
+	Status JobStatusInput `pulumi:"status"`
 }
 
 func (JobTypeArgs) ElementType() reflect.Type {
@@ -151,28 +151,28 @@ func (o JobTypeOutput) ToJobTypeOutputWithContext(ctx context.Context) JobTypeOu
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o JobTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o JobTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v JobType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o JobTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o JobTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v JobType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o JobTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v JobType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o JobTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v JobType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o JobTypeOutput) Spec() JobSpecPtrOutput {
-	return o.ApplyT(func(v JobType) *JobSpec { return v.Spec }).(JobSpecPtrOutput)
+func (o JobTypeOutput) Spec() JobSpecOutput {
+	return o.ApplyT(func(v JobType) JobSpec { return v.Spec }).(JobSpecOutput)
 }
 
 // Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o JobTypeOutput) Status() JobStatusPtrOutput {
-	return o.ApplyT(func(v JobType) *JobStatus { return v.Status }).(JobStatusPtrOutput)
+func (o JobTypeOutput) Status() JobStatusOutput {
+	return o.ApplyT(func(v JobType) JobStatus { return v.Status }).(JobStatusOutput)
 }
 
 type JobTypeArrayOutput struct{ *pulumi.OutputState }
@@ -206,9 +206,9 @@ type JobCondition struct {
 	// (brief) reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of job condition, Complete or Failed.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // JobConditionInput is an input type that accepts JobConditionArgs and JobConditionOutput values.
@@ -234,9 +234,9 @@ type JobConditionArgs struct {
 	// (brief) reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of job condition, Complete or Failed.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (JobConditionArgs) ElementType() reflect.Type {
@@ -313,13 +313,13 @@ func (o JobConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o JobConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o JobConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v JobCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of job condition, Complete or Failed.
-func (o JobConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o JobConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v JobCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type JobConditionArrayOutput struct{ *pulumi.OutputState }
@@ -345,13 +345,13 @@ func (o JobConditionArrayOutput) Index(i pulumi.IntInput) JobConditionOutput {
 // JobList is a collection of jobs.
 type JobListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of Jobs.
 	Items []JobType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // JobListTypeInput is an input type that accepts JobListTypeArgs and JobListTypeOutput values.
@@ -369,13 +369,13 @@ type JobListTypeInput interface {
 // JobList is a collection of jobs.
 type JobListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of Jobs.
 	Items JobTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (JobListTypeArgs) ElementType() reflect.Type {
@@ -406,8 +406,8 @@ func (o JobListTypeOutput) ToJobListTypeOutputWithContext(ctx context.Context) J
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o JobListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o JobListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v JobListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of Jobs.
@@ -416,13 +416,13 @@ func (o JobListTypeOutput) Items() JobTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o JobListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JobListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o JobListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v JobListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o JobListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v JobListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o JobListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v JobListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // JobSpec describes how the job execution will look like.
@@ -440,7 +440,7 @@ type JobSpec struct {
 	// A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
 	TtlSecondsAfterFinished *int `pulumi:"ttlSecondsAfterFinished"`
 }
@@ -472,7 +472,7 @@ type JobSpecArgs struct {
 	// A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
 	TtlSecondsAfterFinished pulumi.IntPtrInput `pulumi:"ttlSecondsAfterFinished"`
 }
@@ -587,8 +587,8 @@ func (o JobSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-func (o JobSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v JobSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o JobSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v JobSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
@@ -680,7 +680,7 @@ func (o JobSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 

--- a/sdk/go/kubernetes/batch/v1beta1/cronJob.go
+++ b/sdk/go/kubernetes/batch/v1beta1/cronJob.go
@@ -15,15 +15,15 @@ type CronJob struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec CronJobSpecPtrOutput `pulumi:"spec"`
+	Spec CronJobSpecOutput `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status CronJobStatusPtrOutput `pulumi:"status"`
+	Status CronJobStatusOutput `pulumi:"status"`
 }
 
 // NewCronJob registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v1beta1/cronJobList.go
+++ b/sdk/go/kubernetes/batch/v1beta1/cronJobList.go
@@ -16,13 +16,13 @@ type CronJobList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items CronJobTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCronJobList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/batch/v1beta1/pulumiTypes.go
@@ -16,15 +16,15 @@ import (
 // CronJob represents the configuration of a single cron job.
 type CronJobType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *CronJobSpec `pulumi:"spec"`
+	Spec CronJobSpec `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *CronJobStatus `pulumi:"status"`
+	Status CronJobStatus `pulumi:"status"`
 }
 
 // CronJobTypeInput is an input type that accepts CronJobTypeArgs and CronJobTypeOutput values.
@@ -42,15 +42,15 @@ type CronJobTypeInput interface {
 // CronJob represents the configuration of a single cron job.
 type CronJobTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec CronJobSpecPtrInput `pulumi:"spec"`
+	Spec CronJobSpecInput `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status CronJobStatusPtrInput `pulumi:"status"`
+	Status CronJobStatusInput `pulumi:"status"`
 }
 
 func (CronJobTypeArgs) ElementType() reflect.Type {
@@ -107,28 +107,28 @@ func (o CronJobTypeOutput) ToCronJobTypeOutputWithContext(ctx context.Context) C
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CronJobTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CronJobTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CronJobTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CronJobTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CronJobTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CronJobType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CronJobTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CronJobType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o CronJobTypeOutput) Spec() CronJobSpecPtrOutput {
-	return o.ApplyT(func(v CronJobType) *CronJobSpec { return v.Spec }).(CronJobSpecPtrOutput)
+func (o CronJobTypeOutput) Spec() CronJobSpecOutput {
+	return o.ApplyT(func(v CronJobType) CronJobSpec { return v.Spec }).(CronJobSpecOutput)
 }
 
 // Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o CronJobTypeOutput) Status() CronJobStatusPtrOutput {
-	return o.ApplyT(func(v CronJobType) *CronJobStatus { return v.Status }).(CronJobStatusPtrOutput)
+func (o CronJobTypeOutput) Status() CronJobStatusOutput {
+	return o.ApplyT(func(v CronJobType) CronJobStatus { return v.Status }).(CronJobStatusOutput)
 }
 
 type CronJobTypeArrayOutput struct{ *pulumi.OutputState }
@@ -154,13 +154,13 @@ func (o CronJobTypeArrayOutput) Index(i pulumi.IntInput) CronJobTypeOutput {
 // CronJobList is a collection of cron jobs.
 type CronJobListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items []CronJobType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CronJobListTypeInput is an input type that accepts CronJobListTypeArgs and CronJobListTypeOutput values.
@@ -178,13 +178,13 @@ type CronJobListTypeInput interface {
 // CronJobList is a collection of cron jobs.
 type CronJobListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items CronJobTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CronJobListTypeArgs) ElementType() reflect.Type {
@@ -215,8 +215,8 @@ func (o CronJobListTypeOutput) ToCronJobListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CronJobListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CronJobListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CronJobs.
@@ -225,13 +225,13 @@ func (o CronJobListTypeOutput) Items() CronJobTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CronJobListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CronJobListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CronJobListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CronJobListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CronJobListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CronJobSpec describes how the job execution will look like and when it will actually run.
@@ -241,9 +241,9 @@ type CronJobSpec struct {
 	// The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
 	FailedJobsHistoryLimit *int `pulumi:"failedJobsHistoryLimit"`
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate *JobTemplateSpec `pulumi:"jobTemplate"`
+	JobTemplate JobTemplateSpec `pulumi:"jobTemplate"`
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-	Schedule *string `pulumi:"schedule"`
+	Schedule string `pulumi:"schedule"`
 	// Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
 	StartingDeadlineSeconds *int `pulumi:"startingDeadlineSeconds"`
 	// The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
@@ -271,9 +271,9 @@ type CronJobSpecArgs struct {
 	// The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
 	FailedJobsHistoryLimit pulumi.IntPtrInput `pulumi:"failedJobsHistoryLimit"`
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate JobTemplateSpecPtrInput `pulumi:"jobTemplate"`
+	JobTemplate JobTemplateSpecInput `pulumi:"jobTemplate"`
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-	Schedule pulumi.StringPtrInput `pulumi:"schedule"`
+	Schedule pulumi.StringInput `pulumi:"schedule"`
 	// Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
 	StartingDeadlineSeconds pulumi.IntPtrInput `pulumi:"startingDeadlineSeconds"`
 	// The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
@@ -372,13 +372,13 @@ func (o CronJobSpecOutput) FailedJobsHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // Specifies the job that will be created when executing a CronJob.
-func (o CronJobSpecOutput) JobTemplate() JobTemplateSpecPtrOutput {
-	return o.ApplyT(func(v CronJobSpec) *JobTemplateSpec { return v.JobTemplate }).(JobTemplateSpecPtrOutput)
+func (o CronJobSpecOutput) JobTemplate() JobTemplateSpecOutput {
+	return o.ApplyT(func(v CronJobSpec) JobTemplateSpec { return v.JobTemplate }).(JobTemplateSpecOutput)
 }
 
 // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-func (o CronJobSpecOutput) Schedule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobSpec) *string { return v.Schedule }).(pulumi.StringPtrOutput)
+func (o CronJobSpecOutput) Schedule() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobSpec) string { return v.Schedule }).(pulumi.StringOutput)
 }
 
 // Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
@@ -440,7 +440,7 @@ func (o CronJobSpecPtrOutput) JobTemplate() JobTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.JobTemplate
+		return &v.JobTemplate
 	}).(JobTemplateSpecPtrOutput)
 }
 
@@ -450,7 +450,7 @@ func (o CronJobSpecPtrOutput) Schedule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Schedule
+		return &v.Schedule
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/batch/v2alpha1/cronJob.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/cronJob.go
@@ -15,15 +15,15 @@ type CronJob struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec CronJobSpecPtrOutput `pulumi:"spec"`
+	Spec CronJobSpecOutput `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status CronJobStatusPtrOutput `pulumi:"status"`
+	Status CronJobStatusOutput `pulumi:"status"`
 }
 
 // NewCronJob registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v2alpha1/cronJobList.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/cronJobList.go
@@ -16,13 +16,13 @@ type CronJobList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items CronJobTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCronJobList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/batch/v2alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/pulumiTypes.go
@@ -16,15 +16,15 @@ import (
 // CronJob represents the configuration of a single cron job.
 type CronJobType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *CronJobSpec `pulumi:"spec"`
+	Spec CronJobSpec `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *CronJobStatus `pulumi:"status"`
+	Status CronJobStatus `pulumi:"status"`
 }
 
 // CronJobTypeInput is an input type that accepts CronJobTypeArgs and CronJobTypeOutput values.
@@ -42,15 +42,15 @@ type CronJobTypeInput interface {
 // CronJob represents the configuration of a single cron job.
 type CronJobTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec CronJobSpecPtrInput `pulumi:"spec"`
+	Spec CronJobSpecInput `pulumi:"spec"`
 	// Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status CronJobStatusPtrInput `pulumi:"status"`
+	Status CronJobStatusInput `pulumi:"status"`
 }
 
 func (CronJobTypeArgs) ElementType() reflect.Type {
@@ -107,28 +107,28 @@ func (o CronJobTypeOutput) ToCronJobTypeOutputWithContext(ctx context.Context) C
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CronJobTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CronJobTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CronJobTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CronJobTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CronJobTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CronJobType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CronJobTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CronJobType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o CronJobTypeOutput) Spec() CronJobSpecPtrOutput {
-	return o.ApplyT(func(v CronJobType) *CronJobSpec { return v.Spec }).(CronJobSpecPtrOutput)
+func (o CronJobTypeOutput) Spec() CronJobSpecOutput {
+	return o.ApplyT(func(v CronJobType) CronJobSpec { return v.Spec }).(CronJobSpecOutput)
 }
 
 // Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o CronJobTypeOutput) Status() CronJobStatusPtrOutput {
-	return o.ApplyT(func(v CronJobType) *CronJobStatus { return v.Status }).(CronJobStatusPtrOutput)
+func (o CronJobTypeOutput) Status() CronJobStatusOutput {
+	return o.ApplyT(func(v CronJobType) CronJobStatus { return v.Status }).(CronJobStatusOutput)
 }
 
 type CronJobTypeArrayOutput struct{ *pulumi.OutputState }
@@ -154,13 +154,13 @@ func (o CronJobTypeArrayOutput) Index(i pulumi.IntInput) CronJobTypeOutput {
 // CronJobList is a collection of cron jobs.
 type CronJobListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items []CronJobType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CronJobListTypeInput is an input type that accepts CronJobListTypeArgs and CronJobListTypeOutput values.
@@ -178,13 +178,13 @@ type CronJobListTypeInput interface {
 // CronJobList is a collection of cron jobs.
 type CronJobListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CronJobs.
 	Items CronJobTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CronJobListTypeArgs) ElementType() reflect.Type {
@@ -215,8 +215,8 @@ func (o CronJobListTypeOutput) ToCronJobListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CronJobListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CronJobListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CronJobs.
@@ -225,13 +225,13 @@ func (o CronJobListTypeOutput) Items() CronJobTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CronJobListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CronJobListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CronJobListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CronJobListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CronJobListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CronJobListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CronJobSpec describes how the job execution will look like and when it will actually run.
@@ -241,9 +241,9 @@ type CronJobSpec struct {
 	// The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
 	FailedJobsHistoryLimit *int `pulumi:"failedJobsHistoryLimit"`
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate *JobTemplateSpec `pulumi:"jobTemplate"`
+	JobTemplate JobTemplateSpec `pulumi:"jobTemplate"`
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-	Schedule *string `pulumi:"schedule"`
+	Schedule string `pulumi:"schedule"`
 	// Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
 	StartingDeadlineSeconds *int `pulumi:"startingDeadlineSeconds"`
 	// The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
@@ -271,9 +271,9 @@ type CronJobSpecArgs struct {
 	// The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
 	FailedJobsHistoryLimit pulumi.IntPtrInput `pulumi:"failedJobsHistoryLimit"`
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate JobTemplateSpecPtrInput `pulumi:"jobTemplate"`
+	JobTemplate JobTemplateSpecInput `pulumi:"jobTemplate"`
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-	Schedule pulumi.StringPtrInput `pulumi:"schedule"`
+	Schedule pulumi.StringInput `pulumi:"schedule"`
 	// Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
 	StartingDeadlineSeconds pulumi.IntPtrInput `pulumi:"startingDeadlineSeconds"`
 	// The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
@@ -372,13 +372,13 @@ func (o CronJobSpecOutput) FailedJobsHistoryLimit() pulumi.IntPtrOutput {
 }
 
 // Specifies the job that will be created when executing a CronJob.
-func (o CronJobSpecOutput) JobTemplate() JobTemplateSpecPtrOutput {
-	return o.ApplyT(func(v CronJobSpec) *JobTemplateSpec { return v.JobTemplate }).(JobTemplateSpecPtrOutput)
+func (o CronJobSpecOutput) JobTemplate() JobTemplateSpecOutput {
+	return o.ApplyT(func(v CronJobSpec) JobTemplateSpec { return v.JobTemplate }).(JobTemplateSpecOutput)
 }
 
 // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-func (o CronJobSpecOutput) Schedule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CronJobSpec) *string { return v.Schedule }).(pulumi.StringPtrOutput)
+func (o CronJobSpecOutput) Schedule() pulumi.StringOutput {
+	return o.ApplyT(func(v CronJobSpec) string { return v.Schedule }).(pulumi.StringOutput)
 }
 
 // Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
@@ -440,7 +440,7 @@ func (o CronJobSpecPtrOutput) JobTemplate() JobTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.JobTemplate
+		return &v.JobTemplate
 	}).(JobTemplateSpecPtrOutput)
 }
 
@@ -450,7 +450,7 @@ func (o CronJobSpecPtrOutput) Schedule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Schedule
+		return &v.Schedule
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequest.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequest.go
@@ -15,14 +15,14 @@ type CertificateSigningRequest struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The certificate request itself and any additional information.
-	Spec CertificateSigningRequestSpecPtrOutput `pulumi:"spec"`
+	Spec CertificateSigningRequestSpecOutput `pulumi:"spec"`
 	// Derived information about the request.
-	Status CertificateSigningRequestStatusPtrOutput `pulumi:"status"`
+	Status CertificateSigningRequestStatusOutput `pulumi:"status"`
 }
 
 // NewCertificateSigningRequest registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestList.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestList.go
@@ -15,11 +15,11 @@ type CertificateSigningRequestList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput                   `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput                      `pulumi:"apiVersion"`
 	Items      CertificateSigningRequestTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCertificateSigningRequestList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/certificates/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/pulumiTypes.go
@@ -14,14 +14,14 @@ import (
 // Describes a certificate signing request
 type CertificateSigningRequestType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The certificate request itself and any additional information.
-	Spec *CertificateSigningRequestSpec `pulumi:"spec"`
+	Spec CertificateSigningRequestSpec `pulumi:"spec"`
 	// Derived information about the request.
-	Status *CertificateSigningRequestStatus `pulumi:"status"`
+	Status CertificateSigningRequestStatus `pulumi:"status"`
 }
 
 // CertificateSigningRequestTypeInput is an input type that accepts CertificateSigningRequestTypeArgs and CertificateSigningRequestTypeOutput values.
@@ -39,14 +39,14 @@ type CertificateSigningRequestTypeInput interface {
 // Describes a certificate signing request
 type CertificateSigningRequestTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The certificate request itself and any additional information.
-	Spec CertificateSigningRequestSpecPtrInput `pulumi:"spec"`
+	Spec CertificateSigningRequestSpecInput `pulumi:"spec"`
 	// Derived information about the request.
-	Status CertificateSigningRequestStatusPtrInput `pulumi:"status"`
+	Status CertificateSigningRequestStatusInput `pulumi:"status"`
 }
 
 func (CertificateSigningRequestTypeArgs) ElementType() reflect.Type {
@@ -103,27 +103,27 @@ func (o CertificateSigningRequestTypeOutput) ToCertificateSigningRequestTypeOutp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CertificateSigningRequestTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CertificateSigningRequestTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CertificateSigningRequestTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CertificateSigningRequestTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CertificateSigningRequestType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The certificate request itself and any additional information.
-func (o CertificateSigningRequestTypeOutput) Spec() CertificateSigningRequestSpecPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestType) *CertificateSigningRequestSpec { return v.Spec }).(CertificateSigningRequestSpecPtrOutput)
+func (o CertificateSigningRequestTypeOutput) Spec() CertificateSigningRequestSpecOutput {
+	return o.ApplyT(func(v CertificateSigningRequestType) CertificateSigningRequestSpec { return v.Spec }).(CertificateSigningRequestSpecOutput)
 }
 
 // Derived information about the request.
-func (o CertificateSigningRequestTypeOutput) Status() CertificateSigningRequestStatusPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestType) *CertificateSigningRequestStatus { return v.Status }).(CertificateSigningRequestStatusPtrOutput)
+func (o CertificateSigningRequestTypeOutput) Status() CertificateSigningRequestStatusOutput {
+	return o.ApplyT(func(v CertificateSigningRequestType) CertificateSigningRequestStatus { return v.Status }).(CertificateSigningRequestStatusOutput)
 }
 
 type CertificateSigningRequestTypeArrayOutput struct{ *pulumi.OutputState }
@@ -154,7 +154,7 @@ type CertificateSigningRequestCondition struct {
 	// brief reason for the request state
 	Reason *string `pulumi:"reason"`
 	// request approval state, currently Approved or Denied.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // CertificateSigningRequestConditionInput is an input type that accepts CertificateSigningRequestConditionArgs and CertificateSigningRequestConditionOutput values.
@@ -177,7 +177,7 @@ type CertificateSigningRequestConditionArgs struct {
 	// brief reason for the request state
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// request approval state, currently Approved or Denied.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (CertificateSigningRequestConditionArgs) ElementType() reflect.Type {
@@ -248,8 +248,8 @@ func (o CertificateSigningRequestConditionOutput) Reason() pulumi.StringPtrOutpu
 }
 
 // request approval state, currently Approved or Denied.
-func (o CertificateSigningRequestConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type CertificateSigningRequestConditionArrayOutput struct{ *pulumi.OutputState }
@@ -274,11 +274,11 @@ func (o CertificateSigningRequestConditionArrayOutput) Index(i pulumi.IntInput) 
 
 type CertificateSigningRequestListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string                         `pulumi:"apiVersion"`
+	ApiVersion string                          `pulumi:"apiVersion"`
 	Items      []CertificateSigningRequestType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CertificateSigningRequestListTypeInput is an input type that accepts CertificateSigningRequestListTypeArgs and CertificateSigningRequestListTypeOutput values.
@@ -295,11 +295,11 @@ type CertificateSigningRequestListTypeInput interface {
 
 type CertificateSigningRequestListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput                   `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput                      `pulumi:"apiVersion"`
 	Items      CertificateSigningRequestTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CertificateSigningRequestListTypeArgs) ElementType() reflect.Type {
@@ -329,8 +329,8 @@ func (o CertificateSigningRequestListTypeOutput) ToCertificateSigningRequestList
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CertificateSigningRequestListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o CertificateSigningRequestListTypeOutput) Items() CertificateSigningRequestTypeArrayOutput {
@@ -338,12 +338,12 @@ func (o CertificateSigningRequestListTypeOutput) Items() CertificateSigningReque
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CertificateSigningRequestListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o CertificateSigningRequestListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CertificateSigningRequestListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CertificateSigningRequestListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // This information is immutable after the request is created. Only the Request and Usages fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.
@@ -353,7 +353,7 @@ type CertificateSigningRequestSpec struct {
 	// Group information about the requesting user. See user.Info interface for details.
 	Groups []string `pulumi:"groups"`
 	// Base64-encoded PKCS#10 CSR data
-	Request *string `pulumi:"request"`
+	Request string `pulumi:"request"`
 	// Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted:
 	//  1. If it's a kubelet client certificate, it is assigned
 	//     "kubernetes.io/kube-apiserver-client-kubelet".
@@ -390,7 +390,7 @@ type CertificateSigningRequestSpecArgs struct {
 	// Group information about the requesting user. See user.Info interface for details.
 	Groups pulumi.StringArrayInput `pulumi:"groups"`
 	// Base64-encoded PKCS#10 CSR data
-	Request pulumi.StringPtrInput `pulumi:"request"`
+	Request pulumi.StringInput `pulumi:"request"`
 	// Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted:
 	//  1. If it's a kubelet client certificate, it is assigned
 	//     "kubernetes.io/kube-apiserver-client-kubelet".
@@ -498,8 +498,8 @@ func (o CertificateSigningRequestSpecOutput) Groups() pulumi.StringArrayOutput {
 }
 
 // Base64-encoded PKCS#10 CSR data
-func (o CertificateSigningRequestSpecOutput) Request() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CertificateSigningRequestSpec) *string { return v.Request }).(pulumi.StringPtrOutput)
+func (o CertificateSigningRequestSpecOutput) Request() pulumi.StringOutput {
+	return o.ApplyT(func(v CertificateSigningRequestSpec) string { return v.Request }).(pulumi.StringOutput)
 }
 
 // Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted:
@@ -573,7 +573,7 @@ func (o CertificateSigningRequestSpecPtrOutput) Request() pulumi.StringPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.Request
+		return &v.Request
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/coordination/v1/lease.go
+++ b/sdk/go/kubernetes/coordination/v1/lease.go
@@ -15,13 +15,13 @@ type Lease struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LeaseSpecPtrOutput `pulumi:"spec"`
+	Spec LeaseSpecOutput `pulumi:"spec"`
 }
 
 // NewLease registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/coordination/v1/leaseList.go
+++ b/sdk/go/kubernetes/coordination/v1/leaseList.go
@@ -16,13 +16,13 @@ type LeaseList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items LeaseTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewLeaseList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/coordination/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/coordination/v1/pulumiTypes.go
@@ -14,13 +14,13 @@ import (
 // Lease defines a lease concept.
 type LeaseType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *LeaseSpec `pulumi:"spec"`
+	Spec LeaseSpec `pulumi:"spec"`
 }
 
 // LeaseTypeInput is an input type that accepts LeaseTypeArgs and LeaseTypeOutput values.
@@ -38,13 +38,13 @@ type LeaseTypeInput interface {
 // Lease defines a lease concept.
 type LeaseTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LeaseSpecPtrInput `pulumi:"spec"`
+	Spec LeaseSpecInput `pulumi:"spec"`
 }
 
 func (LeaseTypeArgs) ElementType() reflect.Type {
@@ -101,23 +101,23 @@ func (o LeaseTypeOutput) ToLeaseTypeOutputWithContext(ctx context.Context) Lease
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LeaseTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LeaseTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LeaseTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LeaseTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o LeaseTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v LeaseType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o LeaseTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v LeaseType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o LeaseTypeOutput) Spec() LeaseSpecPtrOutput {
-	return o.ApplyT(func(v LeaseType) *LeaseSpec { return v.Spec }).(LeaseSpecPtrOutput)
+func (o LeaseTypeOutput) Spec() LeaseSpecOutput {
+	return o.ApplyT(func(v LeaseType) LeaseSpec { return v.Spec }).(LeaseSpecOutput)
 }
 
 type LeaseTypeArrayOutput struct{ *pulumi.OutputState }
@@ -143,13 +143,13 @@ func (o LeaseTypeArrayOutput) Index(i pulumi.IntInput) LeaseTypeOutput {
 // LeaseList is a list of Lease objects.
 type LeaseListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []LeaseType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // LeaseListTypeInput is an input type that accepts LeaseListTypeArgs and LeaseListTypeOutput values.
@@ -167,13 +167,13 @@ type LeaseListTypeInput interface {
 // LeaseList is a list of Lease objects.
 type LeaseListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items LeaseTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (LeaseListTypeArgs) ElementType() reflect.Type {
@@ -204,8 +204,8 @@ func (o LeaseListTypeOutput) ToLeaseListTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LeaseListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LeaseListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -214,13 +214,13 @@ func (o LeaseListTypeOutput) Items() LeaseTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LeaseListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LeaseListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o LeaseListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o LeaseListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v LeaseListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // LeaseSpec is a specification of a Lease.

--- a/sdk/go/kubernetes/coordination/v1beta1/lease.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/lease.go
@@ -15,13 +15,13 @@ type Lease struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LeaseSpecPtrOutput `pulumi:"spec"`
+	Spec LeaseSpecOutput `pulumi:"spec"`
 }
 
 // NewLease registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/coordination/v1beta1/leaseList.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/leaseList.go
@@ -16,13 +16,13 @@ type LeaseList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items LeaseTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewLeaseList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/coordination/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/pulumiTypes.go
@@ -14,13 +14,13 @@ import (
 // Lease defines a lease concept.
 type LeaseType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *LeaseSpec `pulumi:"spec"`
+	Spec LeaseSpec `pulumi:"spec"`
 }
 
 // LeaseTypeInput is an input type that accepts LeaseTypeArgs and LeaseTypeOutput values.
@@ -38,13 +38,13 @@ type LeaseTypeInput interface {
 // Lease defines a lease concept.
 type LeaseTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LeaseSpecPtrInput `pulumi:"spec"`
+	Spec LeaseSpecInput `pulumi:"spec"`
 }
 
 func (LeaseTypeArgs) ElementType() reflect.Type {
@@ -101,23 +101,23 @@ func (o LeaseTypeOutput) ToLeaseTypeOutputWithContext(ctx context.Context) Lease
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LeaseTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LeaseTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LeaseTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LeaseTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o LeaseTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v LeaseType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o LeaseTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v LeaseType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o LeaseTypeOutput) Spec() LeaseSpecPtrOutput {
-	return o.ApplyT(func(v LeaseType) *LeaseSpec { return v.Spec }).(LeaseSpecPtrOutput)
+func (o LeaseTypeOutput) Spec() LeaseSpecOutput {
+	return o.ApplyT(func(v LeaseType) LeaseSpec { return v.Spec }).(LeaseSpecOutput)
 }
 
 type LeaseTypeArrayOutput struct{ *pulumi.OutputState }
@@ -143,13 +143,13 @@ func (o LeaseTypeArrayOutput) Index(i pulumi.IntInput) LeaseTypeOutput {
 // LeaseList is a list of Lease objects.
 type LeaseListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []LeaseType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // LeaseListTypeInput is an input type that accepts LeaseListTypeArgs and LeaseListTypeOutput values.
@@ -167,13 +167,13 @@ type LeaseListTypeInput interface {
 // LeaseList is a list of Lease objects.
 type LeaseListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items LeaseTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (LeaseListTypeArgs) ElementType() reflect.Type {
@@ -204,8 +204,8 @@ func (o LeaseListTypeOutput) ToLeaseListTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LeaseListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LeaseListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -214,13 +214,13 @@ func (o LeaseListTypeOutput) Items() LeaseTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LeaseListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LeaseListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LeaseListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o LeaseListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v LeaseListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o LeaseListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v LeaseListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // LeaseSpec is a specification of a Lease.

--- a/sdk/go/kubernetes/core/v1/binding.go
+++ b/sdk/go/kubernetes/core/v1/binding.go
@@ -16,13 +16,13 @@ type Binding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The target object that you want to bind to the standard object.
-	Target ObjectReferencePtrOutput `pulumi:"target"`
+	Target ObjectReferenceOutput `pulumi:"target"`
 }
 
 // NewBinding registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/componentStatus.go
+++ b/sdk/go/kubernetes/core/v1/componentStatus.go
@@ -15,13 +15,13 @@ type ComponentStatus struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of component conditions observed
 	Conditions ComponentConditionArrayOutput `pulumi:"conditions"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 }
 
 // NewComponentStatus registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/componentStatusList.go
+++ b/sdk/go/kubernetes/core/v1/componentStatusList.go
@@ -16,13 +16,13 @@ type ComponentStatusList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ComponentStatus objects.
 	Items ComponentStatusTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewComponentStatusList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/configMap.go
+++ b/sdk/go/kubernetes/core/v1/configMap.go
@@ -15,17 +15,17 @@ type ConfigMap struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
 	BinaryData pulumi.StringMapOutput `pulumi:"binaryData"`
 	// Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
 	Data pulumi.StringMapOutput `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable pulumi.BoolPtrOutput `pulumi:"immutable"`
+	Immutable pulumi.BoolOutput `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 }
 
 // NewConfigMap registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/configMapList.go
+++ b/sdk/go/kubernetes/core/v1/configMapList.go
@@ -16,13 +16,13 @@ type ConfigMapList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of ConfigMaps.
 	Items ConfigMapTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewConfigMapList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/endpoints.go
+++ b/sdk/go/kubernetes/core/v1/endpoints.go
@@ -26,11 +26,11 @@ type Endpoints struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
 	Subsets EndpointSubsetArrayOutput `pulumi:"subsets"`
 }

--- a/sdk/go/kubernetes/core/v1/endpointsList.go
+++ b/sdk/go/kubernetes/core/v1/endpointsList.go
@@ -16,13 +16,13 @@ type EndpointsList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of endpoints.
 	Items EndpointsTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewEndpointsList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/event.go
+++ b/sdk/go/kubernetes/core/v1/event.go
@@ -16,39 +16,39 @@ type Event struct {
 	pulumi.CustomResourceState
 
 	// What action was taken/failed regarding to the Regarding object.
-	Action pulumi.StringPtrOutput `pulumi:"action"`
+	Action pulumi.StringOutput `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// The number of times this event has occurred.
-	Count pulumi.IntPtrOutput `pulumi:"count"`
+	Count pulumi.IntOutput `pulumi:"count"`
 	// Time when this Event was first observed.
-	EventTime pulumi.StringPtrOutput `pulumi:"eventTime"`
+	EventTime pulumi.StringOutput `pulumi:"eventTime"`
 	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-	FirstTimestamp pulumi.StringPtrOutput `pulumi:"firstTimestamp"`
+	FirstTimestamp pulumi.StringOutput `pulumi:"firstTimestamp"`
 	// The object that this event is about.
-	InvolvedObject ObjectReferencePtrOutput `pulumi:"involvedObject"`
+	InvolvedObject ObjectReferenceOutput `pulumi:"involvedObject"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp pulumi.StringPtrOutput `pulumi:"lastTimestamp"`
+	LastTimestamp pulumi.StringOutput `pulumi:"lastTimestamp"`
 	// A human-readable description of the status of this operation.
-	Message pulumi.StringPtrOutput `pulumi:"message"`
+	Message pulumi.StringOutput `pulumi:"message"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-	Reason pulumi.StringPtrOutput `pulumi:"reason"`
+	Reason pulumi.StringOutput `pulumi:"reason"`
 	// Optional secondary object for more complex actions.
-	Related ObjectReferencePtrOutput `pulumi:"related"`
+	Related ObjectReferenceOutput `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingComponent pulumi.StringPtrOutput `pulumi:"reportingComponent"`
+	ReportingComponent pulumi.StringOutput `pulumi:"reportingComponent"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance pulumi.StringPtrOutput `pulumi:"reportingInstance"`
+	ReportingInstance pulumi.StringOutput `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series EventSeriesPtrOutput `pulumi:"series"`
+	Series EventSeriesOutput `pulumi:"series"`
 	// The component reporting this event. Should be a short machine understandable string.
-	Source EventSourcePtrOutput `pulumi:"source"`
+	Source EventSourceOutput `pulumi:"source"`
 	// Type of this event (Normal, Warning), new types could be added in the future
-	Type pulumi.StringPtrOutput `pulumi:"type"`
+	Type pulumi.StringOutput `pulumi:"type"`
 }
 
 // NewEvent registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/eventList.go
+++ b/sdk/go/kubernetes/core/v1/eventList.go
@@ -16,13 +16,13 @@ type EventList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of events
 	Items EventTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewEventList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/limitRange.go
+++ b/sdk/go/kubernetes/core/v1/limitRange.go
@@ -15,13 +15,13 @@ type LimitRange struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LimitRangeSpecPtrOutput `pulumi:"spec"`
+	Spec LimitRangeSpecOutput `pulumi:"spec"`
 }
 
 // NewLimitRange registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/limitRangeList.go
+++ b/sdk/go/kubernetes/core/v1/limitRangeList.go
@@ -16,13 +16,13 @@ type LimitRangeList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Items LimitRangeTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewLimitRangeList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/namespace.go
+++ b/sdk/go/kubernetes/core/v1/namespace.go
@@ -15,15 +15,15 @@ type Namespace struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec NamespaceSpecPtrOutput `pulumi:"spec"`
+	Spec NamespaceSpecOutput `pulumi:"spec"`
 	// Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status NamespaceStatusPtrOutput `pulumi:"status"`
+	Status NamespaceStatusOutput `pulumi:"status"`
 }
 
 // NewNamespace registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/namespaceList.go
+++ b/sdk/go/kubernetes/core/v1/namespaceList.go
@@ -16,13 +16,13 @@ type NamespaceList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	Items NamespaceTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewNamespaceList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/node.go
+++ b/sdk/go/kubernetes/core/v1/node.go
@@ -15,15 +15,15 @@ type Node struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec NodeSpecPtrOutput `pulumi:"spec"`
+	Spec NodeSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status NodeStatusPtrOutput `pulumi:"status"`
+	Status NodeStatusOutput `pulumi:"status"`
 }
 
 // NewNode registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/nodeList.go
+++ b/sdk/go/kubernetes/core/v1/nodeList.go
@@ -16,13 +16,13 @@ type NodeList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of nodes
 	Items NodeTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewNodeList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/persistentVolume.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolume.go
@@ -15,15 +15,15 @@ type PersistentVolume struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Spec PersistentVolumeSpecPtrOutput `pulumi:"spec"`
+	Spec PersistentVolumeSpecOutput `pulumi:"spec"`
 	// Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Status PersistentVolumeStatusPtrOutput `pulumi:"status"`
+	Status PersistentVolumeStatusOutput `pulumi:"status"`
 }
 
 // NewPersistentVolume registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/persistentVolumeClaim.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeClaim.go
@@ -15,15 +15,15 @@ type PersistentVolumeClaim struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Spec PersistentVolumeClaimSpecPtrOutput `pulumi:"spec"`
+	Spec PersistentVolumeClaimSpecOutput `pulumi:"spec"`
 	// Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Status PersistentVolumeClaimStatusPtrOutput `pulumi:"status"`
+	Status PersistentVolumeClaimStatusOutput `pulumi:"status"`
 }
 
 // NewPersistentVolumeClaim registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/persistentVolumeClaimList.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeClaimList.go
@@ -16,13 +16,13 @@ type PersistentVolumeClaimList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	Items PersistentVolumeClaimTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPersistentVolumeClaimList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/persistentVolumeList.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeList.go
@@ -16,13 +16,13 @@ type PersistentVolumeList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 	Items PersistentVolumeTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPersistentVolumeList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/pod.go
+++ b/sdk/go/kubernetes/core/v1/pod.go
@@ -30,15 +30,15 @@ type Pod struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec PodSpecPtrOutput `pulumi:"spec"`
+	Spec PodSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status PodStatusPtrOutput `pulumi:"status"`
+	Status PodStatusOutput `pulumi:"status"`
 }
 
 // NewPod registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/podList.go
+++ b/sdk/go/kubernetes/core/v1/podList.go
@@ -16,13 +16,13 @@ type PodList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
 	Items PodTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/podTemplate.go
+++ b/sdk/go/kubernetes/core/v1/podTemplate.go
@@ -15,13 +15,13 @@ type PodTemplate struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Template PodTemplateSpecPtrOutput `pulumi:"template"`
+	Template PodTemplateSpecOutput `pulumi:"template"`
 }
 
 // NewPodTemplate registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/podTemplateList.go
+++ b/sdk/go/kubernetes/core/v1/podTemplateList.go
@@ -16,13 +16,13 @@ type PodTemplateList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of pod templates
 	Items PodTemplateTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodTemplateList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/core/v1/pulumiTypes.go
@@ -22,7 +22,7 @@ type AWSElasticBlockStoreVolumeSource struct {
 	// Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	ReadOnly *bool `pulumi:"readOnly"`
 	// Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-	VolumeID *string `pulumi:"volumeID"`
+	VolumeID string `pulumi:"volumeID"`
 }
 
 // AWSElasticBlockStoreVolumeSourceInput is an input type that accepts AWSElasticBlockStoreVolumeSourceArgs and AWSElasticBlockStoreVolumeSourceOutput values.
@@ -48,7 +48,7 @@ type AWSElasticBlockStoreVolumeSourceArgs struct {
 	// Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-	VolumeID pulumi.StringPtrInput `pulumi:"volumeID"`
+	VolumeID pulumi.StringInput `pulumi:"volumeID"`
 }
 
 func (AWSElasticBlockStoreVolumeSourceArgs) ElementType() reflect.Type {
@@ -148,8 +148,8 @@ func (o AWSElasticBlockStoreVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput 
 }
 
 // Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-func (o AWSElasticBlockStoreVolumeSourceOutput) VolumeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AWSElasticBlockStoreVolumeSource) *string { return v.VolumeID }).(pulumi.StringPtrOutput)
+func (o AWSElasticBlockStoreVolumeSourceOutput) VolumeID() pulumi.StringOutput {
+	return o.ApplyT(func(v AWSElasticBlockStoreVolumeSource) string { return v.VolumeID }).(pulumi.StringOutput)
 }
 
 type AWSElasticBlockStoreVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -206,7 +206,7 @@ func (o AWSElasticBlockStoreVolumeSourcePtrOutput) VolumeID() pulumi.StringPtrOu
 		if v == nil {
 			return nil
 		}
-		return v.VolumeID
+		return &v.VolumeID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -387,9 +387,9 @@ func (o AffinityPtrOutput) PodAntiAffinity() PodAntiAffinityPtrOutput {
 // AttachedVolume describes a volume attached to a node
 type AttachedVolume struct {
 	// DevicePath represents the device path where the volume should be available
-	DevicePath *string `pulumi:"devicePath"`
+	DevicePath string `pulumi:"devicePath"`
 	// Name of the attached volume
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // AttachedVolumeInput is an input type that accepts AttachedVolumeArgs and AttachedVolumeOutput values.
@@ -407,9 +407,9 @@ type AttachedVolumeInput interface {
 // AttachedVolume describes a volume attached to a node
 type AttachedVolumeArgs struct {
 	// DevicePath represents the device path where the volume should be available
-	DevicePath pulumi.StringPtrInput `pulumi:"devicePath"`
+	DevicePath pulumi.StringInput `pulumi:"devicePath"`
 	// Name of the attached volume
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (AttachedVolumeArgs) ElementType() reflect.Type {
@@ -466,13 +466,13 @@ func (o AttachedVolumeOutput) ToAttachedVolumeOutputWithContext(ctx context.Cont
 }
 
 // DevicePath represents the device path where the volume should be available
-func (o AttachedVolumeOutput) DevicePath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AttachedVolume) *string { return v.DevicePath }).(pulumi.StringPtrOutput)
+func (o AttachedVolumeOutput) DevicePath() pulumi.StringOutput {
+	return o.ApplyT(func(v AttachedVolume) string { return v.DevicePath }).(pulumi.StringOutput)
 }
 
 // Name of the attached volume
-func (o AttachedVolumeOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AttachedVolume) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o AttachedVolumeOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v AttachedVolume) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type AttachedVolumeArrayOutput struct{ *pulumi.OutputState }
@@ -500,9 +500,9 @@ type AzureDiskVolumeSource struct {
 	// Host Caching mode: None, Read Only, Read Write.
 	CachingMode *string `pulumi:"cachingMode"`
 	// The Name of the data disk in the blob storage
-	DiskName *string `pulumi:"diskName"`
+	DiskName string `pulumi:"diskName"`
 	// The URI the data disk in the blob storage
-	DiskURI *string `pulumi:"diskURI"`
+	DiskURI string `pulumi:"diskURI"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	FsType *string `pulumi:"fsType"`
 	// Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
@@ -528,9 +528,9 @@ type AzureDiskVolumeSourceArgs struct {
 	// Host Caching mode: None, Read Only, Read Write.
 	CachingMode pulumi.StringPtrInput `pulumi:"cachingMode"`
 	// The Name of the data disk in the blob storage
-	DiskName pulumi.StringPtrInput `pulumi:"diskName"`
+	DiskName pulumi.StringInput `pulumi:"diskName"`
 	// The URI the data disk in the blob storage
-	DiskURI pulumi.StringPtrInput `pulumi:"diskURI"`
+	DiskURI pulumi.StringInput `pulumi:"diskURI"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
@@ -624,13 +624,13 @@ func (o AzureDiskVolumeSourceOutput) CachingMode() pulumi.StringPtrOutput {
 }
 
 // The Name of the data disk in the blob storage
-func (o AzureDiskVolumeSourceOutput) DiskName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureDiskVolumeSource) *string { return v.DiskName }).(pulumi.StringPtrOutput)
+func (o AzureDiskVolumeSourceOutput) DiskName() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureDiskVolumeSource) string { return v.DiskName }).(pulumi.StringOutput)
 }
 
 // The URI the data disk in the blob storage
-func (o AzureDiskVolumeSourceOutput) DiskURI() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureDiskVolumeSource) *string { return v.DiskURI }).(pulumi.StringPtrOutput)
+func (o AzureDiskVolumeSourceOutput) DiskURI() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureDiskVolumeSource) string { return v.DiskURI }).(pulumi.StringOutput)
 }
 
 // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
@@ -682,7 +682,7 @@ func (o AzureDiskVolumeSourcePtrOutput) DiskName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.DiskName
+		return &v.DiskName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -692,7 +692,7 @@ func (o AzureDiskVolumeSourcePtrOutput) DiskURI() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.DiskURI
+		return &v.DiskURI
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -731,11 +731,11 @@ type AzureFilePersistentVolumeSource struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// the name of secret that contains Azure Storage Account Name and Key
-	SecretName *string `pulumi:"secretName"`
+	SecretName string `pulumi:"secretName"`
 	// the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
 	SecretNamespace *string `pulumi:"secretNamespace"`
 	// Share Name
-	ShareName *string `pulumi:"shareName"`
+	ShareName string `pulumi:"shareName"`
 }
 
 // AzureFilePersistentVolumeSourceInput is an input type that accepts AzureFilePersistentVolumeSourceArgs and AzureFilePersistentVolumeSourceOutput values.
@@ -755,11 +755,11 @@ type AzureFilePersistentVolumeSourceArgs struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// the name of secret that contains Azure Storage Account Name and Key
-	SecretName pulumi.StringPtrInput `pulumi:"secretName"`
+	SecretName pulumi.StringInput `pulumi:"secretName"`
 	// the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
 	SecretNamespace pulumi.StringPtrInput `pulumi:"secretNamespace"`
 	// Share Name
-	ShareName pulumi.StringPtrInput `pulumi:"shareName"`
+	ShareName pulumi.StringInput `pulumi:"shareName"`
 }
 
 func (AzureFilePersistentVolumeSourceArgs) ElementType() reflect.Type {
@@ -847,8 +847,8 @@ func (o AzureFilePersistentVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // the name of secret that contains Azure Storage Account Name and Key
-func (o AzureFilePersistentVolumeSourceOutput) SecretName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureFilePersistentVolumeSource) *string { return v.SecretName }).(pulumi.StringPtrOutput)
+func (o AzureFilePersistentVolumeSourceOutput) SecretName() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureFilePersistentVolumeSource) string { return v.SecretName }).(pulumi.StringOutput)
 }
 
 // the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
@@ -857,8 +857,8 @@ func (o AzureFilePersistentVolumeSourceOutput) SecretNamespace() pulumi.StringPt
 }
 
 // Share Name
-func (o AzureFilePersistentVolumeSourceOutput) ShareName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureFilePersistentVolumeSource) *string { return v.ShareName }).(pulumi.StringPtrOutput)
+func (o AzureFilePersistentVolumeSourceOutput) ShareName() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureFilePersistentVolumeSource) string { return v.ShareName }).(pulumi.StringOutput)
 }
 
 type AzureFilePersistentVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -895,7 +895,7 @@ func (o AzureFilePersistentVolumeSourcePtrOutput) SecretName() pulumi.StringPtrO
 		if v == nil {
 			return nil
 		}
-		return v.SecretName
+		return &v.SecretName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -915,7 +915,7 @@ func (o AzureFilePersistentVolumeSourcePtrOutput) ShareName() pulumi.StringPtrOu
 		if v == nil {
 			return nil
 		}
-		return v.ShareName
+		return &v.ShareName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -924,9 +924,9 @@ type AzureFileVolumeSource struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// the name of secret that contains Azure Storage Account Name and Key
-	SecretName *string `pulumi:"secretName"`
+	SecretName string `pulumi:"secretName"`
 	// Share Name
-	ShareName *string `pulumi:"shareName"`
+	ShareName string `pulumi:"shareName"`
 }
 
 // AzureFileVolumeSourceInput is an input type that accepts AzureFileVolumeSourceArgs and AzureFileVolumeSourceOutput values.
@@ -946,9 +946,9 @@ type AzureFileVolumeSourceArgs struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// the name of secret that contains Azure Storage Account Name and Key
-	SecretName pulumi.StringPtrInput `pulumi:"secretName"`
+	SecretName pulumi.StringInput `pulumi:"secretName"`
 	// Share Name
-	ShareName pulumi.StringPtrInput `pulumi:"shareName"`
+	ShareName pulumi.StringInput `pulumi:"shareName"`
 }
 
 func (AzureFileVolumeSourceArgs) ElementType() reflect.Type {
@@ -1036,13 +1036,13 @@ func (o AzureFileVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // the name of secret that contains Azure Storage Account Name and Key
-func (o AzureFileVolumeSourceOutput) SecretName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureFileVolumeSource) *string { return v.SecretName }).(pulumi.StringPtrOutput)
+func (o AzureFileVolumeSourceOutput) SecretName() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureFileVolumeSource) string { return v.SecretName }).(pulumi.StringOutput)
 }
 
 // Share Name
-func (o AzureFileVolumeSourceOutput) ShareName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AzureFileVolumeSource) *string { return v.ShareName }).(pulumi.StringPtrOutput)
+func (o AzureFileVolumeSourceOutput) ShareName() pulumi.StringOutput {
+	return o.ApplyT(func(v AzureFileVolumeSource) string { return v.ShareName }).(pulumi.StringOutput)
 }
 
 type AzureFileVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -1079,7 +1079,7 @@ func (o AzureFileVolumeSourcePtrOutput) SecretName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.SecretName
+		return &v.SecretName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1089,20 +1089,20 @@ func (o AzureFileVolumeSourcePtrOutput) ShareName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ShareName
+		return &v.ShareName
 	}).(pulumi.StringPtrOutput)
 }
 
 // Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
 type BindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The target object that you want to bind to the standard object.
-	Target *ObjectReference `pulumi:"target"`
+	Target ObjectReference `pulumi:"target"`
 }
 
 // BindingTypeInput is an input type that accepts BindingTypeArgs and BindingTypeOutput values.
@@ -1120,13 +1120,13 @@ type BindingTypeInput interface {
 // Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
 type BindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The target object that you want to bind to the standard object.
-	Target ObjectReferencePtrInput `pulumi:"target"`
+	Target ObjectReferenceInput `pulumi:"target"`
 }
 
 func (BindingTypeArgs) ElementType() reflect.Type {
@@ -1157,23 +1157,23 @@ func (o BindingTypeOutput) ToBindingTypeOutputWithContext(ctx context.Context) B
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o BindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v BindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o BindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v BindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o BindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v BindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o BindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v BindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o BindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v BindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o BindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v BindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The target object that you want to bind to the standard object.
-func (o BindingTypeOutput) Target() ObjectReferencePtrOutput {
-	return o.ApplyT(func(v BindingType) *ObjectReference { return v.Target }).(ObjectReferencePtrOutput)
+func (o BindingTypeOutput) Target() ObjectReferenceOutput {
+	return o.ApplyT(func(v BindingType) ObjectReference { return v.Target }).(ObjectReferenceOutput)
 }
 
 // Represents storage that is managed by an external CSI volume driver (Beta feature)
@@ -1183,7 +1183,7 @@ type CSIPersistentVolumeSource struct {
 	// ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
 	ControllerPublishSecretRef *SecretReference `pulumi:"controllerPublishSecretRef"`
 	// Driver is the name of the driver to use for this volume. Required.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
 	FsType *string `pulumi:"fsType"`
 	// NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
@@ -1195,7 +1195,7 @@ type CSIPersistentVolumeSource struct {
 	// Attributes of the volume to publish.
 	VolumeAttributes map[string]string `pulumi:"volumeAttributes"`
 	// VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
-	VolumeHandle *string `pulumi:"volumeHandle"`
+	VolumeHandle string `pulumi:"volumeHandle"`
 }
 
 // CSIPersistentVolumeSourceInput is an input type that accepts CSIPersistentVolumeSourceArgs and CSIPersistentVolumeSourceOutput values.
@@ -1217,7 +1217,7 @@ type CSIPersistentVolumeSourceArgs struct {
 	// ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
 	ControllerPublishSecretRef SecretReferencePtrInput `pulumi:"controllerPublishSecretRef"`
 	// Driver is the name of the driver to use for this volume. Required.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
@@ -1229,7 +1229,7 @@ type CSIPersistentVolumeSourceArgs struct {
 	// Attributes of the volume to publish.
 	VolumeAttributes pulumi.StringMapInput `pulumi:"volumeAttributes"`
 	// VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
-	VolumeHandle pulumi.StringPtrInput `pulumi:"volumeHandle"`
+	VolumeHandle pulumi.StringInput `pulumi:"volumeHandle"`
 }
 
 func (CSIPersistentVolumeSourceArgs) ElementType() reflect.Type {
@@ -1322,8 +1322,8 @@ func (o CSIPersistentVolumeSourceOutput) ControllerPublishSecretRef() SecretRefe
 }
 
 // Driver is the name of the driver to use for this volume. Required.
-func (o CSIPersistentVolumeSourceOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIPersistentVolumeSource) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o CSIPersistentVolumeSourceOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIPersistentVolumeSource) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
@@ -1352,8 +1352,8 @@ func (o CSIPersistentVolumeSourceOutput) VolumeAttributes() pulumi.StringMapOutp
 }
 
 // VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
-func (o CSIPersistentVolumeSourceOutput) VolumeHandle() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIPersistentVolumeSource) *string { return v.VolumeHandle }).(pulumi.StringPtrOutput)
+func (o CSIPersistentVolumeSourceOutput) VolumeHandle() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIPersistentVolumeSource) string { return v.VolumeHandle }).(pulumi.StringOutput)
 }
 
 type CSIPersistentVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -1400,7 +1400,7 @@ func (o CSIPersistentVolumeSourcePtrOutput) Driver() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Driver
+		return &v.Driver
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1460,14 +1460,14 @@ func (o CSIPersistentVolumeSourcePtrOutput) VolumeHandle() pulumi.StringPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.VolumeHandle
+		return &v.VolumeHandle
 	}).(pulumi.StringPtrOutput)
 }
 
 // Represents a source location of a volume to mount, managed by an external CSI driver
 type CSIVolumeSource struct {
 	// Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 	// Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
 	FsType *string `pulumi:"fsType"`
 	// NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
@@ -1493,7 +1493,7 @@ type CSIVolumeSourceInput interface {
 // Represents a source location of a volume to mount, managed by an external CSI driver
 type CSIVolumeSourceArgs struct {
 	// Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 	// Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
@@ -1584,8 +1584,8 @@ func (o CSIVolumeSourceOutput) ToCSIVolumeSourcePtrOutputWithContext(ctx context
 }
 
 // Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
-func (o CSIVolumeSourceOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIVolumeSource) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o CSIVolumeSourceOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIVolumeSource) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 // Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
@@ -1632,7 +1632,7 @@ func (o CSIVolumeSourcePtrOutput) Driver() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Driver
+		return &v.Driver
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2302,7 +2302,7 @@ type CinderPersistentVolumeSource struct {
 	// Optional: points to a secret object containing parameters used to connect to OpenStack.
 	SecretRef *SecretReference `pulumi:"secretRef"`
 	// volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-	VolumeID *string `pulumi:"volumeID"`
+	VolumeID string `pulumi:"volumeID"`
 }
 
 // CinderPersistentVolumeSourceInput is an input type that accepts CinderPersistentVolumeSourceArgs and CinderPersistentVolumeSourceOutput values.
@@ -2326,7 +2326,7 @@ type CinderPersistentVolumeSourceArgs struct {
 	// Optional: points to a secret object containing parameters used to connect to OpenStack.
 	SecretRef SecretReferencePtrInput `pulumi:"secretRef"`
 	// volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-	VolumeID pulumi.StringPtrInput `pulumi:"volumeID"`
+	VolumeID pulumi.StringInput `pulumi:"volumeID"`
 }
 
 func (CinderPersistentVolumeSourceArgs) ElementType() reflect.Type {
@@ -2424,8 +2424,8 @@ func (o CinderPersistentVolumeSourceOutput) SecretRef() SecretReferencePtrOutput
 }
 
 // volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-func (o CinderPersistentVolumeSourceOutput) VolumeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CinderPersistentVolumeSource) *string { return v.VolumeID }).(pulumi.StringPtrOutput)
+func (o CinderPersistentVolumeSourceOutput) VolumeID() pulumi.StringOutput {
+	return o.ApplyT(func(v CinderPersistentVolumeSource) string { return v.VolumeID }).(pulumi.StringOutput)
 }
 
 type CinderPersistentVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -2482,7 +2482,7 @@ func (o CinderPersistentVolumeSourcePtrOutput) VolumeID() pulumi.StringPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.VolumeID
+		return &v.VolumeID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2495,7 +2495,7 @@ type CinderVolumeSource struct {
 	// Optional: points to a secret object containing parameters used to connect to OpenStack.
 	SecretRef *LocalObjectReference `pulumi:"secretRef"`
 	// volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-	VolumeID *string `pulumi:"volumeID"`
+	VolumeID string `pulumi:"volumeID"`
 }
 
 // CinderVolumeSourceInput is an input type that accepts CinderVolumeSourceArgs and CinderVolumeSourceOutput values.
@@ -2519,7 +2519,7 @@ type CinderVolumeSourceArgs struct {
 	// Optional: points to a secret object containing parameters used to connect to OpenStack.
 	SecretRef LocalObjectReferencePtrInput `pulumi:"secretRef"`
 	// volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-	VolumeID pulumi.StringPtrInput `pulumi:"volumeID"`
+	VolumeID pulumi.StringInput `pulumi:"volumeID"`
 }
 
 func (CinderVolumeSourceArgs) ElementType() reflect.Type {
@@ -2617,8 +2617,8 @@ func (o CinderVolumeSourceOutput) SecretRef() LocalObjectReferencePtrOutput {
 }
 
 // volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
-func (o CinderVolumeSourceOutput) VolumeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CinderVolumeSource) *string { return v.VolumeID }).(pulumi.StringPtrOutput)
+func (o CinderVolumeSourceOutput) VolumeID() pulumi.StringOutput {
+	return o.ApplyT(func(v CinderVolumeSource) string { return v.VolumeID }).(pulumi.StringOutput)
 }
 
 type CinderVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -2675,7 +2675,7 @@ func (o CinderVolumeSourcePtrOutput) VolumeID() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.VolumeID
+		return &v.VolumeID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2822,9 +2822,9 @@ type ComponentCondition struct {
 	// Message about the condition for a component. For example, information about a health check.
 	Message *string `pulumi:"message"`
 	// Status of the condition for a component. Valid values for "Healthy": "True", "False", or "Unknown".
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of condition for a component. Valid value: "Healthy"
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // ComponentConditionInput is an input type that accepts ComponentConditionArgs and ComponentConditionOutput values.
@@ -2846,9 +2846,9 @@ type ComponentConditionArgs struct {
 	// Message about the condition for a component. For example, information about a health check.
 	Message pulumi.StringPtrInput `pulumi:"message"`
 	// Status of the condition for a component. Valid values for "Healthy": "True", "False", or "Unknown".
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of condition for a component. Valid value: "Healthy"
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (ComponentConditionArgs) ElementType() reflect.Type {
@@ -2915,13 +2915,13 @@ func (o ComponentConditionOutput) Message() pulumi.StringPtrOutput {
 }
 
 // Status of the condition for a component. Valid values for "Healthy": "True", "False", or "Unknown".
-func (o ComponentConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o ComponentConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of condition for a component. Valid value: "Healthy"
-func (o ComponentConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o ComponentConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type ComponentConditionArrayOutput struct{ *pulumi.OutputState }
@@ -2947,13 +2947,13 @@ func (o ComponentConditionArrayOutput) Index(i pulumi.IntInput) ComponentConditi
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatusType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of component conditions observed
 	Conditions []ComponentCondition `pulumi:"conditions"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 }
 
 // ComponentStatusTypeInput is an input type that accepts ComponentStatusTypeArgs and ComponentStatusTypeOutput values.
@@ -2971,13 +2971,13 @@ type ComponentStatusTypeInput interface {
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatusTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of component conditions observed
 	Conditions ComponentConditionArrayInput `pulumi:"conditions"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 }
 
 func (ComponentStatusTypeArgs) ElementType() reflect.Type {
@@ -3034,8 +3034,8 @@ func (o ComponentStatusTypeOutput) ToComponentStatusTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ComponentStatusTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentStatusType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ComponentStatusTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentStatusType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of component conditions observed
@@ -3044,13 +3044,13 @@ func (o ComponentStatusTypeOutput) Conditions() ComponentConditionArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ComponentStatusTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentStatusType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ComponentStatusTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentStatusType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ComponentStatusTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ComponentStatusType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ComponentStatusTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ComponentStatusType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 type ComponentStatusTypeArrayOutput struct{ *pulumi.OutputState }
@@ -3076,13 +3076,13 @@ func (o ComponentStatusTypeArrayOutput) Index(i pulumi.IntInput) ComponentStatus
 // Status of all the conditions for the component as a list of ComponentStatus objects.
 type ComponentStatusListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ComponentStatus objects.
 	Items []ComponentStatusType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ComponentStatusListTypeInput is an input type that accepts ComponentStatusListTypeArgs and ComponentStatusListTypeOutput values.
@@ -3100,13 +3100,13 @@ type ComponentStatusListTypeInput interface {
 // Status of all the conditions for the component as a list of ComponentStatus objects.
 type ComponentStatusListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ComponentStatus objects.
 	Items ComponentStatusTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ComponentStatusListTypeArgs) ElementType() reflect.Type {
@@ -3137,8 +3137,8 @@ func (o ComponentStatusListTypeOutput) ToComponentStatusListTypeOutputWithContex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ComponentStatusListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentStatusListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ComponentStatusListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentStatusListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ComponentStatus objects.
@@ -3147,29 +3147,29 @@ func (o ComponentStatusListTypeOutput) Items() ComponentStatusTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ComponentStatusListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ComponentStatusListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ComponentStatusListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ComponentStatusListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ComponentStatusListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ComponentStatusListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ComponentStatusListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ComponentStatusListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ConfigMap holds configuration data for pods to consume.
 type ConfigMapType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
 	BinaryData map[string]string `pulumi:"binaryData"`
 	// Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
 	Data map[string]string `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable *bool `pulumi:"immutable"`
+	Immutable bool `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 }
 
 // ConfigMapTypeInput is an input type that accepts ConfigMapTypeArgs and ConfigMapTypeOutput values.
@@ -3187,17 +3187,17 @@ type ConfigMapTypeInput interface {
 // ConfigMap holds configuration data for pods to consume.
 type ConfigMapTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
 	BinaryData pulumi.StringMapInput `pulumi:"binaryData"`
 	// Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
 	Data pulumi.StringMapInput `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable pulumi.BoolPtrInput `pulumi:"immutable"`
+	Immutable pulumi.BoolInput `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 }
 
 func (ConfigMapTypeArgs) ElementType() reflect.Type {
@@ -3254,8 +3254,8 @@ func (o ConfigMapTypeOutput) ToConfigMapTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ConfigMapTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ConfigMapTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
@@ -3269,18 +3269,18 @@ func (o ConfigMapTypeOutput) Data() pulumi.StringMapOutput {
 }
 
 // Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-func (o ConfigMapTypeOutput) Immutable() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v ConfigMapType) *bool { return v.Immutable }).(pulumi.BoolPtrOutput)
+func (o ConfigMapTypeOutput) Immutable() pulumi.BoolOutput {
+	return o.ApplyT(func(v ConfigMapType) bool { return v.Immutable }).(pulumi.BoolOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ConfigMapTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ConfigMapTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ConfigMapTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ConfigMapType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ConfigMapTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ConfigMapType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 type ConfigMapTypeArrayOutput struct{ *pulumi.OutputState }
@@ -3467,7 +3467,7 @@ func (o ConfigMapEnvSourcePtrOutput) Optional() pulumi.BoolPtrOutput {
 // Selects a key from a ConfigMap.
 type ConfigMapKeySelector struct {
 	// The key to select.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name *string `pulumi:"name"`
 	// Specify whether the ConfigMap or its key must be defined
@@ -3489,7 +3489,7 @@ type ConfigMapKeySelectorInput interface {
 // Selects a key from a ConfigMap.
 type ConfigMapKeySelectorArgs struct {
 	// The key to select.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name pulumi.StringPtrInput `pulumi:"name"`
 	// Specify whether the ConfigMap or its key must be defined
@@ -3576,8 +3576,8 @@ func (o ConfigMapKeySelectorOutput) ToConfigMapKeySelectorPtrOutputWithContext(c
 }
 
 // The key to select.
-func (o ConfigMapKeySelectorOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapKeySelector) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o ConfigMapKeySelectorOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapKeySelector) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -3614,7 +3614,7 @@ func (o ConfigMapKeySelectorPtrOutput) Key() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Key
+		return &v.Key
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3641,13 +3641,13 @@ func (o ConfigMapKeySelectorPtrOutput) Optional() pulumi.BoolPtrOutput {
 // ConfigMapList is a resource containing a list of ConfigMap objects.
 type ConfigMapListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of ConfigMaps.
 	Items []ConfigMapType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ConfigMapListTypeInput is an input type that accepts ConfigMapListTypeArgs and ConfigMapListTypeOutput values.
@@ -3665,13 +3665,13 @@ type ConfigMapListTypeInput interface {
 // ConfigMapList is a resource containing a list of ConfigMap objects.
 type ConfigMapListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of ConfigMaps.
 	Items ConfigMapTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ConfigMapListTypeArgs) ElementType() reflect.Type {
@@ -3702,8 +3702,8 @@ func (o ConfigMapListTypeOutput) ToConfigMapListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ConfigMapListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ConfigMapListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of ConfigMaps.
@@ -3712,23 +3712,23 @@ func (o ConfigMapListTypeOutput) Items() ConfigMapTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ConfigMapListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ConfigMapListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ConfigMapListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ConfigMapListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ConfigMapListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ConfigMapListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.
 type ConfigMapNodeConfigSource struct {
 	// KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
-	KubeletConfigKey *string `pulumi:"kubeletConfigKey"`
+	KubeletConfigKey string `pulumi:"kubeletConfigKey"`
 	// Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 	// ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
 	ResourceVersion *string `pulumi:"resourceVersion"`
 	// UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
@@ -3750,11 +3750,11 @@ type ConfigMapNodeConfigSourceInput interface {
 // ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.
 type ConfigMapNodeConfigSourceArgs struct {
 	// KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
-	KubeletConfigKey pulumi.StringPtrInput `pulumi:"kubeletConfigKey"`
+	KubeletConfigKey pulumi.StringInput `pulumi:"kubeletConfigKey"`
 	// Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 	// ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
 	ResourceVersion pulumi.StringPtrInput `pulumi:"resourceVersion"`
 	// UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
@@ -3841,18 +3841,18 @@ func (o ConfigMapNodeConfigSourceOutput) ToConfigMapNodeConfigSourcePtrOutputWit
 }
 
 // KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
-func (o ConfigMapNodeConfigSourceOutput) KubeletConfigKey() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapNodeConfigSource) *string { return v.KubeletConfigKey }).(pulumi.StringPtrOutput)
+func (o ConfigMapNodeConfigSourceOutput) KubeletConfigKey() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapNodeConfigSource) string { return v.KubeletConfigKey }).(pulumi.StringOutput)
 }
 
 // Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
-func (o ConfigMapNodeConfigSourceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapNodeConfigSource) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ConfigMapNodeConfigSourceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapNodeConfigSource) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
-func (o ConfigMapNodeConfigSourceOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ConfigMapNodeConfigSource) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ConfigMapNodeConfigSourceOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ConfigMapNodeConfigSource) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 // ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
@@ -3889,7 +3889,7 @@ func (o ConfigMapNodeConfigSourcePtrOutput) KubeletConfigKey() pulumi.StringPtrO
 		if v == nil {
 			return nil
 		}
-		return v.KubeletConfigKey
+		return &v.KubeletConfigKey
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3899,7 +3899,7 @@ func (o ConfigMapNodeConfigSourcePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3909,7 +3909,7 @@ func (o ConfigMapNodeConfigSourcePtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -4331,7 +4331,7 @@ type Container struct {
 	// Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	LivenessProbe *Probe `pulumi:"livenessProbe"`
 	// Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
 	Ports []ContainerPort `pulumi:"ports"`
 	// Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
@@ -4391,7 +4391,7 @@ type ContainerArgs struct {
 	// Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	LivenessProbe ProbePtrInput `pulumi:"livenessProbe"`
 	// Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
 	Ports ContainerPortArrayInput `pulumi:"ports"`
 	// Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
@@ -4514,8 +4514,8 @@ func (o ContainerOutput) LivenessProbe() ProbePtrOutput {
 }
 
 // Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
-func (o ContainerOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Container) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ContainerOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Container) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
@@ -4717,7 +4717,7 @@ func (o ContainerImageArrayOutput) Index(i pulumi.IntInput) ContainerImageOutput
 // ContainerPort represents a network port in a single container.
 type ContainerPort struct {
 	// Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
-	ContainerPort *int `pulumi:"containerPort"`
+	ContainerPort int `pulumi:"containerPort"`
 	// What host IP to bind the external port to.
 	HostIP *string `pulumi:"hostIP"`
 	// Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
@@ -4743,7 +4743,7 @@ type ContainerPortInput interface {
 // ContainerPort represents a network port in a single container.
 type ContainerPortArgs struct {
 	// Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
-	ContainerPort pulumi.IntPtrInput `pulumi:"containerPort"`
+	ContainerPort pulumi.IntInput `pulumi:"containerPort"`
 	// What host IP to bind the external port to.
 	HostIP pulumi.StringPtrInput `pulumi:"hostIP"`
 	// Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
@@ -4808,8 +4808,8 @@ func (o ContainerPortOutput) ToContainerPortOutputWithContext(ctx context.Contex
 }
 
 // Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
-func (o ContainerPortOutput) ContainerPort() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ContainerPort) *int { return v.ContainerPort }).(pulumi.IntPtrOutput)
+func (o ContainerPortOutput) ContainerPort() pulumi.IntOutput {
+	return o.ApplyT(func(v ContainerPort) int { return v.ContainerPort }).(pulumi.IntOutput)
 }
 
 // What host IP to bind the external port to.
@@ -5167,7 +5167,7 @@ type ContainerStateTerminated struct {
 	// Container's ID in the format 'docker://<container_id>'
 	ContainerID *string `pulumi:"containerID"`
 	// Exit status from the last termination of the container
-	ExitCode *int `pulumi:"exitCode"`
+	ExitCode int `pulumi:"exitCode"`
 	// Time at which the container last terminated
 	FinishedAt *string `pulumi:"finishedAt"`
 	// Message regarding the last termination of the container
@@ -5197,7 +5197,7 @@ type ContainerStateTerminatedArgs struct {
 	// Container's ID in the format 'docker://<container_id>'
 	ContainerID pulumi.StringPtrInput `pulumi:"containerID"`
 	// Exit status from the last termination of the container
-	ExitCode pulumi.IntPtrInput `pulumi:"exitCode"`
+	ExitCode pulumi.IntInput `pulumi:"exitCode"`
 	// Time at which the container last terminated
 	FinishedAt pulumi.StringPtrInput `pulumi:"finishedAt"`
 	// Message regarding the last termination of the container
@@ -5295,8 +5295,8 @@ func (o ContainerStateTerminatedOutput) ContainerID() pulumi.StringPtrOutput {
 }
 
 // Exit status from the last termination of the container
-func (o ContainerStateTerminatedOutput) ExitCode() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ContainerStateTerminated) *int { return v.ExitCode }).(pulumi.IntPtrOutput)
+func (o ContainerStateTerminatedOutput) ExitCode() pulumi.IntOutput {
+	return o.ApplyT(func(v ContainerStateTerminated) int { return v.ExitCode }).(pulumi.IntOutput)
 }
 
 // Time at which the container last terminated
@@ -5358,7 +5358,7 @@ func (o ContainerStateTerminatedPtrOutput) ExitCode() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ExitCode
+		return &v.ExitCode
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -5572,17 +5572,17 @@ type ContainerStatus struct {
 	// Container's ID in the format 'docker://<container_id>'.
 	ContainerID *string `pulumi:"containerID"`
 	// The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
-	Image *string `pulumi:"image"`
+	Image string `pulumi:"image"`
 	// ImageID of the container's image.
-	ImageID *string `pulumi:"imageID"`
+	ImageID string `pulumi:"imageID"`
 	// Details about the container's last termination condition.
 	LastState *ContainerState `pulumi:"lastState"`
 	// This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Specifies whether the container has passed its readiness probe.
-	Ready *bool `pulumi:"ready"`
+	Ready bool `pulumi:"ready"`
 	// The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
-	RestartCount *int `pulumi:"restartCount"`
+	RestartCount int `pulumi:"restartCount"`
 	// Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
 	Started *bool `pulumi:"started"`
 	// Details about the container's current condition.
@@ -5606,17 +5606,17 @@ type ContainerStatusArgs struct {
 	// Container's ID in the format 'docker://<container_id>'.
 	ContainerID pulumi.StringPtrInput `pulumi:"containerID"`
 	// The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
-	Image pulumi.StringPtrInput `pulumi:"image"`
+	Image pulumi.StringInput `pulumi:"image"`
 	// ImageID of the container's image.
-	ImageID pulumi.StringPtrInput `pulumi:"imageID"`
+	ImageID pulumi.StringInput `pulumi:"imageID"`
 	// Details about the container's last termination condition.
 	LastState ContainerStatePtrInput `pulumi:"lastState"`
 	// This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Specifies whether the container has passed its readiness probe.
-	Ready pulumi.BoolPtrInput `pulumi:"ready"`
+	Ready pulumi.BoolInput `pulumi:"ready"`
 	// The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
-	RestartCount pulumi.IntPtrInput `pulumi:"restartCount"`
+	RestartCount pulumi.IntInput `pulumi:"restartCount"`
 	// Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
 	Started pulumi.BoolPtrInput `pulumi:"started"`
 	// Details about the container's current condition.
@@ -5682,13 +5682,13 @@ func (o ContainerStatusOutput) ContainerID() pulumi.StringPtrOutput {
 }
 
 // The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
-func (o ContainerStatusOutput) Image() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ContainerStatus) *string { return v.Image }).(pulumi.StringPtrOutput)
+func (o ContainerStatusOutput) Image() pulumi.StringOutput {
+	return o.ApplyT(func(v ContainerStatus) string { return v.Image }).(pulumi.StringOutput)
 }
 
 // ImageID of the container's image.
-func (o ContainerStatusOutput) ImageID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ContainerStatus) *string { return v.ImageID }).(pulumi.StringPtrOutput)
+func (o ContainerStatusOutput) ImageID() pulumi.StringOutput {
+	return o.ApplyT(func(v ContainerStatus) string { return v.ImageID }).(pulumi.StringOutput)
 }
 
 // Details about the container's last termination condition.
@@ -5697,18 +5697,18 @@ func (o ContainerStatusOutput) LastState() ContainerStatePtrOutput {
 }
 
 // This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
-func (o ContainerStatusOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ContainerStatus) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ContainerStatusOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ContainerStatus) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Specifies whether the container has passed its readiness probe.
-func (o ContainerStatusOutput) Ready() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v ContainerStatus) *bool { return v.Ready }).(pulumi.BoolPtrOutput)
+func (o ContainerStatusOutput) Ready() pulumi.BoolOutput {
+	return o.ApplyT(func(v ContainerStatus) bool { return v.Ready }).(pulumi.BoolOutput)
 }
 
 // The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
-func (o ContainerStatusOutput) RestartCount() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ContainerStatus) *int { return v.RestartCount }).(pulumi.IntPtrOutput)
+func (o ContainerStatusOutput) RestartCount() pulumi.IntOutput {
+	return o.ApplyT(func(v ContainerStatus) int { return v.RestartCount }).(pulumi.IntOutput)
 }
 
 // Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
@@ -5744,7 +5744,7 @@ func (o ContainerStatusArrayOutput) Index(i pulumi.IntInput) ContainerStatusOutp
 // DaemonEndpoint contains information about a single Daemon endpoint.
 type DaemonEndpoint struct {
 	// Port number of the given endpoint.
-	Port *int `pulumi:"Port"`
+	Port int `pulumi:"Port"`
 }
 
 // DaemonEndpointInput is an input type that accepts DaemonEndpointArgs and DaemonEndpointOutput values.
@@ -5762,7 +5762,7 @@ type DaemonEndpointInput interface {
 // DaemonEndpoint contains information about a single Daemon endpoint.
 type DaemonEndpointArgs struct {
 	// Port number of the given endpoint.
-	Port pulumi.IntPtrInput `pulumi:"Port"`
+	Port pulumi.IntInput `pulumi:"Port"`
 }
 
 func (DaemonEndpointArgs) ElementType() reflect.Type {
@@ -5845,8 +5845,8 @@ func (o DaemonEndpointOutput) ToDaemonEndpointPtrOutputWithContext(ctx context.C
 }
 
 // Port number of the given endpoint.
-func (o DaemonEndpointOutput) Port() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonEndpoint) *int { return v.Port }).(pulumi.IntPtrOutput)
+func (o DaemonEndpointOutput) Port() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonEndpoint) int { return v.Port }).(pulumi.IntOutput)
 }
 
 type DaemonEndpointPtrOutput struct{ *pulumi.OutputState }
@@ -5873,7 +5873,7 @@ func (o DaemonEndpointPtrOutput) Port() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Port
+		return &v.Port
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -6020,7 +6020,7 @@ type DownwardAPIVolumeFile struct {
 	// Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 	Mode *int `pulumi:"mode"`
 	// Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 	// Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 	ResourceFieldRef *ResourceFieldSelector `pulumi:"resourceFieldRef"`
 }
@@ -6044,7 +6044,7 @@ type DownwardAPIVolumeFileArgs struct {
 	// Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 	Mode pulumi.IntPtrInput `pulumi:"mode"`
 	// Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 	// Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 	ResourceFieldRef ResourceFieldSelectorPtrInput `pulumi:"resourceFieldRef"`
 }
@@ -6113,8 +6113,8 @@ func (o DownwardAPIVolumeFileOutput) Mode() pulumi.IntPtrOutput {
 }
 
 // Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
-func (o DownwardAPIVolumeFileOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DownwardAPIVolumeFile) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o DownwardAPIVolumeFileOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v DownwardAPIVolumeFile) string { return v.Path }).(pulumi.StringOutput)
 }
 
 // Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
@@ -6457,7 +6457,7 @@ type EndpointAddress struct {
 	// The Hostname of this endpoint
 	Hostname *string `pulumi:"hostname"`
 	// The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
-	Ip *string `pulumi:"ip"`
+	Ip string `pulumi:"ip"`
 	// Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
 	NodeName *string `pulumi:"nodeName"`
 	// Reference to object providing the endpoint.
@@ -6481,7 +6481,7 @@ type EndpointAddressArgs struct {
 	// The Hostname of this endpoint
 	Hostname pulumi.StringPtrInput `pulumi:"hostname"`
 	// The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
-	Ip pulumi.StringPtrInput `pulumi:"ip"`
+	Ip pulumi.StringInput `pulumi:"ip"`
 	// Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
 	NodeName pulumi.StringPtrInput `pulumi:"nodeName"`
 	// Reference to object providing the endpoint.
@@ -6547,8 +6547,8 @@ func (o EndpointAddressOutput) Hostname() pulumi.StringPtrOutput {
 }
 
 // The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
-func (o EndpointAddressOutput) Ip() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointAddress) *string { return v.Ip }).(pulumi.StringPtrOutput)
+func (o EndpointAddressOutput) Ip() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointAddress) string { return v.Ip }).(pulumi.StringOutput)
 }
 
 // Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
@@ -6588,7 +6588,7 @@ type EndpointPort struct {
 	// The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
 	Name *string `pulumi:"name"`
 	// The port number of the endpoint.
-	Port *int `pulumi:"port"`
+	Port int `pulumi:"port"`
 	// The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
 	Protocol *string `pulumi:"protocol"`
 }
@@ -6612,7 +6612,7 @@ type EndpointPortArgs struct {
 	// The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
 	Name pulumi.StringPtrInput `pulumi:"name"`
 	// The port number of the endpoint.
-	Port pulumi.IntPtrInput `pulumi:"port"`
+	Port pulumi.IntInput `pulumi:"port"`
 	// The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
 	Protocol pulumi.StringPtrInput `pulumi:"protocol"`
 }
@@ -6681,8 +6681,8 @@ func (o EndpointPortOutput) Name() pulumi.StringPtrOutput {
 }
 
 // The port number of the endpoint.
-func (o EndpointPortOutput) Port() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v EndpointPort) *int { return v.Port }).(pulumi.IntPtrOutput)
+func (o EndpointPortOutput) Port() pulumi.IntOutput {
+	return o.ApplyT(func(v EndpointPort) int { return v.Port }).(pulumi.IntOutput)
 }
 
 // The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
@@ -6865,11 +6865,11 @@ func (o EndpointSubsetArrayOutput) Index(i pulumi.IntInput) EndpointSubsetOutput
 //  ]
 type EndpointsType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
 	Subsets []EndpointSubset `pulumi:"subsets"`
 }
@@ -6900,11 +6900,11 @@ type EndpointsTypeInput interface {
 //  ]
 type EndpointsTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
 	Subsets EndpointSubsetArrayInput `pulumi:"subsets"`
 }
@@ -6974,18 +6974,18 @@ func (o EndpointsTypeOutput) ToEndpointsTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EndpointsTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointsType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EndpointsTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointsType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EndpointsTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointsType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EndpointsTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointsType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o EndpointsTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v EndpointsType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o EndpointsTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v EndpointsType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
@@ -7016,13 +7016,13 @@ func (o EndpointsTypeArrayOutput) Index(i pulumi.IntInput) EndpointsTypeOutput {
 // EndpointsList is a list of endpoints.
 type EndpointsListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of endpoints.
 	Items []EndpointsType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // EndpointsListTypeInput is an input type that accepts EndpointsListTypeArgs and EndpointsListTypeOutput values.
@@ -7040,13 +7040,13 @@ type EndpointsListTypeInput interface {
 // EndpointsList is a list of endpoints.
 type EndpointsListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of endpoints.
 	Items EndpointsTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (EndpointsListTypeArgs) ElementType() reflect.Type {
@@ -7077,8 +7077,8 @@ func (o EndpointsListTypeOutput) ToEndpointsListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EndpointsListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointsListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EndpointsListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointsListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of endpoints.
@@ -7087,13 +7087,13 @@ func (o EndpointsListTypeOutput) Items() EndpointsTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EndpointsListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointsListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EndpointsListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointsListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EndpointsListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v EndpointsListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o EndpointsListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v EndpointsListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // EnvFromSource represents the source of a set of ConfigMaps
@@ -7219,7 +7219,7 @@ func (o EnvFromSourceArrayOutput) Index(i pulumi.IntInput) EnvFromSourceOutput {
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
 	// Name of the environment variable. Must be a C_IDENTIFIER.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
 	Value *string `pulumi:"value"`
 	// Source for the environment variable's value. Cannot be used if value is not empty.
@@ -7241,7 +7241,7 @@ type EnvVarInput interface {
 // EnvVar represents an environment variable present in a Container.
 type EnvVarArgs struct {
 	// Name of the environment variable. Must be a C_IDENTIFIER.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
 	Value pulumi.StringPtrInput `pulumi:"value"`
 	// Source for the environment variable's value. Cannot be used if value is not empty.
@@ -7302,8 +7302,8 @@ func (o EnvVarOutput) ToEnvVarOutputWithContext(ctx context.Context) EnvVarOutpu
 }
 
 // Name of the environment variable. Must be a C_IDENTIFIER.
-func (o EnvVarOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EnvVar) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o EnvVarOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v EnvVar) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
@@ -7548,7 +7548,7 @@ type EphemeralContainer struct {
 	// Probes are not allowed for ephemeral containers.
 	LivenessProbe *Probe `pulumi:"livenessProbe"`
 	// Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Ports are not allowed for ephemeral containers.
 	Ports []ContainerPort `pulumi:"ports"`
 	// Probes are not allowed for ephemeral containers.
@@ -7610,7 +7610,7 @@ type EphemeralContainerArgs struct {
 	// Probes are not allowed for ephemeral containers.
 	LivenessProbe ProbePtrInput `pulumi:"livenessProbe"`
 	// Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Ports are not allowed for ephemeral containers.
 	Ports ContainerPortArrayInput `pulumi:"ports"`
 	// Probes are not allowed for ephemeral containers.
@@ -7735,8 +7735,8 @@ func (o EphemeralContainerOutput) LivenessProbe() ProbePtrOutput {
 }
 
 // Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
-func (o EphemeralContainerOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EphemeralContainer) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o EphemeralContainerOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v EphemeralContainer) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Ports are not allowed for ephemeral containers.
@@ -7832,39 +7832,39 @@ func (o EphemeralContainerArrayOutput) Index(i pulumi.IntInput) EphemeralContain
 // Event is a report of an event somewhere in the cluster.
 type EventType struct {
 	// What action was taken/failed regarding to the Regarding object.
-	Action *string `pulumi:"action"`
+	Action string `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// The number of times this event has occurred.
-	Count *int `pulumi:"count"`
+	Count int `pulumi:"count"`
 	// Time when this Event was first observed.
-	EventTime *string `pulumi:"eventTime"`
+	EventTime string `pulumi:"eventTime"`
 	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-	FirstTimestamp *string `pulumi:"firstTimestamp"`
+	FirstTimestamp string `pulumi:"firstTimestamp"`
 	// The object that this event is about.
-	InvolvedObject *ObjectReference `pulumi:"involvedObject"`
+	InvolvedObject ObjectReference `pulumi:"involvedObject"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp *string `pulumi:"lastTimestamp"`
+	LastTimestamp string `pulumi:"lastTimestamp"`
 	// A human-readable description of the status of this operation.
-	Message *string `pulumi:"message"`
+	Message string `pulumi:"message"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-	Reason *string `pulumi:"reason"`
+	Reason string `pulumi:"reason"`
 	// Optional secondary object for more complex actions.
-	Related *ObjectReference `pulumi:"related"`
+	Related ObjectReference `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingComponent *string `pulumi:"reportingComponent"`
+	ReportingComponent string `pulumi:"reportingComponent"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance *string `pulumi:"reportingInstance"`
+	ReportingInstance string `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series *EventSeries `pulumi:"series"`
+	Series EventSeries `pulumi:"series"`
 	// The component reporting this event. Should be a short machine understandable string.
-	Source *EventSource `pulumi:"source"`
+	Source EventSource `pulumi:"source"`
 	// Type of this event (Normal, Warning), new types could be added in the future
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // EventTypeInput is an input type that accepts EventTypeArgs and EventTypeOutput values.
@@ -7882,39 +7882,39 @@ type EventTypeInput interface {
 // Event is a report of an event somewhere in the cluster.
 type EventTypeArgs struct {
 	// What action was taken/failed regarding to the Regarding object.
-	Action pulumi.StringPtrInput `pulumi:"action"`
+	Action pulumi.StringInput `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// The number of times this event has occurred.
-	Count pulumi.IntPtrInput `pulumi:"count"`
+	Count pulumi.IntInput `pulumi:"count"`
 	// Time when this Event was first observed.
-	EventTime pulumi.StringPtrInput `pulumi:"eventTime"`
+	EventTime pulumi.StringInput `pulumi:"eventTime"`
 	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-	FirstTimestamp pulumi.StringPtrInput `pulumi:"firstTimestamp"`
+	FirstTimestamp pulumi.StringInput `pulumi:"firstTimestamp"`
 	// The object that this event is about.
-	InvolvedObject ObjectReferencePtrInput `pulumi:"involvedObject"`
+	InvolvedObject ObjectReferenceInput `pulumi:"involvedObject"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp pulumi.StringPtrInput `pulumi:"lastTimestamp"`
+	LastTimestamp pulumi.StringInput `pulumi:"lastTimestamp"`
 	// A human-readable description of the status of this operation.
-	Message pulumi.StringPtrInput `pulumi:"message"`
+	Message pulumi.StringInput `pulumi:"message"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-	Reason pulumi.StringPtrInput `pulumi:"reason"`
+	Reason pulumi.StringInput `pulumi:"reason"`
 	// Optional secondary object for more complex actions.
-	Related ObjectReferencePtrInput `pulumi:"related"`
+	Related ObjectReferenceInput `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingComponent pulumi.StringPtrInput `pulumi:"reportingComponent"`
+	ReportingComponent pulumi.StringInput `pulumi:"reportingComponent"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance pulumi.StringPtrInput `pulumi:"reportingInstance"`
+	ReportingInstance pulumi.StringInput `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series EventSeriesPtrInput `pulumi:"series"`
+	Series EventSeriesInput `pulumi:"series"`
 	// The component reporting this event. Should be a short machine understandable string.
-	Source EventSourcePtrInput `pulumi:"source"`
+	Source EventSourceInput `pulumi:"source"`
 	// Type of this event (Normal, Warning), new types could be added in the future
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (EventTypeArgs) ElementType() reflect.Type {
@@ -7971,88 +7971,88 @@ func (o EventTypeOutput) ToEventTypeOutputWithContext(ctx context.Context) Event
 }
 
 // What action was taken/failed regarding to the Regarding object.
-func (o EventTypeOutput) Action() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Action }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Action() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Action }).(pulumi.StringOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EventTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // The number of times this event has occurred.
-func (o EventTypeOutput) Count() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v EventType) *int { return v.Count }).(pulumi.IntPtrOutput)
+func (o EventTypeOutput) Count() pulumi.IntOutput {
+	return o.ApplyT(func(v EventType) int { return v.Count }).(pulumi.IntOutput)
 }
 
 // Time when this Event was first observed.
-func (o EventTypeOutput) EventTime() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.EventTime }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) EventTime() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.EventTime }).(pulumi.StringOutput)
 }
 
 // The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-func (o EventTypeOutput) FirstTimestamp() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.FirstTimestamp }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) FirstTimestamp() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.FirstTimestamp }).(pulumi.StringOutput)
 }
 
 // The object that this event is about.
-func (o EventTypeOutput) InvolvedObject() ObjectReferencePtrOutput {
-	return o.ApplyT(func(v EventType) *ObjectReference { return v.InvolvedObject }).(ObjectReferencePtrOutput)
+func (o EventTypeOutput) InvolvedObject() ObjectReferenceOutput {
+	return o.ApplyT(func(v EventType) ObjectReference { return v.InvolvedObject }).(ObjectReferenceOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EventTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // The time at which the most recent occurrence of this event was recorded.
-func (o EventTypeOutput) LastTimestamp() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.LastTimestamp }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) LastTimestamp() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.LastTimestamp }).(pulumi.StringOutput)
 }
 
 // A human-readable description of the status of this operation.
-func (o EventTypeOutput) Message() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Message }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Message() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Message }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o EventTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v EventType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o EventTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v EventType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-func (o EventTypeOutput) Reason() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Reason }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Reason() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Reason }).(pulumi.StringOutput)
 }
 
 // Optional secondary object for more complex actions.
-func (o EventTypeOutput) Related() ObjectReferencePtrOutput {
-	return o.ApplyT(func(v EventType) *ObjectReference { return v.Related }).(ObjectReferencePtrOutput)
+func (o EventTypeOutput) Related() ObjectReferenceOutput {
+	return o.ApplyT(func(v EventType) ObjectReference { return v.Related }).(ObjectReferenceOutput)
 }
 
 // Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-func (o EventTypeOutput) ReportingComponent() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ReportingComponent }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ReportingComponent() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ReportingComponent }).(pulumi.StringOutput)
 }
 
 // ID of the controller instance, e.g. `kubelet-xyzf`.
-func (o EventTypeOutput) ReportingInstance() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ReportingInstance }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ReportingInstance() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ReportingInstance }).(pulumi.StringOutput)
 }
 
 // Data about the Event series this event represents or nil if it's a singleton Event.
-func (o EventTypeOutput) Series() EventSeriesPtrOutput {
-	return o.ApplyT(func(v EventType) *EventSeries { return v.Series }).(EventSeriesPtrOutput)
+func (o EventTypeOutput) Series() EventSeriesOutput {
+	return o.ApplyT(func(v EventType) EventSeries { return v.Series }).(EventSeriesOutput)
 }
 
 // The component reporting this event. Should be a short machine understandable string.
-func (o EventTypeOutput) Source() EventSourcePtrOutput {
-	return o.ApplyT(func(v EventType) *EventSource { return v.Source }).(EventSourcePtrOutput)
+func (o EventTypeOutput) Source() EventSourceOutput {
+	return o.ApplyT(func(v EventType) EventSource { return v.Source }).(EventSourceOutput)
 }
 
 // Type of this event (Normal, Warning), new types could be added in the future
-func (o EventTypeOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type EventTypeArrayOutput struct{ *pulumi.OutputState }
@@ -8078,13 +8078,13 @@ func (o EventTypeArrayOutput) Index(i pulumi.IntInput) EventTypeOutput {
 // EventList is a list of events.
 type EventListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of events
 	Items []EventType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // EventListTypeInput is an input type that accepts EventListTypeArgs and EventListTypeOutput values.
@@ -8102,13 +8102,13 @@ type EventListTypeInput interface {
 // EventList is a list of events.
 type EventListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of events
 	Items EventTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (EventListTypeArgs) ElementType() reflect.Type {
@@ -8139,8 +8139,8 @@ func (o EventListTypeOutput) ToEventListTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EventListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EventListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EventListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of events
@@ -8149,13 +8149,13 @@ func (o EventListTypeOutput) Items() EventTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EventListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EventListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EventListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EventListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v EventListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o EventListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v EventListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
@@ -8838,7 +8838,7 @@ func (o FCVolumeSourcePtrOutput) Wwids() pulumi.StringArrayOutput {
 // FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.
 type FlexPersistentVolumeSource struct {
 	// Driver is the name of the driver to use for this volume.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	FsType *string `pulumi:"fsType"`
 	// Optional: Extra command options if any.
@@ -8864,7 +8864,7 @@ type FlexPersistentVolumeSourceInput interface {
 // FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.
 type FlexPersistentVolumeSourceArgs struct {
 	// Driver is the name of the driver to use for this volume.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// Optional: Extra command options if any.
@@ -8955,8 +8955,8 @@ func (o FlexPersistentVolumeSourceOutput) ToFlexPersistentVolumeSourcePtrOutputW
 }
 
 // Driver is the name of the driver to use for this volume.
-func (o FlexPersistentVolumeSourceOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlexPersistentVolumeSource) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o FlexPersistentVolumeSourceOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v FlexPersistentVolumeSource) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
@@ -9003,7 +9003,7 @@ func (o FlexPersistentVolumeSourcePtrOutput) Driver() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Driver
+		return &v.Driver
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9050,7 +9050,7 @@ func (o FlexPersistentVolumeSourcePtrOutput) SecretRef() SecretReferencePtrOutpu
 // FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
 type FlexVolumeSource struct {
 	// Driver is the name of the driver to use for this volume.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	FsType *string `pulumi:"fsType"`
 	// Optional: Extra command options if any.
@@ -9076,7 +9076,7 @@ type FlexVolumeSourceInput interface {
 // FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
 type FlexVolumeSourceArgs struct {
 	// Driver is the name of the driver to use for this volume.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// Optional: Extra command options if any.
@@ -9167,8 +9167,8 @@ func (o FlexVolumeSourceOutput) ToFlexVolumeSourcePtrOutputWithContext(ctx conte
 }
 
 // Driver is the name of the driver to use for this volume.
-func (o FlexVolumeSourceOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlexVolumeSource) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o FlexVolumeSourceOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v FlexVolumeSource) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
@@ -9215,7 +9215,7 @@ func (o FlexVolumeSourcePtrOutput) Driver() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Driver
+		return &v.Driver
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9423,7 +9423,7 @@ type GCEPersistentDiskVolumeSource struct {
 	// The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	Partition *int `pulumi:"partition"`
 	// Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-	PdName *string `pulumi:"pdName"`
+	PdName string `pulumi:"pdName"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	ReadOnly *bool `pulumi:"readOnly"`
 }
@@ -9449,7 +9449,7 @@ type GCEPersistentDiskVolumeSourceArgs struct {
 	// The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	Partition pulumi.IntPtrInput `pulumi:"partition"`
 	// Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-	PdName pulumi.StringPtrInput `pulumi:"pdName"`
+	PdName pulumi.StringInput `pulumi:"pdName"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 }
@@ -9546,8 +9546,8 @@ func (o GCEPersistentDiskVolumeSourceOutput) Partition() pulumi.IntPtrOutput {
 }
 
 // Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-func (o GCEPersistentDiskVolumeSourceOutput) PdName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GCEPersistentDiskVolumeSource) *string { return v.PdName }).(pulumi.StringPtrOutput)
+func (o GCEPersistentDiskVolumeSourceOutput) PdName() pulumi.StringOutput {
+	return o.ApplyT(func(v GCEPersistentDiskVolumeSource) string { return v.PdName }).(pulumi.StringOutput)
 }
 
 // ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -9599,7 +9599,7 @@ func (o GCEPersistentDiskVolumeSourcePtrOutput) PdName() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.PdName
+		return &v.PdName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9620,7 +9620,7 @@ type GitRepoVolumeSource struct {
 	// Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
 	Directory *string `pulumi:"directory"`
 	// Repository URL
-	Repository *string `pulumi:"repository"`
+	Repository string `pulumi:"repository"`
 	// Commit hash for the specified revision.
 	Revision *string `pulumi:"revision"`
 }
@@ -9644,7 +9644,7 @@ type GitRepoVolumeSourceArgs struct {
 	// Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
 	Directory pulumi.StringPtrInput `pulumi:"directory"`
 	// Repository URL
-	Repository pulumi.StringPtrInput `pulumi:"repository"`
+	Repository pulumi.StringInput `pulumi:"repository"`
 	// Commit hash for the specified revision.
 	Revision pulumi.StringPtrInput `pulumi:"revision"`
 }
@@ -9736,8 +9736,8 @@ func (o GitRepoVolumeSourceOutput) Directory() pulumi.StringPtrOutput {
 }
 
 // Repository URL
-func (o GitRepoVolumeSourceOutput) Repository() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GitRepoVolumeSource) *string { return v.Repository }).(pulumi.StringPtrOutput)
+func (o GitRepoVolumeSourceOutput) Repository() pulumi.StringOutput {
+	return o.ApplyT(func(v GitRepoVolumeSource) string { return v.Repository }).(pulumi.StringOutput)
 }
 
 // Commit hash for the specified revision.
@@ -9779,7 +9779,7 @@ func (o GitRepoVolumeSourcePtrOutput) Repository() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Repository
+		return &v.Repository
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9796,11 +9796,11 @@ func (o GitRepoVolumeSourcePtrOutput) Revision() pulumi.StringPtrOutput {
 // Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsPersistentVolumeSource struct {
 	// EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Endpoints *string `pulumi:"endpoints"`
+	Endpoints string `pulumi:"endpoints"`
 	// EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	EndpointsNamespace *string `pulumi:"endpointsNamespace"`
 	// Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	ReadOnly *bool `pulumi:"readOnly"`
 }
@@ -9820,11 +9820,11 @@ type GlusterfsPersistentVolumeSourceInput interface {
 // Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsPersistentVolumeSourceArgs struct {
 	// EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Endpoints pulumi.StringPtrInput `pulumi:"endpoints"`
+	Endpoints pulumi.StringInput `pulumi:"endpoints"`
 	// EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	EndpointsNamespace pulumi.StringPtrInput `pulumi:"endpointsNamespace"`
 	// Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 }
@@ -9909,8 +9909,8 @@ func (o GlusterfsPersistentVolumeSourceOutput) ToGlusterfsPersistentVolumeSource
 }
 
 // EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-func (o GlusterfsPersistentVolumeSourceOutput) Endpoints() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GlusterfsPersistentVolumeSource) *string { return v.Endpoints }).(pulumi.StringPtrOutput)
+func (o GlusterfsPersistentVolumeSourceOutput) Endpoints() pulumi.StringOutput {
+	return o.ApplyT(func(v GlusterfsPersistentVolumeSource) string { return v.Endpoints }).(pulumi.StringOutput)
 }
 
 // EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
@@ -9919,8 +9919,8 @@ func (o GlusterfsPersistentVolumeSourceOutput) EndpointsNamespace() pulumi.Strin
 }
 
 // Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-func (o GlusterfsPersistentVolumeSourceOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GlusterfsPersistentVolumeSource) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o GlusterfsPersistentVolumeSourceOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v GlusterfsPersistentVolumeSource) string { return v.Path }).(pulumi.StringOutput)
 }
 
 // ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
@@ -9952,7 +9952,7 @@ func (o GlusterfsPersistentVolumeSourcePtrOutput) Endpoints() pulumi.StringPtrOu
 		if v == nil {
 			return nil
 		}
-		return v.Endpoints
+		return &v.Endpoints
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9972,7 +9972,7 @@ func (o GlusterfsPersistentVolumeSourcePtrOutput) Path() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -9989,9 +9989,9 @@ func (o GlusterfsPersistentVolumeSourcePtrOutput) ReadOnly() pulumi.BoolPtrOutpu
 // Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsVolumeSource struct {
 	// EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Endpoints *string `pulumi:"endpoints"`
+	Endpoints string `pulumi:"endpoints"`
 	// Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	ReadOnly *bool `pulumi:"readOnly"`
 }
@@ -10011,9 +10011,9 @@ type GlusterfsVolumeSourceInput interface {
 // Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsVolumeSourceArgs struct {
 	// EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Endpoints pulumi.StringPtrInput `pulumi:"endpoints"`
+	Endpoints pulumi.StringInput `pulumi:"endpoints"`
 	// Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 }
@@ -10098,13 +10098,13 @@ func (o GlusterfsVolumeSourceOutput) ToGlusterfsVolumeSourcePtrOutputWithContext
 }
 
 // EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-func (o GlusterfsVolumeSourceOutput) Endpoints() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GlusterfsVolumeSource) *string { return v.Endpoints }).(pulumi.StringPtrOutput)
+func (o GlusterfsVolumeSourceOutput) Endpoints() pulumi.StringOutput {
+	return o.ApplyT(func(v GlusterfsVolumeSource) string { return v.Endpoints }).(pulumi.StringOutput)
 }
 
 // Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-func (o GlusterfsVolumeSourceOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GlusterfsVolumeSource) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o GlusterfsVolumeSourceOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v GlusterfsVolumeSource) string { return v.Path }).(pulumi.StringOutput)
 }
 
 // ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
@@ -10136,7 +10136,7 @@ func (o GlusterfsVolumeSourcePtrOutput) Endpoints() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Endpoints
+		return &v.Endpoints
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -10146,7 +10146,7 @@ func (o GlusterfsVolumeSourcePtrOutput) Path() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -10375,9 +10375,9 @@ func (o HTTPGetActionPtrOutput) Scheme() pulumi.StringPtrOutput {
 // HTTPHeader describes a custom header to be used in HTTP probes
 type HTTPHeader struct {
 	// The header field name
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The header field value
-	Value *string `pulumi:"value"`
+	Value string `pulumi:"value"`
 }
 
 // HTTPHeaderInput is an input type that accepts HTTPHeaderArgs and HTTPHeaderOutput values.
@@ -10395,9 +10395,9 @@ type HTTPHeaderInput interface {
 // HTTPHeader describes a custom header to be used in HTTP probes
 type HTTPHeaderArgs struct {
 	// The header field name
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// The header field value
-	Value pulumi.StringPtrInput `pulumi:"value"`
+	Value pulumi.StringInput `pulumi:"value"`
 }
 
 func (HTTPHeaderArgs) ElementType() reflect.Type {
@@ -10454,13 +10454,13 @@ func (o HTTPHeaderOutput) ToHTTPHeaderOutputWithContext(ctx context.Context) HTT
 }
 
 // The header field name
-func (o HTTPHeaderOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HTTPHeader) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o HTTPHeaderOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v HTTPHeader) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // The header field value
-func (o HTTPHeaderOutput) Value() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HTTPHeader) *string { return v.Value }).(pulumi.StringPtrOutput)
+func (o HTTPHeaderOutput) Value() pulumi.StringOutput {
+	return o.ApplyT(func(v HTTPHeader) string { return v.Value }).(pulumi.StringOutput)
 }
 
 type HTTPHeaderArrayOutput struct{ *pulumi.OutputState }
@@ -10771,7 +10771,7 @@ func (o HostAliasArrayOutput) Index(i pulumi.IntInput) HostAliasOutput {
 // Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
 type HostPathVolumeSource struct {
 	// Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 	// Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 	Type *string `pulumi:"type"`
 }
@@ -10791,7 +10791,7 @@ type HostPathVolumeSourceInput interface {
 // Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
 type HostPathVolumeSourceArgs struct {
 	// Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 	// Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 	Type pulumi.StringPtrInput `pulumi:"type"`
 }
@@ -10876,8 +10876,8 @@ func (o HostPathVolumeSourceOutput) ToHostPathVolumeSourcePtrOutputWithContext(c
 }
 
 // Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-func (o HostPathVolumeSourceOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v HostPathVolumeSource) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o HostPathVolumeSourceOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v HostPathVolumeSource) string { return v.Path }).(pulumi.StringOutput)
 }
 
 // Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
@@ -10909,7 +10909,7 @@ func (o HostPathVolumeSourcePtrOutput) Path() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -10934,11 +10934,11 @@ type ISCSIPersistentVolumeSource struct {
 	// Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
 	InitiatorName *string `pulumi:"initiatorName"`
 	// Target iSCSI Qualified Name.
-	Iqn *string `pulumi:"iqn"`
+	Iqn string `pulumi:"iqn"`
 	// iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
 	IscsiInterface *string `pulumi:"iscsiInterface"`
 	// iSCSI Target Lun number.
-	Lun *int `pulumi:"lun"`
+	Lun int `pulumi:"lun"`
 	// iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
 	Portals []string `pulumi:"portals"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
@@ -10946,7 +10946,7 @@ type ISCSIPersistentVolumeSource struct {
 	// CHAP Secret for iSCSI target and initiator authentication
 	SecretRef *SecretReference `pulumi:"secretRef"`
 	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-	TargetPortal *string `pulumi:"targetPortal"`
+	TargetPortal string `pulumi:"targetPortal"`
 }
 
 // ISCSIPersistentVolumeSourceInput is an input type that accepts ISCSIPersistentVolumeSourceArgs and ISCSIPersistentVolumeSourceOutput values.
@@ -10972,11 +10972,11 @@ type ISCSIPersistentVolumeSourceArgs struct {
 	// Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
 	InitiatorName pulumi.StringPtrInput `pulumi:"initiatorName"`
 	// Target iSCSI Qualified Name.
-	Iqn pulumi.StringPtrInput `pulumi:"iqn"`
+	Iqn pulumi.StringInput `pulumi:"iqn"`
 	// iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
 	IscsiInterface pulumi.StringPtrInput `pulumi:"iscsiInterface"`
 	// iSCSI Target Lun number.
-	Lun pulumi.IntPtrInput `pulumi:"lun"`
+	Lun pulumi.IntInput `pulumi:"lun"`
 	// iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
 	Portals pulumi.StringArrayInput `pulumi:"portals"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
@@ -10984,7 +10984,7 @@ type ISCSIPersistentVolumeSourceArgs struct {
 	// CHAP Secret for iSCSI target and initiator authentication
 	SecretRef SecretReferencePtrInput `pulumi:"secretRef"`
 	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-	TargetPortal pulumi.StringPtrInput `pulumi:"targetPortal"`
+	TargetPortal pulumi.StringInput `pulumi:"targetPortal"`
 }
 
 func (ISCSIPersistentVolumeSourceArgs) ElementType() reflect.Type {
@@ -11087,8 +11087,8 @@ func (o ISCSIPersistentVolumeSourceOutput) InitiatorName() pulumi.StringPtrOutpu
 }
 
 // Target iSCSI Qualified Name.
-func (o ISCSIPersistentVolumeSourceOutput) Iqn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ISCSIPersistentVolumeSource) *string { return v.Iqn }).(pulumi.StringPtrOutput)
+func (o ISCSIPersistentVolumeSourceOutput) Iqn() pulumi.StringOutput {
+	return o.ApplyT(func(v ISCSIPersistentVolumeSource) string { return v.Iqn }).(pulumi.StringOutput)
 }
 
 // iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
@@ -11097,8 +11097,8 @@ func (o ISCSIPersistentVolumeSourceOutput) IscsiInterface() pulumi.StringPtrOutp
 }
 
 // iSCSI Target Lun number.
-func (o ISCSIPersistentVolumeSourceOutput) Lun() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ISCSIPersistentVolumeSource) *int { return v.Lun }).(pulumi.IntPtrOutput)
+func (o ISCSIPersistentVolumeSourceOutput) Lun() pulumi.IntOutput {
+	return o.ApplyT(func(v ISCSIPersistentVolumeSource) int { return v.Lun }).(pulumi.IntOutput)
 }
 
 // iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
@@ -11117,8 +11117,8 @@ func (o ISCSIPersistentVolumeSourceOutput) SecretRef() SecretReferencePtrOutput 
 }
 
 // iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-func (o ISCSIPersistentVolumeSourceOutput) TargetPortal() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ISCSIPersistentVolumeSource) *string { return v.TargetPortal }).(pulumi.StringPtrOutput)
+func (o ISCSIPersistentVolumeSourceOutput) TargetPortal() pulumi.StringOutput {
+	return o.ApplyT(func(v ISCSIPersistentVolumeSource) string { return v.TargetPortal }).(pulumi.StringOutput)
 }
 
 type ISCSIPersistentVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -11185,7 +11185,7 @@ func (o ISCSIPersistentVolumeSourcePtrOutput) Iqn() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Iqn
+		return &v.Iqn
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -11205,7 +11205,7 @@ func (o ISCSIPersistentVolumeSourcePtrOutput) Lun() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Lun
+		return &v.Lun
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -11245,7 +11245,7 @@ func (o ISCSIPersistentVolumeSourcePtrOutput) TargetPortal() pulumi.StringPtrOut
 		if v == nil {
 			return nil
 		}
-		return v.TargetPortal
+		return &v.TargetPortal
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -11260,11 +11260,11 @@ type ISCSIVolumeSource struct {
 	// Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
 	InitiatorName *string `pulumi:"initiatorName"`
 	// Target iSCSI Qualified Name.
-	Iqn *string `pulumi:"iqn"`
+	Iqn string `pulumi:"iqn"`
 	// iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
 	IscsiInterface *string `pulumi:"iscsiInterface"`
 	// iSCSI Target Lun number.
-	Lun *int `pulumi:"lun"`
+	Lun int `pulumi:"lun"`
 	// iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
 	Portals []string `pulumi:"portals"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
@@ -11272,7 +11272,7 @@ type ISCSIVolumeSource struct {
 	// CHAP Secret for iSCSI target and initiator authentication
 	SecretRef *LocalObjectReference `pulumi:"secretRef"`
 	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-	TargetPortal *string `pulumi:"targetPortal"`
+	TargetPortal string `pulumi:"targetPortal"`
 }
 
 // ISCSIVolumeSourceInput is an input type that accepts ISCSIVolumeSourceArgs and ISCSIVolumeSourceOutput values.
@@ -11298,11 +11298,11 @@ type ISCSIVolumeSourceArgs struct {
 	// Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
 	InitiatorName pulumi.StringPtrInput `pulumi:"initiatorName"`
 	// Target iSCSI Qualified Name.
-	Iqn pulumi.StringPtrInput `pulumi:"iqn"`
+	Iqn pulumi.StringInput `pulumi:"iqn"`
 	// iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
 	IscsiInterface pulumi.StringPtrInput `pulumi:"iscsiInterface"`
 	// iSCSI Target Lun number.
-	Lun pulumi.IntPtrInput `pulumi:"lun"`
+	Lun pulumi.IntInput `pulumi:"lun"`
 	// iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
 	Portals pulumi.StringArrayInput `pulumi:"portals"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
@@ -11310,7 +11310,7 @@ type ISCSIVolumeSourceArgs struct {
 	// CHAP Secret for iSCSI target and initiator authentication
 	SecretRef LocalObjectReferencePtrInput `pulumi:"secretRef"`
 	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-	TargetPortal pulumi.StringPtrInput `pulumi:"targetPortal"`
+	TargetPortal pulumi.StringInput `pulumi:"targetPortal"`
 }
 
 func (ISCSIVolumeSourceArgs) ElementType() reflect.Type {
@@ -11413,8 +11413,8 @@ func (o ISCSIVolumeSourceOutput) InitiatorName() pulumi.StringPtrOutput {
 }
 
 // Target iSCSI Qualified Name.
-func (o ISCSIVolumeSourceOutput) Iqn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ISCSIVolumeSource) *string { return v.Iqn }).(pulumi.StringPtrOutput)
+func (o ISCSIVolumeSourceOutput) Iqn() pulumi.StringOutput {
+	return o.ApplyT(func(v ISCSIVolumeSource) string { return v.Iqn }).(pulumi.StringOutput)
 }
 
 // iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
@@ -11423,8 +11423,8 @@ func (o ISCSIVolumeSourceOutput) IscsiInterface() pulumi.StringPtrOutput {
 }
 
 // iSCSI Target Lun number.
-func (o ISCSIVolumeSourceOutput) Lun() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ISCSIVolumeSource) *int { return v.Lun }).(pulumi.IntPtrOutput)
+func (o ISCSIVolumeSourceOutput) Lun() pulumi.IntOutput {
+	return o.ApplyT(func(v ISCSIVolumeSource) int { return v.Lun }).(pulumi.IntOutput)
 }
 
 // iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
@@ -11443,8 +11443,8 @@ func (o ISCSIVolumeSourceOutput) SecretRef() LocalObjectReferencePtrOutput {
 }
 
 // iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-func (o ISCSIVolumeSourceOutput) TargetPortal() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ISCSIVolumeSource) *string { return v.TargetPortal }).(pulumi.StringPtrOutput)
+func (o ISCSIVolumeSourceOutput) TargetPortal() pulumi.StringOutput {
+	return o.ApplyT(func(v ISCSIVolumeSource) string { return v.TargetPortal }).(pulumi.StringOutput)
 }
 
 type ISCSIVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -11511,7 +11511,7 @@ func (o ISCSIVolumeSourcePtrOutput) Iqn() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Iqn
+		return &v.Iqn
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -11531,7 +11531,7 @@ func (o ISCSIVolumeSourcePtrOutput) Lun() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Lun
+		return &v.Lun
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -11571,18 +11571,18 @@ func (o ISCSIVolumeSourcePtrOutput) TargetPortal() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.TargetPortal
+		return &v.TargetPortal
 	}).(pulumi.StringPtrOutput)
 }
 
 // Maps a string key to a path within a volume.
 type KeyToPath struct {
 	// The key to project.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 	Mode *int `pulumi:"mode"`
 	// The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 }
 
 // KeyToPathInput is an input type that accepts KeyToPathArgs and KeyToPathOutput values.
@@ -11600,11 +11600,11 @@ type KeyToPathInput interface {
 // Maps a string key to a path within a volume.
 type KeyToPathArgs struct {
 	// The key to project.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
 	Mode pulumi.IntPtrInput `pulumi:"mode"`
 	// The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 }
 
 func (KeyToPathArgs) ElementType() reflect.Type {
@@ -11661,8 +11661,8 @@ func (o KeyToPathOutput) ToKeyToPathOutputWithContext(ctx context.Context) KeyTo
 }
 
 // The key to project.
-func (o KeyToPathOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v KeyToPath) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o KeyToPathOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v KeyToPath) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
@@ -11671,8 +11671,8 @@ func (o KeyToPathOutput) Mode() pulumi.IntPtrOutput {
 }
 
 // The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-func (o KeyToPathOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v KeyToPath) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o KeyToPathOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v KeyToPath) string { return v.Path }).(pulumi.StringOutput)
 }
 
 type KeyToPathArrayOutput struct{ *pulumi.OutputState }
@@ -11853,13 +11853,13 @@ func (o LifecyclePtrOutput) PreStop() HandlerPtrOutput {
 // LimitRange sets resource usage limits for each kind of resource in a Namespace.
 type LimitRangeType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *LimitRangeSpec `pulumi:"spec"`
+	Spec LimitRangeSpec `pulumi:"spec"`
 }
 
 // LimitRangeTypeInput is an input type that accepts LimitRangeTypeArgs and LimitRangeTypeOutput values.
@@ -11877,13 +11877,13 @@ type LimitRangeTypeInput interface {
 // LimitRange sets resource usage limits for each kind of resource in a Namespace.
 type LimitRangeTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec LimitRangeSpecPtrInput `pulumi:"spec"`
+	Spec LimitRangeSpecInput `pulumi:"spec"`
 }
 
 func (LimitRangeTypeArgs) ElementType() reflect.Type {
@@ -11940,23 +11940,23 @@ func (o LimitRangeTypeOutput) ToLimitRangeTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LimitRangeTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitRangeType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LimitRangeTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitRangeType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LimitRangeTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitRangeType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LimitRangeTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitRangeType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o LimitRangeTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v LimitRangeType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o LimitRangeTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v LimitRangeType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o LimitRangeTypeOutput) Spec() LimitRangeSpecPtrOutput {
-	return o.ApplyT(func(v LimitRangeType) *LimitRangeSpec { return v.Spec }).(LimitRangeSpecPtrOutput)
+func (o LimitRangeTypeOutput) Spec() LimitRangeSpecOutput {
+	return o.ApplyT(func(v LimitRangeType) LimitRangeSpec { return v.Spec }).(LimitRangeSpecOutput)
 }
 
 type LimitRangeTypeArrayOutput struct{ *pulumi.OutputState }
@@ -11992,7 +11992,7 @@ type LimitRangeItem struct {
 	// Min usage constraints on this kind by resource name.
 	Min map[string]string `pulumi:"min"`
 	// Type of resource that this limit applies to.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // LimitRangeItemInput is an input type that accepts LimitRangeItemArgs and LimitRangeItemOutput values.
@@ -12020,7 +12020,7 @@ type LimitRangeItemArgs struct {
 	// Min usage constraints on this kind by resource name.
 	Min pulumi.StringMapInput `pulumi:"min"`
 	// Type of resource that this limit applies to.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (LimitRangeItemArgs) ElementType() reflect.Type {
@@ -12102,8 +12102,8 @@ func (o LimitRangeItemOutput) Min() pulumi.StringMapOutput {
 }
 
 // Type of resource that this limit applies to.
-func (o LimitRangeItemOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitRangeItem) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o LimitRangeItemOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitRangeItem) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type LimitRangeItemArrayOutput struct{ *pulumi.OutputState }
@@ -12129,13 +12129,13 @@ func (o LimitRangeItemArrayOutput) Index(i pulumi.IntInput) LimitRangeItemOutput
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Items []LimitRangeType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // LimitRangeListTypeInput is an input type that accepts LimitRangeListTypeArgs and LimitRangeListTypeOutput values.
@@ -12153,13 +12153,13 @@ type LimitRangeListTypeInput interface {
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Items LimitRangeTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (LimitRangeListTypeArgs) ElementType() reflect.Type {
@@ -12190,8 +12190,8 @@ func (o LimitRangeListTypeOutput) ToLimitRangeListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o LimitRangeListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitRangeListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o LimitRangeListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitRangeListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -12200,13 +12200,13 @@ func (o LimitRangeListTypeOutput) Items() LimitRangeTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LimitRangeListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitRangeListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o LimitRangeListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitRangeListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o LimitRangeListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v LimitRangeListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o LimitRangeListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v LimitRangeListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // LimitRangeSpec defines a min/max usage limit for resources that match on kind.
@@ -12779,7 +12779,7 @@ type LocalVolumeSource struct {
 	// Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a fileystem if unspecified.
 	FsType *string `pulumi:"fsType"`
 	// The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 }
 
 // LocalVolumeSourceInput is an input type that accepts LocalVolumeSourceArgs and LocalVolumeSourceOutput values.
@@ -12799,7 +12799,7 @@ type LocalVolumeSourceArgs struct {
 	// Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a fileystem if unspecified.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 }
 
 func (LocalVolumeSourceArgs) ElementType() reflect.Type {
@@ -12887,8 +12887,8 @@ func (o LocalVolumeSourceOutput) FsType() pulumi.StringPtrOutput {
 }
 
 // The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
-func (o LocalVolumeSourceOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LocalVolumeSource) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o LocalVolumeSourceOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v LocalVolumeSource) string { return v.Path }).(pulumi.StringOutput)
 }
 
 type LocalVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -12925,18 +12925,18 @@ func (o LocalVolumeSourcePtrOutput) Path() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
 // Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
 type NFSVolumeSource struct {
 	// Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 	// ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	ReadOnly *bool `pulumi:"readOnly"`
 	// Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-	Server *string `pulumi:"server"`
+	Server string `pulumi:"server"`
 }
 
 // NFSVolumeSourceInput is an input type that accepts NFSVolumeSourceArgs and NFSVolumeSourceOutput values.
@@ -12954,11 +12954,11 @@ type NFSVolumeSourceInput interface {
 // Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
 type NFSVolumeSourceArgs struct {
 	// Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 	// ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-	Server pulumi.StringPtrInput `pulumi:"server"`
+	Server pulumi.StringInput `pulumi:"server"`
 }
 
 func (NFSVolumeSourceArgs) ElementType() reflect.Type {
@@ -13041,8 +13041,8 @@ func (o NFSVolumeSourceOutput) ToNFSVolumeSourcePtrOutputWithContext(ctx context
 }
 
 // Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-func (o NFSVolumeSourceOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NFSVolumeSource) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o NFSVolumeSourceOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v NFSVolumeSource) string { return v.Path }).(pulumi.StringOutput)
 }
 
 // ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
@@ -13051,8 +13051,8 @@ func (o NFSVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
-func (o NFSVolumeSourceOutput) Server() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NFSVolumeSource) *string { return v.Server }).(pulumi.StringPtrOutput)
+func (o NFSVolumeSourceOutput) Server() pulumi.StringOutput {
+	return o.ApplyT(func(v NFSVolumeSource) string { return v.Server }).(pulumi.StringOutput)
 }
 
 type NFSVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -13079,7 +13079,7 @@ func (o NFSVolumeSourcePtrOutput) Path() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -13099,22 +13099,22 @@ func (o NFSVolumeSourcePtrOutput) Server() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Server
+		return &v.Server
 	}).(pulumi.StringPtrOutput)
 }
 
 // Namespace provides a scope for Names. Use of multiple namespaces is optional.
 type NamespaceType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *NamespaceSpec `pulumi:"spec"`
+	Spec NamespaceSpec `pulumi:"spec"`
 	// Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *NamespaceStatus `pulumi:"status"`
+	Status NamespaceStatus `pulumi:"status"`
 }
 
 // NamespaceTypeInput is an input type that accepts NamespaceTypeArgs and NamespaceTypeOutput values.
@@ -13132,15 +13132,15 @@ type NamespaceTypeInput interface {
 // Namespace provides a scope for Names. Use of multiple namespaces is optional.
 type NamespaceTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec NamespaceSpecPtrInput `pulumi:"spec"`
+	Spec NamespaceSpecInput `pulumi:"spec"`
 	// Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status NamespaceStatusPtrInput `pulumi:"status"`
+	Status NamespaceStatusInput `pulumi:"status"`
 }
 
 func (NamespaceTypeArgs) ElementType() reflect.Type {
@@ -13197,28 +13197,28 @@ func (o NamespaceTypeOutput) ToNamespaceTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NamespaceTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NamespaceTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NamespaceTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NamespaceTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NamespaceTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v NamespaceType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o NamespaceTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v NamespaceType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o NamespaceTypeOutput) Spec() NamespaceSpecPtrOutput {
-	return o.ApplyT(func(v NamespaceType) *NamespaceSpec { return v.Spec }).(NamespaceSpecPtrOutput)
+func (o NamespaceTypeOutput) Spec() NamespaceSpecOutput {
+	return o.ApplyT(func(v NamespaceType) NamespaceSpec { return v.Spec }).(NamespaceSpecOutput)
 }
 
 // Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o NamespaceTypeOutput) Status() NamespaceStatusPtrOutput {
-	return o.ApplyT(func(v NamespaceType) *NamespaceStatus { return v.Status }).(NamespaceStatusPtrOutput)
+func (o NamespaceTypeOutput) Status() NamespaceStatusOutput {
+	return o.ApplyT(func(v NamespaceType) NamespaceStatus { return v.Status }).(NamespaceStatusOutput)
 }
 
 type NamespaceTypeArrayOutput struct{ *pulumi.OutputState }
@@ -13247,9 +13247,9 @@ type NamespaceCondition struct {
 	Message            *string `pulumi:"message"`
 	Reason             *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of namespace controller condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // NamespaceConditionInput is an input type that accepts NamespaceConditionArgs and NamespaceConditionOutput values.
@@ -13270,9 +13270,9 @@ type NamespaceConditionArgs struct {
 	Message            pulumi.StringPtrInput `pulumi:"message"`
 	Reason             pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of namespace controller condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (NamespaceConditionArgs) ElementType() reflect.Type {
@@ -13341,13 +13341,13 @@ func (o NamespaceConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o NamespaceConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o NamespaceConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of namespace controller condition.
-func (o NamespaceConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o NamespaceConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type NamespaceConditionArrayOutput struct{ *pulumi.OutputState }
@@ -13373,13 +13373,13 @@ func (o NamespaceConditionArrayOutput) Index(i pulumi.IntInput) NamespaceConditi
 // NamespaceList is a list of Namespaces.
 type NamespaceListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	Items []NamespaceType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // NamespaceListTypeInput is an input type that accepts NamespaceListTypeArgs and NamespaceListTypeOutput values.
@@ -13397,13 +13397,13 @@ type NamespaceListTypeInput interface {
 // NamespaceList is a list of Namespaces.
 type NamespaceListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	Items NamespaceTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (NamespaceListTypeArgs) ElementType() reflect.Type {
@@ -13434,8 +13434,8 @@ func (o NamespaceListTypeOutput) ToNamespaceListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NamespaceListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NamespaceListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
@@ -13444,13 +13444,13 @@ func (o NamespaceListTypeOutput) Items() NamespaceTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NamespaceListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NamespaceListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NamespaceListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NamespaceListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NamespaceListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v NamespaceListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o NamespaceListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v NamespaceListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // NamespaceSpec describes the attributes on a Namespace.
@@ -13747,15 +13747,15 @@ func (o NamespaceStatusPtrOutput) Phase() pulumi.StringPtrOutput {
 // Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
 type NodeType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *NodeSpec `pulumi:"spec"`
+	Spec NodeSpec `pulumi:"spec"`
 	// Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *NodeStatus `pulumi:"status"`
+	Status NodeStatus `pulumi:"status"`
 }
 
 // NodeTypeInput is an input type that accepts NodeTypeArgs and NodeTypeOutput values.
@@ -13773,15 +13773,15 @@ type NodeTypeInput interface {
 // Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
 type NodeTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec NodeSpecPtrInput `pulumi:"spec"`
+	Spec NodeSpecInput `pulumi:"spec"`
 	// Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status NodeStatusPtrInput `pulumi:"status"`
+	Status NodeStatusInput `pulumi:"status"`
 }
 
 func (NodeTypeArgs) ElementType() reflect.Type {
@@ -13838,28 +13838,28 @@ func (o NodeTypeOutput) ToNodeTypeOutputWithContext(ctx context.Context) NodeTyp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NodeTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NodeTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NodeTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NodeTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NodeTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v NodeType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o NodeTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v NodeType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o NodeTypeOutput) Spec() NodeSpecPtrOutput {
-	return o.ApplyT(func(v NodeType) *NodeSpec { return v.Spec }).(NodeSpecPtrOutput)
+func (o NodeTypeOutput) Spec() NodeSpecOutput {
+	return o.ApplyT(func(v NodeType) NodeSpec { return v.Spec }).(NodeSpecOutput)
 }
 
 // Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o NodeTypeOutput) Status() NodeStatusPtrOutput {
-	return o.ApplyT(func(v NodeType) *NodeStatus { return v.Status }).(NodeStatusPtrOutput)
+func (o NodeTypeOutput) Status() NodeStatusOutput {
+	return o.ApplyT(func(v NodeType) NodeStatus { return v.Status }).(NodeStatusOutput)
 }
 
 type NodeTypeArrayOutput struct{ *pulumi.OutputState }
@@ -13885,9 +13885,9 @@ func (o NodeTypeArrayOutput) Index(i pulumi.IntInput) NodeTypeOutput {
 // NodeAddress contains information for the node's address.
 type NodeAddress struct {
 	// The node address.
-	Address *string `pulumi:"address"`
+	Address string `pulumi:"address"`
 	// Node address type, one of Hostname, ExternalIP or InternalIP.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // NodeAddressInput is an input type that accepts NodeAddressArgs and NodeAddressOutput values.
@@ -13905,9 +13905,9 @@ type NodeAddressInput interface {
 // NodeAddress contains information for the node's address.
 type NodeAddressArgs struct {
 	// The node address.
-	Address pulumi.StringPtrInput `pulumi:"address"`
+	Address pulumi.StringInput `pulumi:"address"`
 	// Node address type, one of Hostname, ExternalIP or InternalIP.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (NodeAddressArgs) ElementType() reflect.Type {
@@ -13964,13 +13964,13 @@ func (o NodeAddressOutput) ToNodeAddressOutputWithContext(ctx context.Context) N
 }
 
 // The node address.
-func (o NodeAddressOutput) Address() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeAddress) *string { return v.Address }).(pulumi.StringPtrOutput)
+func (o NodeAddressOutput) Address() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeAddress) string { return v.Address }).(pulumi.StringOutput)
 }
 
 // Node address type, one of Hostname, ExternalIP or InternalIP.
-func (o NodeAddressOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeAddress) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o NodeAddressOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeAddress) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type NodeAddressArrayOutput struct{ *pulumi.OutputState }
@@ -14161,9 +14161,9 @@ type NodeCondition struct {
 	// (brief) reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of node condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // NodeConditionInput is an input type that accepts NodeConditionArgs and NodeConditionOutput values.
@@ -14189,9 +14189,9 @@ type NodeConditionArgs struct {
 	// (brief) reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of node condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (NodeConditionArgs) ElementType() reflect.Type {
@@ -14268,13 +14268,13 @@ func (o NodeConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o NodeConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o NodeConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of node condition.
-func (o NodeConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o NodeConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type NodeConditionArrayOutput struct{ *pulumi.OutputState }
@@ -14765,13 +14765,13 @@ func (o NodeDaemonEndpointsPtrOutput) KubeletEndpoint() DaemonEndpointPtrOutput 
 // NodeList is the whole list of all Nodes which have been registered with master.
 type NodeListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of nodes
 	Items []NodeType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // NodeListTypeInput is an input type that accepts NodeListTypeArgs and NodeListTypeOutput values.
@@ -14789,13 +14789,13 @@ type NodeListTypeInput interface {
 // NodeList is the whole list of all Nodes which have been registered with master.
 type NodeListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of nodes
 	Items NodeTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (NodeListTypeArgs) ElementType() reflect.Type {
@@ -14826,8 +14826,8 @@ func (o NodeListTypeOutput) ToNodeListTypeOutputWithContext(ctx context.Context)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NodeListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NodeListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of nodes
@@ -14836,13 +14836,13 @@ func (o NodeListTypeOutput) Items() NodeTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NodeListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NodeListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NodeListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v NodeListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o NodeListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v NodeListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
@@ -14984,9 +14984,9 @@ func (o NodeSelectorPtrOutput) NodeSelectorTerms() NodeSelectorTermArrayOutput {
 // A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-	Operator *string `pulumi:"operator"`
+	Operator string `pulumi:"operator"`
 	// An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 	Values []string `pulumi:"values"`
 }
@@ -15006,9 +15006,9 @@ type NodeSelectorRequirementInput interface {
 // A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 type NodeSelectorRequirementArgs struct {
 	// The label key that the selector applies to.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-	Operator pulumi.StringPtrInput `pulumi:"operator"`
+	Operator pulumi.StringInput `pulumi:"operator"`
 	// An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 	Values pulumi.StringArrayInput `pulumi:"values"`
 }
@@ -15067,13 +15067,13 @@ func (o NodeSelectorRequirementOutput) ToNodeSelectorRequirementOutputWithContex
 }
 
 // The label key that the selector applies to.
-func (o NodeSelectorRequirementOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSelectorRequirement) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o NodeSelectorRequirementOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSelectorRequirement) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-func (o NodeSelectorRequirementOutput) Operator() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSelectorRequirement) *string { return v.Operator }).(pulumi.StringPtrOutput)
+func (o NodeSelectorRequirementOutput) Operator() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSelectorRequirement) string { return v.Operator }).(pulumi.StringOutput)
 }
 
 // An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
@@ -15141,48 +15141,6 @@ func (i NodeSelectorTermArgs) ToNodeSelectorTermOutputWithContext(ctx context.Co
 	return pulumi.ToOutputWithContext(ctx, i).(NodeSelectorTermOutput)
 }
 
-func (i NodeSelectorTermArgs) ToNodeSelectorTermPtrOutput() NodeSelectorTermPtrOutput {
-	return i.ToNodeSelectorTermPtrOutputWithContext(context.Background())
-}
-
-func (i NodeSelectorTermArgs) ToNodeSelectorTermPtrOutputWithContext(ctx context.Context) NodeSelectorTermPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(NodeSelectorTermOutput).ToNodeSelectorTermPtrOutputWithContext(ctx)
-}
-
-// NodeSelectorTermPtrInput is an input type that accepts NodeSelectorTermArgs, NodeSelectorTermPtr and NodeSelectorTermPtrOutput values.
-// You can construct a concrete instance of `NodeSelectorTermPtrInput` via:
-//
-// 		 NodeSelectorTermArgs{...}
-//
-//  or:
-//
-// 		 nil
-//
-type NodeSelectorTermPtrInput interface {
-	pulumi.Input
-
-	ToNodeSelectorTermPtrOutput() NodeSelectorTermPtrOutput
-	ToNodeSelectorTermPtrOutputWithContext(context.Context) NodeSelectorTermPtrOutput
-}
-
-type nodeSelectorTermPtrType NodeSelectorTermArgs
-
-func NodeSelectorTermPtr(v *NodeSelectorTermArgs) NodeSelectorTermPtrInput {
-	return (*nodeSelectorTermPtrType)(v)
-}
-
-func (*nodeSelectorTermPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**NodeSelectorTerm)(nil)).Elem()
-}
-
-func (i *nodeSelectorTermPtrType) ToNodeSelectorTermPtrOutput() NodeSelectorTermPtrOutput {
-	return i.ToNodeSelectorTermPtrOutputWithContext(context.Background())
-}
-
-func (i *nodeSelectorTermPtrType) ToNodeSelectorTermPtrOutputWithContext(ctx context.Context) NodeSelectorTermPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(NodeSelectorTermPtrOutput)
-}
-
 // NodeSelectorTermArrayInput is an input type that accepts NodeSelectorTermArray and NodeSelectorTermArrayOutput values.
 // You can construct a concrete instance of `NodeSelectorTermArrayInput` via:
 //
@@ -15224,16 +15182,6 @@ func (o NodeSelectorTermOutput) ToNodeSelectorTermOutputWithContext(ctx context.
 	return o
 }
 
-func (o NodeSelectorTermOutput) ToNodeSelectorTermPtrOutput() NodeSelectorTermPtrOutput {
-	return o.ToNodeSelectorTermPtrOutputWithContext(context.Background())
-}
-
-func (o NodeSelectorTermOutput) ToNodeSelectorTermPtrOutputWithContext(ctx context.Context) NodeSelectorTermPtrOutput {
-	return o.ApplyT(func(v NodeSelectorTerm) *NodeSelectorTerm {
-		return &v
-	}).(NodeSelectorTermPtrOutput)
-}
-
 // A list of node selector requirements by node's labels.
 func (o NodeSelectorTermOutput) MatchExpressions() NodeSelectorRequirementArrayOutput {
 	return o.ApplyT(func(v NodeSelectorTerm) []NodeSelectorRequirement { return v.MatchExpressions }).(NodeSelectorRequirementArrayOutput)
@@ -15242,44 +15190,6 @@ func (o NodeSelectorTermOutput) MatchExpressions() NodeSelectorRequirementArrayO
 // A list of node selector requirements by node's fields.
 func (o NodeSelectorTermOutput) MatchFields() NodeSelectorRequirementArrayOutput {
 	return o.ApplyT(func(v NodeSelectorTerm) []NodeSelectorRequirement { return v.MatchFields }).(NodeSelectorRequirementArrayOutput)
-}
-
-type NodeSelectorTermPtrOutput struct{ *pulumi.OutputState }
-
-func (NodeSelectorTermPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**NodeSelectorTerm)(nil)).Elem()
-}
-
-func (o NodeSelectorTermPtrOutput) ToNodeSelectorTermPtrOutput() NodeSelectorTermPtrOutput {
-	return o
-}
-
-func (o NodeSelectorTermPtrOutput) ToNodeSelectorTermPtrOutputWithContext(ctx context.Context) NodeSelectorTermPtrOutput {
-	return o
-}
-
-func (o NodeSelectorTermPtrOutput) Elem() NodeSelectorTermOutput {
-	return o.ApplyT(func(v *NodeSelectorTerm) NodeSelectorTerm { return *v }).(NodeSelectorTermOutput)
-}
-
-// A list of node selector requirements by node's labels.
-func (o NodeSelectorTermPtrOutput) MatchExpressions() NodeSelectorRequirementArrayOutput {
-	return o.ApplyT(func(v *NodeSelectorTerm) []NodeSelectorRequirement {
-		if v == nil {
-			return nil
-		}
-		return v.MatchExpressions
-	}).(NodeSelectorRequirementArrayOutput)
-}
-
-// A list of node selector requirements by node's fields.
-func (o NodeSelectorTermPtrOutput) MatchFields() NodeSelectorRequirementArrayOutput {
-	return o.ApplyT(func(v *NodeSelectorTerm) []NodeSelectorRequirement {
-		if v == nil {
-			return nil
-		}
-		return v.MatchFields
-	}).(NodeSelectorRequirementArrayOutput)
 }
 
 type NodeSelectorTermArrayOutput struct{ *pulumi.OutputState }
@@ -15881,25 +15791,25 @@ func (o NodeStatusPtrOutput) VolumesInUse() pulumi.StringArrayOutput {
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
 type NodeSystemInfo struct {
 	// The Architecture reported by the node
-	Architecture *string `pulumi:"architecture"`
+	Architecture string `pulumi:"architecture"`
 	// Boot ID reported by the node.
-	BootID *string `pulumi:"bootID"`
+	BootID string `pulumi:"bootID"`
 	// ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
-	ContainerRuntimeVersion *string `pulumi:"containerRuntimeVersion"`
+	ContainerRuntimeVersion string `pulumi:"containerRuntimeVersion"`
 	// Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
-	KernelVersion *string `pulumi:"kernelVersion"`
+	KernelVersion string `pulumi:"kernelVersion"`
 	// KubeProxy Version reported by the node.
-	KubeProxyVersion *string `pulumi:"kubeProxyVersion"`
+	KubeProxyVersion string `pulumi:"kubeProxyVersion"`
 	// Kubelet Version reported by the node.
-	KubeletVersion *string `pulumi:"kubeletVersion"`
+	KubeletVersion string `pulumi:"kubeletVersion"`
 	// MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
-	MachineID *string `pulumi:"machineID"`
+	MachineID string `pulumi:"machineID"`
 	// The Operating System reported by the node
-	OperatingSystem *string `pulumi:"operatingSystem"`
+	OperatingSystem string `pulumi:"operatingSystem"`
 	// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
-	OsImage *string `pulumi:"osImage"`
+	OsImage string `pulumi:"osImage"`
 	// SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html
-	SystemUUID *string `pulumi:"systemUUID"`
+	SystemUUID string `pulumi:"systemUUID"`
 }
 
 // NodeSystemInfoInput is an input type that accepts NodeSystemInfoArgs and NodeSystemInfoOutput values.
@@ -15917,25 +15827,25 @@ type NodeSystemInfoInput interface {
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
 type NodeSystemInfoArgs struct {
 	// The Architecture reported by the node
-	Architecture pulumi.StringPtrInput `pulumi:"architecture"`
+	Architecture pulumi.StringInput `pulumi:"architecture"`
 	// Boot ID reported by the node.
-	BootID pulumi.StringPtrInput `pulumi:"bootID"`
+	BootID pulumi.StringInput `pulumi:"bootID"`
 	// ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
-	ContainerRuntimeVersion pulumi.StringPtrInput `pulumi:"containerRuntimeVersion"`
+	ContainerRuntimeVersion pulumi.StringInput `pulumi:"containerRuntimeVersion"`
 	// Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
-	KernelVersion pulumi.StringPtrInput `pulumi:"kernelVersion"`
+	KernelVersion pulumi.StringInput `pulumi:"kernelVersion"`
 	// KubeProxy Version reported by the node.
-	KubeProxyVersion pulumi.StringPtrInput `pulumi:"kubeProxyVersion"`
+	KubeProxyVersion pulumi.StringInput `pulumi:"kubeProxyVersion"`
 	// Kubelet Version reported by the node.
-	KubeletVersion pulumi.StringPtrInput `pulumi:"kubeletVersion"`
+	KubeletVersion pulumi.StringInput `pulumi:"kubeletVersion"`
 	// MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
-	MachineID pulumi.StringPtrInput `pulumi:"machineID"`
+	MachineID pulumi.StringInput `pulumi:"machineID"`
 	// The Operating System reported by the node
-	OperatingSystem pulumi.StringPtrInput `pulumi:"operatingSystem"`
+	OperatingSystem pulumi.StringInput `pulumi:"operatingSystem"`
 	// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
-	OsImage pulumi.StringPtrInput `pulumi:"osImage"`
+	OsImage pulumi.StringInput `pulumi:"osImage"`
 	// SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html
-	SystemUUID pulumi.StringPtrInput `pulumi:"systemUUID"`
+	SystemUUID pulumi.StringInput `pulumi:"systemUUID"`
 }
 
 func (NodeSystemInfoArgs) ElementType() reflect.Type {
@@ -16018,53 +15928,53 @@ func (o NodeSystemInfoOutput) ToNodeSystemInfoPtrOutputWithContext(ctx context.C
 }
 
 // The Architecture reported by the node
-func (o NodeSystemInfoOutput) Architecture() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.Architecture }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) Architecture() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.Architecture }).(pulumi.StringOutput)
 }
 
 // Boot ID reported by the node.
-func (o NodeSystemInfoOutput) BootID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.BootID }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) BootID() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.BootID }).(pulumi.StringOutput)
 }
 
 // ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
-func (o NodeSystemInfoOutput) ContainerRuntimeVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.ContainerRuntimeVersion }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) ContainerRuntimeVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.ContainerRuntimeVersion }).(pulumi.StringOutput)
 }
 
 // Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
-func (o NodeSystemInfoOutput) KernelVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.KernelVersion }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) KernelVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.KernelVersion }).(pulumi.StringOutput)
 }
 
 // KubeProxy Version reported by the node.
-func (o NodeSystemInfoOutput) KubeProxyVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.KubeProxyVersion }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) KubeProxyVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.KubeProxyVersion }).(pulumi.StringOutput)
 }
 
 // Kubelet Version reported by the node.
-func (o NodeSystemInfoOutput) KubeletVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.KubeletVersion }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) KubeletVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.KubeletVersion }).(pulumi.StringOutput)
 }
 
 // MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
-func (o NodeSystemInfoOutput) MachineID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.MachineID }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) MachineID() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.MachineID }).(pulumi.StringOutput)
 }
 
 // The Operating System reported by the node
-func (o NodeSystemInfoOutput) OperatingSystem() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.OperatingSystem }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) OperatingSystem() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.OperatingSystem }).(pulumi.StringOutput)
 }
 
 // OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
-func (o NodeSystemInfoOutput) OsImage() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.OsImage }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) OsImage() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.OsImage }).(pulumi.StringOutput)
 }
 
 // SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html
-func (o NodeSystemInfoOutput) SystemUUID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NodeSystemInfo) *string { return v.SystemUUID }).(pulumi.StringPtrOutput)
+func (o NodeSystemInfoOutput) SystemUUID() pulumi.StringOutput {
+	return o.ApplyT(func(v NodeSystemInfo) string { return v.SystemUUID }).(pulumi.StringOutput)
 }
 
 type NodeSystemInfoPtrOutput struct{ *pulumi.OutputState }
@@ -16091,7 +16001,7 @@ func (o NodeSystemInfoPtrOutput) Architecture() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Architecture
+		return &v.Architecture
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16101,7 +16011,7 @@ func (o NodeSystemInfoPtrOutput) BootID() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.BootID
+		return &v.BootID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16111,7 +16021,7 @@ func (o NodeSystemInfoPtrOutput) ContainerRuntimeVersion() pulumi.StringPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.ContainerRuntimeVersion
+		return &v.ContainerRuntimeVersion
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16121,7 +16031,7 @@ func (o NodeSystemInfoPtrOutput) KernelVersion() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.KernelVersion
+		return &v.KernelVersion
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16131,7 +16041,7 @@ func (o NodeSystemInfoPtrOutput) KubeProxyVersion() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.KubeProxyVersion
+		return &v.KubeProxyVersion
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16141,7 +16051,7 @@ func (o NodeSystemInfoPtrOutput) KubeletVersion() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.KubeletVersion
+		return &v.KubeletVersion
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16151,7 +16061,7 @@ func (o NodeSystemInfoPtrOutput) MachineID() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.MachineID
+		return &v.MachineID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16161,7 +16071,7 @@ func (o NodeSystemInfoPtrOutput) OperatingSystem() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.OperatingSystem
+		return &v.OperatingSystem
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16171,7 +16081,7 @@ func (o NodeSystemInfoPtrOutput) OsImage() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.OsImage
+		return &v.OsImage
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16181,7 +16091,7 @@ func (o NodeSystemInfoPtrOutput) SystemUUID() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.SystemUUID
+		return &v.SystemUUID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16190,7 +16100,7 @@ type ObjectFieldSelector struct {
 	// Version of the schema the FieldPath is written in terms of, defaults to "v1".
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Path of the field to select in the specified API version.
-	FieldPath *string `pulumi:"fieldPath"`
+	FieldPath string `pulumi:"fieldPath"`
 }
 
 // ObjectFieldSelectorInput is an input type that accepts ObjectFieldSelectorArgs and ObjectFieldSelectorOutput values.
@@ -16210,7 +16120,7 @@ type ObjectFieldSelectorArgs struct {
 	// Version of the schema the FieldPath is written in terms of, defaults to "v1".
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Path of the field to select in the specified API version.
-	FieldPath pulumi.StringPtrInput `pulumi:"fieldPath"`
+	FieldPath pulumi.StringInput `pulumi:"fieldPath"`
 }
 
 func (ObjectFieldSelectorArgs) ElementType() reflect.Type {
@@ -16298,8 +16208,8 @@ func (o ObjectFieldSelectorOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Path of the field to select in the specified API version.
-func (o ObjectFieldSelectorOutput) FieldPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ObjectFieldSelector) *string { return v.FieldPath }).(pulumi.StringPtrOutput)
+func (o ObjectFieldSelectorOutput) FieldPath() pulumi.StringOutput {
+	return o.ApplyT(func(v ObjectFieldSelector) string { return v.FieldPath }).(pulumi.StringOutput)
 }
 
 type ObjectFieldSelectorPtrOutput struct{ *pulumi.OutputState }
@@ -16336,7 +16246,7 @@ func (o ObjectFieldSelectorPtrOutput) FieldPath() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.FieldPath
+		return &v.FieldPath
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -16639,15 +16549,15 @@ func (o ObjectReferenceArrayOutput) Index(i pulumi.IntInput) ObjectReferenceOutp
 // PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 type PersistentVolumeType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Spec *PersistentVolumeSpec `pulumi:"spec"`
+	Spec PersistentVolumeSpec `pulumi:"spec"`
 	// Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Status *PersistentVolumeStatus `pulumi:"status"`
+	Status PersistentVolumeStatus `pulumi:"status"`
 }
 
 // PersistentVolumeTypeInput is an input type that accepts PersistentVolumeTypeArgs and PersistentVolumeTypeOutput values.
@@ -16665,15 +16575,15 @@ type PersistentVolumeTypeInput interface {
 // PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 type PersistentVolumeTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Spec PersistentVolumeSpecPtrInput `pulumi:"spec"`
+	Spec PersistentVolumeSpecInput `pulumi:"spec"`
 	// Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-	Status PersistentVolumeStatusPtrInput `pulumi:"status"`
+	Status PersistentVolumeStatusInput `pulumi:"status"`
 }
 
 func (PersistentVolumeTypeArgs) ElementType() reflect.Type {
@@ -16730,28 +16640,28 @@ func (o PersistentVolumeTypeOutput) ToPersistentVolumeTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PersistentVolumeTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PersistentVolumeTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PersistentVolumeTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PersistentVolumeType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-func (o PersistentVolumeTypeOutput) Spec() PersistentVolumeSpecPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeType) *PersistentVolumeSpec { return v.Spec }).(PersistentVolumeSpecPtrOutput)
+func (o PersistentVolumeTypeOutput) Spec() PersistentVolumeSpecOutput {
+	return o.ApplyT(func(v PersistentVolumeType) PersistentVolumeSpec { return v.Spec }).(PersistentVolumeSpecOutput)
 }
 
 // Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-func (o PersistentVolumeTypeOutput) Status() PersistentVolumeStatusPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeType) *PersistentVolumeStatus { return v.Status }).(PersistentVolumeStatusPtrOutput)
+func (o PersistentVolumeTypeOutput) Status() PersistentVolumeStatusOutput {
+	return o.ApplyT(func(v PersistentVolumeType) PersistentVolumeStatus { return v.Status }).(PersistentVolumeStatusOutput)
 }
 
 type PersistentVolumeTypeArrayOutput struct{ *pulumi.OutputState }
@@ -16777,15 +16687,15 @@ func (o PersistentVolumeTypeArrayOutput) Index(i pulumi.IntInput) PersistentVolu
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaimType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Spec *PersistentVolumeClaimSpec `pulumi:"spec"`
+	Spec PersistentVolumeClaimSpec `pulumi:"spec"`
 	// Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Status *PersistentVolumeClaimStatus `pulumi:"status"`
+	Status PersistentVolumeClaimStatus `pulumi:"status"`
 }
 
 // PersistentVolumeClaimTypeInput is an input type that accepts PersistentVolumeClaimTypeArgs and PersistentVolumeClaimTypeOutput values.
@@ -16803,15 +16713,15 @@ type PersistentVolumeClaimTypeInput interface {
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaimTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Spec PersistentVolumeClaimSpecPtrInput `pulumi:"spec"`
+	Spec PersistentVolumeClaimSpecInput `pulumi:"spec"`
 	// Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	Status PersistentVolumeClaimStatusPtrInput `pulumi:"status"`
+	Status PersistentVolumeClaimStatusInput `pulumi:"status"`
 }
 
 func (PersistentVolumeClaimTypeArgs) ElementType() reflect.Type {
@@ -16868,28 +16778,28 @@ func (o PersistentVolumeClaimTypeOutput) ToPersistentVolumeClaimTypeOutputWithCo
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PersistentVolumeClaimTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeClaimTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PersistentVolumeClaimTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PersistentVolumeClaimTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-func (o PersistentVolumeClaimTypeOutput) Spec() PersistentVolumeClaimSpecPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimType) *PersistentVolumeClaimSpec { return v.Spec }).(PersistentVolumeClaimSpecPtrOutput)
+func (o PersistentVolumeClaimTypeOutput) Spec() PersistentVolumeClaimSpecOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimType) PersistentVolumeClaimSpec { return v.Spec }).(PersistentVolumeClaimSpecOutput)
 }
 
 // Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-func (o PersistentVolumeClaimTypeOutput) Status() PersistentVolumeClaimStatusPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimType) *PersistentVolumeClaimStatus { return v.Status }).(PersistentVolumeClaimStatusPtrOutput)
+func (o PersistentVolumeClaimTypeOutput) Status() PersistentVolumeClaimStatusOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimType) PersistentVolumeClaimStatus { return v.Status }).(PersistentVolumeClaimStatusOutput)
 }
 
 type PersistentVolumeClaimTypeArrayOutput struct{ *pulumi.OutputState }
@@ -16922,8 +16832,8 @@ type PersistentVolumeClaimCondition struct {
 	Message *string `pulumi:"message"`
 	// Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
 	Reason *string `pulumi:"reason"`
-	Status *string `pulumi:"status"`
-	Type   *string `pulumi:"type"`
+	Status string  `pulumi:"status"`
+	Type   string  `pulumi:"type"`
 }
 
 // PersistentVolumeClaimConditionInput is an input type that accepts PersistentVolumeClaimConditionArgs and PersistentVolumeClaimConditionOutput values.
@@ -16948,8 +16858,8 @@ type PersistentVolumeClaimConditionArgs struct {
 	Message pulumi.StringPtrInput `pulumi:"message"`
 	// Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
-	Status pulumi.StringPtrInput `pulumi:"status"`
-	Type   pulumi.StringPtrInput `pulumi:"type"`
+	Status pulumi.StringInput    `pulumi:"status"`
+	Type   pulumi.StringInput    `pulumi:"type"`
 }
 
 func (PersistentVolumeClaimConditionArgs) ElementType() reflect.Type {
@@ -17025,12 +16935,12 @@ func (o PersistentVolumeClaimConditionOutput) Reason() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v PersistentVolumeClaimCondition) *string { return v.Reason }).(pulumi.StringPtrOutput)
 }
 
-func (o PersistentVolumeClaimConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
-func (o PersistentVolumeClaimConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type PersistentVolumeClaimConditionArrayOutput struct{ *pulumi.OutputState }
@@ -17056,13 +16966,13 @@ func (o PersistentVolumeClaimConditionArrayOutput) Index(i pulumi.IntInput) Pers
 // PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
 type PersistentVolumeClaimListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	Items []PersistentVolumeClaimType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PersistentVolumeClaimListTypeInput is an input type that accepts PersistentVolumeClaimListTypeArgs and PersistentVolumeClaimListTypeOutput values.
@@ -17080,13 +16990,13 @@ type PersistentVolumeClaimListTypeInput interface {
 // PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
 type PersistentVolumeClaimListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	Items PersistentVolumeClaimTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PersistentVolumeClaimListTypeArgs) ElementType() reflect.Type {
@@ -17117,8 +17027,8 @@ func (o PersistentVolumeClaimListTypeOutput) ToPersistentVolumeClaimListTypeOutp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PersistentVolumeClaimListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
@@ -17127,13 +17037,13 @@ func (o PersistentVolumeClaimListTypeOutput) Items() PersistentVolumeClaimTypeAr
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeClaimListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeClaimListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PersistentVolumeClaimListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
@@ -17582,7 +17492,7 @@ func (o PersistentVolumeClaimStatusPtrOutput) Phase() pulumi.StringPtrOutput {
 // PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
 type PersistentVolumeClaimVolumeSource struct {
 	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	ClaimName *string `pulumi:"claimName"`
+	ClaimName string `pulumi:"claimName"`
 	// Will force the ReadOnly setting in VolumeMounts. Default false.
 	ReadOnly *bool `pulumi:"readOnly"`
 }
@@ -17602,7 +17512,7 @@ type PersistentVolumeClaimVolumeSourceInput interface {
 // PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
 type PersistentVolumeClaimVolumeSourceArgs struct {
 	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-	ClaimName pulumi.StringPtrInput `pulumi:"claimName"`
+	ClaimName pulumi.StringInput `pulumi:"claimName"`
 	// Will force the ReadOnly setting in VolumeMounts. Default false.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 }
@@ -17687,8 +17597,8 @@ func (o PersistentVolumeClaimVolumeSourceOutput) ToPersistentVolumeClaimVolumeSo
 }
 
 // ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-func (o PersistentVolumeClaimVolumeSourceOutput) ClaimName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeClaimVolumeSource) *string { return v.ClaimName }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeClaimVolumeSourceOutput) ClaimName() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeClaimVolumeSource) string { return v.ClaimName }).(pulumi.StringOutput)
 }
 
 // Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -17720,7 +17630,7 @@ func (o PersistentVolumeClaimVolumeSourcePtrOutput) ClaimName() pulumi.StringPtr
 		if v == nil {
 			return nil
 		}
-		return v.ClaimName
+		return &v.ClaimName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -17737,13 +17647,13 @@ func (o PersistentVolumeClaimVolumeSourcePtrOutput) ReadOnly() pulumi.BoolPtrOut
 // PersistentVolumeList is a list of PersistentVolume items.
 type PersistentVolumeListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 	Items []PersistentVolumeType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PersistentVolumeListTypeInput is an input type that accepts PersistentVolumeListTypeArgs and PersistentVolumeListTypeOutput values.
@@ -17761,13 +17671,13 @@ type PersistentVolumeListTypeInput interface {
 // PersistentVolumeList is a list of PersistentVolume items.
 type PersistentVolumeListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 	Items PersistentVolumeTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PersistentVolumeListTypeArgs) ElementType() reflect.Type {
@@ -17798,8 +17708,8 @@ func (o PersistentVolumeListTypeOutput) ToPersistentVolumeListTypeOutputWithCont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PersistentVolumeListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
@@ -17808,13 +17718,13 @@ func (o PersistentVolumeListTypeOutput) Items() PersistentVolumeTypeArrayOutput 
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PersistentVolumeListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PersistentVolumeListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PersistentVolumeListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PersistentVolumeListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PersistentVolumeListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PersistentVolumeListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PersistentVolumeSpec is the specification of a persistent volume.
@@ -18683,7 +18593,7 @@ type PhotonPersistentDiskVolumeSource struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	FsType *string `pulumi:"fsType"`
 	// ID that identifies Photon Controller persistent disk
-	PdID *string `pulumi:"pdID"`
+	PdID string `pulumi:"pdID"`
 }
 
 // PhotonPersistentDiskVolumeSourceInput is an input type that accepts PhotonPersistentDiskVolumeSourceArgs and PhotonPersistentDiskVolumeSourceOutput values.
@@ -18703,7 +18613,7 @@ type PhotonPersistentDiskVolumeSourceArgs struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// ID that identifies Photon Controller persistent disk
-	PdID pulumi.StringPtrInput `pulumi:"pdID"`
+	PdID pulumi.StringInput `pulumi:"pdID"`
 }
 
 func (PhotonPersistentDiskVolumeSourceArgs) ElementType() reflect.Type {
@@ -18791,8 +18701,8 @@ func (o PhotonPersistentDiskVolumeSourceOutput) FsType() pulumi.StringPtrOutput 
 }
 
 // ID that identifies Photon Controller persistent disk
-func (o PhotonPersistentDiskVolumeSourceOutput) PdID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PhotonPersistentDiskVolumeSource) *string { return v.PdID }).(pulumi.StringPtrOutput)
+func (o PhotonPersistentDiskVolumeSourceOutput) PdID() pulumi.StringOutput {
+	return o.ApplyT(func(v PhotonPersistentDiskVolumeSource) string { return v.PdID }).(pulumi.StringOutput)
 }
 
 type PhotonPersistentDiskVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -18829,7 +18739,7 @@ func (o PhotonPersistentDiskVolumeSourcePtrOutput) PdID() pulumi.StringPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.PdID
+		return &v.PdID
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -18851,15 +18761,15 @@ func (o PhotonPersistentDiskVolumeSourcePtrOutput) PdID() pulumi.StringPtrOutput
 // by setting the 'customTimeouts' option on the resource.
 type PodType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *PodSpec `pulumi:"spec"`
+	Spec PodSpec `pulumi:"spec"`
 	// Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *PodStatus `pulumi:"status"`
+	Status PodStatus `pulumi:"status"`
 }
 
 // PodTypeInput is an input type that accepts PodTypeArgs and PodTypeOutput values.
@@ -18892,15 +18802,15 @@ type PodTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type PodTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec PodSpecPtrInput `pulumi:"spec"`
+	Spec PodSpecInput `pulumi:"spec"`
 	// Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status PodStatusPtrInput `pulumi:"status"`
+	Status PodStatusInput `pulumi:"status"`
 }
 
 func (PodTypeArgs) ElementType() reflect.Type {
@@ -18972,28 +18882,28 @@ func (o PodTypeOutput) ToPodTypeOutputWithContext(ctx context.Context) PodTypeOu
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o PodTypeOutput) Spec() PodSpecPtrOutput {
-	return o.ApplyT(func(v PodType) *PodSpec { return v.Spec }).(PodSpecPtrOutput)
+func (o PodTypeOutput) Spec() PodSpecOutput {
+	return o.ApplyT(func(v PodType) PodSpec { return v.Spec }).(PodSpecOutput)
 }
 
 // Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o PodTypeOutput) Status() PodStatusPtrOutput {
-	return o.ApplyT(func(v PodType) *PodStatus { return v.Status }).(PodStatusPtrOutput)
+func (o PodTypeOutput) Status() PodStatusOutput {
+	return o.ApplyT(func(v PodType) PodStatus { return v.Status }).(PodStatusOutput)
 }
 
 type PodTypeArrayOutput struct{ *pulumi.OutputState }
@@ -19180,7 +19090,7 @@ type PodAffinityTerm struct {
 	// namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
 	Namespaces []string `pulumi:"namespaces"`
 	// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-	TopologyKey *string `pulumi:"topologyKey"`
+	TopologyKey string `pulumi:"topologyKey"`
 }
 
 // PodAffinityTermInput is an input type that accepts PodAffinityTermArgs and PodAffinityTermOutput values.
@@ -19202,7 +19112,7 @@ type PodAffinityTermArgs struct {
 	// namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
 	Namespaces pulumi.StringArrayInput `pulumi:"namespaces"`
 	// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-	TopologyKey pulumi.StringPtrInput `pulumi:"topologyKey"`
+	TopologyKey pulumi.StringInput `pulumi:"topologyKey"`
 }
 
 func (PodAffinityTermArgs) ElementType() reflect.Type {
@@ -19215,48 +19125,6 @@ func (i PodAffinityTermArgs) ToPodAffinityTermOutput() PodAffinityTermOutput {
 
 func (i PodAffinityTermArgs) ToPodAffinityTermOutputWithContext(ctx context.Context) PodAffinityTermOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PodAffinityTermOutput)
-}
-
-func (i PodAffinityTermArgs) ToPodAffinityTermPtrOutput() PodAffinityTermPtrOutput {
-	return i.ToPodAffinityTermPtrOutputWithContext(context.Background())
-}
-
-func (i PodAffinityTermArgs) ToPodAffinityTermPtrOutputWithContext(ctx context.Context) PodAffinityTermPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PodAffinityTermOutput).ToPodAffinityTermPtrOutputWithContext(ctx)
-}
-
-// PodAffinityTermPtrInput is an input type that accepts PodAffinityTermArgs, PodAffinityTermPtr and PodAffinityTermPtrOutput values.
-// You can construct a concrete instance of `PodAffinityTermPtrInput` via:
-//
-// 		 PodAffinityTermArgs{...}
-//
-//  or:
-//
-// 		 nil
-//
-type PodAffinityTermPtrInput interface {
-	pulumi.Input
-
-	ToPodAffinityTermPtrOutput() PodAffinityTermPtrOutput
-	ToPodAffinityTermPtrOutputWithContext(context.Context) PodAffinityTermPtrOutput
-}
-
-type podAffinityTermPtrType PodAffinityTermArgs
-
-func PodAffinityTermPtr(v *PodAffinityTermArgs) PodAffinityTermPtrInput {
-	return (*podAffinityTermPtrType)(v)
-}
-
-func (*podAffinityTermPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**PodAffinityTerm)(nil)).Elem()
-}
-
-func (i *podAffinityTermPtrType) ToPodAffinityTermPtrOutput() PodAffinityTermPtrOutput {
-	return i.ToPodAffinityTermPtrOutputWithContext(context.Background())
-}
-
-func (i *podAffinityTermPtrType) ToPodAffinityTermPtrOutputWithContext(ctx context.Context) PodAffinityTermPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PodAffinityTermPtrOutput)
 }
 
 // PodAffinityTermArrayInput is an input type that accepts PodAffinityTermArray and PodAffinityTermArrayOutput values.
@@ -19300,16 +19168,6 @@ func (o PodAffinityTermOutput) ToPodAffinityTermOutputWithContext(ctx context.Co
 	return o
 }
 
-func (o PodAffinityTermOutput) ToPodAffinityTermPtrOutput() PodAffinityTermPtrOutput {
-	return o.ToPodAffinityTermPtrOutputWithContext(context.Background())
-}
-
-func (o PodAffinityTermOutput) ToPodAffinityTermPtrOutputWithContext(ctx context.Context) PodAffinityTermPtrOutput {
-	return o.ApplyT(func(v PodAffinityTerm) *PodAffinityTerm {
-		return &v
-	}).(PodAffinityTermPtrOutput)
-}
-
 // A label query over a set of resources, in this case pods.
 func (o PodAffinityTermOutput) LabelSelector() metav1.LabelSelectorPtrOutput {
 	return o.ApplyT(func(v PodAffinityTerm) *metav1.LabelSelector { return v.LabelSelector }).(metav1.LabelSelectorPtrOutput)
@@ -19321,56 +19179,8 @@ func (o PodAffinityTermOutput) Namespaces() pulumi.StringArrayOutput {
 }
 
 // This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-func (o PodAffinityTermOutput) TopologyKey() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodAffinityTerm) *string { return v.TopologyKey }).(pulumi.StringPtrOutput)
-}
-
-type PodAffinityTermPtrOutput struct{ *pulumi.OutputState }
-
-func (PodAffinityTermPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**PodAffinityTerm)(nil)).Elem()
-}
-
-func (o PodAffinityTermPtrOutput) ToPodAffinityTermPtrOutput() PodAffinityTermPtrOutput {
-	return o
-}
-
-func (o PodAffinityTermPtrOutput) ToPodAffinityTermPtrOutputWithContext(ctx context.Context) PodAffinityTermPtrOutput {
-	return o
-}
-
-func (o PodAffinityTermPtrOutput) Elem() PodAffinityTermOutput {
-	return o.ApplyT(func(v *PodAffinityTerm) PodAffinityTerm { return *v }).(PodAffinityTermOutput)
-}
-
-// A label query over a set of resources, in this case pods.
-func (o PodAffinityTermPtrOutput) LabelSelector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v *PodAffinityTerm) *metav1.LabelSelector {
-		if v == nil {
-			return nil
-		}
-		return v.LabelSelector
-	}).(metav1.LabelSelectorPtrOutput)
-}
-
-// namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
-func (o PodAffinityTermPtrOutput) Namespaces() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PodAffinityTerm) []string {
-		if v == nil {
-			return nil
-		}
-		return v.Namespaces
-	}).(pulumi.StringArrayOutput)
-}
-
-// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-func (o PodAffinityTermPtrOutput) TopologyKey() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *PodAffinityTerm) *string {
-		if v == nil {
-			return nil
-		}
-		return v.TopologyKey
-	}).(pulumi.StringPtrOutput)
+func (o PodAffinityTermOutput) TopologyKey() pulumi.StringOutput {
+	return o.ApplyT(func(v PodAffinityTerm) string { return v.TopologyKey }).(pulumi.StringOutput)
 }
 
 type PodAffinityTermArrayOutput struct{ *pulumi.OutputState }
@@ -19561,9 +19371,9 @@ type PodCondition struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // PodConditionInput is an input type that accepts PodConditionArgs and PodConditionOutput values.
@@ -19589,9 +19399,9 @@ type PodConditionArgs struct {
 	// Unique, one-word, CamelCase reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (PodConditionArgs) ElementType() reflect.Type {
@@ -19668,13 +19478,13 @@ func (o PodConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-func (o PodConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o PodConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v PodCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-func (o PodConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o PodConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v PodCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type PodConditionArrayOutput struct{ *pulumi.OutputState }
@@ -20087,13 +19897,13 @@ func (o PodIPArrayOutput) Index(i pulumi.IntInput) PodIPOutput {
 // PodList is a list of Pods.
 type PodListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
 	Items []PodType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodListTypeInput is an input type that accepts PodListTypeArgs and PodListTypeOutput values.
@@ -20111,13 +19921,13 @@ type PodListTypeInput interface {
 // PodList is a list of Pods.
 type PodListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
 	Items PodTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodListTypeArgs) ElementType() reflect.Type {
@@ -20148,8 +19958,8 @@ func (o PodListTypeOutput) ToPodListTypeOutputWithContext(ctx context.Context) P
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
@@ -20158,19 +19968,19 @@ func (o PodListTypeOutput) Items() PodTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodReadinessGate contains the reference to a pod condition
 type PodReadinessGate struct {
 	// ConditionType refers to a condition in the pod's condition list with matching type.
-	ConditionType *string `pulumi:"conditionType"`
+	ConditionType string `pulumi:"conditionType"`
 }
 
 // PodReadinessGateInput is an input type that accepts PodReadinessGateArgs and PodReadinessGateOutput values.
@@ -20188,7 +19998,7 @@ type PodReadinessGateInput interface {
 // PodReadinessGate contains the reference to a pod condition
 type PodReadinessGateArgs struct {
 	// ConditionType refers to a condition in the pod's condition list with matching type.
-	ConditionType pulumi.StringPtrInput `pulumi:"conditionType"`
+	ConditionType pulumi.StringInput `pulumi:"conditionType"`
 }
 
 func (PodReadinessGateArgs) ElementType() reflect.Type {
@@ -20245,8 +20055,8 @@ func (o PodReadinessGateOutput) ToPodReadinessGateOutputWithContext(ctx context.
 }
 
 // ConditionType refers to a condition in the pod's condition list with matching type.
-func (o PodReadinessGateOutput) ConditionType() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodReadinessGate) *string { return v.ConditionType }).(pulumi.StringPtrOutput)
+func (o PodReadinessGateOutput) ConditionType() pulumi.StringOutput {
+	return o.ApplyT(func(v PodReadinessGate) string { return v.ConditionType }).(pulumi.StringOutput)
 }
 
 type PodReadinessGateArrayOutput struct{ *pulumi.OutputState }
@@ -21719,13 +21529,13 @@ func (o PodStatusPtrOutput) StartTime() pulumi.StringPtrOutput {
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplateType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Template *PodTemplateSpec `pulumi:"template"`
+	Template PodTemplateSpec `pulumi:"template"`
 }
 
 // PodTemplateTypeInput is an input type that accepts PodTemplateTypeArgs and PodTemplateTypeOutput values.
@@ -21743,13 +21553,13 @@ type PodTemplateTypeInput interface {
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplateTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Template PodTemplateSpecPtrInput `pulumi:"template"`
+	Template PodTemplateSpecInput `pulumi:"template"`
 }
 
 func (PodTemplateTypeArgs) ElementType() reflect.Type {
@@ -21806,23 +21616,23 @@ func (o PodTemplateTypeOutput) ToPodTemplateTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodTemplateTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodTemplateType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodTemplateTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodTemplateType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodTemplateTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodTemplateType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodTemplateTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodTemplateType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodTemplateTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodTemplateType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodTemplateTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodTemplateType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o PodTemplateTypeOutput) Template() PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v PodTemplateType) *PodTemplateSpec { return v.Template }).(PodTemplateSpecPtrOutput)
+func (o PodTemplateTypeOutput) Template() PodTemplateSpecOutput {
+	return o.ApplyT(func(v PodTemplateType) PodTemplateSpec { return v.Template }).(PodTemplateSpecOutput)
 }
 
 type PodTemplateTypeArrayOutput struct{ *pulumi.OutputState }
@@ -21848,13 +21658,13 @@ func (o PodTemplateTypeArrayOutput) Index(i pulumi.IntInput) PodTemplateTypeOutp
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of pod templates
 	Items []PodTemplateType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodTemplateListTypeInput is an input type that accepts PodTemplateListTypeArgs and PodTemplateListTypeOutput values.
@@ -21872,13 +21682,13 @@ type PodTemplateListTypeInput interface {
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of pod templates
 	Items PodTemplateTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodTemplateListTypeArgs) ElementType() reflect.Type {
@@ -21909,8 +21719,8 @@ func (o PodTemplateListTypeOutput) ToPodTemplateListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodTemplateListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodTemplateListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodTemplateListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodTemplateListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of pod templates
@@ -21919,13 +21729,13 @@ func (o PodTemplateListTypeOutput) Items() PodTemplateTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodTemplateListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodTemplateListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodTemplateListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodTemplateListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodTemplateListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodTemplateListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodTemplateListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodTemplateListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodTemplateSpec describes the data a pod should have when created from a template
@@ -22090,7 +21900,7 @@ type PortworxVolumeSource struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// VolumeID uniquely identifies a Portworx volume
-	VolumeID *string `pulumi:"volumeID"`
+	VolumeID string `pulumi:"volumeID"`
 }
 
 // PortworxVolumeSourceInput is an input type that accepts PortworxVolumeSourceArgs and PortworxVolumeSourceOutput values.
@@ -22112,7 +21922,7 @@ type PortworxVolumeSourceArgs struct {
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// VolumeID uniquely identifies a Portworx volume
-	VolumeID pulumi.StringPtrInput `pulumi:"volumeID"`
+	VolumeID pulumi.StringInput `pulumi:"volumeID"`
 }
 
 func (PortworxVolumeSourceArgs) ElementType() reflect.Type {
@@ -22205,8 +22015,8 @@ func (o PortworxVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // VolumeID uniquely identifies a Portworx volume
-func (o PortworxVolumeSourceOutput) VolumeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PortworxVolumeSource) *string { return v.VolumeID }).(pulumi.StringPtrOutput)
+func (o PortworxVolumeSourceOutput) VolumeID() pulumi.StringOutput {
+	return o.ApplyT(func(v PortworxVolumeSource) string { return v.VolumeID }).(pulumi.StringOutput)
 }
 
 type PortworxVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -22253,16 +22063,16 @@ func (o PortworxVolumeSourcePtrOutput) VolumeID() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.VolumeID
+		return &v.VolumeID
 	}).(pulumi.StringPtrOutput)
 }
 
 // An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 type PreferredSchedulingTerm struct {
 	// A node selector term, associated with the corresponding weight.
-	Preference *NodeSelectorTerm `pulumi:"preference"`
+	Preference NodeSelectorTerm `pulumi:"preference"`
 	// Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-	Weight *int `pulumi:"weight"`
+	Weight int `pulumi:"weight"`
 }
 
 // PreferredSchedulingTermInput is an input type that accepts PreferredSchedulingTermArgs and PreferredSchedulingTermOutput values.
@@ -22280,9 +22090,9 @@ type PreferredSchedulingTermInput interface {
 // An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 type PreferredSchedulingTermArgs struct {
 	// A node selector term, associated with the corresponding weight.
-	Preference NodeSelectorTermPtrInput `pulumi:"preference"`
+	Preference NodeSelectorTermInput `pulumi:"preference"`
 	// Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-	Weight pulumi.IntPtrInput `pulumi:"weight"`
+	Weight pulumi.IntInput `pulumi:"weight"`
 }
 
 func (PreferredSchedulingTermArgs) ElementType() reflect.Type {
@@ -22339,13 +22149,13 @@ func (o PreferredSchedulingTermOutput) ToPreferredSchedulingTermOutputWithContex
 }
 
 // A node selector term, associated with the corresponding weight.
-func (o PreferredSchedulingTermOutput) Preference() NodeSelectorTermPtrOutput {
-	return o.ApplyT(func(v PreferredSchedulingTerm) *NodeSelectorTerm { return v.Preference }).(NodeSelectorTermPtrOutput)
+func (o PreferredSchedulingTermOutput) Preference() NodeSelectorTermOutput {
+	return o.ApplyT(func(v PreferredSchedulingTerm) NodeSelectorTerm { return v.Preference }).(NodeSelectorTermOutput)
 }
 
 // Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-func (o PreferredSchedulingTermOutput) Weight() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PreferredSchedulingTerm) *int { return v.Weight }).(pulumi.IntPtrOutput)
+func (o PreferredSchedulingTermOutput) Weight() pulumi.IntOutput {
+	return o.ApplyT(func(v PreferredSchedulingTerm) int { return v.Weight }).(pulumi.IntOutput)
 }
 
 type PreferredSchedulingTermArrayOutput struct{ *pulumi.OutputState }
@@ -22799,13 +22609,13 @@ type QuobyteVolumeSource struct {
 	// ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
-	Registry *string `pulumi:"registry"`
+	Registry string `pulumi:"registry"`
 	// Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
 	Tenant *string `pulumi:"tenant"`
 	// User to map volume access to Defaults to serivceaccount user
 	User *string `pulumi:"user"`
 	// Volume is a string that references an already created Quobyte volume by name.
-	Volume *string `pulumi:"volume"`
+	Volume string `pulumi:"volume"`
 }
 
 // QuobyteVolumeSourceInput is an input type that accepts QuobyteVolumeSourceArgs and QuobyteVolumeSourceOutput values.
@@ -22827,13 +22637,13 @@ type QuobyteVolumeSourceArgs struct {
 	// ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
-	Registry pulumi.StringPtrInput `pulumi:"registry"`
+	Registry pulumi.StringInput `pulumi:"registry"`
 	// Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
 	Tenant pulumi.StringPtrInput `pulumi:"tenant"`
 	// User to map volume access to Defaults to serivceaccount user
 	User pulumi.StringPtrInput `pulumi:"user"`
 	// Volume is a string that references an already created Quobyte volume by name.
-	Volume pulumi.StringPtrInput `pulumi:"volume"`
+	Volume pulumi.StringInput `pulumi:"volume"`
 }
 
 func (QuobyteVolumeSourceArgs) ElementType() reflect.Type {
@@ -22926,8 +22736,8 @@ func (o QuobyteVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
-func (o QuobyteVolumeSourceOutput) Registry() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v QuobyteVolumeSource) *string { return v.Registry }).(pulumi.StringPtrOutput)
+func (o QuobyteVolumeSourceOutput) Registry() pulumi.StringOutput {
+	return o.ApplyT(func(v QuobyteVolumeSource) string { return v.Registry }).(pulumi.StringOutput)
 }
 
 // Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
@@ -22941,8 +22751,8 @@ func (o QuobyteVolumeSourceOutput) User() pulumi.StringPtrOutput {
 }
 
 // Volume is a string that references an already created Quobyte volume by name.
-func (o QuobyteVolumeSourceOutput) Volume() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v QuobyteVolumeSource) *string { return v.Volume }).(pulumi.StringPtrOutput)
+func (o QuobyteVolumeSourceOutput) Volume() pulumi.StringOutput {
+	return o.ApplyT(func(v QuobyteVolumeSource) string { return v.Volume }).(pulumi.StringOutput)
 }
 
 type QuobyteVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -22989,7 +22799,7 @@ func (o QuobyteVolumeSourcePtrOutput) Registry() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Registry
+		return &v.Registry
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -23019,7 +22829,7 @@ func (o QuobyteVolumeSourcePtrOutput) Volume() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Volume
+		return &v.Volume
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -23028,7 +22838,7 @@ type RBDPersistentVolumeSource struct {
 	// Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	FsType *string `pulumi:"fsType"`
 	// The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-	Image *string `pulumi:"image"`
+	Image string `pulumi:"image"`
 	// Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	Keyring *string `pulumi:"keyring"`
 	// A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23060,7 +22870,7 @@ type RBDPersistentVolumeSourceArgs struct {
 	// Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-	Image pulumi.StringPtrInput `pulumi:"image"`
+	Image pulumi.StringInput `pulumi:"image"`
 	// Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	Keyring pulumi.StringPtrInput `pulumi:"keyring"`
 	// A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23160,8 +22970,8 @@ func (o RBDPersistentVolumeSourceOutput) FsType() pulumi.StringPtrOutput {
 }
 
 // The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-func (o RBDPersistentVolumeSourceOutput) Image() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RBDPersistentVolumeSource) *string { return v.Image }).(pulumi.StringPtrOutput)
+func (o RBDPersistentVolumeSourceOutput) Image() pulumi.StringOutput {
+	return o.ApplyT(func(v RBDPersistentVolumeSource) string { return v.Image }).(pulumi.StringOutput)
 }
 
 // Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23228,7 +23038,7 @@ func (o RBDPersistentVolumeSourcePtrOutput) Image() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Image
+		return &v.Image
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -23297,7 +23107,7 @@ type RBDVolumeSource struct {
 	// Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	FsType *string `pulumi:"fsType"`
 	// The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-	Image *string `pulumi:"image"`
+	Image string `pulumi:"image"`
 	// Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	Keyring *string `pulumi:"keyring"`
 	// A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23329,7 +23139,7 @@ type RBDVolumeSourceArgs struct {
 	// Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-	Image pulumi.StringPtrInput `pulumi:"image"`
+	Image pulumi.StringInput `pulumi:"image"`
 	// Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	Keyring pulumi.StringPtrInput `pulumi:"keyring"`
 	// A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23429,8 +23239,8 @@ func (o RBDVolumeSourceOutput) FsType() pulumi.StringPtrOutput {
 }
 
 // The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
-func (o RBDVolumeSourceOutput) Image() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RBDVolumeSource) *string { return v.Image }).(pulumi.StringPtrOutput)
+func (o RBDVolumeSourceOutput) Image() pulumi.StringOutput {
+	return o.ApplyT(func(v RBDVolumeSource) string { return v.Image }).(pulumi.StringOutput)
 }
 
 // Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23497,7 +23307,7 @@ func (o RBDVolumeSourcePtrOutput) Image() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Image
+		return &v.Image
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -23564,15 +23374,15 @@ func (o RBDVolumeSourcePtrOutput) User() pulumi.StringPtrOutput {
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationControllerType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ReplicationControllerSpec `pulumi:"spec"`
+	Spec ReplicationControllerSpec `pulumi:"spec"`
 	// Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ReplicationControllerStatus `pulumi:"status"`
+	Status ReplicationControllerStatus `pulumi:"status"`
 }
 
 // ReplicationControllerTypeInput is an input type that accepts ReplicationControllerTypeArgs and ReplicationControllerTypeOutput values.
@@ -23590,15 +23400,15 @@ type ReplicationControllerTypeInput interface {
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationControllerTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicationControllerSpecPtrInput `pulumi:"spec"`
+	Spec ReplicationControllerSpecInput `pulumi:"spec"`
 	// Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicationControllerStatusPtrInput `pulumi:"status"`
+	Status ReplicationControllerStatusInput `pulumi:"status"`
 }
 
 func (ReplicationControllerTypeArgs) ElementType() reflect.Type {
@@ -23655,28 +23465,28 @@ func (o ReplicationControllerTypeOutput) ToReplicationControllerTypeOutputWithCo
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicationControllerTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicationControllerTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ReplicationControllerTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ReplicationControllerTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ReplicationControllerType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicationControllerTypeOutput) Spec() ReplicationControllerSpecPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerType) *ReplicationControllerSpec { return v.Spec }).(ReplicationControllerSpecPtrOutput)
+func (o ReplicationControllerTypeOutput) Spec() ReplicationControllerSpecOutput {
+	return o.ApplyT(func(v ReplicationControllerType) ReplicationControllerSpec { return v.Spec }).(ReplicationControllerSpecOutput)
 }
 
 // Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicationControllerTypeOutput) Status() ReplicationControllerStatusPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerType) *ReplicationControllerStatus { return v.Status }).(ReplicationControllerStatusPtrOutput)
+func (o ReplicationControllerTypeOutput) Status() ReplicationControllerStatusOutput {
+	return o.ApplyT(func(v ReplicationControllerType) ReplicationControllerStatus { return v.Status }).(ReplicationControllerStatusOutput)
 }
 
 type ReplicationControllerTypeArrayOutput struct{ *pulumi.OutputState }
@@ -23708,9 +23518,9 @@ type ReplicationControllerCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of replication controller condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // ReplicationControllerConditionInput is an input type that accepts ReplicationControllerConditionArgs and ReplicationControllerConditionOutput values.
@@ -23734,9 +23544,9 @@ type ReplicationControllerConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of replication controller condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (ReplicationControllerConditionArgs) ElementType() reflect.Type {
@@ -23808,13 +23618,13 @@ func (o ReplicationControllerConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o ReplicationControllerConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of replication controller condition.
-func (o ReplicationControllerConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type ReplicationControllerConditionArrayOutput struct{ *pulumi.OutputState }
@@ -23840,13 +23650,13 @@ func (o ReplicationControllerConditionArrayOutput) Index(i pulumi.IntInput) Repl
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items []ReplicationControllerType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ReplicationControllerListTypeInput is an input type that accepts ReplicationControllerListTypeArgs and ReplicationControllerListTypeOutput values.
@@ -23864,13 +23674,13 @@ type ReplicationControllerListTypeInput interface {
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicationControllerTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ReplicationControllerListTypeArgs) ElementType() reflect.Type {
@@ -23901,8 +23711,8 @@ func (o ReplicationControllerListTypeOutput) ToReplicationControllerListTypeOutp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicationControllerListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -23911,13 +23721,13 @@ func (o ReplicationControllerListTypeOutput) Items() ReplicationControllerTypeAr
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicationControllerListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicationControllerListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicationControllerListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicationControllerListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ReplicationControllerListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ReplicationControllerListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ReplicationControllerSpec is the specification of a replication controller.
@@ -24126,7 +23936,7 @@ type ReplicationControllerStatus struct {
 	// The number of ready replicas for this replication controller.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 }
 
 // ReplicationControllerStatusInput is an input type that accepts ReplicationControllerStatusArgs and ReplicationControllerStatusOutput values.
@@ -24154,7 +23964,7 @@ type ReplicationControllerStatusArgs struct {
 	// The number of ready replicas for this replication controller.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 }
 
 func (ReplicationControllerStatusArgs) ElementType() reflect.Type {
@@ -24262,8 +24072,8 @@ func (o ReplicationControllerStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
-func (o ReplicationControllerStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ReplicationControllerStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ReplicationControllerStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ReplicationControllerStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 type ReplicationControllerStatusPtrOutput struct{ *pulumi.OutputState }
@@ -24340,7 +24150,7 @@ func (o ReplicationControllerStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -24351,7 +24161,7 @@ type ResourceFieldSelector struct {
 	// Specifies the output format of the exposed resources, defaults to "1"
 	Divisor *string `pulumi:"divisor"`
 	// Required: resource to select
-	Resource *string `pulumi:"resource"`
+	Resource string `pulumi:"resource"`
 }
 
 // ResourceFieldSelectorInput is an input type that accepts ResourceFieldSelectorArgs and ResourceFieldSelectorOutput values.
@@ -24373,7 +24183,7 @@ type ResourceFieldSelectorArgs struct {
 	// Specifies the output format of the exposed resources, defaults to "1"
 	Divisor pulumi.StringPtrInput `pulumi:"divisor"`
 	// Required: resource to select
-	Resource pulumi.StringPtrInput `pulumi:"resource"`
+	Resource pulumi.StringInput `pulumi:"resource"`
 }
 
 func (ResourceFieldSelectorArgs) ElementType() reflect.Type {
@@ -24466,8 +24276,8 @@ func (o ResourceFieldSelectorOutput) Divisor() pulumi.StringPtrOutput {
 }
 
 // Required: resource to select
-func (o ResourceFieldSelectorOutput) Resource() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceFieldSelector) *string { return v.Resource }).(pulumi.StringPtrOutput)
+func (o ResourceFieldSelectorOutput) Resource() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceFieldSelector) string { return v.Resource }).(pulumi.StringOutput)
 }
 
 type ResourceFieldSelectorPtrOutput struct{ *pulumi.OutputState }
@@ -24514,22 +24324,22 @@ func (o ResourceFieldSelectorPtrOutput) Resource() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Resource
+		return &v.Resource
 	}).(pulumi.StringPtrOutput)
 }
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuotaType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ResourceQuotaSpec `pulumi:"spec"`
+	Spec ResourceQuotaSpec `pulumi:"spec"`
 	// Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ResourceQuotaStatus `pulumi:"status"`
+	Status ResourceQuotaStatus `pulumi:"status"`
 }
 
 // ResourceQuotaTypeInput is an input type that accepts ResourceQuotaTypeArgs and ResourceQuotaTypeOutput values.
@@ -24547,15 +24357,15 @@ type ResourceQuotaTypeInput interface {
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuotaTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ResourceQuotaSpecPtrInput `pulumi:"spec"`
+	Spec ResourceQuotaSpecInput `pulumi:"spec"`
 	// Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ResourceQuotaStatusPtrInput `pulumi:"status"`
+	Status ResourceQuotaStatusInput `pulumi:"status"`
 }
 
 func (ResourceQuotaTypeArgs) ElementType() reflect.Type {
@@ -24612,28 +24422,28 @@ func (o ResourceQuotaTypeOutput) ToResourceQuotaTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ResourceQuotaTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ResourceQuotaTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceQuotaType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ResourceQuotaTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ResourceQuotaTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceQuotaType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ResourceQuotaTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ResourceQuotaTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ResourceQuotaType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ResourceQuotaTypeOutput) Spec() ResourceQuotaSpecPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaType) *ResourceQuotaSpec { return v.Spec }).(ResourceQuotaSpecPtrOutput)
+func (o ResourceQuotaTypeOutput) Spec() ResourceQuotaSpecOutput {
+	return o.ApplyT(func(v ResourceQuotaType) ResourceQuotaSpec { return v.Spec }).(ResourceQuotaSpecOutput)
 }
 
 // Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ResourceQuotaTypeOutput) Status() ResourceQuotaStatusPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaType) *ResourceQuotaStatus { return v.Status }).(ResourceQuotaStatusPtrOutput)
+func (o ResourceQuotaTypeOutput) Status() ResourceQuotaStatusOutput {
+	return o.ApplyT(func(v ResourceQuotaType) ResourceQuotaStatus { return v.Status }).(ResourceQuotaStatusOutput)
 }
 
 type ResourceQuotaTypeArrayOutput struct{ *pulumi.OutputState }
@@ -24659,13 +24469,13 @@ func (o ResourceQuotaTypeArrayOutput) Index(i pulumi.IntInput) ResourceQuotaType
 // ResourceQuotaList is a list of ResourceQuota items.
 type ResourceQuotaListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
 	Items []ResourceQuotaType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ResourceQuotaListTypeInput is an input type that accepts ResourceQuotaListTypeArgs and ResourceQuotaListTypeOutput values.
@@ -24683,13 +24493,13 @@ type ResourceQuotaListTypeInput interface {
 // ResourceQuotaList is a list of ResourceQuota items.
 type ResourceQuotaListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
 	Items ResourceQuotaTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ResourceQuotaListTypeArgs) ElementType() reflect.Type {
@@ -24720,8 +24530,8 @@ func (o ResourceQuotaListTypeOutput) ToResourceQuotaListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ResourceQuotaListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ResourceQuotaListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceQuotaListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
@@ -24730,13 +24540,13 @@ func (o ResourceQuotaListTypeOutput) Items() ResourceQuotaTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ResourceQuotaListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ResourceQuotaListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ResourceQuotaListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ResourceQuotaListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ResourceQuotaListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ResourceQuotaListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ResourceQuotaListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
@@ -25421,13 +25231,13 @@ type ScaleIOPersistentVolumeSource struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
 	FsType *string `pulumi:"fsType"`
 	// The host address of the ScaleIO API Gateway.
-	Gateway *string `pulumi:"gateway"`
+	Gateway string `pulumi:"gateway"`
 	// The name of the ScaleIO Protection Domain for the configured storage.
 	ProtectionDomain *string `pulumi:"protectionDomain"`
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-	SecretRef *SecretReference `pulumi:"secretRef"`
+	SecretRef SecretReference `pulumi:"secretRef"`
 	// Flag to enable/disable SSL communication with Gateway, default false
 	SslEnabled *bool `pulumi:"sslEnabled"`
 	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
@@ -25435,7 +25245,7 @@ type ScaleIOPersistentVolumeSource struct {
 	// The ScaleIO Storage Pool associated with the protection domain.
 	StoragePool *string `pulumi:"storagePool"`
 	// The name of the storage system as configured in ScaleIO.
-	System *string `pulumi:"system"`
+	System string `pulumi:"system"`
 	// The name of a volume already created in the ScaleIO system that is associated with this volume source.
 	VolumeName *string `pulumi:"volumeName"`
 }
@@ -25457,13 +25267,13 @@ type ScaleIOPersistentVolumeSourceArgs struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// The host address of the ScaleIO API Gateway.
-	Gateway pulumi.StringPtrInput `pulumi:"gateway"`
+	Gateway pulumi.StringInput `pulumi:"gateway"`
 	// The name of the ScaleIO Protection Domain for the configured storage.
 	ProtectionDomain pulumi.StringPtrInput `pulumi:"protectionDomain"`
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-	SecretRef SecretReferencePtrInput `pulumi:"secretRef"`
+	SecretRef SecretReferenceInput `pulumi:"secretRef"`
 	// Flag to enable/disable SSL communication with Gateway, default false
 	SslEnabled pulumi.BoolPtrInput `pulumi:"sslEnabled"`
 	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
@@ -25471,7 +25281,7 @@ type ScaleIOPersistentVolumeSourceArgs struct {
 	// The ScaleIO Storage Pool associated with the protection domain.
 	StoragePool pulumi.StringPtrInput `pulumi:"storagePool"`
 	// The name of the storage system as configured in ScaleIO.
-	System pulumi.StringPtrInput `pulumi:"system"`
+	System pulumi.StringInput `pulumi:"system"`
 	// The name of a volume already created in the ScaleIO system that is associated with this volume source.
 	VolumeName pulumi.StringPtrInput `pulumi:"volumeName"`
 }
@@ -25561,8 +25371,8 @@ func (o ScaleIOPersistentVolumeSourceOutput) FsType() pulumi.StringPtrOutput {
 }
 
 // The host address of the ScaleIO API Gateway.
-func (o ScaleIOPersistentVolumeSourceOutput) Gateway() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) *string { return v.Gateway }).(pulumi.StringPtrOutput)
+func (o ScaleIOPersistentVolumeSourceOutput) Gateway() pulumi.StringOutput {
+	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) string { return v.Gateway }).(pulumi.StringOutput)
 }
 
 // The name of the ScaleIO Protection Domain for the configured storage.
@@ -25576,8 +25386,8 @@ func (o ScaleIOPersistentVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-func (o ScaleIOPersistentVolumeSourceOutput) SecretRef() SecretReferencePtrOutput {
-	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) *SecretReference { return v.SecretRef }).(SecretReferencePtrOutput)
+func (o ScaleIOPersistentVolumeSourceOutput) SecretRef() SecretReferenceOutput {
+	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) SecretReference { return v.SecretRef }).(SecretReferenceOutput)
 }
 
 // Flag to enable/disable SSL communication with Gateway, default false
@@ -25596,8 +25406,8 @@ func (o ScaleIOPersistentVolumeSourceOutput) StoragePool() pulumi.StringPtrOutpu
 }
 
 // The name of the storage system as configured in ScaleIO.
-func (o ScaleIOPersistentVolumeSourceOutput) System() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) *string { return v.System }).(pulumi.StringPtrOutput)
+func (o ScaleIOPersistentVolumeSourceOutput) System() pulumi.StringOutput {
+	return o.ApplyT(func(v ScaleIOPersistentVolumeSource) string { return v.System }).(pulumi.StringOutput)
 }
 
 // The name of a volume already created in the ScaleIO system that is associated with this volume source.
@@ -25639,7 +25449,7 @@ func (o ScaleIOPersistentVolumeSourcePtrOutput) Gateway() pulumi.StringPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.Gateway
+		return &v.Gateway
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -25669,7 +25479,7 @@ func (o ScaleIOPersistentVolumeSourcePtrOutput) SecretRef() SecretReferencePtrOu
 		if v == nil {
 			return nil
 		}
-		return v.SecretRef
+		return &v.SecretRef
 	}).(SecretReferencePtrOutput)
 }
 
@@ -25709,7 +25519,7 @@ func (o ScaleIOPersistentVolumeSourcePtrOutput) System() pulumi.StringPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.System
+		return &v.System
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -25728,13 +25538,13 @@ type ScaleIOVolumeSource struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
 	FsType *string `pulumi:"fsType"`
 	// The host address of the ScaleIO API Gateway.
-	Gateway *string `pulumi:"gateway"`
+	Gateway string `pulumi:"gateway"`
 	// The name of the ScaleIO Protection Domain for the configured storage.
 	ProtectionDomain *string `pulumi:"protectionDomain"`
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-	SecretRef *LocalObjectReference `pulumi:"secretRef"`
+	SecretRef LocalObjectReference `pulumi:"secretRef"`
 	// Flag to enable/disable SSL communication with Gateway, default false
 	SslEnabled *bool `pulumi:"sslEnabled"`
 	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
@@ -25742,7 +25552,7 @@ type ScaleIOVolumeSource struct {
 	// The ScaleIO Storage Pool associated with the protection domain.
 	StoragePool *string `pulumi:"storagePool"`
 	// The name of the storage system as configured in ScaleIO.
-	System *string `pulumi:"system"`
+	System string `pulumi:"system"`
 	// The name of a volume already created in the ScaleIO system that is associated with this volume source.
 	VolumeName *string `pulumi:"volumeName"`
 }
@@ -25764,13 +25574,13 @@ type ScaleIOVolumeSourceArgs struct {
 	// Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
 	FsType pulumi.StringPtrInput `pulumi:"fsType"`
 	// The host address of the ScaleIO API Gateway.
-	Gateway pulumi.StringPtrInput `pulumi:"gateway"`
+	Gateway pulumi.StringInput `pulumi:"gateway"`
 	// The name of the ScaleIO Protection Domain for the configured storage.
 	ProtectionDomain pulumi.StringPtrInput `pulumi:"protectionDomain"`
 	// Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-	SecretRef LocalObjectReferencePtrInput `pulumi:"secretRef"`
+	SecretRef LocalObjectReferenceInput `pulumi:"secretRef"`
 	// Flag to enable/disable SSL communication with Gateway, default false
 	SslEnabled pulumi.BoolPtrInput `pulumi:"sslEnabled"`
 	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
@@ -25778,7 +25588,7 @@ type ScaleIOVolumeSourceArgs struct {
 	// The ScaleIO Storage Pool associated with the protection domain.
 	StoragePool pulumi.StringPtrInput `pulumi:"storagePool"`
 	// The name of the storage system as configured in ScaleIO.
-	System pulumi.StringPtrInput `pulumi:"system"`
+	System pulumi.StringInput `pulumi:"system"`
 	// The name of a volume already created in the ScaleIO system that is associated with this volume source.
 	VolumeName pulumi.StringPtrInput `pulumi:"volumeName"`
 }
@@ -25868,8 +25678,8 @@ func (o ScaleIOVolumeSourceOutput) FsType() pulumi.StringPtrOutput {
 }
 
 // The host address of the ScaleIO API Gateway.
-func (o ScaleIOVolumeSourceOutput) Gateway() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScaleIOVolumeSource) *string { return v.Gateway }).(pulumi.StringPtrOutput)
+func (o ScaleIOVolumeSourceOutput) Gateway() pulumi.StringOutput {
+	return o.ApplyT(func(v ScaleIOVolumeSource) string { return v.Gateway }).(pulumi.StringOutput)
 }
 
 // The name of the ScaleIO Protection Domain for the configured storage.
@@ -25883,8 +25693,8 @@ func (o ScaleIOVolumeSourceOutput) ReadOnly() pulumi.BoolPtrOutput {
 }
 
 // SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-func (o ScaleIOVolumeSourceOutput) SecretRef() LocalObjectReferencePtrOutput {
-	return o.ApplyT(func(v ScaleIOVolumeSource) *LocalObjectReference { return v.SecretRef }).(LocalObjectReferencePtrOutput)
+func (o ScaleIOVolumeSourceOutput) SecretRef() LocalObjectReferenceOutput {
+	return o.ApplyT(func(v ScaleIOVolumeSource) LocalObjectReference { return v.SecretRef }).(LocalObjectReferenceOutput)
 }
 
 // Flag to enable/disable SSL communication with Gateway, default false
@@ -25903,8 +25713,8 @@ func (o ScaleIOVolumeSourceOutput) StoragePool() pulumi.StringPtrOutput {
 }
 
 // The name of the storage system as configured in ScaleIO.
-func (o ScaleIOVolumeSourceOutput) System() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScaleIOVolumeSource) *string { return v.System }).(pulumi.StringPtrOutput)
+func (o ScaleIOVolumeSourceOutput) System() pulumi.StringOutput {
+	return o.ApplyT(func(v ScaleIOVolumeSource) string { return v.System }).(pulumi.StringOutput)
 }
 
 // The name of a volume already created in the ScaleIO system that is associated with this volume source.
@@ -25946,7 +25756,7 @@ func (o ScaleIOVolumeSourcePtrOutput) Gateway() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Gateway
+		return &v.Gateway
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -25976,7 +25786,7 @@ func (o ScaleIOVolumeSourcePtrOutput) SecretRef() LocalObjectReferencePtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.SecretRef
+		return &v.SecretRef
 	}).(LocalObjectReferencePtrOutput)
 }
 
@@ -26016,7 +25826,7 @@ func (o ScaleIOVolumeSourcePtrOutput) System() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.System
+		return &v.System
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -26169,9 +25979,9 @@ func (o ScopeSelectorPtrOutput) MatchExpressions() ScopedResourceSelectorRequire
 // A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
 type ScopedResourceSelectorRequirement struct {
 	// Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
-	Operator *string `pulumi:"operator"`
+	Operator string `pulumi:"operator"`
 	// The name of the scope that the selector applies to.
-	ScopeName *string `pulumi:"scopeName"`
+	ScopeName string `pulumi:"scopeName"`
 	// An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
 	Values []string `pulumi:"values"`
 }
@@ -26191,9 +26001,9 @@ type ScopedResourceSelectorRequirementInput interface {
 // A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
 type ScopedResourceSelectorRequirementArgs struct {
 	// Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
-	Operator pulumi.StringPtrInput `pulumi:"operator"`
+	Operator pulumi.StringInput `pulumi:"operator"`
 	// The name of the scope that the selector applies to.
-	ScopeName pulumi.StringPtrInput `pulumi:"scopeName"`
+	ScopeName pulumi.StringInput `pulumi:"scopeName"`
 	// An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
 	Values pulumi.StringArrayInput `pulumi:"values"`
 }
@@ -26252,13 +26062,13 @@ func (o ScopedResourceSelectorRequirementOutput) ToScopedResourceSelectorRequire
 }
 
 // Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
-func (o ScopedResourceSelectorRequirementOutput) Operator() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScopedResourceSelectorRequirement) *string { return v.Operator }).(pulumi.StringPtrOutput)
+func (o ScopedResourceSelectorRequirementOutput) Operator() pulumi.StringOutput {
+	return o.ApplyT(func(v ScopedResourceSelectorRequirement) string { return v.Operator }).(pulumi.StringOutput)
 }
 
 // The name of the scope that the selector applies to.
-func (o ScopedResourceSelectorRequirementOutput) ScopeName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ScopedResourceSelectorRequirement) *string { return v.ScopeName }).(pulumi.StringPtrOutput)
+func (o ScopedResourceSelectorRequirementOutput) ScopeName() pulumi.StringOutput {
+	return o.ApplyT(func(v ScopedResourceSelectorRequirement) string { return v.ScopeName }).(pulumi.StringOutput)
 }
 
 // An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
@@ -26299,19 +26109,19 @@ func (o ScopedResourceSelectorRequirementArrayOutput) Index(i pulumi.IntInput) S
 // https://kubernetes.io/docs/concepts/configuration/secret/#risks
 type SecretType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
 	Data map[string]string `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable *bool `pulumi:"immutable"`
+	Immutable bool `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.
 	StringData map[string]string `pulumi:"stringData"`
 	// Used to facilitate programmatic handling of secret data.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // SecretTypeInput is an input type that accepts SecretTypeArgs and SecretTypeOutput values.
@@ -26339,19 +26149,19 @@ type SecretTypeInput interface {
 // https://kubernetes.io/docs/concepts/configuration/secret/#risks
 type SecretTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
 	Data pulumi.StringMapInput `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable pulumi.BoolPtrInput `pulumi:"immutable"`
+	Immutable pulumi.BoolInput `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.
 	StringData pulumi.StringMapInput `pulumi:"stringData"`
 	// Used to facilitate programmatic handling of secret data.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (SecretTypeArgs) ElementType() reflect.Type {
@@ -26418,8 +26228,8 @@ func (o SecretTypeOutput) ToSecretTypeOutputWithContext(ctx context.Context) Sec
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SecretTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SecretTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
@@ -26428,18 +26238,18 @@ func (o SecretTypeOutput) Data() pulumi.StringMapOutput {
 }
 
 // Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-func (o SecretTypeOutput) Immutable() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v SecretType) *bool { return v.Immutable }).(pulumi.BoolPtrOutput)
+func (o SecretTypeOutput) Immutable() pulumi.BoolOutput {
+	return o.ApplyT(func(v SecretType) bool { return v.Immutable }).(pulumi.BoolOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SecretTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SecretTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o SecretTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v SecretType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o SecretTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v SecretType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.
@@ -26448,8 +26258,8 @@ func (o SecretTypeOutput) StringData() pulumi.StringMapOutput {
 }
 
 // Used to facilitate programmatic handling of secret data.
-func (o SecretTypeOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretType) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o SecretTypeOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretType) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type SecretTypeArrayOutput struct{ *pulumi.OutputState }
@@ -26636,7 +26446,7 @@ func (o SecretEnvSourcePtrOutput) Optional() pulumi.BoolPtrOutput {
 // SecretKeySelector selects a key of a Secret.
 type SecretKeySelector struct {
 	// The key of the secret to select from.  Must be a valid secret key.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name *string `pulumi:"name"`
 	// Specify whether the Secret or its key must be defined
@@ -26658,7 +26468,7 @@ type SecretKeySelectorInput interface {
 // SecretKeySelector selects a key of a Secret.
 type SecretKeySelectorArgs struct {
 	// The key of the secret to select from.  Must be a valid secret key.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name pulumi.StringPtrInput `pulumi:"name"`
 	// Specify whether the Secret or its key must be defined
@@ -26745,8 +26555,8 @@ func (o SecretKeySelectorOutput) ToSecretKeySelectorPtrOutputWithContext(ctx con
 }
 
 // The key of the secret to select from.  Must be a valid secret key.
-func (o SecretKeySelectorOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretKeySelector) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o SecretKeySelectorOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretKeySelector) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -26783,7 +26593,7 @@ func (o SecretKeySelectorPtrOutput) Key() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Key
+		return &v.Key
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -26810,13 +26620,13 @@ func (o SecretKeySelectorPtrOutput) Optional() pulumi.BoolPtrOutput {
 // SecretList is a list of Secret.
 type SecretListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Items []SecretType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // SecretListTypeInput is an input type that accepts SecretListTypeArgs and SecretListTypeOutput values.
@@ -26834,13 +26644,13 @@ type SecretListTypeInput interface {
 // SecretList is a list of Secret.
 type SecretListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Items SecretTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (SecretListTypeArgs) ElementType() reflect.Type {
@@ -26871,8 +26681,8 @@ func (o SecretListTypeOutput) ToSecretListTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o SecretListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o SecretListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
@@ -26881,13 +26691,13 @@ func (o SecretListTypeOutput) Items() SecretTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SecretListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SecretListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SecretListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v SecretListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o SecretListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v SecretListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o SecretListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v SecretListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // Adapts a secret into a projected volume.
@@ -27759,15 +27569,15 @@ func (o SecurityContextPtrOutput) WindowsOptions() WindowsSecurityContextOptions
 // by setting the 'customTimeouts' option on the resource.
 type ServiceType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ServiceSpec `pulumi:"spec"`
+	Spec ServiceSpec `pulumi:"spec"`
 	// Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ServiceStatus `pulumi:"status"`
+	Status ServiceStatus `pulumi:"status"`
 }
 
 // ServiceTypeInput is an input type that accepts ServiceTypeArgs and ServiceTypeOutput values.
@@ -27810,15 +27620,15 @@ type ServiceTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type ServiceTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ServiceSpecPtrInput `pulumi:"spec"`
+	Spec ServiceSpecInput `pulumi:"spec"`
 	// Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ServiceStatusPtrInput `pulumi:"status"`
+	Status ServiceStatusInput `pulumi:"status"`
 }
 
 func (ServiceTypeArgs) ElementType() reflect.Type {
@@ -27900,28 +27710,28 @@ func (o ServiceTypeOutput) ToServiceTypeOutputWithContext(ctx context.Context) S
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ServiceTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ServiceTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ServiceTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ServiceTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ServiceType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ServiceTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ServiceType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ServiceTypeOutput) Spec() ServiceSpecPtrOutput {
-	return o.ApplyT(func(v ServiceType) *ServiceSpec { return v.Spec }).(ServiceSpecPtrOutput)
+func (o ServiceTypeOutput) Spec() ServiceSpecOutput {
+	return o.ApplyT(func(v ServiceType) ServiceSpec { return v.Spec }).(ServiceSpecOutput)
 }
 
 // Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ServiceTypeOutput) Status() ServiceStatusPtrOutput {
-	return o.ApplyT(func(v ServiceType) *ServiceStatus { return v.Status }).(ServiceStatusPtrOutput)
+func (o ServiceTypeOutput) Status() ServiceStatusOutput {
+	return o.ApplyT(func(v ServiceType) ServiceStatus { return v.Status }).(ServiceStatusOutput)
 }
 
 type ServiceTypeArrayOutput struct{ *pulumi.OutputState }
@@ -27947,15 +27757,15 @@ func (o ServiceTypeArrayOutput) Index(i pulumi.IntInput) ServiceTypeOutput {
 // ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
 type ServiceAccountType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-	AutomountServiceAccountToken *bool `pulumi:"automountServiceAccountToken"`
+	AutomountServiceAccountToken bool `pulumi:"automountServiceAccountToken"`
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets []LocalObjectReference `pulumi:"imagePullSecrets"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Secrets []ObjectReference `pulumi:"secrets"`
 }
@@ -27975,15 +27785,15 @@ type ServiceAccountTypeInput interface {
 // ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
 type ServiceAccountTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-	AutomountServiceAccountToken pulumi.BoolPtrInput `pulumi:"automountServiceAccountToken"`
+	AutomountServiceAccountToken pulumi.BoolInput `pulumi:"automountServiceAccountToken"`
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets LocalObjectReferenceArrayInput `pulumi:"imagePullSecrets"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Secrets ObjectReferenceArrayInput `pulumi:"secrets"`
 }
@@ -28042,13 +27852,13 @@ func (o ServiceAccountTypeOutput) ToServiceAccountTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ServiceAccountTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ServiceAccountTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-func (o ServiceAccountTypeOutput) AutomountServiceAccountToken() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v ServiceAccountType) *bool { return v.AutomountServiceAccountToken }).(pulumi.BoolPtrOutput)
+func (o ServiceAccountTypeOutput) AutomountServiceAccountToken() pulumi.BoolOutput {
+	return o.ApplyT(func(v ServiceAccountType) bool { return v.AutomountServiceAccountToken }).(pulumi.BoolOutput)
 }
 
 // ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -28057,13 +27867,13 @@ func (o ServiceAccountTypeOutput) ImagePullSecrets() LocalObjectReferenceArrayOu
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceAccountTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ServiceAccountTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ServiceAccountTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ServiceAccountType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ServiceAccountTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ServiceAccountType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
@@ -28094,13 +27904,13 @@ func (o ServiceAccountTypeArrayOutput) Index(i pulumi.IntInput) ServiceAccountTy
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	Items []ServiceAccountType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ServiceAccountListTypeInput is an input type that accepts ServiceAccountListTypeArgs and ServiceAccountListTypeOutput values.
@@ -28118,13 +27928,13 @@ type ServiceAccountListTypeInput interface {
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	Items ServiceAccountTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ServiceAccountListTypeArgs) ElementType() reflect.Type {
@@ -28155,8 +27965,8 @@ func (o ServiceAccountListTypeOutput) ToServiceAccountListTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ServiceAccountListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ServiceAccountListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -28165,13 +27975,13 @@ func (o ServiceAccountListTypeOutput) Items() ServiceAccountTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceAccountListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ServiceAccountListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceAccountListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ServiceAccountListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ServiceAccountListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ServiceAccountListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
@@ -28181,7 +27991,7 @@ type ServiceAccountTokenProjection struct {
 	// ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
 	ExpirationSeconds *int `pulumi:"expirationSeconds"`
 	// Path is the path relative to the mount point of the file to project the token into.
-	Path *string `pulumi:"path"`
+	Path string `pulumi:"path"`
 }
 
 // ServiceAccountTokenProjectionInput is an input type that accepts ServiceAccountTokenProjectionArgs and ServiceAccountTokenProjectionOutput values.
@@ -28203,7 +28013,7 @@ type ServiceAccountTokenProjectionArgs struct {
 	// ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
 	ExpirationSeconds pulumi.IntPtrInput `pulumi:"expirationSeconds"`
 	// Path is the path relative to the mount point of the file to project the token into.
-	Path pulumi.StringPtrInput `pulumi:"path"`
+	Path pulumi.StringInput `pulumi:"path"`
 }
 
 func (ServiceAccountTokenProjectionArgs) ElementType() reflect.Type {
@@ -28296,8 +28106,8 @@ func (o ServiceAccountTokenProjectionOutput) ExpirationSeconds() pulumi.IntPtrOu
 }
 
 // Path is the path relative to the mount point of the file to project the token into.
-func (o ServiceAccountTokenProjectionOutput) Path() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountTokenProjection) *string { return v.Path }).(pulumi.StringPtrOutput)
+func (o ServiceAccountTokenProjectionOutput) Path() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountTokenProjection) string { return v.Path }).(pulumi.StringOutput)
 }
 
 type ServiceAccountTokenProjectionPtrOutput struct{ *pulumi.OutputState }
@@ -28344,20 +28154,20 @@ func (o ServiceAccountTokenProjectionPtrOutput) Path() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Path
+		return &v.Path
 	}).(pulumi.StringPtrOutput)
 }
 
 // ServiceList holds a list of services.
 type ServiceListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of services
 	Items []ServiceType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ServiceListTypeInput is an input type that accepts ServiceListTypeArgs and ServiceListTypeOutput values.
@@ -28375,13 +28185,13 @@ type ServiceListTypeInput interface {
 // ServiceList holds a list of services.
 type ServiceListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of services
 	Items ServiceTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ServiceListTypeArgs) ElementType() reflect.Type {
@@ -28412,8 +28222,8 @@ func (o ServiceListTypeOutput) ToServiceListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ServiceListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ServiceListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of services
@@ -28422,13 +28232,13 @@ func (o ServiceListTypeOutput) Items() ServiceTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ServiceListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ServiceListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ServiceListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ServiceListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ServiceListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ServicePort contains information on service's port.
@@ -28440,7 +28250,7 @@ type ServicePort struct {
 	// The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
 	NodePort *int `pulumi:"nodePort"`
 	// The port that will be exposed by this service.
-	Port *int `pulumi:"port"`
+	Port int `pulumi:"port"`
 	// The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
 	Protocol *string `pulumi:"protocol"`
 	// Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
@@ -28468,7 +28278,7 @@ type ServicePortArgs struct {
 	// The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
 	NodePort pulumi.IntPtrInput `pulumi:"nodePort"`
 	// The port that will be exposed by this service.
-	Port pulumi.IntPtrInput `pulumi:"port"`
+	Port pulumi.IntInput `pulumi:"port"`
 	// The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
 	Protocol pulumi.StringPtrInput `pulumi:"protocol"`
 	// Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
@@ -28544,8 +28354,8 @@ func (o ServicePortOutput) NodePort() pulumi.IntPtrOutput {
 }
 
 // The port that will be exposed by this service.
-func (o ServicePortOutput) Port() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ServicePort) *int { return v.Port }).(pulumi.IntPtrOutput)
+func (o ServicePortOutput) Port() pulumi.IntOutput {
+	return o.ApplyT(func(v ServicePort) int { return v.Port }).(pulumi.IntOutput)
 }
 
 // The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
@@ -29679,9 +29489,9 @@ func (o StorageOSVolumeSourcePtrOutput) VolumeNamespace() pulumi.StringPtrOutput
 // Sysctl defines a kernel parameter to be set
 type Sysctl struct {
 	// Name of a property to set
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Value of a property to set
-	Value *string `pulumi:"value"`
+	Value string `pulumi:"value"`
 }
 
 // SysctlInput is an input type that accepts SysctlArgs and SysctlOutput values.
@@ -29699,9 +29509,9 @@ type SysctlInput interface {
 // Sysctl defines a kernel parameter to be set
 type SysctlArgs struct {
 	// Name of a property to set
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Value of a property to set
-	Value pulumi.StringPtrInput `pulumi:"value"`
+	Value pulumi.StringInput `pulumi:"value"`
 }
 
 func (SysctlArgs) ElementType() reflect.Type {
@@ -29758,13 +29568,13 @@ func (o SysctlOutput) ToSysctlOutputWithContext(ctx context.Context) SysctlOutpu
 }
 
 // Name of a property to set
-func (o SysctlOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Sysctl) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o SysctlOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Sysctl) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Value of a property to set
-func (o SysctlOutput) Value() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Sysctl) *string { return v.Value }).(pulumi.StringPtrOutput)
+func (o SysctlOutput) Value() pulumi.StringOutput {
+	return o.ApplyT(func(v Sysctl) string { return v.Value }).(pulumi.StringOutput)
 }
 
 type SysctlArrayOutput struct{ *pulumi.OutputState }
@@ -29945,9 +29755,9 @@ func (o TCPSocketActionPtrOutput) Port() pulumi.AnyOutput {
 // The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
 type Taint struct {
 	// Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-	Effect *string `pulumi:"effect"`
+	Effect string `pulumi:"effect"`
 	// Required. The taint key to be applied to a node.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
 	TimeAdded *string `pulumi:"timeAdded"`
 	// The taint value corresponding to the taint key.
@@ -29969,9 +29779,9 @@ type TaintInput interface {
 // The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
 type TaintArgs struct {
 	// Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-	Effect pulumi.StringPtrInput `pulumi:"effect"`
+	Effect pulumi.StringInput `pulumi:"effect"`
 	// Required. The taint key to be applied to a node.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
 	TimeAdded pulumi.StringPtrInput `pulumi:"timeAdded"`
 	// The taint value corresponding to the taint key.
@@ -30032,13 +29842,13 @@ func (o TaintOutput) ToTaintOutputWithContext(ctx context.Context) TaintOutput {
 }
 
 // Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-func (o TaintOutput) Effect() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Taint) *string { return v.Effect }).(pulumi.StringPtrOutput)
+func (o TaintOutput) Effect() pulumi.StringOutput {
+	return o.ApplyT(func(v Taint) string { return v.Effect }).(pulumi.StringOutput)
 }
 
 // Required. The taint key to be applied to a node.
-func (o TaintOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Taint) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o TaintOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v Taint) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
@@ -30212,7 +30022,7 @@ func (o TolerationArrayOutput) Index(i pulumi.IntInput) TolerationOutput {
 // A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.
 type TopologySelectorLabelRequirement struct {
 	// The label key that the selector applies to.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
 	Values []string `pulumi:"values"`
 }
@@ -30232,7 +30042,7 @@ type TopologySelectorLabelRequirementInput interface {
 // A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.
 type TopologySelectorLabelRequirementArgs struct {
 	// The label key that the selector applies to.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
 	Values pulumi.StringArrayInput `pulumi:"values"`
 }
@@ -30291,8 +30101,8 @@ func (o TopologySelectorLabelRequirementOutput) ToTopologySelectorLabelRequireme
 }
 
 // The label key that the selector applies to.
-func (o TopologySelectorLabelRequirementOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TopologySelectorLabelRequirement) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o TopologySelectorLabelRequirementOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v TopologySelectorLabelRequirement) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
@@ -30427,11 +30237,11 @@ type TopologySpreadConstraint struct {
 	// LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
 	LabelSelector *metav1.LabelSelector `pulumi:"labelSelector"`
 	// MaxSkew describes the degree to which pods may be unevenly distributed. It's the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It's a required field. Default value is 1 and 0 is not allowed.
-	MaxSkew *int `pulumi:"maxSkew"`
+	MaxSkew int `pulumi:"maxSkew"`
 	// TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
-	TopologyKey *string `pulumi:"topologyKey"`
+	TopologyKey string `pulumi:"topologyKey"`
 	// WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It's considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
-	WhenUnsatisfiable *string `pulumi:"whenUnsatisfiable"`
+	WhenUnsatisfiable string `pulumi:"whenUnsatisfiable"`
 }
 
 // TopologySpreadConstraintInput is an input type that accepts TopologySpreadConstraintArgs and TopologySpreadConstraintOutput values.
@@ -30451,11 +30261,11 @@ type TopologySpreadConstraintArgs struct {
 	// LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
 	LabelSelector metav1.LabelSelectorPtrInput `pulumi:"labelSelector"`
 	// MaxSkew describes the degree to which pods may be unevenly distributed. It's the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It's a required field. Default value is 1 and 0 is not allowed.
-	MaxSkew pulumi.IntPtrInput `pulumi:"maxSkew"`
+	MaxSkew pulumi.IntInput `pulumi:"maxSkew"`
 	// TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
-	TopologyKey pulumi.StringPtrInput `pulumi:"topologyKey"`
+	TopologyKey pulumi.StringInput `pulumi:"topologyKey"`
 	// WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It's considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
-	WhenUnsatisfiable pulumi.StringPtrInput `pulumi:"whenUnsatisfiable"`
+	WhenUnsatisfiable pulumi.StringInput `pulumi:"whenUnsatisfiable"`
 }
 
 func (TopologySpreadConstraintArgs) ElementType() reflect.Type {
@@ -30517,18 +30327,18 @@ func (o TopologySpreadConstraintOutput) LabelSelector() metav1.LabelSelectorPtrO
 }
 
 // MaxSkew describes the degree to which pods may be unevenly distributed. It's the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It's a required field. Default value is 1 and 0 is not allowed.
-func (o TopologySpreadConstraintOutput) MaxSkew() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v TopologySpreadConstraint) *int { return v.MaxSkew }).(pulumi.IntPtrOutput)
+func (o TopologySpreadConstraintOutput) MaxSkew() pulumi.IntOutput {
+	return o.ApplyT(func(v TopologySpreadConstraint) int { return v.MaxSkew }).(pulumi.IntOutput)
 }
 
 // TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
-func (o TopologySpreadConstraintOutput) TopologyKey() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TopologySpreadConstraint) *string { return v.TopologyKey }).(pulumi.StringPtrOutput)
+func (o TopologySpreadConstraintOutput) TopologyKey() pulumi.StringOutput {
+	return o.ApplyT(func(v TopologySpreadConstraint) string { return v.TopologyKey }).(pulumi.StringOutput)
 }
 
 // WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It's considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
-func (o TopologySpreadConstraintOutput) WhenUnsatisfiable() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TopologySpreadConstraint) *string { return v.WhenUnsatisfiable }).(pulumi.StringPtrOutput)
+func (o TopologySpreadConstraintOutput) WhenUnsatisfiable() pulumi.StringOutput {
+	return o.ApplyT(func(v TopologySpreadConstraint) string { return v.WhenUnsatisfiable }).(pulumi.StringOutput)
 }
 
 type TopologySpreadConstraintArrayOutput struct{ *pulumi.OutputState }
@@ -30556,9 +30366,9 @@ type TypedLocalObjectReference struct {
 	// APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
 	ApiGroup *string `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // TypedLocalObjectReferenceInput is an input type that accepts TypedLocalObjectReferenceArgs and TypedLocalObjectReferenceOutput values.
@@ -30578,9 +30388,9 @@ type TypedLocalObjectReferenceArgs struct {
 	// APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
 	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (TypedLocalObjectReferenceArgs) ElementType() reflect.Type {
@@ -30668,13 +30478,13 @@ func (o TypedLocalObjectReferenceOutput) ApiGroup() pulumi.StringPtrOutput {
 }
 
 // Kind is the type of resource being referenced
-func (o TypedLocalObjectReferenceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TypedLocalObjectReference) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o TypedLocalObjectReferenceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v TypedLocalObjectReference) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name is the name of resource being referenced
-func (o TypedLocalObjectReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v TypedLocalObjectReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o TypedLocalObjectReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v TypedLocalObjectReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type TypedLocalObjectReferencePtrOutput struct{ *pulumi.OutputState }
@@ -30711,7 +30521,7 @@ func (o TypedLocalObjectReferencePtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -30721,7 +30531,7 @@ func (o TypedLocalObjectReferencePtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -30762,7 +30572,7 @@ type Volume struct {
 	// ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
 	Iscsi *ISCSIVolumeSource `pulumi:"iscsi"`
 	// Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	Nfs *NFSVolumeSource `pulumi:"nfs"`
 	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
@@ -30836,7 +30646,7 @@ type VolumeArgs struct {
 	// ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
 	Iscsi ISCSIVolumeSourcePtrInput `pulumi:"iscsi"`
 	// Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	Nfs NFSVolumeSourcePtrInput `pulumi:"nfs"`
 	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
@@ -31000,8 +30810,8 @@ func (o VolumeOutput) Iscsi() ISCSIVolumeSourcePtrOutput {
 }
 
 // Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-func (o VolumeOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Volume) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o VolumeOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Volume) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
@@ -31082,9 +30892,9 @@ func (o VolumeArrayOutput) Index(i pulumi.IntInput) VolumeOutput {
 // volumeDevice describes a mapping of a raw block device within a container.
 type VolumeDevice struct {
 	// devicePath is the path inside of the container that the device will be mapped to.
-	DevicePath *string `pulumi:"devicePath"`
+	DevicePath string `pulumi:"devicePath"`
 	// name must match the name of a persistentVolumeClaim in the pod
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // VolumeDeviceInput is an input type that accepts VolumeDeviceArgs and VolumeDeviceOutput values.
@@ -31102,9 +30912,9 @@ type VolumeDeviceInput interface {
 // volumeDevice describes a mapping of a raw block device within a container.
 type VolumeDeviceArgs struct {
 	// devicePath is the path inside of the container that the device will be mapped to.
-	DevicePath pulumi.StringPtrInput `pulumi:"devicePath"`
+	DevicePath pulumi.StringInput `pulumi:"devicePath"`
 	// name must match the name of a persistentVolumeClaim in the pod
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (VolumeDeviceArgs) ElementType() reflect.Type {
@@ -31161,13 +30971,13 @@ func (o VolumeDeviceOutput) ToVolumeDeviceOutputWithContext(ctx context.Context)
 }
 
 // devicePath is the path inside of the container that the device will be mapped to.
-func (o VolumeDeviceOutput) DevicePath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeDevice) *string { return v.DevicePath }).(pulumi.StringPtrOutput)
+func (o VolumeDeviceOutput) DevicePath() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeDevice) string { return v.DevicePath }).(pulumi.StringOutput)
 }
 
 // name must match the name of a persistentVolumeClaim in the pod
-func (o VolumeDeviceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeDevice) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o VolumeDeviceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeDevice) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type VolumeDeviceArrayOutput struct{ *pulumi.OutputState }
@@ -31193,11 +31003,11 @@ func (o VolumeDeviceArrayOutput) Index(i pulumi.IntInput) VolumeDeviceOutput {
 // VolumeMount describes a mounting of a Volume within a container.
 type VolumeMount struct {
 	// Path within the container at which the volume should be mounted.  Must not contain ':'.
-	MountPath *string `pulumi:"mountPath"`
+	MountPath string `pulumi:"mountPath"`
 	// mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
 	MountPropagation *string `pulumi:"mountPropagation"`
 	// This must match the Name of a Volume.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 	ReadOnly *bool `pulumi:"readOnly"`
 	// Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
@@ -31221,11 +31031,11 @@ type VolumeMountInput interface {
 // VolumeMount describes a mounting of a Volume within a container.
 type VolumeMountArgs struct {
 	// Path within the container at which the volume should be mounted.  Must not contain ':'.
-	MountPath pulumi.StringPtrInput `pulumi:"mountPath"`
+	MountPath pulumi.StringInput `pulumi:"mountPath"`
 	// mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
 	MountPropagation pulumi.StringPtrInput `pulumi:"mountPropagation"`
 	// This must match the Name of a Volume.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
 	// Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
@@ -31288,8 +31098,8 @@ func (o VolumeMountOutput) ToVolumeMountOutputWithContext(ctx context.Context) V
 }
 
 // Path within the container at which the volume should be mounted.  Must not contain ':'.
-func (o VolumeMountOutput) MountPath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeMount) *string { return v.MountPath }).(pulumi.StringPtrOutput)
+func (o VolumeMountOutput) MountPath() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeMount) string { return v.MountPath }).(pulumi.StringOutput)
 }
 
 // mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
@@ -31298,8 +31108,8 @@ func (o VolumeMountOutput) MountPropagation() pulumi.StringPtrOutput {
 }
 
 // This must match the Name of a Volume.
-func (o VolumeMountOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeMount) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o VolumeMountOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeMount) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
@@ -31611,7 +31421,7 @@ type VsphereVirtualDiskVolumeSource struct {
 	// Storage Policy Based Management (SPBM) profile name.
 	StoragePolicyName *string `pulumi:"storagePolicyName"`
 	// Path that identifies vSphere volume vmdk
-	VolumePath *string `pulumi:"volumePath"`
+	VolumePath string `pulumi:"volumePath"`
 }
 
 // VsphereVirtualDiskVolumeSourceInput is an input type that accepts VsphereVirtualDiskVolumeSourceArgs and VsphereVirtualDiskVolumeSourceOutput values.
@@ -31635,7 +31445,7 @@ type VsphereVirtualDiskVolumeSourceArgs struct {
 	// Storage Policy Based Management (SPBM) profile name.
 	StoragePolicyName pulumi.StringPtrInput `pulumi:"storagePolicyName"`
 	// Path that identifies vSphere volume vmdk
-	VolumePath pulumi.StringPtrInput `pulumi:"volumePath"`
+	VolumePath pulumi.StringInput `pulumi:"volumePath"`
 }
 
 func (VsphereVirtualDiskVolumeSourceArgs) ElementType() reflect.Type {
@@ -31733,8 +31543,8 @@ func (o VsphereVirtualDiskVolumeSourceOutput) StoragePolicyName() pulumi.StringP
 }
 
 // Path that identifies vSphere volume vmdk
-func (o VsphereVirtualDiskVolumeSourceOutput) VolumePath() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VsphereVirtualDiskVolumeSource) *string { return v.VolumePath }).(pulumi.StringPtrOutput)
+func (o VsphereVirtualDiskVolumeSourceOutput) VolumePath() pulumi.StringOutput {
+	return o.ApplyT(func(v VsphereVirtualDiskVolumeSource) string { return v.VolumePath }).(pulumi.StringOutput)
 }
 
 type VsphereVirtualDiskVolumeSourcePtrOutput struct{ *pulumi.OutputState }
@@ -31791,16 +31601,16 @@ func (o VsphereVirtualDiskVolumeSourcePtrOutput) VolumePath() pulumi.StringPtrOu
 		if v == nil {
 			return nil
 		}
-		return v.VolumePath
+		return &v.VolumePath
 	}).(pulumi.StringPtrOutput)
 }
 
 // The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
 type WeightedPodAffinityTerm struct {
 	// Required. A pod affinity term, associated with the corresponding weight.
-	PodAffinityTerm *PodAffinityTerm `pulumi:"podAffinityTerm"`
+	PodAffinityTerm PodAffinityTerm `pulumi:"podAffinityTerm"`
 	// weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-	Weight *int `pulumi:"weight"`
+	Weight int `pulumi:"weight"`
 }
 
 // WeightedPodAffinityTermInput is an input type that accepts WeightedPodAffinityTermArgs and WeightedPodAffinityTermOutput values.
@@ -31818,9 +31628,9 @@ type WeightedPodAffinityTermInput interface {
 // The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
 type WeightedPodAffinityTermArgs struct {
 	// Required. A pod affinity term, associated with the corresponding weight.
-	PodAffinityTerm PodAffinityTermPtrInput `pulumi:"podAffinityTerm"`
+	PodAffinityTerm PodAffinityTermInput `pulumi:"podAffinityTerm"`
 	// weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-	Weight pulumi.IntPtrInput `pulumi:"weight"`
+	Weight pulumi.IntInput `pulumi:"weight"`
 }
 
 func (WeightedPodAffinityTermArgs) ElementType() reflect.Type {
@@ -31877,13 +31687,13 @@ func (o WeightedPodAffinityTermOutput) ToWeightedPodAffinityTermOutputWithContex
 }
 
 // Required. A pod affinity term, associated with the corresponding weight.
-func (o WeightedPodAffinityTermOutput) PodAffinityTerm() PodAffinityTermPtrOutput {
-	return o.ApplyT(func(v WeightedPodAffinityTerm) *PodAffinityTerm { return v.PodAffinityTerm }).(PodAffinityTermPtrOutput)
+func (o WeightedPodAffinityTermOutput) PodAffinityTerm() PodAffinityTermOutput {
+	return o.ApplyT(func(v WeightedPodAffinityTerm) PodAffinityTerm { return v.PodAffinityTerm }).(PodAffinityTermOutput)
 }
 
 // weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-func (o WeightedPodAffinityTermOutput) Weight() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v WeightedPodAffinityTerm) *int { return v.Weight }).(pulumi.IntPtrOutput)
+func (o WeightedPodAffinityTermOutput) Weight() pulumi.IntOutput {
+	return o.ApplyT(func(v WeightedPodAffinityTerm) int { return v.Weight }).(pulumi.IntOutput)
 }
 
 type WeightedPodAffinityTermArrayOutput struct{ *pulumi.OutputState }
@@ -32261,7 +32071,6 @@ func init() {
 	pulumi.RegisterOutputType(NodeSelectorRequirementOutput{})
 	pulumi.RegisterOutputType(NodeSelectorRequirementArrayOutput{})
 	pulumi.RegisterOutputType(NodeSelectorTermOutput{})
-	pulumi.RegisterOutputType(NodeSelectorTermPtrOutput{})
 	pulumi.RegisterOutputType(NodeSelectorTermArrayOutput{})
 	pulumi.RegisterOutputType(NodeSpecOutput{})
 	pulumi.RegisterOutputType(NodeSpecPtrOutput{})
@@ -32299,7 +32108,6 @@ func init() {
 	pulumi.RegisterOutputType(PodAffinityOutput{})
 	pulumi.RegisterOutputType(PodAffinityPtrOutput{})
 	pulumi.RegisterOutputType(PodAffinityTermOutput{})
-	pulumi.RegisterOutputType(PodAffinityTermPtrOutput{})
 	pulumi.RegisterOutputType(PodAffinityTermArrayOutput{})
 	pulumi.RegisterOutputType(PodAntiAffinityOutput{})
 	pulumi.RegisterOutputType(PodAntiAffinityPtrOutput{})

--- a/sdk/go/kubernetes/core/v1/replicationController.go
+++ b/sdk/go/kubernetes/core/v1/replicationController.go
@@ -15,15 +15,15 @@ type ReplicationController struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicationControllerSpecPtrOutput `pulumi:"spec"`
+	Spec ReplicationControllerSpecOutput `pulumi:"spec"`
 	// Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicationControllerStatusPtrOutput `pulumi:"status"`
+	Status ReplicationControllerStatusOutput `pulumi:"status"`
 }
 
 // NewReplicationController registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/replicationControllerList.go
+++ b/sdk/go/kubernetes/core/v1/replicationControllerList.go
@@ -16,13 +16,13 @@ type ReplicationControllerList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicationControllerTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewReplicationControllerList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/resourceQuota.go
+++ b/sdk/go/kubernetes/core/v1/resourceQuota.go
@@ -15,15 +15,15 @@ type ResourceQuota struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ResourceQuotaSpecPtrOutput `pulumi:"spec"`
+	Spec ResourceQuotaSpecOutput `pulumi:"spec"`
 	// Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ResourceQuotaStatusPtrOutput `pulumi:"status"`
+	Status ResourceQuotaStatusOutput `pulumi:"status"`
 }
 
 // NewResourceQuota registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/resourceQuotaList.go
+++ b/sdk/go/kubernetes/core/v1/resourceQuotaList.go
@@ -16,13 +16,13 @@ type ResourceQuotaList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
 	Items ResourceQuotaTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewResourceQuotaList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/secret.go
+++ b/sdk/go/kubernetes/core/v1/secret.go
@@ -25,19 +25,19 @@ type Secret struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
 	Data pulumi.StringMapOutput `pulumi:"data"`
 	// Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is an alpha field enabled by ImmutableEphemeralVolumes feature gate.
-	Immutable pulumi.BoolPtrOutput `pulumi:"immutable"`
+	Immutable pulumi.BoolOutput `pulumi:"immutable"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.
 	StringData pulumi.StringMapOutput `pulumi:"stringData"`
 	// Used to facilitate programmatic handling of secret data.
-	Type pulumi.StringPtrOutput `pulumi:"type"`
+	Type pulumi.StringOutput `pulumi:"type"`
 }
 
 // NewSecret registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/secretList.go
+++ b/sdk/go/kubernetes/core/v1/secretList.go
@@ -16,13 +16,13 @@ type SecretList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Items SecretTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewSecretList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/service.go
+++ b/sdk/go/kubernetes/core/v1/service.go
@@ -40,15 +40,15 @@ type Service struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ServiceSpecPtrOutput `pulumi:"spec"`
+	Spec ServiceSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ServiceStatusPtrOutput `pulumi:"status"`
+	Status ServiceStatusOutput `pulumi:"status"`
 }
 
 // NewService registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/serviceAccount.go
+++ b/sdk/go/kubernetes/core/v1/serviceAccount.go
@@ -15,15 +15,15 @@ type ServiceAccount struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-	AutomountServiceAccountToken pulumi.BoolPtrOutput `pulumi:"automountServiceAccountToken"`
+	AutomountServiceAccountToken pulumi.BoolOutput `pulumi:"automountServiceAccountToken"`
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets LocalObjectReferenceArrayOutput `pulumi:"imagePullSecrets"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
 	Secrets ObjectReferenceArrayOutput `pulumi:"secrets"`
 }

--- a/sdk/go/kubernetes/core/v1/serviceAccountList.go
+++ b/sdk/go/kubernetes/core/v1/serviceAccountList.go
@@ -16,13 +16,13 @@ type ServiceAccountList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	Items ServiceAccountTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewServiceAccountList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/core/v1/serviceList.go
+++ b/sdk/go/kubernetes/core/v1/serviceList.go
@@ -16,13 +16,13 @@ type ServiceList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of services
 	Items ServiceTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewServiceList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/discovery/v1beta1/endpointSlice.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/endpointSlice.go
@@ -16,15 +16,15 @@ type EndpointSlice struct {
 	pulumi.CustomResourceState
 
 	// addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
-	AddressType pulumi.StringPtrOutput `pulumi:"addressType"`
+	AddressType pulumi.StringOutput `pulumi:"addressType"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
 	Endpoints EndpointArrayOutput `pulumi:"endpoints"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
 	Ports EndpointPortArrayOutput `pulumi:"ports"`
 }

--- a/sdk/go/kubernetes/discovery/v1beta1/endpointSliceList.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/endpointSliceList.go
@@ -16,13 +16,13 @@ type EndpointSliceList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of endpoint slices
 	Items EndpointSliceTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewEndpointSliceList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/discovery/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/pulumiTypes.go
@@ -436,15 +436,15 @@ func (o EndpointPortArrayOutput) Index(i pulumi.IntInput) EndpointPortOutput {
 // EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 type EndpointSliceType struct {
 	// addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
-	AddressType *string `pulumi:"addressType"`
+	AddressType string `pulumi:"addressType"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
 	Endpoints []Endpoint `pulumi:"endpoints"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
 	Ports []EndpointPort `pulumi:"ports"`
 }
@@ -464,15 +464,15 @@ type EndpointSliceTypeInput interface {
 // EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 type EndpointSliceTypeArgs struct {
 	// addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
-	AddressType pulumi.StringPtrInput `pulumi:"addressType"`
+	AddressType pulumi.StringInput `pulumi:"addressType"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
 	Endpoints EndpointArrayInput `pulumi:"endpoints"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
 	Ports EndpointPortArrayInput `pulumi:"ports"`
 }
@@ -531,13 +531,13 @@ func (o EndpointSliceTypeOutput) ToEndpointSliceTypeOutputWithContext(ctx contex
 }
 
 // addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
-func (o EndpointSliceTypeOutput) AddressType() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointSliceType) *string { return v.AddressType }).(pulumi.StringPtrOutput)
+func (o EndpointSliceTypeOutput) AddressType() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointSliceType) string { return v.AddressType }).(pulumi.StringOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EndpointSliceTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointSliceType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EndpointSliceTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointSliceType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
@@ -546,13 +546,13 @@ func (o EndpointSliceTypeOutput) Endpoints() EndpointArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EndpointSliceTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointSliceType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EndpointSliceTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointSliceType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o EndpointSliceTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v EndpointSliceType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o EndpointSliceTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v EndpointSliceType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
@@ -583,13 +583,13 @@ func (o EndpointSliceTypeArrayOutput) Index(i pulumi.IntInput) EndpointSliceType
 // EndpointSliceList represents a list of endpoint slices
 type EndpointSliceListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of endpoint slices
 	Items []EndpointSliceType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // EndpointSliceListTypeInput is an input type that accepts EndpointSliceListTypeArgs and EndpointSliceListTypeOutput values.
@@ -607,13 +607,13 @@ type EndpointSliceListTypeInput interface {
 // EndpointSliceList represents a list of endpoint slices
 type EndpointSliceListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of endpoint slices
 	Items EndpointSliceTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (EndpointSliceListTypeArgs) ElementType() reflect.Type {
@@ -644,8 +644,8 @@ func (o EndpointSliceListTypeOutput) ToEndpointSliceListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EndpointSliceListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointSliceListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EndpointSliceListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointSliceListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of endpoint slices
@@ -654,13 +654,13 @@ func (o EndpointSliceListTypeOutput) Items() EndpointSliceTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EndpointSliceListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EndpointSliceListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EndpointSliceListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EndpointSliceListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o EndpointSliceListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v EndpointSliceListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o EndpointSliceListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v EndpointSliceListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/events/v1beta1/event.go
+++ b/sdk/go/kubernetes/events/v1beta1/event.go
@@ -17,38 +17,38 @@ type Event struct {
 	pulumi.CustomResourceState
 
 	// What action was taken/failed regarding to the regarding object.
-	Action pulumi.StringPtrOutput `pulumi:"action"`
+	Action pulumi.StringOutput `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedCount pulumi.IntPtrOutput `pulumi:"deprecatedCount"`
+	DeprecatedCount pulumi.IntOutput `pulumi:"deprecatedCount"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedFirstTimestamp pulumi.StringPtrOutput `pulumi:"deprecatedFirstTimestamp"`
+	DeprecatedFirstTimestamp pulumi.StringOutput `pulumi:"deprecatedFirstTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedLastTimestamp pulumi.StringPtrOutput `pulumi:"deprecatedLastTimestamp"`
+	DeprecatedLastTimestamp pulumi.StringOutput `pulumi:"deprecatedLastTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedSource corev1.EventSourcePtrOutput `pulumi:"deprecatedSource"`
+	DeprecatedSource corev1.EventSourceOutput `pulumi:"deprecatedSource"`
 	// Required. Time when this Event was first observed.
-	EventTime pulumi.StringPtrOutput `pulumi:"eventTime"`
+	EventTime pulumi.StringOutput `pulumi:"eventTime"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
-	Note pulumi.StringPtrOutput `pulumi:"note"`
+	Note pulumi.StringOutput `pulumi:"note"`
 	// Why the action was taken.
-	Reason pulumi.StringPtrOutput `pulumi:"reason"`
+	Reason pulumi.StringOutput `pulumi:"reason"`
 	// The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-	Regarding corev1.ObjectReferencePtrOutput `pulumi:"regarding"`
+	Regarding corev1.ObjectReferenceOutput `pulumi:"regarding"`
 	// Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
-	Related corev1.ObjectReferencePtrOutput `pulumi:"related"`
+	Related corev1.ObjectReferenceOutput `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingController pulumi.StringPtrOutput `pulumi:"reportingController"`
+	ReportingController pulumi.StringOutput `pulumi:"reportingController"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance pulumi.StringPtrOutput `pulumi:"reportingInstance"`
+	ReportingInstance pulumi.StringOutput `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series EventSeriesPtrOutput `pulumi:"series"`
+	Series EventSeriesOutput `pulumi:"series"`
 	// Type of this event (Normal, Warning), new types could be added in the future.
-	Type pulumi.StringPtrOutput `pulumi:"type"`
+	Type pulumi.StringOutput `pulumi:"type"`
 }
 
 // NewEvent registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/events/v1beta1/eventList.go
+++ b/sdk/go/kubernetes/events/v1beta1/eventList.go
@@ -16,13 +16,13 @@ type EventList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items EventTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewEventList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/events/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/events/v1beta1/pulumiTypes.go
@@ -15,38 +15,38 @@ import (
 // Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
 type EventType struct {
 	// What action was taken/failed regarding to the regarding object.
-	Action *string `pulumi:"action"`
+	Action string `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedCount *int `pulumi:"deprecatedCount"`
+	DeprecatedCount int `pulumi:"deprecatedCount"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedFirstTimestamp *string `pulumi:"deprecatedFirstTimestamp"`
+	DeprecatedFirstTimestamp string `pulumi:"deprecatedFirstTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedLastTimestamp *string `pulumi:"deprecatedLastTimestamp"`
+	DeprecatedLastTimestamp string `pulumi:"deprecatedLastTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedSource *corev1.EventSource `pulumi:"deprecatedSource"`
+	DeprecatedSource corev1.EventSource `pulumi:"deprecatedSource"`
 	// Required. Time when this Event was first observed.
-	EventTime *string `pulumi:"eventTime"`
+	EventTime string `pulumi:"eventTime"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
-	Note *string `pulumi:"note"`
+	Note string `pulumi:"note"`
 	// Why the action was taken.
-	Reason *string `pulumi:"reason"`
+	Reason string `pulumi:"reason"`
 	// The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-	Regarding *corev1.ObjectReference `pulumi:"regarding"`
+	Regarding corev1.ObjectReference `pulumi:"regarding"`
 	// Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
-	Related *corev1.ObjectReference `pulumi:"related"`
+	Related corev1.ObjectReference `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingController *string `pulumi:"reportingController"`
+	ReportingController string `pulumi:"reportingController"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance *string `pulumi:"reportingInstance"`
+	ReportingInstance string `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series *EventSeries `pulumi:"series"`
+	Series EventSeries `pulumi:"series"`
 	// Type of this event (Normal, Warning), new types could be added in the future.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // EventTypeInput is an input type that accepts EventTypeArgs and EventTypeOutput values.
@@ -64,38 +64,38 @@ type EventTypeInput interface {
 // Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
 type EventTypeArgs struct {
 	// What action was taken/failed regarding to the regarding object.
-	Action pulumi.StringPtrInput `pulumi:"action"`
+	Action pulumi.StringInput `pulumi:"action"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedCount pulumi.IntPtrInput `pulumi:"deprecatedCount"`
+	DeprecatedCount pulumi.IntInput `pulumi:"deprecatedCount"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedFirstTimestamp pulumi.StringPtrInput `pulumi:"deprecatedFirstTimestamp"`
+	DeprecatedFirstTimestamp pulumi.StringInput `pulumi:"deprecatedFirstTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedLastTimestamp pulumi.StringPtrInput `pulumi:"deprecatedLastTimestamp"`
+	DeprecatedLastTimestamp pulumi.StringInput `pulumi:"deprecatedLastTimestamp"`
 	// Deprecated field assuring backward compatibility with core.v1 Event type
-	DeprecatedSource corev1.EventSourcePtrInput `pulumi:"deprecatedSource"`
+	DeprecatedSource corev1.EventSourceInput `pulumi:"deprecatedSource"`
 	// Required. Time when this Event was first observed.
-	EventTime pulumi.StringPtrInput `pulumi:"eventTime"`
+	EventTime pulumi.StringInput `pulumi:"eventTime"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
-	Note pulumi.StringPtrInput `pulumi:"note"`
+	Note pulumi.StringInput `pulumi:"note"`
 	// Why the action was taken.
-	Reason pulumi.StringPtrInput `pulumi:"reason"`
+	Reason pulumi.StringInput `pulumi:"reason"`
 	// The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-	Regarding corev1.ObjectReferencePtrInput `pulumi:"regarding"`
+	Regarding corev1.ObjectReferenceInput `pulumi:"regarding"`
 	// Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
-	Related corev1.ObjectReferencePtrInput `pulumi:"related"`
+	Related corev1.ObjectReferenceInput `pulumi:"related"`
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-	ReportingController pulumi.StringPtrInput `pulumi:"reportingController"`
+	ReportingController pulumi.StringInput `pulumi:"reportingController"`
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
-	ReportingInstance pulumi.StringPtrInput `pulumi:"reportingInstance"`
+	ReportingInstance pulumi.StringInput `pulumi:"reportingInstance"`
 	// Data about the Event series this event represents or nil if it's a singleton Event.
-	Series EventSeriesPtrInput `pulumi:"series"`
+	Series EventSeriesInput `pulumi:"series"`
 	// Type of this event (Normal, Warning), new types could be added in the future.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (EventTypeArgs) ElementType() reflect.Type {
@@ -152,87 +152,87 @@ func (o EventTypeOutput) ToEventTypeOutputWithContext(ctx context.Context) Event
 }
 
 // What action was taken/failed regarding to the regarding object.
-func (o EventTypeOutput) Action() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Action }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Action() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Action }).(pulumi.StringOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EventTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Deprecated field assuring backward compatibility with core.v1 Event type
-func (o EventTypeOutput) DeprecatedCount() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v EventType) *int { return v.DeprecatedCount }).(pulumi.IntPtrOutput)
+func (o EventTypeOutput) DeprecatedCount() pulumi.IntOutput {
+	return o.ApplyT(func(v EventType) int { return v.DeprecatedCount }).(pulumi.IntOutput)
 }
 
 // Deprecated field assuring backward compatibility with core.v1 Event type
-func (o EventTypeOutput) DeprecatedFirstTimestamp() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.DeprecatedFirstTimestamp }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) DeprecatedFirstTimestamp() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.DeprecatedFirstTimestamp }).(pulumi.StringOutput)
 }
 
 // Deprecated field assuring backward compatibility with core.v1 Event type
-func (o EventTypeOutput) DeprecatedLastTimestamp() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.DeprecatedLastTimestamp }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) DeprecatedLastTimestamp() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.DeprecatedLastTimestamp }).(pulumi.StringOutput)
 }
 
 // Deprecated field assuring backward compatibility with core.v1 Event type
-func (o EventTypeOutput) DeprecatedSource() corev1.EventSourcePtrOutput {
-	return o.ApplyT(func(v EventType) *corev1.EventSource { return v.DeprecatedSource }).(corev1.EventSourcePtrOutput)
+func (o EventTypeOutput) DeprecatedSource() corev1.EventSourceOutput {
+	return o.ApplyT(func(v EventType) corev1.EventSource { return v.DeprecatedSource }).(corev1.EventSourceOutput)
 }
 
 // Required. Time when this Event was first observed.
-func (o EventTypeOutput) EventTime() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.EventTime }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) EventTime() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.EventTime }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EventTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o EventTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v EventType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o EventTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v EventType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
-func (o EventTypeOutput) Note() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Note }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Note() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Note }).(pulumi.StringOutput)
 }
 
 // Why the action was taken.
-func (o EventTypeOutput) Reason() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Reason }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Reason() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Reason }).(pulumi.StringOutput)
 }
 
 // The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-func (o EventTypeOutput) Regarding() corev1.ObjectReferencePtrOutput {
-	return o.ApplyT(func(v EventType) *corev1.ObjectReference { return v.Regarding }).(corev1.ObjectReferencePtrOutput)
+func (o EventTypeOutput) Regarding() corev1.ObjectReferenceOutput {
+	return o.ApplyT(func(v EventType) corev1.ObjectReference { return v.Regarding }).(corev1.ObjectReferenceOutput)
 }
 
 // Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
-func (o EventTypeOutput) Related() corev1.ObjectReferencePtrOutput {
-	return o.ApplyT(func(v EventType) *corev1.ObjectReference { return v.Related }).(corev1.ObjectReferencePtrOutput)
+func (o EventTypeOutput) Related() corev1.ObjectReferenceOutput {
+	return o.ApplyT(func(v EventType) corev1.ObjectReference { return v.Related }).(corev1.ObjectReferenceOutput)
 }
 
 // Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
-func (o EventTypeOutput) ReportingController() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ReportingController }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ReportingController() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ReportingController }).(pulumi.StringOutput)
 }
 
 // ID of the controller instance, e.g. `kubelet-xyzf`.
-func (o EventTypeOutput) ReportingInstance() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.ReportingInstance }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) ReportingInstance() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.ReportingInstance }).(pulumi.StringOutput)
 }
 
 // Data about the Event series this event represents or nil if it's a singleton Event.
-func (o EventTypeOutput) Series() EventSeriesPtrOutput {
-	return o.ApplyT(func(v EventType) *EventSeries { return v.Series }).(EventSeriesPtrOutput)
+func (o EventTypeOutput) Series() EventSeriesOutput {
+	return o.ApplyT(func(v EventType) EventSeries { return v.Series }).(EventSeriesOutput)
 }
 
 // Type of this event (Normal, Warning), new types could be added in the future.
-func (o EventTypeOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventType) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o EventTypeOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v EventType) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type EventTypeArrayOutput struct{ *pulumi.OutputState }
@@ -258,13 +258,13 @@ func (o EventTypeArrayOutput) Index(i pulumi.IntInput) EventTypeOutput {
 // EventList is a list of Event objects.
 type EventListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []EventType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // EventListTypeInput is an input type that accepts EventListTypeArgs and EventListTypeOutput values.
@@ -282,13 +282,13 @@ type EventListTypeInput interface {
 // EventList is a list of Event objects.
 type EventListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items EventTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (EventListTypeArgs) ElementType() reflect.Type {
@@ -319,8 +319,8 @@ func (o EventListTypeOutput) ToEventListTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o EventListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o EventListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v EventListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -329,23 +329,23 @@ func (o EventListTypeOutput) Items() EventTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o EventListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o EventListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v EventListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o EventListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v EventListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o EventListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v EventListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
 type EventSeries struct {
 	// Number of occurrences in this series up to the last heartbeat time
-	Count *int `pulumi:"count"`
+	Count int `pulumi:"count"`
 	// Time when last Event from the series was seen before last heartbeat.
-	LastObservedTime *string `pulumi:"lastObservedTime"`
+	LastObservedTime string `pulumi:"lastObservedTime"`
 	// Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18
-	State *string `pulumi:"state"`
+	State string `pulumi:"state"`
 }
 
 // EventSeriesInput is an input type that accepts EventSeriesArgs and EventSeriesOutput values.
@@ -363,11 +363,11 @@ type EventSeriesInput interface {
 // EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
 type EventSeriesArgs struct {
 	// Number of occurrences in this series up to the last heartbeat time
-	Count pulumi.IntPtrInput `pulumi:"count"`
+	Count pulumi.IntInput `pulumi:"count"`
 	// Time when last Event from the series was seen before last heartbeat.
-	LastObservedTime pulumi.StringPtrInput `pulumi:"lastObservedTime"`
+	LastObservedTime pulumi.StringInput `pulumi:"lastObservedTime"`
 	// Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18
-	State pulumi.StringPtrInput `pulumi:"state"`
+	State pulumi.StringInput `pulumi:"state"`
 }
 
 func (EventSeriesArgs) ElementType() reflect.Type {
@@ -450,18 +450,18 @@ func (o EventSeriesOutput) ToEventSeriesPtrOutputWithContext(ctx context.Context
 }
 
 // Number of occurrences in this series up to the last heartbeat time
-func (o EventSeriesOutput) Count() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v EventSeries) *int { return v.Count }).(pulumi.IntPtrOutput)
+func (o EventSeriesOutput) Count() pulumi.IntOutput {
+	return o.ApplyT(func(v EventSeries) int { return v.Count }).(pulumi.IntOutput)
 }
 
 // Time when last Event from the series was seen before last heartbeat.
-func (o EventSeriesOutput) LastObservedTime() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventSeries) *string { return v.LastObservedTime }).(pulumi.StringPtrOutput)
+func (o EventSeriesOutput) LastObservedTime() pulumi.StringOutput {
+	return o.ApplyT(func(v EventSeries) string { return v.LastObservedTime }).(pulumi.StringOutput)
 }
 
 // Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18
-func (o EventSeriesOutput) State() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v EventSeries) *string { return v.State }).(pulumi.StringPtrOutput)
+func (o EventSeriesOutput) State() pulumi.StringOutput {
+	return o.ApplyT(func(v EventSeries) string { return v.State }).(pulumi.StringOutput)
 }
 
 type EventSeriesPtrOutput struct{ *pulumi.OutputState }
@@ -488,7 +488,7 @@ func (o EventSeriesPtrOutput) Count() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Count
+		return &v.Count
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -498,7 +498,7 @@ func (o EventSeriesPtrOutput) LastObservedTime() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.LastObservedTime
+		return &v.LastObservedTime
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -508,7 +508,7 @@ func (o EventSeriesPtrOutput) State() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.State
+		return &v.State
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/extensions/v1beta1/daemonSet.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/daemonSet.go
@@ -15,15 +15,15 @@ type DaemonSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrOutput `pulumi:"spec"`
+	Spec DaemonSetSpecOutput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrOutput `pulumi:"status"`
+	Status DaemonSetStatusOutput `pulumi:"status"`
 }
 
 // NewDaemonSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/daemonSetList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/daemonSetList.go
@@ -16,13 +16,13 @@ type DaemonSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDaemonSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/deployment.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/deployment.go
@@ -37,15 +37,15 @@ type Deployment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrOutput `pulumi:"spec"`
+	Spec DeploymentSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrOutput `pulumi:"status"`
+	Status DeploymentStatusOutput `pulumi:"status"`
 }
 
 // NewDeployment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/deploymentList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/deploymentList.go
@@ -16,13 +16,13 @@ type DeploymentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewDeploymentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/ingress.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/ingress.go
@@ -29,15 +29,15 @@ type Ingress struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressSpecPtrOutput `pulumi:"spec"`
+	Spec IngressSpecOutput `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status IngressStatusPtrOutput `pulumi:"status"`
+	Status IngressStatusOutput `pulumi:"status"`
 }
 
 // NewIngress registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/ingressList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/ingressList.go
@@ -16,13 +16,13 @@ type IngressList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items IngressTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewIngressList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/networkPolicy.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/networkPolicy.go
@@ -15,13 +15,13 @@ type NetworkPolicy struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec NetworkPolicySpecPtrOutput `pulumi:"spec"`
+	Spec NetworkPolicySpecOutput `pulumi:"spec"`
 }
 
 // NewNetworkPolicy registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/networkPolicyList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/networkPolicyList.go
@@ -16,13 +16,13 @@ type NetworkPolicyList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items NetworkPolicyTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewNetworkPolicyList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicy.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicy.go
@@ -15,13 +15,13 @@ type PodSecurityPolicy struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec PodSecurityPolicySpecPtrOutput `pulumi:"spec"`
+	Spec PodSecurityPolicySpecOutput `pulumi:"spec"`
 }
 
 // NewPodSecurityPolicy registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyList.go
@@ -16,13 +16,13 @@ type PodSecurityPolicyList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items PodSecurityPolicyTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodSecurityPolicyList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/pulumiTypes.go
@@ -15,7 +15,7 @@ import (
 // AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
 type AllowedCSIDriver struct {
 	// Name is the registered name of the CSI driver
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // AllowedCSIDriverInput is an input type that accepts AllowedCSIDriverArgs and AllowedCSIDriverOutput values.
@@ -33,7 +33,7 @@ type AllowedCSIDriverInput interface {
 // AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
 type AllowedCSIDriverArgs struct {
 	// Name is the registered name of the CSI driver
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (AllowedCSIDriverArgs) ElementType() reflect.Type {
@@ -90,8 +90,8 @@ func (o AllowedCSIDriverOutput) ToAllowedCSIDriverOutputWithContext(ctx context.
 }
 
 // Name is the registered name of the CSI driver
-func (o AllowedCSIDriverOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AllowedCSIDriver) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o AllowedCSIDriverOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v AllowedCSIDriver) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type AllowedCSIDriverArrayOutput struct{ *pulumi.OutputState }
@@ -117,7 +117,7 @@ func (o AllowedCSIDriverArrayOutput) Index(i pulumi.IntInput) AllowedCSIDriverOu
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.
 type AllowedFlexVolume struct {
 	// driver is the name of the Flexvolume driver.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 }
 
 // AllowedFlexVolumeInput is an input type that accepts AllowedFlexVolumeArgs and AllowedFlexVolumeOutput values.
@@ -135,7 +135,7 @@ type AllowedFlexVolumeInput interface {
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.
 type AllowedFlexVolumeArgs struct {
 	// driver is the name of the Flexvolume driver.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 }
 
 func (AllowedFlexVolumeArgs) ElementType() reflect.Type {
@@ -192,8 +192,8 @@ func (o AllowedFlexVolumeOutput) ToAllowedFlexVolumeOutputWithContext(ctx contex
 }
 
 // driver is the name of the Flexvolume driver.
-func (o AllowedFlexVolumeOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AllowedFlexVolume) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o AllowedFlexVolumeOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v AllowedFlexVolume) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 type AllowedFlexVolumeArrayOutput struct{ *pulumi.OutputState }
@@ -336,15 +336,15 @@ func (o AllowedHostPathArrayOutput) Index(i pulumi.IntInput) AllowedHostPathOutp
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *DaemonSetSpec `pulumi:"spec"`
+	Spec DaemonSetSpec `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *DaemonSetStatus `pulumi:"status"`
+	Status DaemonSetStatus `pulumi:"status"`
 }
 
 // DaemonSetTypeInput is an input type that accepts DaemonSetTypeArgs and DaemonSetTypeOutput values.
@@ -362,15 +362,15 @@ type DaemonSetTypeInput interface {
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec DaemonSetSpecPtrInput `pulumi:"spec"`
+	Spec DaemonSetSpecInput `pulumi:"spec"`
 	// The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status DaemonSetStatusPtrInput `pulumi:"status"`
+	Status DaemonSetStatusInput `pulumi:"status"`
 }
 
 func (DaemonSetTypeArgs) ElementType() reflect.Type {
@@ -427,28 +427,28 @@ func (o DaemonSetTypeOutput) ToDaemonSetTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DaemonSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DaemonSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Spec() DaemonSetSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetSpec { return v.Spec }).(DaemonSetSpecPtrOutput)
+func (o DaemonSetTypeOutput) Spec() DaemonSetSpecOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetSpec { return v.Spec }).(DaemonSetSpecOutput)
 }
 
 // The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o DaemonSetTypeOutput) Status() DaemonSetStatusPtrOutput {
-	return o.ApplyT(func(v DaemonSetType) *DaemonSetStatus { return v.Status }).(DaemonSetStatusPtrOutput)
+func (o DaemonSetTypeOutput) Status() DaemonSetStatusOutput {
+	return o.ApplyT(func(v DaemonSetType) DaemonSetStatus { return v.Status }).(DaemonSetStatusOutput)
 }
 
 type DaemonSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -480,9 +480,9 @@ type DaemonSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DaemonSetConditionInput is an input type that accepts DaemonSetConditionArgs and DaemonSetConditionOutput values.
@@ -506,9 +506,9 @@ type DaemonSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of DaemonSet condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DaemonSetConditionArgs) ElementType() reflect.Type {
@@ -580,13 +580,13 @@ func (o DaemonSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DaemonSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of DaemonSet condition.
-func (o DaemonSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DaemonSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DaemonSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -612,13 +612,13 @@ func (o DaemonSetConditionArrayOutput) Index(i pulumi.IntInput) DaemonSetConditi
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items []DaemonSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DaemonSetListTypeInput is an input type that accepts DaemonSetListTypeArgs and DaemonSetListTypeOutput values.
@@ -636,13 +636,13 @@ type DaemonSetListTypeInput interface {
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// A list of daemon sets.
 	Items DaemonSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DaemonSetListTypeArgs) ElementType() reflect.Type {
@@ -673,8 +673,8 @@ func (o DaemonSetListTypeOutput) ToDaemonSetListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // A list of daemon sets.
@@ -683,13 +683,13 @@ func (o DaemonSetListTypeOutput) Items() DaemonSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DaemonSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DaemonSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DaemonSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DaemonSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DaemonSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DaemonSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DaemonSetSpec is the specification of a daemon set.
@@ -701,7 +701,7 @@ type DaemonSetSpec struct {
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector *metav1.LabelSelector `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 	// DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.
 	TemplateGeneration *int `pulumi:"templateGeneration"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
@@ -729,7 +729,7 @@ type DaemonSetSpecArgs struct {
 	// A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	Selector metav1.LabelSelectorPtrInput `pulumi:"selector"`
 	// An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 	// DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.
 	TemplateGeneration pulumi.IntPtrInput `pulumi:"templateGeneration"`
 	// An update strategy to replace existing DaemonSet pods with new pods.
@@ -831,8 +831,8 @@ func (o DaemonSetSpecOutput) Selector() metav1.LabelSelectorPtrOutput {
 }
 
 // An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DaemonSetSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DaemonSetSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DaemonSetSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 // DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.
@@ -899,7 +899,7 @@ func (o DaemonSetSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -930,15 +930,15 @@ type DaemonSetStatus struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions []DaemonSetCondition `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled *int `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled int `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled *int `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled int `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable *int `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled *int `pulumi:"numberMisscheduled"`
+	NumberMisscheduled int `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady *int `pulumi:"numberReady"`
+	NumberReady int `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable *int `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -966,15 +966,15 @@ type DaemonSetStatusArgs struct {
 	// Represents the latest available observations of a DaemonSet's current state.
 	Conditions DaemonSetConditionArrayInput `pulumi:"conditions"`
 	// The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	CurrentNumberScheduled pulumi.IntPtrInput `pulumi:"currentNumberScheduled"`
+	CurrentNumberScheduled pulumi.IntInput `pulumi:"currentNumberScheduled"`
 	// The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	DesiredNumberScheduled pulumi.IntPtrInput `pulumi:"desiredNumberScheduled"`
+	DesiredNumberScheduled pulumi.IntInput `pulumi:"desiredNumberScheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberAvailable pulumi.IntPtrInput `pulumi:"numberAvailable"`
 	// The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-	NumberMisscheduled pulumi.IntPtrInput `pulumi:"numberMisscheduled"`
+	NumberMisscheduled pulumi.IntInput `pulumi:"numberMisscheduled"`
 	// The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-	NumberReady pulumi.IntPtrInput `pulumi:"numberReady"`
+	NumberReady pulumi.IntInput `pulumi:"numberReady"`
 	// The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
 	NumberUnavailable pulumi.IntPtrInput `pulumi:"numberUnavailable"`
 	// The most recent generation observed by the daemon set controller.
@@ -1073,13 +1073,13 @@ func (o DaemonSetStatusOutput) Conditions() DaemonSetConditionArrayOutput {
 }
 
 // The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.CurrentNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) CurrentNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.CurrentNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.DesiredNumberScheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) DesiredNumberScheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.DesiredNumberScheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -1088,13 +1088,13 @@ func (o DaemonSetStatusOutput) NumberAvailable() pulumi.IntPtrOutput {
 }
 
 // The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
-func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberMisscheduled }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberMisscheduled() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberMisscheduled }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-func (o DaemonSetStatusOutput) NumberReady() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v DaemonSetStatus) *int { return v.NumberReady }).(pulumi.IntPtrOutput)
+func (o DaemonSetStatusOutput) NumberReady() pulumi.IntOutput {
+	return o.ApplyT(func(v DaemonSetStatus) int { return v.NumberReady }).(pulumi.IntOutput)
 }
 
 // The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
@@ -1156,7 +1156,7 @@ func (o DaemonSetStatusPtrOutput) CurrentNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.CurrentNumberScheduled
+		return &v.CurrentNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1166,7 +1166,7 @@ func (o DaemonSetStatusPtrOutput) DesiredNumberScheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.DesiredNumberScheduled
+		return &v.DesiredNumberScheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1186,7 +1186,7 @@ func (o DaemonSetStatusPtrOutput) NumberMisscheduled() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberMisscheduled
+		return &v.NumberMisscheduled
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1196,7 +1196,7 @@ func (o DaemonSetStatusPtrOutput) NumberReady() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NumberReady
+		return &v.NumberReady
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1407,15 +1407,15 @@ func (o DaemonSetUpdateStrategyPtrOutput) Type() pulumi.StringPtrOutput {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec *DeploymentSpec `pulumi:"spec"`
+	Spec DeploymentSpec `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status *DeploymentStatus `pulumi:"status"`
+	Status DeploymentStatus `pulumi:"status"`
 }
 
 // DeploymentTypeInput is an input type that accepts DeploymentTypeArgs and DeploymentTypeOutput values.
@@ -1455,15 +1455,15 @@ type DeploymentTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type DeploymentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the Deployment.
-	Spec DeploymentSpecPtrInput `pulumi:"spec"`
+	Spec DeploymentSpecInput `pulumi:"spec"`
 	// Most recently observed status of the Deployment.
-	Status DeploymentStatusPtrInput `pulumi:"status"`
+	Status DeploymentStatusInput `pulumi:"status"`
 }
 
 func (DeploymentTypeArgs) ElementType() reflect.Type {
@@ -1542,28 +1542,28 @@ func (o DeploymentTypeOutput) ToDeploymentTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata.
-func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o DeploymentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v DeploymentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the Deployment.
-func (o DeploymentTypeOutput) Spec() DeploymentSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentSpec { return v.Spec }).(DeploymentSpecPtrOutput)
+func (o DeploymentTypeOutput) Spec() DeploymentSpecOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentSpec { return v.Spec }).(DeploymentSpecOutput)
 }
 
 // Most recently observed status of the Deployment.
-func (o DeploymentTypeOutput) Status() DeploymentStatusPtrOutput {
-	return o.ApplyT(func(v DeploymentType) *DeploymentStatus { return v.Status }).(DeploymentStatusPtrOutput)
+func (o DeploymentTypeOutput) Status() DeploymentStatusOutput {
+	return o.ApplyT(func(v DeploymentType) DeploymentStatus { return v.Status }).(DeploymentStatusOutput)
 }
 
 type DeploymentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1597,9 +1597,9 @@ type DeploymentCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of deployment condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // DeploymentConditionInput is an input type that accepts DeploymentConditionArgs and DeploymentConditionOutput values.
@@ -1625,9 +1625,9 @@ type DeploymentConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of deployment condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (DeploymentConditionArgs) ElementType() reflect.Type {
@@ -1704,13 +1704,13 @@ func (o DeploymentConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o DeploymentConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of deployment condition.
-func (o DeploymentConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o DeploymentConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type DeploymentConditionArrayOutput struct{ *pulumi.OutputState }
@@ -1736,13 +1736,13 @@ func (o DeploymentConditionArrayOutput) Index(i pulumi.IntInput) DeploymentCondi
 // DeploymentList is a list of Deployments.
 type DeploymentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items []DeploymentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // DeploymentListTypeInput is an input type that accepts DeploymentListTypeArgs and DeploymentListTypeOutput values.
@@ -1760,13 +1760,13 @@ type DeploymentListTypeInput interface {
 // DeploymentList is a list of Deployments.
 type DeploymentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Deployments.
 	Items DeploymentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (DeploymentListTypeArgs) ElementType() reflect.Type {
@@ -1797,8 +1797,8 @@ func (o DeploymentListTypeOutput) ToDeploymentListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Deployments.
@@ -1807,13 +1807,13 @@ func (o DeploymentListTypeOutput) Items() DeploymentTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o DeploymentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o DeploymentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v DeploymentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o DeploymentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v DeploymentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.
@@ -1823,9 +1823,9 @@ type DeploymentRollback struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// Required: This must match the Name of a deployment.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The config of this deployment rollback.
-	RollbackTo *RollbackConfig `pulumi:"rollbackTo"`
+	RollbackTo RollbackConfig `pulumi:"rollbackTo"`
 	// The annotations to be updated to a deployment
 	UpdatedAnnotations map[string]string `pulumi:"updatedAnnotations"`
 }
@@ -1849,9 +1849,9 @@ type DeploymentRollbackArgs struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// Required: This must match the Name of a deployment.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// The config of this deployment rollback.
-	RollbackTo RollbackConfigPtrInput `pulumi:"rollbackTo"`
+	RollbackTo RollbackConfigInput `pulumi:"rollbackTo"`
 	// The annotations to be updated to a deployment
 	UpdatedAnnotations pulumi.StringMapInput `pulumi:"updatedAnnotations"`
 }
@@ -1894,13 +1894,13 @@ func (o DeploymentRollbackOutput) Kind() pulumi.StringPtrOutput {
 }
 
 // Required: This must match the Name of a deployment.
-func (o DeploymentRollbackOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DeploymentRollback) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o DeploymentRollbackOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v DeploymentRollback) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // The config of this deployment rollback.
-func (o DeploymentRollbackOutput) RollbackTo() RollbackConfigPtrOutput {
-	return o.ApplyT(func(v DeploymentRollback) *RollbackConfig { return v.RollbackTo }).(RollbackConfigPtrOutput)
+func (o DeploymentRollbackOutput) RollbackTo() RollbackConfigOutput {
+	return o.ApplyT(func(v DeploymentRollback) RollbackConfig { return v.RollbackTo }).(RollbackConfigOutput)
 }
 
 // The annotations to be updated to a deployment
@@ -1927,7 +1927,7 @@ type DeploymentSpec struct {
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy *DeploymentStrategy `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template *corev1.PodTemplateSpec `pulumi:"template"`
+	Template corev1.PodTemplateSpec `pulumi:"template"`
 }
 
 // DeploymentSpecInput is an input type that accepts DeploymentSpecArgs and DeploymentSpecOutput values.
@@ -1961,7 +1961,7 @@ type DeploymentSpecArgs struct {
 	// The deployment strategy to use to replace existing pods with new ones.
 	Strategy DeploymentStrategyPtrInput `pulumi:"strategy"`
 	// Template describes the pods that will be created.
-	Template corev1.PodTemplateSpecPtrInput `pulumi:"template"`
+	Template corev1.PodTemplateSpecInput `pulumi:"template"`
 }
 
 func (DeploymentSpecArgs) ElementType() reflect.Type {
@@ -2084,8 +2084,8 @@ func (o DeploymentSpecOutput) Strategy() DeploymentStrategyPtrOutput {
 }
 
 // Template describes the pods that will be created.
-func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecPtrOutput {
-	return o.ApplyT(func(v DeploymentSpec) *corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecPtrOutput)
+func (o DeploymentSpecOutput) Template() corev1.PodTemplateSpecOutput {
+	return o.ApplyT(func(v DeploymentSpec) corev1.PodTemplateSpec { return v.Template }).(corev1.PodTemplateSpecOutput)
 }
 
 type DeploymentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -2192,7 +2192,7 @@ func (o DeploymentSpecPtrOutput) Template() corev1.PodTemplateSpecPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Template
+		return &v.Template
 	}).(corev1.PodTemplateSpecPtrOutput)
 }
 
@@ -2778,7 +2778,7 @@ func (o FSGroupStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 // HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
 type HTTPIngressPath struct {
 	// Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-	Backend *IngressBackend `pulumi:"backend"`
+	Backend IngressBackend `pulumi:"backend"`
 	// Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
 	Path *string `pulumi:"path"`
 	// PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
@@ -2810,7 +2810,7 @@ type HTTPIngressPathInput interface {
 // HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
 type HTTPIngressPathArgs struct {
 	// Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-	Backend IngressBackendPtrInput `pulumi:"backend"`
+	Backend IngressBackendInput `pulumi:"backend"`
 	// Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
@@ -2881,8 +2881,8 @@ func (o HTTPIngressPathOutput) ToHTTPIngressPathOutputWithContext(ctx context.Co
 }
 
 // Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-func (o HTTPIngressPathOutput) Backend() IngressBackendPtrOutput {
-	return o.ApplyT(func(v HTTPIngressPath) *IngressBackend { return v.Backend }).(IngressBackendPtrOutput)
+func (o HTTPIngressPathOutput) Backend() IngressBackendOutput {
+	return o.ApplyT(func(v HTTPIngressPath) IngressBackend { return v.Backend }).(IngressBackendOutput)
 }
 
 // Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
@@ -3064,9 +3064,9 @@ func (o HTTPIngressRuleValuePtrOutput) Paths() HTTPIngressPathArrayOutput {
 // HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.
 type HostPortRange struct {
 	// max is the end of the range, inclusive.
-	Max *int `pulumi:"max"`
+	Max int `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min *int `pulumi:"min"`
+	Min int `pulumi:"min"`
 }
 
 // HostPortRangeInput is an input type that accepts HostPortRangeArgs and HostPortRangeOutput values.
@@ -3084,9 +3084,9 @@ type HostPortRangeInput interface {
 // HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.
 type HostPortRangeArgs struct {
 	// max is the end of the range, inclusive.
-	Max pulumi.IntPtrInput `pulumi:"max"`
+	Max pulumi.IntInput `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min pulumi.IntPtrInput `pulumi:"min"`
+	Min pulumi.IntInput `pulumi:"min"`
 }
 
 func (HostPortRangeArgs) ElementType() reflect.Type {
@@ -3143,13 +3143,13 @@ func (o HostPortRangeOutput) ToHostPortRangeOutputWithContext(ctx context.Contex
 }
 
 // max is the end of the range, inclusive.
-func (o HostPortRangeOutput) Max() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HostPortRange) *int { return v.Max }).(pulumi.IntPtrOutput)
+func (o HostPortRangeOutput) Max() pulumi.IntOutput {
+	return o.ApplyT(func(v HostPortRange) int { return v.Max }).(pulumi.IntOutput)
 }
 
 // min is the start of the range, inclusive.
-func (o HostPortRangeOutput) Min() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HostPortRange) *int { return v.Min }).(pulumi.IntPtrOutput)
+func (o HostPortRangeOutput) Min() pulumi.IntOutput {
+	return o.ApplyT(func(v HostPortRange) int { return v.Min }).(pulumi.IntOutput)
 }
 
 type HostPortRangeArrayOutput struct{ *pulumi.OutputState }
@@ -3175,9 +3175,9 @@ func (o HostPortRangeArrayOutput) Index(i pulumi.IntInput) HostPortRangeOutput {
 // IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.
 type IDRange struct {
 	// max is the end of the range, inclusive.
-	Max *int `pulumi:"max"`
+	Max int `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min *int `pulumi:"min"`
+	Min int `pulumi:"min"`
 }
 
 // IDRangeInput is an input type that accepts IDRangeArgs and IDRangeOutput values.
@@ -3195,9 +3195,9 @@ type IDRangeInput interface {
 // IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.
 type IDRangeArgs struct {
 	// max is the end of the range, inclusive.
-	Max pulumi.IntPtrInput `pulumi:"max"`
+	Max pulumi.IntInput `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min pulumi.IntPtrInput `pulumi:"min"`
+	Min pulumi.IntInput `pulumi:"min"`
 }
 
 func (IDRangeArgs) ElementType() reflect.Type {
@@ -3254,13 +3254,13 @@ func (o IDRangeOutput) ToIDRangeOutputWithContext(ctx context.Context) IDRangeOu
 }
 
 // max is the end of the range, inclusive.
-func (o IDRangeOutput) Max() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v IDRange) *int { return v.Max }).(pulumi.IntPtrOutput)
+func (o IDRangeOutput) Max() pulumi.IntOutput {
+	return o.ApplyT(func(v IDRange) int { return v.Max }).(pulumi.IntOutput)
 }
 
 // min is the start of the range, inclusive.
-func (o IDRangeOutput) Min() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v IDRange) *int { return v.Min }).(pulumi.IntPtrOutput)
+func (o IDRangeOutput) Min() pulumi.IntOutput {
+	return o.ApplyT(func(v IDRange) int { return v.Min }).(pulumi.IntOutput)
 }
 
 type IDRangeArrayOutput struct{ *pulumi.OutputState }
@@ -3286,7 +3286,7 @@ func (o IDRangeArrayOutput) Index(i pulumi.IntInput) IDRangeOutput {
 // DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"
-	Cidr *string `pulumi:"cidr"`
+	Cidr string `pulumi:"cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range
 	Except []string `pulumi:"except"`
 }
@@ -3306,7 +3306,7 @@ type IPBlockInput interface {
 // DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
 type IPBlockArgs struct {
 	// CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"
-	Cidr pulumi.StringPtrInput `pulumi:"cidr"`
+	Cidr pulumi.StringInput `pulumi:"cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range
 	Except pulumi.StringArrayInput `pulumi:"except"`
 }
@@ -3391,8 +3391,8 @@ func (o IPBlockOutput) ToIPBlockPtrOutputWithContext(ctx context.Context) IPBloc
 }
 
 // CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"
-func (o IPBlockOutput) Cidr() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IPBlock) *string { return v.Cidr }).(pulumi.StringPtrOutput)
+func (o IPBlockOutput) Cidr() pulumi.StringOutput {
+	return o.ApplyT(func(v IPBlock) string { return v.Cidr }).(pulumi.StringOutput)
 }
 
 // Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range
@@ -3424,7 +3424,7 @@ func (o IPBlockPtrOutput) Cidr() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Cidr
+		return &v.Cidr
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3455,15 +3455,15 @@ func (o IPBlockPtrOutput) Except() pulumi.StringArrayOutput {
 // by setting the 'customTimeouts' option on the resource.
 type IngressType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *IngressSpec `pulumi:"spec"`
+	Spec IngressSpec `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *IngressStatus `pulumi:"status"`
+	Status IngressStatus `pulumi:"status"`
 }
 
 // IngressTypeInput is an input type that accepts IngressTypeArgs and IngressTypeOutput values.
@@ -3495,15 +3495,15 @@ type IngressTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type IngressTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressSpecPtrInput `pulumi:"spec"`
+	Spec IngressSpecInput `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status IngressStatusPtrInput `pulumi:"status"`
+	Status IngressStatusInput `pulumi:"status"`
 }
 
 func (IngressTypeArgs) ElementType() reflect.Type {
@@ -3574,28 +3574,28 @@ func (o IngressTypeOutput) ToIngressTypeOutputWithContext(ctx context.Context) I
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o IngressTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v IngressType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o IngressTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v IngressType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o IngressTypeOutput) Spec() IngressSpecPtrOutput {
-	return o.ApplyT(func(v IngressType) *IngressSpec { return v.Spec }).(IngressSpecPtrOutput)
+func (o IngressTypeOutput) Spec() IngressSpecOutput {
+	return o.ApplyT(func(v IngressType) IngressSpec { return v.Spec }).(IngressSpecOutput)
 }
 
 // Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o IngressTypeOutput) Status() IngressStatusPtrOutput {
-	return o.ApplyT(func(v IngressType) *IngressStatus { return v.Status }).(IngressStatusPtrOutput)
+func (o IngressTypeOutput) Status() IngressStatusOutput {
+	return o.ApplyT(func(v IngressType) IngressStatus { return v.Status }).(IngressStatusOutput)
 }
 
 type IngressTypeArrayOutput struct{ *pulumi.OutputState }
@@ -3623,7 +3623,7 @@ type IngressBackend struct {
 	// Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
 	Resource *corev1.TypedLocalObjectReference `pulumi:"resource"`
 	// Specifies the name of the referenced service.
-	ServiceName *string `pulumi:"serviceName"`
+	ServiceName string `pulumi:"serviceName"`
 	// Specifies the port of the referenced service.
 	ServicePort interface{} `pulumi:"servicePort"`
 }
@@ -3645,7 +3645,7 @@ type IngressBackendArgs struct {
 	// Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
 	Resource corev1.TypedLocalObjectReferencePtrInput `pulumi:"resource"`
 	// Specifies the name of the referenced service.
-	ServiceName pulumi.StringPtrInput `pulumi:"serviceName"`
+	ServiceName pulumi.StringInput `pulumi:"serviceName"`
 	// Specifies the port of the referenced service.
 	ServicePort pulumi.Input `pulumi:"servicePort"`
 }
@@ -3735,8 +3735,8 @@ func (o IngressBackendOutput) Resource() corev1.TypedLocalObjectReferencePtrOutp
 }
 
 // Specifies the name of the referenced service.
-func (o IngressBackendOutput) ServiceName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressBackend) *string { return v.ServiceName }).(pulumi.StringPtrOutput)
+func (o IngressBackendOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressBackend) string { return v.ServiceName }).(pulumi.StringOutput)
 }
 
 // Specifies the port of the referenced service.
@@ -3778,7 +3778,7 @@ func (o IngressBackendPtrOutput) ServiceName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ServiceName
+		return &v.ServiceName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -3795,13 +3795,13 @@ func (o IngressBackendPtrOutput) ServicePort() pulumi.AnyOutput {
 // IngressList is a collection of Ingress.
 type IngressListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items []IngressType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // IngressListTypeInput is an input type that accepts IngressListTypeArgs and IngressListTypeOutput values.
@@ -3819,13 +3819,13 @@ type IngressListTypeInput interface {
 // IngressList is a collection of Ingress.
 type IngressListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items IngressTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (IngressListTypeArgs) ElementType() reflect.Type {
@@ -3856,8 +3856,8 @@ func (o IngressListTypeOutput) ToIngressListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Ingress.
@@ -3866,13 +3866,13 @@ func (o IngressListTypeOutput) Items() IngressTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o IngressListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v IngressListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o IngressListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v IngressListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
@@ -4447,13 +4447,13 @@ func (o IngressTLSArrayOutput) Index(i pulumi.IntInput) IngressTLSOutput {
 // DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec *NetworkPolicySpec `pulumi:"spec"`
+	Spec NetworkPolicySpec `pulumi:"spec"`
 }
 
 // NetworkPolicyTypeInput is an input type that accepts NetworkPolicyTypeArgs and NetworkPolicyTypeOutput values.
@@ -4471,13 +4471,13 @@ type NetworkPolicyTypeInput interface {
 // DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec NetworkPolicySpecPtrInput `pulumi:"spec"`
+	Spec NetworkPolicySpecInput `pulumi:"spec"`
 }
 
 func (NetworkPolicyTypeArgs) ElementType() reflect.Type {
@@ -4534,23 +4534,23 @@ func (o NetworkPolicyTypeOutput) ToNetworkPolicyTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NetworkPolicyTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NetworkPolicyTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NetworkPolicyTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o NetworkPolicyTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v NetworkPolicyType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior for this NetworkPolicy.
-func (o NetworkPolicyTypeOutput) Spec() NetworkPolicySpecPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *NetworkPolicySpec { return v.Spec }).(NetworkPolicySpecPtrOutput)
+func (o NetworkPolicyTypeOutput) Spec() NetworkPolicySpecOutput {
+	return o.ApplyT(func(v NetworkPolicyType) NetworkPolicySpec { return v.Spec }).(NetworkPolicySpecOutput)
 }
 
 type NetworkPolicyTypeArrayOutput struct{ *pulumi.OutputState }
@@ -4798,13 +4798,13 @@ func (o NetworkPolicyIngressRuleArrayOutput) Index(i pulumi.IntInput) NetworkPol
 // DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.
 type NetworkPolicyListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []NetworkPolicyType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // NetworkPolicyListTypeInput is an input type that accepts NetworkPolicyListTypeArgs and NetworkPolicyListTypeOutput values.
@@ -4822,13 +4822,13 @@ type NetworkPolicyListTypeInput interface {
 // DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.
 type NetworkPolicyListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items NetworkPolicyTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (NetworkPolicyListTypeArgs) ElementType() reflect.Type {
@@ -4859,8 +4859,8 @@ func (o NetworkPolicyListTypeOutput) ToNetworkPolicyListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NetworkPolicyListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -4869,13 +4869,13 @@ func (o NetworkPolicyListTypeOutput) Items() NetworkPolicyTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NetworkPolicyListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NetworkPolicyListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o NetworkPolicyListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.
@@ -5128,7 +5128,7 @@ type NetworkPolicySpec struct {
 	// List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default).
 	Ingress []NetworkPolicyIngressRule `pulumi:"ingress"`
 	// Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-	PodSelector *metav1.LabelSelector `pulumi:"podSelector"`
+	PodSelector metav1.LabelSelector `pulumi:"podSelector"`
 	// List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
 	PolicyTypes []string `pulumi:"policyTypes"`
 }
@@ -5152,7 +5152,7 @@ type NetworkPolicySpecArgs struct {
 	// List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default).
 	Ingress NetworkPolicyIngressRuleArrayInput `pulumi:"ingress"`
 	// Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-	PodSelector metav1.LabelSelectorPtrInput `pulumi:"podSelector"`
+	PodSelector metav1.LabelSelectorInput `pulumi:"podSelector"`
 	// List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
 	PolicyTypes pulumi.StringArrayInput `pulumi:"policyTypes"`
 }
@@ -5247,8 +5247,8 @@ func (o NetworkPolicySpecOutput) Ingress() NetworkPolicyIngressRuleArrayOutput {
 }
 
 // Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-func (o NetworkPolicySpecOutput) PodSelector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v NetworkPolicySpec) *metav1.LabelSelector { return v.PodSelector }).(metav1.LabelSelectorPtrOutput)
+func (o NetworkPolicySpecOutput) PodSelector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v NetworkPolicySpec) metav1.LabelSelector { return v.PodSelector }).(metav1.LabelSelectorOutput)
 }
 
 // List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
@@ -5300,7 +5300,7 @@ func (o NetworkPolicySpecPtrOutput) PodSelector() metav1.LabelSelectorPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.PodSelector
+		return &v.PodSelector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 
@@ -5317,13 +5317,13 @@ func (o NetworkPolicySpecPtrOutput) PolicyTypes() pulumi.StringArrayOutput {
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
 type PodSecurityPolicyType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec *PodSecurityPolicySpec `pulumi:"spec"`
+	Spec PodSecurityPolicySpec `pulumi:"spec"`
 }
 
 // PodSecurityPolicyTypeInput is an input type that accepts PodSecurityPolicyTypeArgs and PodSecurityPolicyTypeOutput values.
@@ -5341,13 +5341,13 @@ type PodSecurityPolicyTypeInput interface {
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
 type PodSecurityPolicyTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec PodSecurityPolicySpecPtrInput `pulumi:"spec"`
+	Spec PodSecurityPolicySpecInput `pulumi:"spec"`
 }
 
 func (PodSecurityPolicyTypeArgs) ElementType() reflect.Type {
@@ -5404,23 +5404,23 @@ func (o PodSecurityPolicyTypeOutput) ToPodSecurityPolicyTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodSecurityPolicyTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodSecurityPolicyTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodSecurityPolicyTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec defines the policy enforced.
-func (o PodSecurityPolicyTypeOutput) Spec() PodSecurityPolicySpecPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *PodSecurityPolicySpec { return v.Spec }).(PodSecurityPolicySpecPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Spec() PodSecurityPolicySpecOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) PodSecurityPolicySpec { return v.Spec }).(PodSecurityPolicySpecOutput)
 }
 
 type PodSecurityPolicyTypeArrayOutput struct{ *pulumi.OutputState }
@@ -5446,13 +5446,13 @@ func (o PodSecurityPolicyTypeArrayOutput) Index(i pulumi.IntInput) PodSecurityPo
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.
 type PodSecurityPolicyListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items []PodSecurityPolicyType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodSecurityPolicyListTypeInput is an input type that accepts PodSecurityPolicyListTypeArgs and PodSecurityPolicyListTypeOutput values.
@@ -5470,13 +5470,13 @@ type PodSecurityPolicyListTypeInput interface {
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.
 type PodSecurityPolicyListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items PodSecurityPolicyTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodSecurityPolicyListTypeArgs) ElementType() reflect.Type {
@@ -5507,8 +5507,8 @@ func (o PodSecurityPolicyListTypeOutput) ToPodSecurityPolicyListTypeOutputWithCo
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodSecurityPolicyListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is a list of schema objects.
@@ -5517,13 +5517,13 @@ func (o PodSecurityPolicyListTypeOutput) Items() PodSecurityPolicyTypeArrayOutpu
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodSecurityPolicyListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodSecurityPolicyListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.
@@ -5553,7 +5553,7 @@ type PodSecurityPolicySpec struct {
 	// Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 	ForbiddenSysctls []string `pulumi:"forbiddenSysctls"`
 	// fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-	FsGroup *FSGroupStrategyOptions `pulumi:"fsGroup"`
+	FsGroup FSGroupStrategyOptions `pulumi:"fsGroup"`
 	// hostIPC determines if the policy allows the use of HostIPC in the pod spec.
 	HostIPC *bool `pulumi:"hostIPC"`
 	// hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
@@ -5571,13 +5571,13 @@ type PodSecurityPolicySpec struct {
 	// RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
 	RunAsGroup *RunAsGroupStrategyOptions `pulumi:"runAsGroup"`
 	// runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-	RunAsUser *RunAsUserStrategyOptions `pulumi:"runAsUser"`
+	RunAsUser RunAsUserStrategyOptions `pulumi:"runAsUser"`
 	// runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
 	RuntimeClass *RuntimeClassStrategyOptions `pulumi:"runtimeClass"`
 	// seLinux is the strategy that will dictate the allowable labels that may be set.
-	SeLinux *SELinuxStrategyOptions `pulumi:"seLinux"`
+	SeLinux SELinuxStrategyOptions `pulumi:"seLinux"`
 	// supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-	SupplementalGroups *SupplementalGroupsStrategyOptions `pulumi:"supplementalGroups"`
+	SupplementalGroups SupplementalGroupsStrategyOptions `pulumi:"supplementalGroups"`
 	// volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
 	Volumes []string `pulumi:"volumes"`
 }
@@ -5621,7 +5621,7 @@ type PodSecurityPolicySpecArgs struct {
 	// Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 	ForbiddenSysctls pulumi.StringArrayInput `pulumi:"forbiddenSysctls"`
 	// fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-	FsGroup FSGroupStrategyOptionsPtrInput `pulumi:"fsGroup"`
+	FsGroup FSGroupStrategyOptionsInput `pulumi:"fsGroup"`
 	// hostIPC determines if the policy allows the use of HostIPC in the pod spec.
 	HostIPC pulumi.BoolPtrInput `pulumi:"hostIPC"`
 	// hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
@@ -5639,13 +5639,13 @@ type PodSecurityPolicySpecArgs struct {
 	// RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
 	RunAsGroup RunAsGroupStrategyOptionsPtrInput `pulumi:"runAsGroup"`
 	// runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-	RunAsUser RunAsUserStrategyOptionsPtrInput `pulumi:"runAsUser"`
+	RunAsUser RunAsUserStrategyOptionsInput `pulumi:"runAsUser"`
 	// runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
 	RuntimeClass RuntimeClassStrategyOptionsPtrInput `pulumi:"runtimeClass"`
 	// seLinux is the strategy that will dictate the allowable labels that may be set.
-	SeLinux SELinuxStrategyOptionsPtrInput `pulumi:"seLinux"`
+	SeLinux SELinuxStrategyOptionsInput `pulumi:"seLinux"`
 	// supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-	SupplementalGroups SupplementalGroupsStrategyOptionsPtrInput `pulumi:"supplementalGroups"`
+	SupplementalGroups SupplementalGroupsStrategyOptionsInput `pulumi:"supplementalGroups"`
 	// volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
 	Volumes pulumi.StringArrayInput `pulumi:"volumes"`
 }
@@ -5784,8 +5784,8 @@ func (o PodSecurityPolicySpecOutput) ForbiddenSysctls() pulumi.StringArrayOutput
 }
 
 // fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-func (o PodSecurityPolicySpecOutput) FsGroup() FSGroupStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *FSGroupStrategyOptions { return v.FsGroup }).(FSGroupStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) FsGroup() FSGroupStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) FSGroupStrategyOptions { return v.FsGroup }).(FSGroupStrategyOptionsOutput)
 }
 
 // hostIPC determines if the policy allows the use of HostIPC in the pod spec.
@@ -5829,8 +5829,8 @@ func (o PodSecurityPolicySpecOutput) RunAsGroup() RunAsGroupStrategyOptionsPtrOu
 }
 
 // runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-func (o PodSecurityPolicySpecOutput) RunAsUser() RunAsUserStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *RunAsUserStrategyOptions { return v.RunAsUser }).(RunAsUserStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) RunAsUser() RunAsUserStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) RunAsUserStrategyOptions { return v.RunAsUser }).(RunAsUserStrategyOptionsOutput)
 }
 
 // runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
@@ -5839,13 +5839,13 @@ func (o PodSecurityPolicySpecOutput) RuntimeClass() RuntimeClassStrategyOptionsP
 }
 
 // seLinux is the strategy that will dictate the allowable labels that may be set.
-func (o PodSecurityPolicySpecOutput) SeLinux() SELinuxStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *SELinuxStrategyOptions { return v.SeLinux }).(SELinuxStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) SeLinux() SELinuxStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) SELinuxStrategyOptions { return v.SeLinux }).(SELinuxStrategyOptionsOutput)
 }
 
 // supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-func (o PodSecurityPolicySpecOutput) SupplementalGroups() SupplementalGroupsStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *SupplementalGroupsStrategyOptions { return v.SupplementalGroups }).(SupplementalGroupsStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) SupplementalGroups() SupplementalGroupsStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) SupplementalGroupsStrategyOptions { return v.SupplementalGroups }).(SupplementalGroupsStrategyOptionsOutput)
 }
 
 // volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
@@ -5981,7 +5981,7 @@ func (o PodSecurityPolicySpecPtrOutput) FsGroup() FSGroupStrategyOptionsPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.FsGroup
+		return &v.FsGroup
 	}).(FSGroupStrategyOptionsPtrOutput)
 }
 
@@ -6071,7 +6071,7 @@ func (o PodSecurityPolicySpecPtrOutput) RunAsUser() RunAsUserStrategyOptionsPtrO
 		if v == nil {
 			return nil
 		}
-		return v.RunAsUser
+		return &v.RunAsUser
 	}).(RunAsUserStrategyOptionsPtrOutput)
 }
 
@@ -6091,7 +6091,7 @@ func (o PodSecurityPolicySpecPtrOutput) SeLinux() SELinuxStrategyOptionsPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.SeLinux
+		return &v.SeLinux
 	}).(SELinuxStrategyOptionsPtrOutput)
 }
 
@@ -6101,7 +6101,7 @@ func (o PodSecurityPolicySpecPtrOutput) SupplementalGroups() SupplementalGroupsS
 		if v == nil {
 			return nil
 		}
-		return v.SupplementalGroups
+		return &v.SupplementalGroups
 	}).(SupplementalGroupsStrategyOptionsPtrOutput)
 }
 
@@ -6118,15 +6118,15 @@ func (o PodSecurityPolicySpecPtrOutput) Volumes() pulumi.StringArrayOutput {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *ReplicaSetSpec `pulumi:"spec"`
+	Spec ReplicaSetSpec `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *ReplicaSetStatus `pulumi:"status"`
+	Status ReplicaSetStatus `pulumi:"status"`
 }
 
 // ReplicaSetTypeInput is an input type that accepts ReplicaSetTypeArgs and ReplicaSetTypeOutput values.
@@ -6144,15 +6144,15 @@ type ReplicaSetTypeInput interface {
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrInput `pulumi:"spec"`
+	Spec ReplicaSetSpecInput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrInput `pulumi:"status"`
+	Status ReplicaSetStatusInput `pulumi:"status"`
 }
 
 func (ReplicaSetTypeArgs) ElementType() reflect.Type {
@@ -6209,28 +6209,28 @@ func (o ReplicaSetTypeOutput) ToReplicaSetTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ReplicaSetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ReplicaSetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecPtrOutput)
+func (o ReplicaSetTypeOutput) Spec() ReplicaSetSpecOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetSpec { return v.Spec }).(ReplicaSetSpecOutput)
 }
 
 // Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusPtrOutput {
-	return o.ApplyT(func(v ReplicaSetType) *ReplicaSetStatus { return v.Status }).(ReplicaSetStatusPtrOutput)
+func (o ReplicaSetTypeOutput) Status() ReplicaSetStatusOutput {
+	return o.ApplyT(func(v ReplicaSetType) ReplicaSetStatus { return v.Status }).(ReplicaSetStatusOutput)
 }
 
 type ReplicaSetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -6262,9 +6262,9 @@ type ReplicaSetCondition struct {
 	// The reason for the condition's last transition.
 	Reason *string `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 	// Type of replica set condition.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // ReplicaSetConditionInput is an input type that accepts ReplicaSetConditionArgs and ReplicaSetConditionOutput values.
@@ -6288,9 +6288,9 @@ type ReplicaSetConditionArgs struct {
 	// The reason for the condition's last transition.
 	Reason pulumi.StringPtrInput `pulumi:"reason"`
 	// Status of the condition, one of True, False, Unknown.
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 	// Type of replica set condition.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (ReplicaSetConditionArgs) ElementType() reflect.Type {
@@ -6362,13 +6362,13 @@ func (o ReplicaSetConditionOutput) Reason() pulumi.StringPtrOutput {
 }
 
 // Status of the condition, one of True, False, Unknown.
-func (o ReplicaSetConditionOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // Type of replica set condition.
-func (o ReplicaSetConditionOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetCondition) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o ReplicaSetConditionOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetCondition) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type ReplicaSetConditionArrayOutput struct{ *pulumi.OutputState }
@@ -6394,13 +6394,13 @@ func (o ReplicaSetConditionArrayOutput) Index(i pulumi.IntInput) ReplicaSetCondi
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items []ReplicaSetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ReplicaSetListTypeInput is an input type that accepts ReplicaSetListTypeArgs and ReplicaSetListTypeOutput values.
@@ -6418,13 +6418,13 @@ type ReplicaSetListTypeInput interface {
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ReplicaSetListTypeArgs) ElementType() reflect.Type {
@@ -6455,8 +6455,8 @@ func (o ReplicaSetListTypeOutput) ToReplicaSetListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -6465,13 +6465,13 @@ func (o ReplicaSetListTypeOutput) Items() ReplicaSetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ReplicaSetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ReplicaSetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ReplicaSetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ReplicaSetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ReplicaSetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ReplicaSetSpec is the specification of a ReplicaSet.
@@ -6680,7 +6680,7 @@ type ReplicaSetStatus struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas *int `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 }
 
 // ReplicaSetStatusInput is an input type that accepts ReplicaSetStatusArgs and ReplicaSetStatusOutput values.
@@ -6708,7 +6708,7 @@ type ReplicaSetStatusArgs struct {
 	// The number of ready replicas for this replica set.
 	ReadyReplicas pulumi.IntPtrInput `pulumi:"readyReplicas"`
 	// Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 }
 
 func (ReplicaSetStatusArgs) ElementType() reflect.Type {
@@ -6816,8 +6816,8 @@ func (o ReplicaSetStatusOutput) ReadyReplicas() pulumi.IntPtrOutput {
 }
 
 // Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
-func (o ReplicaSetStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ReplicaSetStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ReplicaSetStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ReplicaSetStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 type ReplicaSetStatusPtrOutput struct{ *pulumi.OutputState }
@@ -6894,7 +6894,7 @@ func (o ReplicaSetStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -7330,7 +7330,7 @@ type RunAsGroupStrategyOptions struct {
 	// ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges []IDRange `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 }
 
 // RunAsGroupStrategyOptionsInput is an input type that accepts RunAsGroupStrategyOptionsArgs and RunAsGroupStrategyOptionsOutput values.
@@ -7350,7 +7350,7 @@ type RunAsGroupStrategyOptionsArgs struct {
 	// ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges IDRangeArrayInput `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 }
 
 func (RunAsGroupStrategyOptionsArgs) ElementType() reflect.Type {
@@ -7438,8 +7438,8 @@ func (o RunAsGroupStrategyOptionsOutput) Ranges() IDRangeArrayOutput {
 }
 
 // rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-func (o RunAsGroupStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RunAsGroupStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o RunAsGroupStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v RunAsGroupStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 type RunAsGroupStrategyOptionsPtrOutput struct{ *pulumi.OutputState }
@@ -7476,7 +7476,7 @@ func (o RunAsGroupStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -7485,7 +7485,7 @@ type RunAsUserStrategyOptions struct {
 	// ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges []IDRange `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 }
 
 // RunAsUserStrategyOptionsInput is an input type that accepts RunAsUserStrategyOptionsArgs and RunAsUserStrategyOptionsOutput values.
@@ -7505,7 +7505,7 @@ type RunAsUserStrategyOptionsArgs struct {
 	// ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges IDRangeArrayInput `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 }
 
 func (RunAsUserStrategyOptionsArgs) ElementType() reflect.Type {
@@ -7593,8 +7593,8 @@ func (o RunAsUserStrategyOptionsOutput) Ranges() IDRangeArrayOutput {
 }
 
 // rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-func (o RunAsUserStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RunAsUserStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o RunAsUserStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v RunAsUserStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 type RunAsUserStrategyOptionsPtrOutput struct{ *pulumi.OutputState }
@@ -7631,7 +7631,7 @@ func (o RunAsUserStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -7793,7 +7793,7 @@ func (o RuntimeClassStrategyOptionsPtrOutput) DefaultRuntimeClassName() pulumi.S
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.
 type SELinuxStrategyOptions struct {
 	// rule is the strategy that will dictate the allowable labels that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 	// seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 	SeLinuxOptions *corev1.SELinuxOptions `pulumi:"seLinuxOptions"`
 }
@@ -7813,7 +7813,7 @@ type SELinuxStrategyOptionsInput interface {
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.
 type SELinuxStrategyOptionsArgs struct {
 	// rule is the strategy that will dictate the allowable labels that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 	// seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 	SeLinuxOptions corev1.SELinuxOptionsPtrInput `pulumi:"seLinuxOptions"`
 }
@@ -7898,8 +7898,8 @@ func (o SELinuxStrategyOptionsOutput) ToSELinuxStrategyOptionsPtrOutputWithConte
 }
 
 // rule is the strategy that will dictate the allowable labels that may be set.
-func (o SELinuxStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SELinuxStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o SELinuxStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v SELinuxStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 // seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -7931,7 +7931,7 @@ func (o SELinuxStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -8176,7 +8176,7 @@ func (o ScaleSpecPtrOutput) Replicas() pulumi.IntPtrOutput {
 // represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
-	Replicas *int `pulumi:"replicas"`
+	Replicas int `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector map[string]string `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -8198,7 +8198,7 @@ type ScaleStatusInput interface {
 // represents the current status of a scale subresource.
 type ScaleStatusArgs struct {
 	// actual number of observed instances of the scaled object.
-	Replicas pulumi.IntPtrInput `pulumi:"replicas"`
+	Replicas pulumi.IntInput `pulumi:"replicas"`
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	Selector pulumi.StringMapInput `pulumi:"selector"`
 	// label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -8285,8 +8285,8 @@ func (o ScaleStatusOutput) ToScaleStatusPtrOutputWithContext(ctx context.Context
 }
 
 // actual number of observed instances of the scaled object.
-func (o ScaleStatusOutput) Replicas() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v ScaleStatus) *int { return v.Replicas }).(pulumi.IntPtrOutput)
+func (o ScaleStatusOutput) Replicas() pulumi.IntOutput {
+	return o.ApplyT(func(v ScaleStatus) int { return v.Replicas }).(pulumi.IntOutput)
 }
 
 // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
@@ -8323,7 +8323,7 @@ func (o ScaleStatusPtrOutput) Replicas() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Replicas
+		return &v.Replicas
 	}).(pulumi.IntPtrOutput)
 }
 

--- a/sdk/go/kubernetes/extensions/v1beta1/replicaSet.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/replicaSet.go
@@ -15,15 +15,15 @@ type ReplicaSet struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec ReplicaSetSpecPtrOutput `pulumi:"spec"`
+	Spec ReplicaSetSpecOutput `pulumi:"spec"`
 	// Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status ReplicaSetStatusPtrOutput `pulumi:"status"`
+	Status ReplicaSetStatusOutput `pulumi:"status"`
 }
 
 // NewReplicaSet registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/extensions/v1beta1/replicaSetList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/replicaSetList.go
@@ -16,13 +16,13 @@ type ReplicaSetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
 	Items ReplicaSetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewReplicaSetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchema.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchema.go
@@ -15,15 +15,15 @@ type FlowSchema struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec FlowSchemaSpecPtrOutput `pulumi:"spec"`
+	Spec FlowSchemaSpecOutput `pulumi:"spec"`
 	// `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status FlowSchemaStatusPtrOutput `pulumi:"status"`
+	Status FlowSchemaStatusOutput `pulumi:"status"`
 }
 
 // NewFlowSchema registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaList.go
@@ -16,13 +16,13 @@ type FlowSchemaList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// `items` is a list of FlowSchemas.
 	Items FlowSchemaTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewFlowSchemaList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfiguration.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfiguration.go
@@ -15,15 +15,15 @@ type PriorityLevelConfiguration struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec PriorityLevelConfigurationSpecPtrOutput `pulumi:"spec"`
+	Spec PriorityLevelConfigurationSpecOutput `pulumi:"spec"`
 	// `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status PriorityLevelConfigurationStatusPtrOutput `pulumi:"status"`
+	Status PriorityLevelConfigurationStatusOutput `pulumi:"status"`
 }
 
 // NewPriorityLevelConfiguration registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationList.go
@@ -16,13 +16,13 @@ type PriorityLevelConfigurationList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// `items` is a list of request-priorities.
 	Items PriorityLevelConfigurationTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPriorityLevelConfigurationList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/pulumiTypes.go
@@ -14,7 +14,7 @@ import (
 // FlowDistinguisherMethod specifies the method of a flow distinguisher.
 type FlowDistinguisherMethod struct {
 	// `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // FlowDistinguisherMethodInput is an input type that accepts FlowDistinguisherMethodArgs and FlowDistinguisherMethodOutput values.
@@ -32,7 +32,7 @@ type FlowDistinguisherMethodInput interface {
 // FlowDistinguisherMethod specifies the method of a flow distinguisher.
 type FlowDistinguisherMethodArgs struct {
 	// `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (FlowDistinguisherMethodArgs) ElementType() reflect.Type {
@@ -115,8 +115,8 @@ func (o FlowDistinguisherMethodOutput) ToFlowDistinguisherMethodPtrOutputWithCon
 }
 
 // `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
-func (o FlowDistinguisherMethodOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlowDistinguisherMethod) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o FlowDistinguisherMethodOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v FlowDistinguisherMethod) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type FlowDistinguisherMethodPtrOutput struct{ *pulumi.OutputState }
@@ -143,22 +143,22 @@ func (o FlowDistinguisherMethodPtrOutput) Type() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Type
+		return &v.Type
 	}).(pulumi.StringPtrOutput)
 }
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *FlowSchemaSpec `pulumi:"spec"`
+	Spec FlowSchemaSpec `pulumi:"spec"`
 	// `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *FlowSchemaStatus `pulumi:"status"`
+	Status FlowSchemaStatus `pulumi:"status"`
 }
 
 // FlowSchemaTypeInput is an input type that accepts FlowSchemaTypeArgs and FlowSchemaTypeOutput values.
@@ -176,15 +176,15 @@ type FlowSchemaTypeInput interface {
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec FlowSchemaSpecPtrInput `pulumi:"spec"`
+	Spec FlowSchemaSpecInput `pulumi:"spec"`
 	// `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status FlowSchemaStatusPtrInput `pulumi:"status"`
+	Status FlowSchemaStatusInput `pulumi:"status"`
 }
 
 func (FlowSchemaTypeArgs) ElementType() reflect.Type {
@@ -241,28 +241,28 @@ func (o FlowSchemaTypeOutput) ToFlowSchemaTypeOutputWithContext(ctx context.Cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o FlowSchemaTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlowSchemaType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o FlowSchemaTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v FlowSchemaType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o FlowSchemaTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlowSchemaType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o FlowSchemaTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v FlowSchemaType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o FlowSchemaTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v FlowSchemaType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o FlowSchemaTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v FlowSchemaType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o FlowSchemaTypeOutput) Spec() FlowSchemaSpecPtrOutput {
-	return o.ApplyT(func(v FlowSchemaType) *FlowSchemaSpec { return v.Spec }).(FlowSchemaSpecPtrOutput)
+func (o FlowSchemaTypeOutput) Spec() FlowSchemaSpecOutput {
+	return o.ApplyT(func(v FlowSchemaType) FlowSchemaSpec { return v.Spec }).(FlowSchemaSpecOutput)
 }
 
 // `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o FlowSchemaTypeOutput) Status() FlowSchemaStatusPtrOutput {
-	return o.ApplyT(func(v FlowSchemaType) *FlowSchemaStatus { return v.Status }).(FlowSchemaStatusPtrOutput)
+func (o FlowSchemaTypeOutput) Status() FlowSchemaStatusOutput {
+	return o.ApplyT(func(v FlowSchemaType) FlowSchemaStatus { return v.Status }).(FlowSchemaStatusOutput)
 }
 
 type FlowSchemaTypeArrayOutput struct{ *pulumi.OutputState }
@@ -426,13 +426,13 @@ func (o FlowSchemaConditionArrayOutput) Index(i pulumi.IntInput) FlowSchemaCondi
 // FlowSchemaList is a list of FlowSchema objects.
 type FlowSchemaListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// `items` is a list of FlowSchemas.
 	Items []FlowSchemaType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // FlowSchemaListTypeInput is an input type that accepts FlowSchemaListTypeArgs and FlowSchemaListTypeOutput values.
@@ -450,13 +450,13 @@ type FlowSchemaListTypeInput interface {
 // FlowSchemaList is a list of FlowSchema objects.
 type FlowSchemaListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// `items` is a list of FlowSchemas.
 	Items FlowSchemaTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (FlowSchemaListTypeArgs) ElementType() reflect.Type {
@@ -487,8 +487,8 @@ func (o FlowSchemaListTypeOutput) ToFlowSchemaListTypeOutputWithContext(ctx cont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o FlowSchemaListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlowSchemaListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o FlowSchemaListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v FlowSchemaListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // `items` is a list of FlowSchemas.
@@ -497,13 +497,13 @@ func (o FlowSchemaListTypeOutput) Items() FlowSchemaTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o FlowSchemaListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FlowSchemaListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o FlowSchemaListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v FlowSchemaListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o FlowSchemaListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v FlowSchemaListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o FlowSchemaListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v FlowSchemaListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // FlowSchemaSpec describes how the FlowSchema's specification looks like.
@@ -513,7 +513,7 @@ type FlowSchemaSpec struct {
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
 	MatchingPrecedence *int `pulumi:"matchingPrecedence"`
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
-	PriorityLevelConfiguration *PriorityLevelConfigurationReference `pulumi:"priorityLevelConfiguration"`
+	PriorityLevelConfiguration PriorityLevelConfigurationReference `pulumi:"priorityLevelConfiguration"`
 	// `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
 	Rules []PolicyRulesWithSubjects `pulumi:"rules"`
 }
@@ -537,7 +537,7 @@ type FlowSchemaSpecArgs struct {
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
 	MatchingPrecedence pulumi.IntPtrInput `pulumi:"matchingPrecedence"`
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
-	PriorityLevelConfiguration PriorityLevelConfigurationReferencePtrInput `pulumi:"priorityLevelConfiguration"`
+	PriorityLevelConfiguration PriorityLevelConfigurationReferenceInput `pulumi:"priorityLevelConfiguration"`
 	// `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
 	Rules PolicyRulesWithSubjectsArrayInput `pulumi:"rules"`
 }
@@ -632,8 +632,8 @@ func (o FlowSchemaSpecOutput) MatchingPrecedence() pulumi.IntPtrOutput {
 }
 
 // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
-func (o FlowSchemaSpecOutput) PriorityLevelConfiguration() PriorityLevelConfigurationReferencePtrOutput {
-	return o.ApplyT(func(v FlowSchemaSpec) *PriorityLevelConfigurationReference { return v.PriorityLevelConfiguration }).(PriorityLevelConfigurationReferencePtrOutput)
+func (o FlowSchemaSpecOutput) PriorityLevelConfiguration() PriorityLevelConfigurationReferenceOutput {
+	return o.ApplyT(func(v FlowSchemaSpec) PriorityLevelConfigurationReference { return v.PriorityLevelConfiguration }).(PriorityLevelConfigurationReferenceOutput)
 }
 
 // `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
@@ -685,7 +685,7 @@ func (o FlowSchemaSpecPtrOutput) PriorityLevelConfiguration() PriorityLevelConfi
 		if v == nil {
 			return nil
 		}
-		return v.PriorityLevelConfiguration
+		return &v.PriorityLevelConfiguration
 	}).(PriorityLevelConfigurationReferencePtrOutput)
 }
 
@@ -838,7 +838,7 @@ func (o FlowSchemaStatusPtrOutput) Conditions() FlowSchemaConditionArrayOutput {
 // GroupSubject holds detailed information for group-kind subject.
 type GroupSubject struct {
 	// name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // GroupSubjectInput is an input type that accepts GroupSubjectArgs and GroupSubjectOutput values.
@@ -856,7 +856,7 @@ type GroupSubjectInput interface {
 // GroupSubject holds detailed information for group-kind subject.
 type GroupSubjectArgs struct {
 	// name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (GroupSubjectArgs) ElementType() reflect.Type {
@@ -939,8 +939,8 @@ func (o GroupSubjectOutput) ToGroupSubjectPtrOutputWithContext(ctx context.Conte
 }
 
 // name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
-func (o GroupSubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GroupSubject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o GroupSubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v GroupSubject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type GroupSubjectPtrOutput struct{ *pulumi.OutputState }
@@ -967,7 +967,7 @@ func (o GroupSubjectPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -976,7 +976,7 @@ type LimitResponse struct {
 	// `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
 	Queuing *QueuingConfiguration `pulumi:"queuing"`
 	// `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // LimitResponseInput is an input type that accepts LimitResponseArgs and LimitResponseOutput values.
@@ -996,7 +996,7 @@ type LimitResponseArgs struct {
 	// `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
 	Queuing QueuingConfigurationPtrInput `pulumi:"queuing"`
 	// `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (LimitResponseArgs) ElementType() reflect.Type {
@@ -1084,8 +1084,8 @@ func (o LimitResponseOutput) Queuing() QueuingConfigurationPtrOutput {
 }
 
 // `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
-func (o LimitResponseOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LimitResponse) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o LimitResponseOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v LimitResponse) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type LimitResponsePtrOutput struct{ *pulumi.OutputState }
@@ -1122,7 +1122,7 @@ func (o LimitResponsePtrOutput) Type() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Type
+		return &v.Type
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1555,15 +1555,15 @@ func (o PolicyRulesWithSubjectsArrayOutput) Index(i pulumi.IntInput) PolicyRules
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *PriorityLevelConfigurationSpec `pulumi:"spec"`
+	Spec PriorityLevelConfigurationSpec `pulumi:"spec"`
 	// `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *PriorityLevelConfigurationStatus `pulumi:"status"`
+	Status PriorityLevelConfigurationStatus `pulumi:"status"`
 }
 
 // PriorityLevelConfigurationTypeInput is an input type that accepts PriorityLevelConfigurationTypeArgs and PriorityLevelConfigurationTypeOutput values.
@@ -1581,15 +1581,15 @@ type PriorityLevelConfigurationTypeInput interface {
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec PriorityLevelConfigurationSpecPtrInput `pulumi:"spec"`
+	Spec PriorityLevelConfigurationSpecInput `pulumi:"spec"`
 	// `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status PriorityLevelConfigurationStatusPtrInput `pulumi:"status"`
+	Status PriorityLevelConfigurationStatusInput `pulumi:"status"`
 }
 
 func (PriorityLevelConfigurationTypeArgs) ElementType() reflect.Type {
@@ -1646,28 +1646,28 @@ func (o PriorityLevelConfigurationTypeOutput) ToPriorityLevelConfigurationTypeOu
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityLevelConfigurationTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityLevelConfigurationTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityLevelConfigurationTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PriorityLevelConfigurationTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o PriorityLevelConfigurationTypeOutput) Spec() PriorityLevelConfigurationSpecPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationType) *PriorityLevelConfigurationSpec { return v.Spec }).(PriorityLevelConfigurationSpecPtrOutput)
+func (o PriorityLevelConfigurationTypeOutput) Spec() PriorityLevelConfigurationSpecOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationType) PriorityLevelConfigurationSpec { return v.Spec }).(PriorityLevelConfigurationSpecOutput)
 }
 
 // `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o PriorityLevelConfigurationTypeOutput) Status() PriorityLevelConfigurationStatusPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationType) *PriorityLevelConfigurationStatus { return v.Status }).(PriorityLevelConfigurationStatusPtrOutput)
+func (o PriorityLevelConfigurationTypeOutput) Status() PriorityLevelConfigurationStatusOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationType) PriorityLevelConfigurationStatus { return v.Status }).(PriorityLevelConfigurationStatusOutput)
 }
 
 type PriorityLevelConfigurationTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1831,13 +1831,13 @@ func (o PriorityLevelConfigurationConditionArrayOutput) Index(i pulumi.IntInput)
 // PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
 type PriorityLevelConfigurationListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// `items` is a list of request-priorities.
 	Items []PriorityLevelConfigurationType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PriorityLevelConfigurationListTypeInput is an input type that accepts PriorityLevelConfigurationListTypeArgs and PriorityLevelConfigurationListTypeOutput values.
@@ -1855,13 +1855,13 @@ type PriorityLevelConfigurationListTypeInput interface {
 // PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
 type PriorityLevelConfigurationListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// `items` is a list of request-priorities.
 	Items PriorityLevelConfigurationTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PriorityLevelConfigurationListTypeArgs) ElementType() reflect.Type {
@@ -1892,8 +1892,8 @@ func (o PriorityLevelConfigurationListTypeOutput) ToPriorityLevelConfigurationLi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityLevelConfigurationListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // `items` is a list of request-priorities.
@@ -1902,19 +1902,19 @@ func (o PriorityLevelConfigurationListTypeOutput) Items() PriorityLevelConfigura
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityLevelConfigurationListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityLevelConfigurationListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PriorityLevelConfigurationListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // PriorityLevelConfigurationReferenceInput is an input type that accepts PriorityLevelConfigurationReferenceArgs and PriorityLevelConfigurationReferenceOutput values.
@@ -1932,7 +1932,7 @@ type PriorityLevelConfigurationReferenceInput interface {
 // PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
 type PriorityLevelConfigurationReferenceArgs struct {
 	// `name` is the name of the priority level configuration being referenced Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (PriorityLevelConfigurationReferenceArgs) ElementType() reflect.Type {
@@ -2015,8 +2015,8 @@ func (o PriorityLevelConfigurationReferenceOutput) ToPriorityLevelConfigurationR
 }
 
 // `name` is the name of the priority level configuration being referenced Required.
-func (o PriorityLevelConfigurationReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type PriorityLevelConfigurationReferencePtrOutput struct{ *pulumi.OutputState }
@@ -2043,7 +2043,7 @@ func (o PriorityLevelConfigurationReferencePtrOutput) Name() pulumi.StringPtrOut
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2052,7 +2052,7 @@ type PriorityLevelConfigurationSpec struct {
 	// `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
 	Limited *LimitedPriorityLevelConfiguration `pulumi:"limited"`
 	// `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
-	Type *string `pulumi:"type"`
+	Type string `pulumi:"type"`
 }
 
 // PriorityLevelConfigurationSpecInput is an input type that accepts PriorityLevelConfigurationSpecArgs and PriorityLevelConfigurationSpecOutput values.
@@ -2072,7 +2072,7 @@ type PriorityLevelConfigurationSpecArgs struct {
 	// `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
 	Limited LimitedPriorityLevelConfigurationPtrInput `pulumi:"limited"`
 	// `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
-	Type pulumi.StringPtrInput `pulumi:"type"`
+	Type pulumi.StringInput `pulumi:"type"`
 }
 
 func (PriorityLevelConfigurationSpecArgs) ElementType() reflect.Type {
@@ -2160,8 +2160,8 @@ func (o PriorityLevelConfigurationSpecOutput) Limited() LimitedPriorityLevelConf
 }
 
 // `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
-func (o PriorityLevelConfigurationSpecOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityLevelConfigurationSpec) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o PriorityLevelConfigurationSpecOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityLevelConfigurationSpec) string { return v.Type }).(pulumi.StringOutput)
 }
 
 type PriorityLevelConfigurationSpecPtrOutput struct{ *pulumi.OutputState }
@@ -2198,7 +2198,7 @@ func (o PriorityLevelConfigurationSpecPtrOutput) Type() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Type
+		return &v.Type
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2653,9 +2653,9 @@ func (o ResourcePolicyRuleArrayOutput) Index(i pulumi.IntInput) ResourcePolicyRu
 // ServiceAccountSubject holds detailed information for service-account-kind subject.
 type ServiceAccountSubject struct {
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// `namespace` is the namespace of matching ServiceAccount objects. Required.
-	Namespace *string `pulumi:"namespace"`
+	Namespace string `pulumi:"namespace"`
 }
 
 // ServiceAccountSubjectInput is an input type that accepts ServiceAccountSubjectArgs and ServiceAccountSubjectOutput values.
@@ -2673,9 +2673,9 @@ type ServiceAccountSubjectInput interface {
 // ServiceAccountSubject holds detailed information for service-account-kind subject.
 type ServiceAccountSubjectArgs struct {
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// `namespace` is the namespace of matching ServiceAccount objects. Required.
-	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Namespace pulumi.StringInput `pulumi:"namespace"`
 }
 
 func (ServiceAccountSubjectArgs) ElementType() reflect.Type {
@@ -2758,13 +2758,13 @@ func (o ServiceAccountSubjectOutput) ToServiceAccountSubjectPtrOutputWithContext
 }
 
 // `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
-func (o ServiceAccountSubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountSubject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o ServiceAccountSubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountSubject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // `namespace` is the namespace of matching ServiceAccount objects. Required.
-func (o ServiceAccountSubjectOutput) Namespace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServiceAccountSubject) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+func (o ServiceAccountSubjectOutput) Namespace() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceAccountSubject) string { return v.Namespace }).(pulumi.StringOutput)
 }
 
 type ServiceAccountSubjectPtrOutput struct{ *pulumi.OutputState }
@@ -2791,7 +2791,7 @@ func (o ServiceAccountSubjectPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2801,7 +2801,7 @@ func (o ServiceAccountSubjectPtrOutput) Namespace() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Namespace
+		return &v.Namespace
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2809,7 +2809,7 @@ func (o ServiceAccountSubjectPtrOutput) Namespace() pulumi.StringPtrOutput {
 type Subject struct {
 	Group *GroupSubject `pulumi:"group"`
 	// Required
-	Kind           *string                `pulumi:"kind"`
+	Kind           string                 `pulumi:"kind"`
 	ServiceAccount *ServiceAccountSubject `pulumi:"serviceAccount"`
 	User           *UserSubject           `pulumi:"user"`
 }
@@ -2830,7 +2830,7 @@ type SubjectInput interface {
 type SubjectArgs struct {
 	Group GroupSubjectPtrInput `pulumi:"group"`
 	// Required
-	Kind           pulumi.StringPtrInput         `pulumi:"kind"`
+	Kind           pulumi.StringInput            `pulumi:"kind"`
 	ServiceAccount ServiceAccountSubjectPtrInput `pulumi:"serviceAccount"`
 	User           UserSubjectPtrInput           `pulumi:"user"`
 }
@@ -2893,8 +2893,8 @@ func (o SubjectOutput) Group() GroupSubjectPtrOutput {
 }
 
 // Required
-func (o SubjectOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 func (o SubjectOutput) ServiceAccount() ServiceAccountSubjectPtrOutput {
@@ -2928,7 +2928,7 @@ func (o SubjectArrayOutput) Index(i pulumi.IntInput) SubjectOutput {
 // UserSubject holds detailed information for user-kind subject.
 type UserSubject struct {
 	// `name` is the username that matches, or "*" to match all usernames. Required.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // UserSubjectInput is an input type that accepts UserSubjectArgs and UserSubjectOutput values.
@@ -2946,7 +2946,7 @@ type UserSubjectInput interface {
 // UserSubject holds detailed information for user-kind subject.
 type UserSubjectArgs struct {
 	// `name` is the username that matches, or "*" to match all usernames. Required.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (UserSubjectArgs) ElementType() reflect.Type {
@@ -3029,8 +3029,8 @@ func (o UserSubjectOutput) ToUserSubjectPtrOutputWithContext(ctx context.Context
 }
 
 // `name` is the username that matches, or "*" to match all usernames. Required.
-func (o UserSubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v UserSubject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o UserSubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v UserSubject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type UserSubjectPtrOutput struct{ *pulumi.OutputState }
@@ -3057,7 +3057,7 @@ func (o UserSubjectPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/meta/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/meta/v1/pulumiTypes.go
@@ -17,7 +17,7 @@ type APIGroup struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// name is the name of the group.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// preferredVersion is the version preferred by the API server, which probably is the storage version.
 	PreferredVersion *GroupVersionForDiscovery `pulumi:"preferredVersion"`
 	// a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
@@ -45,7 +45,7 @@ type APIGroupArgs struct {
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// name is the name of the group.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// preferredVersion is the version preferred by the API server, which probably is the storage version.
 	PreferredVersion GroupVersionForDiscoveryPtrInput `pulumi:"preferredVersion"`
 	// a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
@@ -118,8 +118,8 @@ func (o APIGroupOutput) Kind() pulumi.StringPtrOutput {
 }
 
 // name is the name of the group.
-func (o APIGroupOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIGroup) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o APIGroupOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v APIGroup) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // preferredVersion is the version preferred by the API server, which probably is the storage version.
@@ -238,15 +238,15 @@ type APIResource struct {
 	// group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale".
 	Group *string `pulumi:"group"`
 	// kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// name is the plural name of the resource.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// namespaced indicates if a resource is namespaced or not.
-	Namespaced *bool `pulumi:"namespaced"`
+	Namespaced bool `pulumi:"namespaced"`
 	// shortNames is a list of suggested short names of the resource.
 	ShortNames []string `pulumi:"shortNames"`
 	// singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.
-	SingularName *string `pulumi:"singularName"`
+	SingularName string `pulumi:"singularName"`
 	// The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.
 	StorageVersionHash *string `pulumi:"storageVersionHash"`
 	// verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)
@@ -274,15 +274,15 @@ type APIResourceArgs struct {
 	// group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale".
 	Group pulumi.StringPtrInput `pulumi:"group"`
 	// kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// name is the plural name of the resource.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// namespaced indicates if a resource is namespaced or not.
-	Namespaced pulumi.BoolPtrInput `pulumi:"namespaced"`
+	Namespaced pulumi.BoolInput `pulumi:"namespaced"`
 	// shortNames is a list of suggested short names of the resource.
 	ShortNames pulumi.StringArrayInput `pulumi:"shortNames"`
 	// singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.
-	SingularName pulumi.StringPtrInput `pulumi:"singularName"`
+	SingularName pulumi.StringInput `pulumi:"singularName"`
 	// The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.
 	StorageVersionHash pulumi.StringPtrInput `pulumi:"storageVersionHash"`
 	// verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)
@@ -355,18 +355,18 @@ func (o APIResourceOutput) Group() pulumi.StringPtrOutput {
 }
 
 // kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')
-func (o APIResourceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIResource) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o APIResourceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v APIResource) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // name is the plural name of the resource.
-func (o APIResourceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIResource) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o APIResourceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v APIResource) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // namespaced indicates if a resource is namespaced or not.
-func (o APIResourceOutput) Namespaced() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v APIResource) *bool { return v.Namespaced }).(pulumi.BoolPtrOutput)
+func (o APIResourceOutput) Namespaced() pulumi.BoolOutput {
+	return o.ApplyT(func(v APIResource) bool { return v.Namespaced }).(pulumi.BoolOutput)
 }
 
 // shortNames is a list of suggested short names of the resource.
@@ -375,8 +375,8 @@ func (o APIResourceOutput) ShortNames() pulumi.StringArrayOutput {
 }
 
 // singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.
-func (o APIResourceOutput) SingularName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIResource) *string { return v.SingularName }).(pulumi.StringPtrOutput)
+func (o APIResourceOutput) SingularName() pulumi.StringOutput {
+	return o.ApplyT(func(v APIResource) string { return v.SingularName }).(pulumi.StringOutput)
 }
 
 // The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.
@@ -419,7 +419,7 @@ type APIResourceList struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion *string `pulumi:"apiVersion"`
 	// groupVersion is the group and version this APIResourceList is for.
-	GroupVersion *string `pulumi:"groupVersion"`
+	GroupVersion string `pulumi:"groupVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind *string `pulumi:"kind"`
 	// resources contains the name of the resources and if they are namespaced.
@@ -443,7 +443,7 @@ type APIResourceListArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// groupVersion is the group and version this APIResourceList is for.
-	GroupVersion pulumi.StringPtrInput `pulumi:"groupVersion"`
+	GroupVersion pulumi.StringInput `pulumi:"groupVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind pulumi.StringPtrInput `pulumi:"kind"`
 	// resources contains the name of the resources and if they are namespaced.
@@ -483,8 +483,8 @@ func (o APIResourceListOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // groupVersion is the group and version this APIResourceList is for.
-func (o APIResourceListOutput) GroupVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v APIResourceList) *string { return v.GroupVersion }).(pulumi.StringPtrOutput)
+func (o APIResourceListOutput) GroupVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v APIResourceList) string { return v.GroupVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -833,9 +833,9 @@ func (o DeleteOptionsPtrOutput) PropagationPolicy() pulumi.StringPtrOutput {
 // GroupVersion contains the "group/version" and "version" string of a version. It is made a struct to keep extensibility.
 type GroupVersionForDiscovery struct {
 	// groupVersion specifies the API group and version in the form "group/version"
-	GroupVersion *string `pulumi:"groupVersion"`
+	GroupVersion string `pulumi:"groupVersion"`
 	// version specifies the version in the form of "version". This is to save the clients the trouble of splitting the GroupVersion.
-	Version *string `pulumi:"version"`
+	Version string `pulumi:"version"`
 }
 
 // GroupVersionForDiscoveryInput is an input type that accepts GroupVersionForDiscoveryArgs and GroupVersionForDiscoveryOutput values.
@@ -853,9 +853,9 @@ type GroupVersionForDiscoveryInput interface {
 // GroupVersion contains the "group/version" and "version" string of a version. It is made a struct to keep extensibility.
 type GroupVersionForDiscoveryArgs struct {
 	// groupVersion specifies the API group and version in the form "group/version"
-	GroupVersion pulumi.StringPtrInput `pulumi:"groupVersion"`
+	GroupVersion pulumi.StringInput `pulumi:"groupVersion"`
 	// version specifies the version in the form of "version". This is to save the clients the trouble of splitting the GroupVersion.
-	Version pulumi.StringPtrInput `pulumi:"version"`
+	Version pulumi.StringInput `pulumi:"version"`
 }
 
 func (GroupVersionForDiscoveryArgs) ElementType() reflect.Type {
@@ -964,13 +964,13 @@ func (o GroupVersionForDiscoveryOutput) ToGroupVersionForDiscoveryPtrOutputWithC
 }
 
 // groupVersion specifies the API group and version in the form "group/version"
-func (o GroupVersionForDiscoveryOutput) GroupVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GroupVersionForDiscovery) *string { return v.GroupVersion }).(pulumi.StringPtrOutput)
+func (o GroupVersionForDiscoveryOutput) GroupVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v GroupVersionForDiscovery) string { return v.GroupVersion }).(pulumi.StringOutput)
 }
 
 // version specifies the version in the form of "version". This is to save the clients the trouble of splitting the GroupVersion.
-func (o GroupVersionForDiscoveryOutput) Version() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GroupVersionForDiscovery) *string { return v.Version }).(pulumi.StringPtrOutput)
+func (o GroupVersionForDiscoveryOutput) Version() pulumi.StringOutput {
+	return o.ApplyT(func(v GroupVersionForDiscovery) string { return v.Version }).(pulumi.StringOutput)
 }
 
 type GroupVersionForDiscoveryPtrOutput struct{ *pulumi.OutputState }
@@ -997,7 +997,7 @@ func (o GroupVersionForDiscoveryPtrOutput) GroupVersion() pulumi.StringPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.GroupVersion
+		return &v.GroupVersion
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1007,7 +1007,7 @@ func (o GroupVersionForDiscoveryPtrOutput) Version() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Version
+		return &v.Version
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1235,9 +1235,9 @@ func (o LabelSelectorArrayOutput) Index(i pulumi.IntInput) LabelSelectorOutput {
 // A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 type LabelSelectorRequirement struct {
 	// key is the label key that the selector applies to.
-	Key *string `pulumi:"key"`
+	Key string `pulumi:"key"`
 	// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-	Operator *string `pulumi:"operator"`
+	Operator string `pulumi:"operator"`
 	// values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
 	Values []string `pulumi:"values"`
 }
@@ -1257,9 +1257,9 @@ type LabelSelectorRequirementInput interface {
 // A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 type LabelSelectorRequirementArgs struct {
 	// key is the label key that the selector applies to.
-	Key pulumi.StringPtrInput `pulumi:"key"`
+	Key pulumi.StringInput `pulumi:"key"`
 	// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-	Operator pulumi.StringPtrInput `pulumi:"operator"`
+	Operator pulumi.StringInput `pulumi:"operator"`
 	// values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
 	Values pulumi.StringArrayInput `pulumi:"values"`
 }
@@ -1318,13 +1318,13 @@ func (o LabelSelectorRequirementOutput) ToLabelSelectorRequirementOutputWithCont
 }
 
 // key is the label key that the selector applies to.
-func (o LabelSelectorRequirementOutput) Key() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LabelSelectorRequirement) *string { return v.Key }).(pulumi.StringPtrOutput)
+func (o LabelSelectorRequirementOutput) Key() pulumi.StringOutput {
+	return o.ApplyT(func(v LabelSelectorRequirement) string { return v.Key }).(pulumi.StringOutput)
 }
 
 // operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-func (o LabelSelectorRequirementOutput) Operator() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v LabelSelectorRequirement) *string { return v.Operator }).(pulumi.StringPtrOutput)
+func (o LabelSelectorRequirementOutput) Operator() pulumi.StringOutput {
+	return o.ApplyT(func(v LabelSelectorRequirement) string { return v.Operator }).(pulumi.StringOutput)
 }
 
 // values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
@@ -2188,17 +2188,17 @@ func (o ObjectMetaPtrOutput) Uid() pulumi.StringPtrOutput {
 // OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
 type OwnerReference struct {
 	// API version of the referent.
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
 	BlockOwnerDeletion *bool `pulumi:"blockOwnerDeletion"`
 	// If true, this reference points to the managing controller.
 	Controller *bool `pulumi:"controller"`
 	// Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-	Uid *string `pulumi:"uid"`
+	Uid string `pulumi:"uid"`
 }
 
 // OwnerReferenceInput is an input type that accepts OwnerReferenceArgs and OwnerReferenceOutput values.
@@ -2216,17 +2216,17 @@ type OwnerReferenceInput interface {
 // OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
 type OwnerReferenceArgs struct {
 	// API version of the referent.
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
 	BlockOwnerDeletion pulumi.BoolPtrInput `pulumi:"blockOwnerDeletion"`
 	// If true, this reference points to the managing controller.
 	Controller pulumi.BoolPtrInput `pulumi:"controller"`
 	// Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-	Uid pulumi.StringPtrInput `pulumi:"uid"`
+	Uid pulumi.StringInput `pulumi:"uid"`
 }
 
 func (OwnerReferenceArgs) ElementType() reflect.Type {
@@ -2283,8 +2283,8 @@ func (o OwnerReferenceOutput) ToOwnerReferenceOutputWithContext(ctx context.Cont
 }
 
 // API version of the referent.
-func (o OwnerReferenceOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v OwnerReference) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o OwnerReferenceOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v OwnerReference) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
@@ -2298,18 +2298,18 @@ func (o OwnerReferenceOutput) Controller() pulumi.BoolPtrOutput {
 }
 
 // Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o OwnerReferenceOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v OwnerReference) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o OwnerReferenceOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v OwnerReference) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
-func (o OwnerReferenceOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v OwnerReference) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o OwnerReferenceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v OwnerReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-func (o OwnerReferenceOutput) Uid() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v OwnerReference) *string { return v.Uid }).(pulumi.StringPtrOutput)
+func (o OwnerReferenceOutput) Uid() pulumi.StringOutput {
+	return o.ApplyT(func(v OwnerReference) string { return v.Uid }).(pulumi.StringOutput)
 }
 
 type OwnerReferenceArrayOutput struct{ *pulumi.OutputState }
@@ -2490,9 +2490,9 @@ func (o PreconditionsPtrOutput) Uid() pulumi.StringPtrOutput {
 // ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.
 type ServerAddressByClientCIDR struct {
 	// The CIDR with which clients can match their IP to figure out the server address that they should use.
-	ClientCIDR *string `pulumi:"clientCIDR"`
+	ClientCIDR string `pulumi:"clientCIDR"`
 	// Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.
-	ServerAddress *string `pulumi:"serverAddress"`
+	ServerAddress string `pulumi:"serverAddress"`
 }
 
 // ServerAddressByClientCIDRInput is an input type that accepts ServerAddressByClientCIDRArgs and ServerAddressByClientCIDROutput values.
@@ -2510,9 +2510,9 @@ type ServerAddressByClientCIDRInput interface {
 // ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.
 type ServerAddressByClientCIDRArgs struct {
 	// The CIDR with which clients can match their IP to figure out the server address that they should use.
-	ClientCIDR pulumi.StringPtrInput `pulumi:"clientCIDR"`
+	ClientCIDR pulumi.StringInput `pulumi:"clientCIDR"`
 	// Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.
-	ServerAddress pulumi.StringPtrInput `pulumi:"serverAddress"`
+	ServerAddress pulumi.StringInput `pulumi:"serverAddress"`
 }
 
 func (ServerAddressByClientCIDRArgs) ElementType() reflect.Type {
@@ -2569,13 +2569,13 @@ func (o ServerAddressByClientCIDROutput) ToServerAddressByClientCIDROutputWithCo
 }
 
 // The CIDR with which clients can match their IP to figure out the server address that they should use.
-func (o ServerAddressByClientCIDROutput) ClientCIDR() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServerAddressByClientCIDR) *string { return v.ClientCIDR }).(pulumi.StringPtrOutput)
+func (o ServerAddressByClientCIDROutput) ClientCIDR() pulumi.StringOutput {
+	return o.ApplyT(func(v ServerAddressByClientCIDR) string { return v.ClientCIDR }).(pulumi.StringOutput)
 }
 
 // Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.
-func (o ServerAddressByClientCIDROutput) ServerAddress() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ServerAddressByClientCIDR) *string { return v.ServerAddress }).(pulumi.StringPtrOutput)
+func (o ServerAddressByClientCIDROutput) ServerAddress() pulumi.StringOutput {
+	return o.ApplyT(func(v ServerAddressByClientCIDR) string { return v.ServerAddress }).(pulumi.StringOutput)
 }
 
 type ServerAddressByClientCIDRArrayOutput struct{ *pulumi.OutputState }
@@ -2601,21 +2601,21 @@ func (o ServerAddressByClientCIDRArrayOutput) Index(i pulumi.IntInput) ServerAdd
 // Status is a return value for calls that don't return other objects.
 type StatusType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Suggested HTTP return code for this status, 0 if not set.
-	Code *int `pulumi:"code"`
+	Code int `pulumi:"code"`
 	// Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
-	Details *StatusDetails `pulumi:"details"`
+	Details StatusDetails `pulumi:"details"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// A human-readable description of the status of this operation.
-	Message *string `pulumi:"message"`
+	Message string `pulumi:"message"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata *ListMeta `pulumi:"metadata"`
+	Metadata ListMeta `pulumi:"metadata"`
 	// A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
-	Reason *string `pulumi:"reason"`
+	Reason string `pulumi:"reason"`
 	// Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *string `pulumi:"status"`
+	Status string `pulumi:"status"`
 }
 
 // StatusTypeInput is an input type that accepts StatusTypeArgs and StatusTypeOutput values.
@@ -2633,21 +2633,21 @@ type StatusTypeInput interface {
 // Status is a return value for calls that don't return other objects.
 type StatusTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Suggested HTTP return code for this status, 0 if not set.
-	Code pulumi.IntPtrInput `pulumi:"code"`
+	Code pulumi.IntInput `pulumi:"code"`
 	// Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
-	Details StatusDetailsPtrInput `pulumi:"details"`
+	Details StatusDetailsInput `pulumi:"details"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// A human-readable description of the status of this operation.
-	Message pulumi.StringPtrInput `pulumi:"message"`
+	Message pulumi.StringInput `pulumi:"message"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata ListMetaPtrInput `pulumi:"metadata"`
+	Metadata ListMetaInput `pulumi:"metadata"`
 	// A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
-	Reason pulumi.StringPtrInput `pulumi:"reason"`
+	Reason pulumi.StringInput `pulumi:"reason"`
 	// Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status pulumi.StringPtrInput `pulumi:"status"`
+	Status pulumi.StringInput `pulumi:"status"`
 }
 
 func (StatusTypeArgs) ElementType() reflect.Type {
@@ -2678,43 +2678,43 @@ func (o StatusTypeOutput) ToStatusTypeOutputWithContext(ctx context.Context) Sta
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StatusTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatusType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StatusTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StatusType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Suggested HTTP return code for this status, 0 if not set.
-func (o StatusTypeOutput) Code() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v StatusType) *int { return v.Code }).(pulumi.IntPtrOutput)
+func (o StatusTypeOutput) Code() pulumi.IntOutput {
+	return o.ApplyT(func(v StatusType) int { return v.Code }).(pulumi.IntOutput)
 }
 
 // Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
-func (o StatusTypeOutput) Details() StatusDetailsPtrOutput {
-	return o.ApplyT(func(v StatusType) *StatusDetails { return v.Details }).(StatusDetailsPtrOutput)
+func (o StatusTypeOutput) Details() StatusDetailsOutput {
+	return o.ApplyT(func(v StatusType) StatusDetails { return v.Details }).(StatusDetailsOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatusTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatusType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StatusTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StatusType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // A human-readable description of the status of this operation.
-func (o StatusTypeOutput) Message() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatusType) *string { return v.Message }).(pulumi.StringPtrOutput)
+func (o StatusTypeOutput) Message() pulumi.StringOutput {
+	return o.ApplyT(func(v StatusType) string { return v.Message }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StatusTypeOutput) Metadata() ListMetaPtrOutput {
-	return o.ApplyT(func(v StatusType) *ListMeta { return v.Metadata }).(ListMetaPtrOutput)
+func (o StatusTypeOutput) Metadata() ListMetaOutput {
+	return o.ApplyT(func(v StatusType) ListMeta { return v.Metadata }).(ListMetaOutput)
 }
 
 // A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
-func (o StatusTypeOutput) Reason() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatusType) *string { return v.Reason }).(pulumi.StringPtrOutput)
+func (o StatusTypeOutput) Reason() pulumi.StringOutput {
+	return o.ApplyT(func(v StatusType) string { return v.Reason }).(pulumi.StringOutput)
 }
 
 // Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o StatusTypeOutput) Status() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StatusType) *string { return v.Status }).(pulumi.StringPtrOutput)
+func (o StatusTypeOutput) Status() pulumi.StringOutput {
+	return o.ApplyT(func(v StatusType) string { return v.Status }).(pulumi.StringOutput)
 }
 
 // StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
@@ -3088,7 +3088,7 @@ type WatchEvent struct {
 	//  * If Type is Error: *Status is recommended; other types may make sense
 	//    depending on context.
 	Object interface{} `pulumi:"object"`
-	Type   *string     `pulumi:"type"`
+	Type   string      `pulumi:"type"`
 }
 
 // WatchEventInput is an input type that accepts WatchEventArgs and WatchEventOutput values.
@@ -3110,8 +3110,8 @@ type WatchEventArgs struct {
 	//  * If Type is Deleted: the state of the object immediately before deletion.
 	//  * If Type is Error: *Status is recommended; other types may make sense
 	//    depending on context.
-	Object pulumi.Input          `pulumi:"object"`
-	Type   pulumi.StringPtrInput `pulumi:"type"`
+	Object pulumi.Input       `pulumi:"object"`
+	Type   pulumi.StringInput `pulumi:"type"`
 }
 
 func (WatchEventArgs) ElementType() reflect.Type {
@@ -3150,8 +3150,8 @@ func (o WatchEventOutput) Object() pulumi.AnyOutput {
 	return o.ApplyT(func(v WatchEvent) interface{} { return v.Object }).(pulumi.AnyOutput)
 }
 
-func (o WatchEventOutput) Type() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v WatchEvent) *string { return v.Type }).(pulumi.StringPtrOutput)
+func (o WatchEventOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v WatchEvent) string { return v.Type }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/meta/v1/status.go
+++ b/sdk/go/kubernetes/meta/v1/status.go
@@ -14,21 +14,21 @@ type Status struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Suggested HTTP return code for this status, 0 if not set.
-	Code pulumi.IntPtrOutput `pulumi:"code"`
+	Code pulumi.IntOutput `pulumi:"code"`
 	// Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
-	Details StatusDetailsPtrOutput `pulumi:"details"`
+	Details StatusDetailsOutput `pulumi:"details"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// A human-readable description of the status of this operation.
-	Message pulumi.StringPtrOutput `pulumi:"message"`
+	Message pulumi.StringOutput `pulumi:"message"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Metadata ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata ListMetaOutput `pulumi:"metadata"`
 	// A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
-	Reason pulumi.StringPtrOutput `pulumi:"reason"`
+	Reason pulumi.StringOutput `pulumi:"reason"`
 	// Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status pulumi.StringPtrOutput `pulumi:"status"`
+	Status pulumi.StringOutput `pulumi:"status"`
 }
 
 // NewStatus registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1/networkPolicy.go
+++ b/sdk/go/kubernetes/networking/v1/networkPolicy.go
@@ -15,13 +15,13 @@ type NetworkPolicy struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec NetworkPolicySpecPtrOutput `pulumi:"spec"`
+	Spec NetworkPolicySpecOutput `pulumi:"spec"`
 }
 
 // NewNetworkPolicy registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1/networkPolicyList.go
+++ b/sdk/go/kubernetes/networking/v1/networkPolicyList.go
@@ -16,13 +16,13 @@ type NetworkPolicyList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items NetworkPolicyTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewNetworkPolicyList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/networking/v1/pulumiTypes.go
@@ -14,7 +14,7 @@ import (
 // IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
-	Cidr *string `pulumi:"cidr"`
+	Cidr string `pulumi:"cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
 	Except []string `pulumi:"except"`
 }
@@ -34,7 +34,7 @@ type IPBlockInput interface {
 // IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
 type IPBlockArgs struct {
 	// CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
-	Cidr pulumi.StringPtrInput `pulumi:"cidr"`
+	Cidr pulumi.StringInput `pulumi:"cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
 	Except pulumi.StringArrayInput `pulumi:"except"`
 }
@@ -119,8 +119,8 @@ func (o IPBlockOutput) ToIPBlockPtrOutputWithContext(ctx context.Context) IPBloc
 }
 
 // CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
-func (o IPBlockOutput) Cidr() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IPBlock) *string { return v.Cidr }).(pulumi.StringPtrOutput)
+func (o IPBlockOutput) Cidr() pulumi.StringOutput {
+	return o.ApplyT(func(v IPBlock) string { return v.Cidr }).(pulumi.StringOutput)
 }
 
 // Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
@@ -152,7 +152,7 @@ func (o IPBlockPtrOutput) Cidr() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Cidr
+		return &v.Cidr
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -169,13 +169,13 @@ func (o IPBlockPtrOutput) Except() pulumi.StringArrayOutput {
 // NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec *NetworkPolicySpec `pulumi:"spec"`
+	Spec NetworkPolicySpec `pulumi:"spec"`
 }
 
 // NetworkPolicyTypeInput is an input type that accepts NetworkPolicyTypeArgs and NetworkPolicyTypeOutput values.
@@ -193,13 +193,13 @@ type NetworkPolicyTypeInput interface {
 // NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior for this NetworkPolicy.
-	Spec NetworkPolicySpecPtrInput `pulumi:"spec"`
+	Spec NetworkPolicySpecInput `pulumi:"spec"`
 }
 
 func (NetworkPolicyTypeArgs) ElementType() reflect.Type {
@@ -256,23 +256,23 @@ func (o NetworkPolicyTypeOutput) ToNetworkPolicyTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NetworkPolicyTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NetworkPolicyTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NetworkPolicyTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o NetworkPolicyTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v NetworkPolicyType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior for this NetworkPolicy.
-func (o NetworkPolicyTypeOutput) Spec() NetworkPolicySpecPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyType) *NetworkPolicySpec { return v.Spec }).(NetworkPolicySpecPtrOutput)
+func (o NetworkPolicyTypeOutput) Spec() NetworkPolicySpecOutput {
+	return o.ApplyT(func(v NetworkPolicyType) NetworkPolicySpec { return v.Spec }).(NetworkPolicySpecOutput)
 }
 
 type NetworkPolicyTypeArrayOutput struct{ *pulumi.OutputState }
@@ -520,13 +520,13 @@ func (o NetworkPolicyIngressRuleArrayOutput) Index(i pulumi.IntInput) NetworkPol
 // NetworkPolicyList is a list of NetworkPolicy objects.
 type NetworkPolicyListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []NetworkPolicyType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // NetworkPolicyListTypeInput is an input type that accepts NetworkPolicyListTypeArgs and NetworkPolicyListTypeOutput values.
@@ -544,13 +544,13 @@ type NetworkPolicyListTypeInput interface {
 // NetworkPolicyList is a list of NetworkPolicy objects.
 type NetworkPolicyListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items NetworkPolicyTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (NetworkPolicyListTypeArgs) ElementType() reflect.Type {
@@ -581,8 +581,8 @@ func (o NetworkPolicyListTypeOutput) ToNetworkPolicyListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o NetworkPolicyListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -591,13 +591,13 @@ func (o NetworkPolicyListTypeOutput) Items() NetworkPolicyTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o NetworkPolicyListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o NetworkPolicyListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o NetworkPolicyListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v NetworkPolicyListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o NetworkPolicyListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v NetworkPolicyListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed
@@ -850,7 +850,7 @@ type NetworkPolicySpec struct {
 	// List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
 	Ingress []NetworkPolicyIngressRule `pulumi:"ingress"`
 	// Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-	PodSelector *metav1.LabelSelector `pulumi:"podSelector"`
+	PodSelector metav1.LabelSelector `pulumi:"podSelector"`
 	// List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
 	PolicyTypes []string `pulumi:"policyTypes"`
 }
@@ -874,7 +874,7 @@ type NetworkPolicySpecArgs struct {
 	// List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
 	Ingress NetworkPolicyIngressRuleArrayInput `pulumi:"ingress"`
 	// Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-	PodSelector metav1.LabelSelectorPtrInput `pulumi:"podSelector"`
+	PodSelector metav1.LabelSelectorInput `pulumi:"podSelector"`
 	// List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
 	PolicyTypes pulumi.StringArrayInput `pulumi:"policyTypes"`
 }
@@ -969,8 +969,8 @@ func (o NetworkPolicySpecOutput) Ingress() NetworkPolicyIngressRuleArrayOutput {
 }
 
 // Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
-func (o NetworkPolicySpecOutput) PodSelector() metav1.LabelSelectorPtrOutput {
-	return o.ApplyT(func(v NetworkPolicySpec) *metav1.LabelSelector { return v.PodSelector }).(metav1.LabelSelectorPtrOutput)
+func (o NetworkPolicySpecOutput) PodSelector() metav1.LabelSelectorOutput {
+	return o.ApplyT(func(v NetworkPolicySpec) metav1.LabelSelector { return v.PodSelector }).(metav1.LabelSelectorOutput)
 }
 
 // List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
@@ -1022,7 +1022,7 @@ func (o NetworkPolicySpecPtrOutput) PodSelector() metav1.LabelSelectorPtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.PodSelector
+		return &v.PodSelector
 	}).(metav1.LabelSelectorPtrOutput)
 }
 

--- a/sdk/go/kubernetes/networking/v1beta1/ingress.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingress.go
@@ -29,15 +29,15 @@ type Ingress struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressSpecPtrOutput `pulumi:"spec"`
+	Spec IngressSpecOutput `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status IngressStatusPtrOutput `pulumi:"status"`
+	Status IngressStatusOutput `pulumi:"status"`
 }
 
 // NewIngress registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1beta1/ingressClass.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressClass.go
@@ -15,13 +15,13 @@ type IngressClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressClassSpecPtrOutput `pulumi:"spec"`
+	Spec IngressClassSpecOutput `pulumi:"spec"`
 }
 
 // NewIngressClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1beta1/ingressClassList.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressClassList.go
@@ -16,13 +16,13 @@ type IngressClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of IngressClasses.
 	Items IngressClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewIngressClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1beta1/ingressList.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressList.go
@@ -16,13 +16,13 @@ type IngressList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items IngressTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewIngressList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/networking/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/networking/v1beta1/pulumiTypes.go
@@ -15,7 +15,7 @@ import (
 // HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
 type HTTPIngressPath struct {
 	// Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-	Backend *IngressBackend `pulumi:"backend"`
+	Backend IngressBackend `pulumi:"backend"`
 	// Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
 	Path *string `pulumi:"path"`
 	// PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
@@ -47,7 +47,7 @@ type HTTPIngressPathInput interface {
 // HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
 type HTTPIngressPathArgs struct {
 	// Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-	Backend IngressBackendPtrInput `pulumi:"backend"`
+	Backend IngressBackendInput `pulumi:"backend"`
 	// Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
@@ -118,8 +118,8 @@ func (o HTTPIngressPathOutput) ToHTTPIngressPathOutputWithContext(ctx context.Co
 }
 
 // Backend defines the referenced service endpoint to which the traffic will be forwarded to.
-func (o HTTPIngressPathOutput) Backend() IngressBackendPtrOutput {
-	return o.ApplyT(func(v HTTPIngressPath) *IngressBackend { return v.Backend }).(IngressBackendPtrOutput)
+func (o HTTPIngressPathOutput) Backend() IngressBackendOutput {
+	return o.ApplyT(func(v HTTPIngressPath) IngressBackend { return v.Backend }).(IngressBackendOutput)
 }
 
 // Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
@@ -315,15 +315,15 @@ func (o HTTPIngressRuleValuePtrOutput) Paths() HTTPIngressPathArrayOutput {
 // by setting the 'customTimeouts' option on the resource.
 type IngressType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *IngressSpec `pulumi:"spec"`
+	Spec IngressSpec `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status *IngressStatus `pulumi:"status"`
+	Status IngressStatus `pulumi:"status"`
 }
 
 // IngressTypeInput is an input type that accepts IngressTypeArgs and IngressTypeOutput values.
@@ -355,15 +355,15 @@ type IngressTypeInput interface {
 // by setting the 'customTimeouts' option on the resource.
 type IngressTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressSpecPtrInput `pulumi:"spec"`
+	Spec IngressSpecInput `pulumi:"spec"`
 	// Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status IngressStatusPtrInput `pulumi:"status"`
+	Status IngressStatusInput `pulumi:"status"`
 }
 
 func (IngressTypeArgs) ElementType() reflect.Type {
@@ -434,28 +434,28 @@ func (o IngressTypeOutput) ToIngressTypeOutputWithContext(ctx context.Context) I
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o IngressTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v IngressType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o IngressTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v IngressType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o IngressTypeOutput) Spec() IngressSpecPtrOutput {
-	return o.ApplyT(func(v IngressType) *IngressSpec { return v.Spec }).(IngressSpecPtrOutput)
+func (o IngressTypeOutput) Spec() IngressSpecOutput {
+	return o.ApplyT(func(v IngressType) IngressSpec { return v.Spec }).(IngressSpecOutput)
 }
 
 // Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o IngressTypeOutput) Status() IngressStatusPtrOutput {
-	return o.ApplyT(func(v IngressType) *IngressStatus { return v.Status }).(IngressStatusPtrOutput)
+func (o IngressTypeOutput) Status() IngressStatusOutput {
+	return o.ApplyT(func(v IngressType) IngressStatus { return v.Status }).(IngressStatusOutput)
 }
 
 type IngressTypeArrayOutput struct{ *pulumi.OutputState }
@@ -483,7 +483,7 @@ type IngressBackend struct {
 	// Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
 	Resource *corev1.TypedLocalObjectReference `pulumi:"resource"`
 	// Specifies the name of the referenced service.
-	ServiceName *string `pulumi:"serviceName"`
+	ServiceName string `pulumi:"serviceName"`
 	// Specifies the port of the referenced service.
 	ServicePort interface{} `pulumi:"servicePort"`
 }
@@ -505,7 +505,7 @@ type IngressBackendArgs struct {
 	// Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
 	Resource corev1.TypedLocalObjectReferencePtrInput `pulumi:"resource"`
 	// Specifies the name of the referenced service.
-	ServiceName pulumi.StringPtrInput `pulumi:"serviceName"`
+	ServiceName pulumi.StringInput `pulumi:"serviceName"`
 	// Specifies the port of the referenced service.
 	ServicePort pulumi.Input `pulumi:"servicePort"`
 }
@@ -595,8 +595,8 @@ func (o IngressBackendOutput) Resource() corev1.TypedLocalObjectReferencePtrOutp
 }
 
 // Specifies the name of the referenced service.
-func (o IngressBackendOutput) ServiceName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressBackend) *string { return v.ServiceName }).(pulumi.StringPtrOutput)
+func (o IngressBackendOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressBackend) string { return v.ServiceName }).(pulumi.StringOutput)
 }
 
 // Specifies the port of the referenced service.
@@ -638,7 +638,7 @@ func (o IngressBackendPtrOutput) ServiceName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ServiceName
+		return &v.ServiceName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -655,13 +655,13 @@ func (o IngressBackendPtrOutput) ServicePort() pulumi.AnyOutput {
 // IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 type IngressClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *IngressClassSpec `pulumi:"spec"`
+	Spec IngressClassSpec `pulumi:"spec"`
 }
 
 // IngressClassTypeInput is an input type that accepts IngressClassTypeArgs and IngressClassTypeOutput values.
@@ -679,13 +679,13 @@ type IngressClassTypeInput interface {
 // IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 type IngressClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec IngressClassSpecPtrInput `pulumi:"spec"`
+	Spec IngressClassSpecInput `pulumi:"spec"`
 }
 
 func (IngressClassTypeArgs) ElementType() reflect.Type {
@@ -742,23 +742,23 @@ func (o IngressClassTypeOutput) ToIngressClassTypeOutputWithContext(ctx context.
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o IngressClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v IngressClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o IngressClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v IngressClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o IngressClassTypeOutput) Spec() IngressClassSpecPtrOutput {
-	return o.ApplyT(func(v IngressClassType) *IngressClassSpec { return v.Spec }).(IngressClassSpecPtrOutput)
+func (o IngressClassTypeOutput) Spec() IngressClassSpecOutput {
+	return o.ApplyT(func(v IngressClassType) IngressClassSpec { return v.Spec }).(IngressClassSpecOutput)
 }
 
 type IngressClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -784,13 +784,13 @@ func (o IngressClassTypeArrayOutput) Index(i pulumi.IntInput) IngressClassTypeOu
 // IngressClassList is a collection of IngressClasses.
 type IngressClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of IngressClasses.
 	Items []IngressClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // IngressClassListTypeInput is an input type that accepts IngressClassListTypeArgs and IngressClassListTypeOutput values.
@@ -808,13 +808,13 @@ type IngressClassListTypeInput interface {
 // IngressClassList is a collection of IngressClasses.
 type IngressClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of IngressClasses.
 	Items IngressClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (IngressClassListTypeArgs) ElementType() reflect.Type {
@@ -845,8 +845,8 @@ func (o IngressClassListTypeOutput) ToIngressClassListTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of IngressClasses.
@@ -855,13 +855,13 @@ func (o IngressClassListTypeOutput) Items() IngressClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata.
-func (o IngressClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v IngressClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o IngressClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v IngressClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // IngressClassSpec provides information about the class of an Ingress.
@@ -1022,13 +1022,13 @@ func (o IngressClassSpecPtrOutput) Parameters() corev1.TypedLocalObjectReference
 // IngressList is a collection of Ingress.
 type IngressListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items []IngressType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // IngressListTypeInput is an input type that accepts IngressListTypeArgs and IngressListTypeOutput values.
@@ -1046,13 +1046,13 @@ type IngressListTypeInput interface {
 // IngressList is a collection of Ingress.
 type IngressListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of Ingress.
 	Items IngressTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (IngressListTypeArgs) ElementType() reflect.Type {
@@ -1083,8 +1083,8 @@ func (o IngressListTypeOutput) ToIngressListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o IngressListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o IngressListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of Ingress.
@@ -1093,13 +1093,13 @@ func (o IngressListTypeOutput) Items() IngressTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o IngressListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v IngressListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o IngressListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v IngressListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o IngressListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v IngressListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o IngressListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v IngressListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.

--- a/sdk/go/kubernetes/node/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/node/v1alpha1/pulumiTypes.go
@@ -151,13 +151,13 @@ func (o OverheadPtrOutput) PodFixed() pulumi.StringMapOutput {
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec *RuntimeClassSpec `pulumi:"spec"`
+	Spec RuntimeClassSpec `pulumi:"spec"`
 }
 
 // RuntimeClassTypeInput is an input type that accepts RuntimeClassTypeArgs and RuntimeClassTypeOutput values.
@@ -175,13 +175,13 @@ type RuntimeClassTypeInput interface {
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec RuntimeClassSpecPtrInput `pulumi:"spec"`
+	Spec RuntimeClassSpecInput `pulumi:"spec"`
 }
 
 func (RuntimeClassTypeArgs) ElementType() reflect.Type {
@@ -238,23 +238,23 @@ func (o RuntimeClassTypeOutput) ToRuntimeClassTypeOutputWithContext(ctx context.
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RuntimeClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RuntimeClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RuntimeClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RuntimeClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o RuntimeClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RuntimeClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RuntimeClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-func (o RuntimeClassTypeOutput) Spec() RuntimeClassSpecPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *RuntimeClassSpec { return v.Spec }).(RuntimeClassSpecPtrOutput)
+func (o RuntimeClassTypeOutput) Spec() RuntimeClassSpecOutput {
+	return o.ApplyT(func(v RuntimeClassType) RuntimeClassSpec { return v.Spec }).(RuntimeClassSpecOutput)
 }
 
 type RuntimeClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -280,13 +280,13 @@ func (o RuntimeClassTypeArrayOutput) Index(i pulumi.IntInput) RuntimeClassTypeOu
 // RuntimeClassList is a list of RuntimeClass objects.
 type RuntimeClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []RuntimeClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RuntimeClassListTypeInput is an input type that accepts RuntimeClassListTypeArgs and RuntimeClassListTypeOutput values.
@@ -304,13 +304,13 @@ type RuntimeClassListTypeInput interface {
 // RuntimeClassList is a list of RuntimeClass objects.
 type RuntimeClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items RuntimeClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RuntimeClassListTypeArgs) ElementType() reflect.Type {
@@ -341,8 +341,8 @@ func (o RuntimeClassListTypeOutput) ToRuntimeClassListTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RuntimeClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RuntimeClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -351,13 +351,13 @@ func (o RuntimeClassListTypeOutput) Items() RuntimeClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RuntimeClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RuntimeClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o RuntimeClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RuntimeClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RuntimeClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RuntimeClassSpec is a specification of a RuntimeClass. It contains parameters that are required to describe the RuntimeClass to the Container Runtime Interface (CRI) implementation, as well as any other components that need to understand how the pod will be run. The RuntimeClassSpec is immutable.
@@ -365,7 +365,7 @@ type RuntimeClassSpec struct {
 	// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
 	Overhead *Overhead `pulumi:"overhead"`
 	// RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.
-	RuntimeHandler *string `pulumi:"runtimeHandler"`
+	RuntimeHandler string `pulumi:"runtimeHandler"`
 	// Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
 	Scheduling *Scheduling `pulumi:"scheduling"`
 }
@@ -387,7 +387,7 @@ type RuntimeClassSpecArgs struct {
 	// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
 	Overhead OverheadPtrInput `pulumi:"overhead"`
 	// RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.
-	RuntimeHandler pulumi.StringPtrInput `pulumi:"runtimeHandler"`
+	RuntimeHandler pulumi.StringInput `pulumi:"runtimeHandler"`
 	// Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
 	Scheduling SchedulingPtrInput `pulumi:"scheduling"`
 }
@@ -477,8 +477,8 @@ func (o RuntimeClassSpecOutput) Overhead() OverheadPtrOutput {
 }
 
 // RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.
-func (o RuntimeClassSpecOutput) RuntimeHandler() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassSpec) *string { return v.RuntimeHandler }).(pulumi.StringPtrOutput)
+func (o RuntimeClassSpecOutput) RuntimeHandler() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassSpec) string { return v.RuntimeHandler }).(pulumi.StringOutput)
 }
 
 // Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
@@ -520,7 +520,7 @@ func (o RuntimeClassSpecPtrOutput) RuntimeHandler() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.RuntimeHandler
+		return &v.RuntimeHandler
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/node/v1alpha1/runtimeClass.go
+++ b/sdk/go/kubernetes/node/v1alpha1/runtimeClass.go
@@ -16,13 +16,13 @@ type RuntimeClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Spec RuntimeClassSpecPtrOutput `pulumi:"spec"`
+	Spec RuntimeClassSpecOutput `pulumi:"spec"`
 }
 
 // NewRuntimeClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/node/v1alpha1/runtimeClassList.go
+++ b/sdk/go/kubernetes/node/v1alpha1/runtimeClassList.go
@@ -16,13 +16,13 @@ type RuntimeClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items RuntimeClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRuntimeClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/node/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/node/v1beta1/pulumiTypes.go
@@ -151,17 +151,17 @@ func (o OverheadPtrOutput) PodFixed() pulumi.StringMapOutput {
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
-	Handler *string `pulumi:"handler"`
+	Handler string `pulumi:"handler"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-	Overhead *Overhead `pulumi:"overhead"`
+	Overhead Overhead `pulumi:"overhead"`
 	// Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
-	Scheduling *Scheduling `pulumi:"scheduling"`
+	Scheduling Scheduling `pulumi:"scheduling"`
 }
 
 // RuntimeClassTypeInput is an input type that accepts RuntimeClassTypeArgs and RuntimeClassTypeOutput values.
@@ -179,17 +179,17 @@ type RuntimeClassTypeInput interface {
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
-	Handler pulumi.StringPtrInput `pulumi:"handler"`
+	Handler pulumi.StringInput `pulumi:"handler"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-	Overhead OverheadPtrInput `pulumi:"overhead"`
+	Overhead OverheadInput `pulumi:"overhead"`
 	// Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
-	Scheduling SchedulingPtrInput `pulumi:"scheduling"`
+	Scheduling SchedulingInput `pulumi:"scheduling"`
 }
 
 func (RuntimeClassTypeArgs) ElementType() reflect.Type {
@@ -246,33 +246,33 @@ func (o RuntimeClassTypeOutput) ToRuntimeClassTypeOutputWithContext(ctx context.
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RuntimeClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RuntimeClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
-func (o RuntimeClassTypeOutput) Handler() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *string { return v.Handler }).(pulumi.StringPtrOutput)
+func (o RuntimeClassTypeOutput) Handler() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassType) string { return v.Handler }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RuntimeClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RuntimeClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o RuntimeClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RuntimeClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RuntimeClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-func (o RuntimeClassTypeOutput) Overhead() OverheadPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *Overhead { return v.Overhead }).(OverheadPtrOutput)
+func (o RuntimeClassTypeOutput) Overhead() OverheadOutput {
+	return o.ApplyT(func(v RuntimeClassType) Overhead { return v.Overhead }).(OverheadOutput)
 }
 
 // Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
-func (o RuntimeClassTypeOutput) Scheduling() SchedulingPtrOutput {
-	return o.ApplyT(func(v RuntimeClassType) *Scheduling { return v.Scheduling }).(SchedulingPtrOutput)
+func (o RuntimeClassTypeOutput) Scheduling() SchedulingOutput {
+	return o.ApplyT(func(v RuntimeClassType) Scheduling { return v.Scheduling }).(SchedulingOutput)
 }
 
 type RuntimeClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -298,13 +298,13 @@ func (o RuntimeClassTypeArrayOutput) Index(i pulumi.IntInput) RuntimeClassTypeOu
 // RuntimeClassList is a list of RuntimeClass objects.
 type RuntimeClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []RuntimeClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RuntimeClassListTypeInput is an input type that accepts RuntimeClassListTypeArgs and RuntimeClassListTypeOutput values.
@@ -322,13 +322,13 @@ type RuntimeClassListTypeInput interface {
 // RuntimeClassList is a list of RuntimeClass objects.
 type RuntimeClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items RuntimeClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RuntimeClassListTypeArgs) ElementType() reflect.Type {
@@ -359,8 +359,8 @@ func (o RuntimeClassListTypeOutput) ToRuntimeClassListTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RuntimeClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RuntimeClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -369,13 +369,13 @@ func (o RuntimeClassListTypeOutput) Items() RuntimeClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RuntimeClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RuntimeClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RuntimeClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o RuntimeClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RuntimeClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RuntimeClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RuntimeClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.

--- a/sdk/go/kubernetes/node/v1beta1/runtimeClass.go
+++ b/sdk/go/kubernetes/node/v1beta1/runtimeClass.go
@@ -16,17 +16,17 @@ type RuntimeClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
-	Handler pulumi.StringPtrOutput `pulumi:"handler"`
+	Handler pulumi.StringOutput `pulumi:"handler"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-	Overhead OverheadPtrOutput `pulumi:"overhead"`
+	Overhead OverheadOutput `pulumi:"overhead"`
 	// Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
-	Scheduling SchedulingPtrOutput `pulumi:"scheduling"`
+	Scheduling SchedulingOutput `pulumi:"scheduling"`
 }
 
 // NewRuntimeClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/node/v1beta1/runtimeClassList.go
+++ b/sdk/go/kubernetes/node/v1beta1/runtimeClassList.go
@@ -16,13 +16,13 @@ type RuntimeClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items RuntimeClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRuntimeClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/pkg/version/pulumiTypes.go
+++ b/sdk/go/kubernetes/pkg/version/pulumiTypes.go
@@ -12,15 +12,15 @@ import (
 
 // Info contains versioning information. how we'll want to distribute that information.
 type Info struct {
-	BuildDate    *string `pulumi:"buildDate"`
-	Compiler     *string `pulumi:"compiler"`
-	GitCommit    *string `pulumi:"gitCommit"`
-	GitTreeState *string `pulumi:"gitTreeState"`
-	GitVersion   *string `pulumi:"gitVersion"`
-	GoVersion    *string `pulumi:"goVersion"`
-	Major        *string `pulumi:"major"`
-	Minor        *string `pulumi:"minor"`
-	Platform     *string `pulumi:"platform"`
+	BuildDate    string `pulumi:"buildDate"`
+	Compiler     string `pulumi:"compiler"`
+	GitCommit    string `pulumi:"gitCommit"`
+	GitTreeState string `pulumi:"gitTreeState"`
+	GitVersion   string `pulumi:"gitVersion"`
+	GoVersion    string `pulumi:"goVersion"`
+	Major        string `pulumi:"major"`
+	Minor        string `pulumi:"minor"`
+	Platform     string `pulumi:"platform"`
 }
 
 // InfoInput is an input type that accepts InfoArgs and InfoOutput values.
@@ -37,15 +37,15 @@ type InfoInput interface {
 
 // Info contains versioning information. how we'll want to distribute that information.
 type InfoArgs struct {
-	BuildDate    pulumi.StringPtrInput `pulumi:"buildDate"`
-	Compiler     pulumi.StringPtrInput `pulumi:"compiler"`
-	GitCommit    pulumi.StringPtrInput `pulumi:"gitCommit"`
-	GitTreeState pulumi.StringPtrInput `pulumi:"gitTreeState"`
-	GitVersion   pulumi.StringPtrInput `pulumi:"gitVersion"`
-	GoVersion    pulumi.StringPtrInput `pulumi:"goVersion"`
-	Major        pulumi.StringPtrInput `pulumi:"major"`
-	Minor        pulumi.StringPtrInput `pulumi:"minor"`
-	Platform     pulumi.StringPtrInput `pulumi:"platform"`
+	BuildDate    pulumi.StringInput `pulumi:"buildDate"`
+	Compiler     pulumi.StringInput `pulumi:"compiler"`
+	GitCommit    pulumi.StringInput `pulumi:"gitCommit"`
+	GitTreeState pulumi.StringInput `pulumi:"gitTreeState"`
+	GitVersion   pulumi.StringInput `pulumi:"gitVersion"`
+	GoVersion    pulumi.StringInput `pulumi:"goVersion"`
+	Major        pulumi.StringInput `pulumi:"major"`
+	Minor        pulumi.StringInput `pulumi:"minor"`
+	Platform     pulumi.StringInput `pulumi:"platform"`
 }
 
 func (InfoArgs) ElementType() reflect.Type {
@@ -75,40 +75,40 @@ func (o InfoOutput) ToInfoOutputWithContext(ctx context.Context) InfoOutput {
 	return o
 }
 
-func (o InfoOutput) BuildDate() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.BuildDate }).(pulumi.StringPtrOutput)
+func (o InfoOutput) BuildDate() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.BuildDate }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) Compiler() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.Compiler }).(pulumi.StringPtrOutput)
+func (o InfoOutput) Compiler() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.Compiler }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) GitCommit() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.GitCommit }).(pulumi.StringPtrOutput)
+func (o InfoOutput) GitCommit() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.GitCommit }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) GitTreeState() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.GitTreeState }).(pulumi.StringPtrOutput)
+func (o InfoOutput) GitTreeState() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.GitTreeState }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) GitVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.GitVersion }).(pulumi.StringPtrOutput)
+func (o InfoOutput) GitVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.GitVersion }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) GoVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.GoVersion }).(pulumi.StringPtrOutput)
+func (o InfoOutput) GoVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.GoVersion }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) Major() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.Major }).(pulumi.StringPtrOutput)
+func (o InfoOutput) Major() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.Major }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) Minor() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.Minor }).(pulumi.StringPtrOutput)
+func (o InfoOutput) Minor() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.Minor }).(pulumi.StringOutput)
 }
 
-func (o InfoOutput) Platform() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Info) *string { return v.Platform }).(pulumi.StringPtrOutput)
+func (o InfoOutput) Platform() pulumi.StringOutput {
+	return o.ApplyT(func(v Info) string { return v.Platform }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudget.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudget.go
@@ -15,14 +15,14 @@ type PodDisruptionBudget struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired behavior of the PodDisruptionBudget.
-	Spec PodDisruptionBudgetSpecPtrOutput `pulumi:"spec"`
+	Spec PodDisruptionBudgetSpecOutput `pulumi:"spec"`
 	// Most recently observed status of the PodDisruptionBudget.
-	Status PodDisruptionBudgetStatusPtrOutput `pulumi:"status"`
+	Status PodDisruptionBudgetStatusOutput `pulumi:"status"`
 }
 
 // NewPodDisruptionBudget registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetList.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetList.go
@@ -16,11 +16,11 @@ type PodDisruptionBudgetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput             `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput                `pulumi:"apiVersion"`
 	Items      PodDisruptionBudgetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Kind     pulumi.StringOutput   `pulumi:"kind"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodDisruptionBudgetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicy.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicy.go
@@ -15,13 +15,13 @@ type PodSecurityPolicy struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec PodSecurityPolicySpecPtrOutput `pulumi:"spec"`
+	Spec PodSecurityPolicySpecOutput `pulumi:"spec"`
 }
 
 // NewPodSecurityPolicy registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyList.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyList.go
@@ -16,13 +16,13 @@ type PodSecurityPolicyList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items PodSecurityPolicyTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodSecurityPolicyList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/policy/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/policy/v1beta1/pulumiTypes.go
@@ -15,7 +15,7 @@ import (
 // AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
 type AllowedCSIDriver struct {
 	// Name is the registered name of the CSI driver
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // AllowedCSIDriverInput is an input type that accepts AllowedCSIDriverArgs and AllowedCSIDriverOutput values.
@@ -33,7 +33,7 @@ type AllowedCSIDriverInput interface {
 // AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
 type AllowedCSIDriverArgs struct {
 	// Name is the registered name of the CSI driver
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (AllowedCSIDriverArgs) ElementType() reflect.Type {
@@ -90,8 +90,8 @@ func (o AllowedCSIDriverOutput) ToAllowedCSIDriverOutputWithContext(ctx context.
 }
 
 // Name is the registered name of the CSI driver
-func (o AllowedCSIDriverOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AllowedCSIDriver) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o AllowedCSIDriverOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v AllowedCSIDriver) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type AllowedCSIDriverArrayOutput struct{ *pulumi.OutputState }
@@ -117,7 +117,7 @@ func (o AllowedCSIDriverArrayOutput) Index(i pulumi.IntInput) AllowedCSIDriverOu
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
 type AllowedFlexVolume struct {
 	// driver is the name of the Flexvolume driver.
-	Driver *string `pulumi:"driver"`
+	Driver string `pulumi:"driver"`
 }
 
 // AllowedFlexVolumeInput is an input type that accepts AllowedFlexVolumeArgs and AllowedFlexVolumeOutput values.
@@ -135,7 +135,7 @@ type AllowedFlexVolumeInput interface {
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
 type AllowedFlexVolumeArgs struct {
 	// driver is the name of the Flexvolume driver.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver pulumi.StringInput `pulumi:"driver"`
 }
 
 func (AllowedFlexVolumeArgs) ElementType() reflect.Type {
@@ -192,8 +192,8 @@ func (o AllowedFlexVolumeOutput) ToAllowedFlexVolumeOutputWithContext(ctx contex
 }
 
 // driver is the name of the Flexvolume driver.
-func (o AllowedFlexVolumeOutput) Driver() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v AllowedFlexVolume) *string { return v.Driver }).(pulumi.StringPtrOutput)
+func (o AllowedFlexVolumeOutput) Driver() pulumi.StringOutput {
+	return o.ApplyT(func(v AllowedFlexVolume) string { return v.Driver }).(pulumi.StringOutput)
 }
 
 type AllowedFlexVolumeArrayOutput struct{ *pulumi.OutputState }
@@ -574,9 +574,9 @@ func (o FSGroupStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 // HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.
 type HostPortRange struct {
 	// max is the end of the range, inclusive.
-	Max *int `pulumi:"max"`
+	Max int `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min *int `pulumi:"min"`
+	Min int `pulumi:"min"`
 }
 
 // HostPortRangeInput is an input type that accepts HostPortRangeArgs and HostPortRangeOutput values.
@@ -594,9 +594,9 @@ type HostPortRangeInput interface {
 // HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.
 type HostPortRangeArgs struct {
 	// max is the end of the range, inclusive.
-	Max pulumi.IntPtrInput `pulumi:"max"`
+	Max pulumi.IntInput `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min pulumi.IntPtrInput `pulumi:"min"`
+	Min pulumi.IntInput `pulumi:"min"`
 }
 
 func (HostPortRangeArgs) ElementType() reflect.Type {
@@ -653,13 +653,13 @@ func (o HostPortRangeOutput) ToHostPortRangeOutputWithContext(ctx context.Contex
 }
 
 // max is the end of the range, inclusive.
-func (o HostPortRangeOutput) Max() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HostPortRange) *int { return v.Max }).(pulumi.IntPtrOutput)
+func (o HostPortRangeOutput) Max() pulumi.IntOutput {
+	return o.ApplyT(func(v HostPortRange) int { return v.Max }).(pulumi.IntOutput)
 }
 
 // min is the start of the range, inclusive.
-func (o HostPortRangeOutput) Min() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v HostPortRange) *int { return v.Min }).(pulumi.IntPtrOutput)
+func (o HostPortRangeOutput) Min() pulumi.IntOutput {
+	return o.ApplyT(func(v HostPortRange) int { return v.Min }).(pulumi.IntOutput)
 }
 
 type HostPortRangeArrayOutput struct{ *pulumi.OutputState }
@@ -685,9 +685,9 @@ func (o HostPortRangeArrayOutput) Index(i pulumi.IntInput) HostPortRangeOutput {
 // IDRange provides a min/max of an allowed range of IDs.
 type IDRange struct {
 	// max is the end of the range, inclusive.
-	Max *int `pulumi:"max"`
+	Max int `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min *int `pulumi:"min"`
+	Min int `pulumi:"min"`
 }
 
 // IDRangeInput is an input type that accepts IDRangeArgs and IDRangeOutput values.
@@ -705,9 +705,9 @@ type IDRangeInput interface {
 // IDRange provides a min/max of an allowed range of IDs.
 type IDRangeArgs struct {
 	// max is the end of the range, inclusive.
-	Max pulumi.IntPtrInput `pulumi:"max"`
+	Max pulumi.IntInput `pulumi:"max"`
 	// min is the start of the range, inclusive.
-	Min pulumi.IntPtrInput `pulumi:"min"`
+	Min pulumi.IntInput `pulumi:"min"`
 }
 
 func (IDRangeArgs) ElementType() reflect.Type {
@@ -764,13 +764,13 @@ func (o IDRangeOutput) ToIDRangeOutputWithContext(ctx context.Context) IDRangeOu
 }
 
 // max is the end of the range, inclusive.
-func (o IDRangeOutput) Max() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v IDRange) *int { return v.Max }).(pulumi.IntPtrOutput)
+func (o IDRangeOutput) Max() pulumi.IntOutput {
+	return o.ApplyT(func(v IDRange) int { return v.Max }).(pulumi.IntOutput)
 }
 
 // min is the start of the range, inclusive.
-func (o IDRangeOutput) Min() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v IDRange) *int { return v.Min }).(pulumi.IntPtrOutput)
+func (o IDRangeOutput) Min() pulumi.IntOutput {
+	return o.ApplyT(func(v IDRange) int { return v.Min }).(pulumi.IntOutput)
 }
 
 type IDRangeArrayOutput struct{ *pulumi.OutputState }
@@ -796,14 +796,14 @@ func (o IDRangeArrayOutput) Index(i pulumi.IntInput) IDRangeOutput {
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 type PodDisruptionBudgetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired behavior of the PodDisruptionBudget.
-	Spec *PodDisruptionBudgetSpec `pulumi:"spec"`
+	Spec PodDisruptionBudgetSpec `pulumi:"spec"`
 	// Most recently observed status of the PodDisruptionBudget.
-	Status *PodDisruptionBudgetStatus `pulumi:"status"`
+	Status PodDisruptionBudgetStatus `pulumi:"status"`
 }
 
 // PodDisruptionBudgetTypeInput is an input type that accepts PodDisruptionBudgetTypeArgs and PodDisruptionBudgetTypeOutput values.
@@ -821,14 +821,14 @@ type PodDisruptionBudgetTypeInput interface {
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 type PodDisruptionBudgetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired behavior of the PodDisruptionBudget.
-	Spec PodDisruptionBudgetSpecPtrInput `pulumi:"spec"`
+	Spec PodDisruptionBudgetSpecInput `pulumi:"spec"`
 	// Most recently observed status of the PodDisruptionBudget.
-	Status PodDisruptionBudgetStatusPtrInput `pulumi:"status"`
+	Status PodDisruptionBudgetStatusInput `pulumi:"status"`
 }
 
 func (PodDisruptionBudgetTypeArgs) ElementType() reflect.Type {
@@ -885,27 +885,27 @@ func (o PodDisruptionBudgetTypeOutput) ToPodDisruptionBudgetTypeOutputWithContex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodDisruptionBudgetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodDisruptionBudgetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodDisruptionBudgetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodDisruptionBudgetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o PodDisruptionBudgetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodDisruptionBudgetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired behavior of the PodDisruptionBudget.
-func (o PodDisruptionBudgetTypeOutput) Spec() PodDisruptionBudgetSpecPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetType) *PodDisruptionBudgetSpec { return v.Spec }).(PodDisruptionBudgetSpecPtrOutput)
+func (o PodDisruptionBudgetTypeOutput) Spec() PodDisruptionBudgetSpecOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetType) PodDisruptionBudgetSpec { return v.Spec }).(PodDisruptionBudgetSpecOutput)
 }
 
 // Most recently observed status of the PodDisruptionBudget.
-func (o PodDisruptionBudgetTypeOutput) Status() PodDisruptionBudgetStatusPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetType) *PodDisruptionBudgetStatus { return v.Status }).(PodDisruptionBudgetStatusPtrOutput)
+func (o PodDisruptionBudgetTypeOutput) Status() PodDisruptionBudgetStatusOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetType) PodDisruptionBudgetStatus { return v.Status }).(PodDisruptionBudgetStatusOutput)
 }
 
 type PodDisruptionBudgetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -931,11 +931,11 @@ func (o PodDisruptionBudgetTypeArrayOutput) Index(i pulumi.IntInput) PodDisrupti
 // PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
 type PodDisruptionBudgetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string                   `pulumi:"apiVersion"`
+	ApiVersion string                    `pulumi:"apiVersion"`
 	Items      []PodDisruptionBudgetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string          `pulumi:"kind"`
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Kind     string          `pulumi:"kind"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodDisruptionBudgetListTypeInput is an input type that accepts PodDisruptionBudgetListTypeArgs and PodDisruptionBudgetListTypeOutput values.
@@ -953,11 +953,11 @@ type PodDisruptionBudgetListTypeInput interface {
 // PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
 type PodDisruptionBudgetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput             `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput                `pulumi:"apiVersion"`
 	Items      PodDisruptionBudgetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput   `pulumi:"kind"`
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Kind     pulumi.StringInput   `pulumi:"kind"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodDisruptionBudgetListTypeArgs) ElementType() reflect.Type {
@@ -988,8 +988,8 @@ func (o PodDisruptionBudgetListTypeOutput) ToPodDisruptionBudgetListTypeOutputWi
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodDisruptionBudgetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodDisruptionBudgetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 func (o PodDisruptionBudgetListTypeOutput) Items() PodDisruptionBudgetTypeArrayOutput {
@@ -997,12 +997,12 @@ func (o PodDisruptionBudgetListTypeOutput) Items() PodDisruptionBudgetTypeArrayO
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodDisruptionBudgetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodDisruptionBudgetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o PodDisruptionBudgetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodDisruptionBudgetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
@@ -1182,15 +1182,15 @@ func (o PodDisruptionBudgetSpecPtrOutput) Selector() metav1.LabelSelectorPtrOutp
 // PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.
 type PodDisruptionBudgetStatus struct {
 	// current number of healthy pods
-	CurrentHealthy *int `pulumi:"currentHealthy"`
+	CurrentHealthy int `pulumi:"currentHealthy"`
 	// minimum desired number of healthy pods
-	DesiredHealthy *int `pulumi:"desiredHealthy"`
+	DesiredHealthy int `pulumi:"desiredHealthy"`
 	// DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
 	DisruptedPods map[string]string `pulumi:"disruptedPods"`
 	// Number of pod disruptions that are currently allowed.
-	DisruptionsAllowed *int `pulumi:"disruptionsAllowed"`
+	DisruptionsAllowed int `pulumi:"disruptionsAllowed"`
 	// total number of pods counted by this disruption budget
-	ExpectedPods *int `pulumi:"expectedPods"`
+	ExpectedPods int `pulumi:"expectedPods"`
 	// Most recent generation observed when updating this PDB status. DisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
 	ObservedGeneration *int `pulumi:"observedGeneration"`
 }
@@ -1210,15 +1210,15 @@ type PodDisruptionBudgetStatusInput interface {
 // PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.
 type PodDisruptionBudgetStatusArgs struct {
 	// current number of healthy pods
-	CurrentHealthy pulumi.IntPtrInput `pulumi:"currentHealthy"`
+	CurrentHealthy pulumi.IntInput `pulumi:"currentHealthy"`
 	// minimum desired number of healthy pods
-	DesiredHealthy pulumi.IntPtrInput `pulumi:"desiredHealthy"`
+	DesiredHealthy pulumi.IntInput `pulumi:"desiredHealthy"`
 	// DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
 	DisruptedPods pulumi.StringMapInput `pulumi:"disruptedPods"`
 	// Number of pod disruptions that are currently allowed.
-	DisruptionsAllowed pulumi.IntPtrInput `pulumi:"disruptionsAllowed"`
+	DisruptionsAllowed pulumi.IntInput `pulumi:"disruptionsAllowed"`
 	// total number of pods counted by this disruption budget
-	ExpectedPods pulumi.IntPtrInput `pulumi:"expectedPods"`
+	ExpectedPods pulumi.IntInput `pulumi:"expectedPods"`
 	// Most recent generation observed when updating this PDB status. DisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
 	ObservedGeneration pulumi.IntPtrInput `pulumi:"observedGeneration"`
 }
@@ -1303,13 +1303,13 @@ func (o PodDisruptionBudgetStatusOutput) ToPodDisruptionBudgetStatusPtrOutputWit
 }
 
 // current number of healthy pods
-func (o PodDisruptionBudgetStatusOutput) CurrentHealthy() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetStatus) *int { return v.CurrentHealthy }).(pulumi.IntPtrOutput)
+func (o PodDisruptionBudgetStatusOutput) CurrentHealthy() pulumi.IntOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetStatus) int { return v.CurrentHealthy }).(pulumi.IntOutput)
 }
 
 // minimum desired number of healthy pods
-func (o PodDisruptionBudgetStatusOutput) DesiredHealthy() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetStatus) *int { return v.DesiredHealthy }).(pulumi.IntPtrOutput)
+func (o PodDisruptionBudgetStatusOutput) DesiredHealthy() pulumi.IntOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetStatus) int { return v.DesiredHealthy }).(pulumi.IntOutput)
 }
 
 // DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
@@ -1318,13 +1318,13 @@ func (o PodDisruptionBudgetStatusOutput) DisruptedPods() pulumi.StringMapOutput 
 }
 
 // Number of pod disruptions that are currently allowed.
-func (o PodDisruptionBudgetStatusOutput) DisruptionsAllowed() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetStatus) *int { return v.DisruptionsAllowed }).(pulumi.IntPtrOutput)
+func (o PodDisruptionBudgetStatusOutput) DisruptionsAllowed() pulumi.IntOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetStatus) int { return v.DisruptionsAllowed }).(pulumi.IntOutput)
 }
 
 // total number of pods counted by this disruption budget
-func (o PodDisruptionBudgetStatusOutput) ExpectedPods() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PodDisruptionBudgetStatus) *int { return v.ExpectedPods }).(pulumi.IntPtrOutput)
+func (o PodDisruptionBudgetStatusOutput) ExpectedPods() pulumi.IntOutput {
+	return o.ApplyT(func(v PodDisruptionBudgetStatus) int { return v.ExpectedPods }).(pulumi.IntOutput)
 }
 
 // Most recent generation observed when updating this PDB status. DisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
@@ -1356,7 +1356,7 @@ func (o PodDisruptionBudgetStatusPtrOutput) CurrentHealthy() pulumi.IntPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.CurrentHealthy
+		return &v.CurrentHealthy
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1366,7 +1366,7 @@ func (o PodDisruptionBudgetStatusPtrOutput) DesiredHealthy() pulumi.IntPtrOutput
 		if v == nil {
 			return nil
 		}
-		return v.DesiredHealthy
+		return &v.DesiredHealthy
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1386,7 +1386,7 @@ func (o PodDisruptionBudgetStatusPtrOutput) DisruptionsAllowed() pulumi.IntPtrOu
 		if v == nil {
 			return nil
 		}
-		return v.DisruptionsAllowed
+		return &v.DisruptionsAllowed
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1396,7 +1396,7 @@ func (o PodDisruptionBudgetStatusPtrOutput) ExpectedPods() pulumi.IntPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ExpectedPods
+		return &v.ExpectedPods
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -1413,13 +1413,13 @@ func (o PodDisruptionBudgetStatusPtrOutput) ObservedGeneration() pulumi.IntPtrOu
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 type PodSecurityPolicyType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec *PodSecurityPolicySpec `pulumi:"spec"`
+	Spec PodSecurityPolicySpec `pulumi:"spec"`
 }
 
 // PodSecurityPolicyTypeInput is an input type that accepts PodSecurityPolicyTypeArgs and PodSecurityPolicyTypeOutput values.
@@ -1437,13 +1437,13 @@ type PodSecurityPolicyTypeInput interface {
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 type PodSecurityPolicyTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec defines the policy enforced.
-	Spec PodSecurityPolicySpecPtrInput `pulumi:"spec"`
+	Spec PodSecurityPolicySpecInput `pulumi:"spec"`
 }
 
 func (PodSecurityPolicyTypeArgs) ElementType() reflect.Type {
@@ -1500,23 +1500,23 @@ func (o PodSecurityPolicyTypeOutput) ToPodSecurityPolicyTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodSecurityPolicyTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodSecurityPolicyTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodSecurityPolicyTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec defines the policy enforced.
-func (o PodSecurityPolicyTypeOutput) Spec() PodSecurityPolicySpecPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyType) *PodSecurityPolicySpec { return v.Spec }).(PodSecurityPolicySpecPtrOutput)
+func (o PodSecurityPolicyTypeOutput) Spec() PodSecurityPolicySpecOutput {
+	return o.ApplyT(func(v PodSecurityPolicyType) PodSecurityPolicySpec { return v.Spec }).(PodSecurityPolicySpecOutput)
 }
 
 type PodSecurityPolicyTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1542,13 +1542,13 @@ func (o PodSecurityPolicyTypeArrayOutput) Index(i pulumi.IntInput) PodSecurityPo
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects.
 type PodSecurityPolicyListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items []PodSecurityPolicyType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodSecurityPolicyListTypeInput is an input type that accepts PodSecurityPolicyListTypeArgs and PodSecurityPolicyListTypeOutput values.
@@ -1566,13 +1566,13 @@ type PodSecurityPolicyListTypeInput interface {
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects.
 type PodSecurityPolicyListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is a list of schema objects.
 	Items PodSecurityPolicyTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodSecurityPolicyListTypeArgs) ElementType() reflect.Type {
@@ -1603,8 +1603,8 @@ func (o PodSecurityPolicyListTypeOutput) ToPodSecurityPolicyListTypeOutputWithCo
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodSecurityPolicyListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is a list of schema objects.
@@ -1613,13 +1613,13 @@ func (o PodSecurityPolicyListTypeOutput) Items() PodSecurityPolicyTypeArrayOutpu
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodSecurityPolicyListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodSecurityPolicyListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicyListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodSecurityPolicyListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodSecurityPolicyListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodSecurityPolicySpec defines the policy enforced.
@@ -1649,7 +1649,7 @@ type PodSecurityPolicySpec struct {
 	// Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 	ForbiddenSysctls []string `pulumi:"forbiddenSysctls"`
 	// fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-	FsGroup *FSGroupStrategyOptions `pulumi:"fsGroup"`
+	FsGroup FSGroupStrategyOptions `pulumi:"fsGroup"`
 	// hostIPC determines if the policy allows the use of HostIPC in the pod spec.
 	HostIPC *bool `pulumi:"hostIPC"`
 	// hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
@@ -1667,13 +1667,13 @@ type PodSecurityPolicySpec struct {
 	// RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
 	RunAsGroup *RunAsGroupStrategyOptions `pulumi:"runAsGroup"`
 	// runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-	RunAsUser *RunAsUserStrategyOptions `pulumi:"runAsUser"`
+	RunAsUser RunAsUserStrategyOptions `pulumi:"runAsUser"`
 	// runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
 	RuntimeClass *RuntimeClassStrategyOptions `pulumi:"runtimeClass"`
 	// seLinux is the strategy that will dictate the allowable labels that may be set.
-	SeLinux *SELinuxStrategyOptions `pulumi:"seLinux"`
+	SeLinux SELinuxStrategyOptions `pulumi:"seLinux"`
 	// supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-	SupplementalGroups *SupplementalGroupsStrategyOptions `pulumi:"supplementalGroups"`
+	SupplementalGroups SupplementalGroupsStrategyOptions `pulumi:"supplementalGroups"`
 	// volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
 	Volumes []string `pulumi:"volumes"`
 }
@@ -1717,7 +1717,7 @@ type PodSecurityPolicySpecArgs struct {
 	// Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 	ForbiddenSysctls pulumi.StringArrayInput `pulumi:"forbiddenSysctls"`
 	// fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-	FsGroup FSGroupStrategyOptionsPtrInput `pulumi:"fsGroup"`
+	FsGroup FSGroupStrategyOptionsInput `pulumi:"fsGroup"`
 	// hostIPC determines if the policy allows the use of HostIPC in the pod spec.
 	HostIPC pulumi.BoolPtrInput `pulumi:"hostIPC"`
 	// hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
@@ -1735,13 +1735,13 @@ type PodSecurityPolicySpecArgs struct {
 	// RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
 	RunAsGroup RunAsGroupStrategyOptionsPtrInput `pulumi:"runAsGroup"`
 	// runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-	RunAsUser RunAsUserStrategyOptionsPtrInput `pulumi:"runAsUser"`
+	RunAsUser RunAsUserStrategyOptionsInput `pulumi:"runAsUser"`
 	// runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
 	RuntimeClass RuntimeClassStrategyOptionsPtrInput `pulumi:"runtimeClass"`
 	// seLinux is the strategy that will dictate the allowable labels that may be set.
-	SeLinux SELinuxStrategyOptionsPtrInput `pulumi:"seLinux"`
+	SeLinux SELinuxStrategyOptionsInput `pulumi:"seLinux"`
 	// supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-	SupplementalGroups SupplementalGroupsStrategyOptionsPtrInput `pulumi:"supplementalGroups"`
+	SupplementalGroups SupplementalGroupsStrategyOptionsInput `pulumi:"supplementalGroups"`
 	// volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
 	Volumes pulumi.StringArrayInput `pulumi:"volumes"`
 }
@@ -1880,8 +1880,8 @@ func (o PodSecurityPolicySpecOutput) ForbiddenSysctls() pulumi.StringArrayOutput
 }
 
 // fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-func (o PodSecurityPolicySpecOutput) FsGroup() FSGroupStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *FSGroupStrategyOptions { return v.FsGroup }).(FSGroupStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) FsGroup() FSGroupStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) FSGroupStrategyOptions { return v.FsGroup }).(FSGroupStrategyOptionsOutput)
 }
 
 // hostIPC determines if the policy allows the use of HostIPC in the pod spec.
@@ -1925,8 +1925,8 @@ func (o PodSecurityPolicySpecOutput) RunAsGroup() RunAsGroupStrategyOptionsPtrOu
 }
 
 // runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
-func (o PodSecurityPolicySpecOutput) RunAsUser() RunAsUserStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *RunAsUserStrategyOptions { return v.RunAsUser }).(RunAsUserStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) RunAsUser() RunAsUserStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) RunAsUserStrategyOptions { return v.RunAsUser }).(RunAsUserStrategyOptionsOutput)
 }
 
 // runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
@@ -1935,13 +1935,13 @@ func (o PodSecurityPolicySpecOutput) RuntimeClass() RuntimeClassStrategyOptionsP
 }
 
 // seLinux is the strategy that will dictate the allowable labels that may be set.
-func (o PodSecurityPolicySpecOutput) SeLinux() SELinuxStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *SELinuxStrategyOptions { return v.SeLinux }).(SELinuxStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) SeLinux() SELinuxStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) SELinuxStrategyOptions { return v.SeLinux }).(SELinuxStrategyOptionsOutput)
 }
 
 // supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-func (o PodSecurityPolicySpecOutput) SupplementalGroups() SupplementalGroupsStrategyOptionsPtrOutput {
-	return o.ApplyT(func(v PodSecurityPolicySpec) *SupplementalGroupsStrategyOptions { return v.SupplementalGroups }).(SupplementalGroupsStrategyOptionsPtrOutput)
+func (o PodSecurityPolicySpecOutput) SupplementalGroups() SupplementalGroupsStrategyOptionsOutput {
+	return o.ApplyT(func(v PodSecurityPolicySpec) SupplementalGroupsStrategyOptions { return v.SupplementalGroups }).(SupplementalGroupsStrategyOptionsOutput)
 }
 
 // volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
@@ -2077,7 +2077,7 @@ func (o PodSecurityPolicySpecPtrOutput) FsGroup() FSGroupStrategyOptionsPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.FsGroup
+		return &v.FsGroup
 	}).(FSGroupStrategyOptionsPtrOutput)
 }
 
@@ -2167,7 +2167,7 @@ func (o PodSecurityPolicySpecPtrOutput) RunAsUser() RunAsUserStrategyOptionsPtrO
 		if v == nil {
 			return nil
 		}
-		return v.RunAsUser
+		return &v.RunAsUser
 	}).(RunAsUserStrategyOptionsPtrOutput)
 }
 
@@ -2187,7 +2187,7 @@ func (o PodSecurityPolicySpecPtrOutput) SeLinux() SELinuxStrategyOptionsPtrOutpu
 		if v == nil {
 			return nil
 		}
-		return v.SeLinux
+		return &v.SeLinux
 	}).(SELinuxStrategyOptionsPtrOutput)
 }
 
@@ -2197,7 +2197,7 @@ func (o PodSecurityPolicySpecPtrOutput) SupplementalGroups() SupplementalGroupsS
 		if v == nil {
 			return nil
 		}
-		return v.SupplementalGroups
+		return &v.SupplementalGroups
 	}).(SupplementalGroupsStrategyOptionsPtrOutput)
 }
 
@@ -2216,7 +2216,7 @@ type RunAsGroupStrategyOptions struct {
 	// ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges []IDRange `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 }
 
 // RunAsGroupStrategyOptionsInput is an input type that accepts RunAsGroupStrategyOptionsArgs and RunAsGroupStrategyOptionsOutput values.
@@ -2236,7 +2236,7 @@ type RunAsGroupStrategyOptionsArgs struct {
 	// ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges IDRangeArrayInput `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 }
 
 func (RunAsGroupStrategyOptionsArgs) ElementType() reflect.Type {
@@ -2324,8 +2324,8 @@ func (o RunAsGroupStrategyOptionsOutput) Ranges() IDRangeArrayOutput {
 }
 
 // rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
-func (o RunAsGroupStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RunAsGroupStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o RunAsGroupStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v RunAsGroupStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 type RunAsGroupStrategyOptionsPtrOutput struct{ *pulumi.OutputState }
@@ -2362,7 +2362,7 @@ func (o RunAsGroupStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2371,7 +2371,7 @@ type RunAsUserStrategyOptions struct {
 	// ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges []IDRange `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 }
 
 // RunAsUserStrategyOptionsInput is an input type that accepts RunAsUserStrategyOptionsArgs and RunAsUserStrategyOptionsOutput values.
@@ -2391,7 +2391,7 @@ type RunAsUserStrategyOptionsArgs struct {
 	// ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
 	Ranges IDRangeArrayInput `pulumi:"ranges"`
 	// rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 }
 
 func (RunAsUserStrategyOptionsArgs) ElementType() reflect.Type {
@@ -2479,8 +2479,8 @@ func (o RunAsUserStrategyOptionsOutput) Ranges() IDRangeArrayOutput {
 }
 
 // rule is the strategy that will dictate the allowable RunAsUser values that may be set.
-func (o RunAsUserStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RunAsUserStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o RunAsUserStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v RunAsUserStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 type RunAsUserStrategyOptionsPtrOutput struct{ *pulumi.OutputState }
@@ -2517,7 +2517,7 @@ func (o RunAsUserStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2679,7 +2679,7 @@ func (o RuntimeClassStrategyOptionsPtrOutput) DefaultRuntimeClassName() pulumi.S
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxStrategyOptions struct {
 	// rule is the strategy that will dictate the allowable labels that may be set.
-	Rule *string `pulumi:"rule"`
+	Rule string `pulumi:"rule"`
 	// seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 	SeLinuxOptions *corev1.SELinuxOptions `pulumi:"seLinuxOptions"`
 }
@@ -2699,7 +2699,7 @@ type SELinuxStrategyOptionsInput interface {
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxStrategyOptionsArgs struct {
 	// rule is the strategy that will dictate the allowable labels that may be set.
-	Rule pulumi.StringPtrInput `pulumi:"rule"`
+	Rule pulumi.StringInput `pulumi:"rule"`
 	// seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 	SeLinuxOptions corev1.SELinuxOptionsPtrInput `pulumi:"seLinuxOptions"`
 }
@@ -2784,8 +2784,8 @@ func (o SELinuxStrategyOptionsOutput) ToSELinuxStrategyOptionsPtrOutputWithConte
 }
 
 // rule is the strategy that will dictate the allowable labels that may be set.
-func (o SELinuxStrategyOptionsOutput) Rule() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SELinuxStrategyOptions) *string { return v.Rule }).(pulumi.StringPtrOutput)
+func (o SELinuxStrategyOptionsOutput) Rule() pulumi.StringOutput {
+	return o.ApplyT(func(v SELinuxStrategyOptions) string { return v.Rule }).(pulumi.StringOutput)
 }
 
 // seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -2817,7 +2817,7 @@ func (o SELinuxStrategyOptionsPtrOutput) Rule() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Rule
+		return &v.Rule
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/kubernetes/rbac/v1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRole.go
@@ -15,13 +15,13 @@ type ClusterRole struct {
 	pulumi.CustomResourceState
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrOutput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleOutput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleBinding.go
@@ -16,13 +16,13 @@ type ClusterRoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleBindingList.go
@@ -16,13 +16,13 @@ type ClusterRoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleList.go
@@ -16,13 +16,13 @@ type ClusterRoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/rbac/v1/pulumiTypes.go
@@ -150,13 +150,13 @@ func (o AggregationRulePtrOutput) ClusterRoleSelectors() metav1.LabelSelectorArr
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 type ClusterRoleType struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule *AggregationRule `pulumi:"aggregationRule"`
+	AggregationRule AggregationRule `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -176,13 +176,13 @@ type ClusterRoleTypeInput interface {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 type ClusterRoleTypeArgs struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrInput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleInput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -241,23 +241,23 @@ func (o ClusterRoleTypeOutput) ToClusterRoleTypeOutputWithContext(ctx context.Co
 }
 
 // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-func (o ClusterRoleTypeOutput) AggregationRule() AggregationRulePtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *AggregationRule { return v.AggregationRule }).(AggregationRulePtrOutput)
+func (o ClusterRoleTypeOutput) AggregationRule() AggregationRuleOutput {
+	return o.ApplyT(func(v ClusterRoleType) AggregationRule { return v.AggregationRule }).(AggregationRuleOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this ClusterRole
@@ -288,13 +288,13 @@ func (o ClusterRoleTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleTypeOutp
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
 type ClusterRoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -314,13 +314,13 @@ type ClusterRoleBindingTypeInput interface {
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
 type ClusterRoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -379,23 +379,23 @@ func (o ClusterRoleBindingTypeOutput) ToClusterRoleBindingTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -426,13 +426,13 @@ func (o ClusterRoleBindingTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleB
 // ClusterRoleBindingList is a collection of ClusterRoleBindings
 type ClusterRoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items []ClusterRoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleBindingListTypeInput is an input type that accepts ClusterRoleBindingListTypeArgs and ClusterRoleBindingListTypeOutput values.
@@ -450,13 +450,13 @@ type ClusterRoleBindingListTypeInput interface {
 // ClusterRoleBindingList is a collection of ClusterRoleBindings
 type ClusterRoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -487,8 +487,8 @@ func (o ClusterRoleBindingListTypeOutput) ToClusterRoleBindingListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoleBindings
@@ -497,25 +497,25 @@ func (o ClusterRoleBindingListTypeOutput) Items() ClusterRoleBindingTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ClusterRoleList is a collection of ClusterRoles
 type ClusterRoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items []ClusterRoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleListTypeInput is an input type that accepts ClusterRoleListTypeArgs and ClusterRoleListTypeOutput values.
@@ -533,13 +533,13 @@ type ClusterRoleListTypeInput interface {
 // ClusterRoleList is a collection of ClusterRoles
 type ClusterRoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleListTypeArgs) ElementType() reflect.Type {
@@ -570,8 +570,8 @@ func (o ClusterRoleListTypeOutput) ToClusterRoleListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoles
@@ -580,13 +580,13 @@ func (o ClusterRoleListTypeOutput) Items() ClusterRoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
@@ -730,11 +730,11 @@ func (o PolicyRuleArrayOutput) Index(i pulumi.IntInput) PolicyRuleOutput {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 type RoleType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -754,11 +754,11 @@ type RoleTypeInput interface {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 type RoleTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -817,18 +817,18 @@ func (o RoleTypeOutput) ToRoleTypeOutputWithContext(ctx context.Context) RoleTyp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this Role
@@ -859,13 +859,13 @@ func (o RoleTypeArrayOutput) Index(i pulumi.IntInput) RoleTypeOutput {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
 type RoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -885,13 +885,13 @@ type RoleBindingTypeInput interface {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
 type RoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -950,23 +950,23 @@ func (o RoleBindingTypeOutput) ToRoleBindingTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o RoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o RoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v RoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -997,13 +997,13 @@ func (o RoleBindingTypeArrayOutput) Index(i pulumi.IntInput) RoleBindingTypeOutp
 // RoleBindingList is a collection of RoleBindings
 type RoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items []RoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleBindingListTypeInput is an input type that accepts RoleBindingListTypeArgs and RoleBindingListTypeOutput values.
@@ -1021,13 +1021,13 @@ type RoleBindingListTypeInput interface {
 // RoleBindingList is a collection of RoleBindings
 type RoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -1058,8 +1058,8 @@ func (o RoleBindingListTypeOutput) ToRoleBindingListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of RoleBindings
@@ -1068,25 +1068,25 @@ func (o RoleBindingListTypeOutput) Items() RoleBindingTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleList is a collection of Roles
 type RoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items []RoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleListTypeInput is an input type that accepts RoleListTypeArgs and RoleListTypeOutput values.
@@ -1104,13 +1104,13 @@ type RoleListTypeInput interface {
 // RoleList is a collection of Roles
 type RoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleListTypeArgs) ElementType() reflect.Type {
@@ -1141,8 +1141,8 @@ func (o RoleListTypeOutput) ToRoleListTypeOutputWithContext(ctx context.Context)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of Roles
@@ -1151,23 +1151,23 @@ func (o RoleListTypeOutput) Items() RoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup *string `pulumi:"apiGroup"`
+	ApiGroup string `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // RoleRefInput is an input type that accepts RoleRefArgs and RoleRefOutput values.
@@ -1185,11 +1185,11 @@ type RoleRefInput interface {
 // RoleRef contains information that points to the role being used
 type RoleRefArgs struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
+	ApiGroup pulumi.StringInput `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (RoleRefArgs) ElementType() reflect.Type {
@@ -1272,18 +1272,18 @@ func (o RoleRefOutput) ToRoleRefPtrOutputWithContext(ctx context.Context) RoleRe
 }
 
 // APIGroup is the group for the resource being referenced
-func (o RoleRefOutput) ApiGroup() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.ApiGroup }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) ApiGroup() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.ApiGroup }).(pulumi.StringOutput)
 }
 
 // Kind is the type of resource being referenced
-func (o RoleRefOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name is the name of resource being referenced
-func (o RoleRefOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type RoleRefPtrOutput struct{ *pulumi.OutputState }
@@ -1310,7 +1310,7 @@ func (o RoleRefPtrOutput) ApiGroup() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ApiGroup
+		return &v.ApiGroup
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1320,7 +1320,7 @@ func (o RoleRefPtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1330,7 +1330,7 @@ func (o RoleRefPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1339,9 +1339,9 @@ type Subject struct {
 	// APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	ApiGroup *string `pulumi:"apiGroup"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace *string `pulumi:"namespace"`
 }
@@ -1363,9 +1363,9 @@ type SubjectArgs struct {
 	// APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
 }
@@ -1429,13 +1429,13 @@ func (o SubjectOutput) ApiGroup() pulumi.StringPtrOutput {
 }
 
 // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-func (o SubjectOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the object being referenced.
-func (o SubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.

--- a/sdk/go/kubernetes/rbac/v1/role.go
+++ b/sdk/go/kubernetes/rbac/v1/role.go
@@ -15,11 +15,11 @@ type Role struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1/roleBinding.go
@@ -16,13 +16,13 @@ type RoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1/roleBindingList.go
@@ -16,13 +16,13 @@ type RoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1/roleList.go
@@ -16,13 +16,13 @@ type RoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRole.go
@@ -15,13 +15,13 @@ type ClusterRole struct {
 	pulumi.CustomResourceState
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrOutput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleOutput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBinding.go
@@ -16,13 +16,13 @@ type ClusterRoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingList.go
@@ -16,13 +16,13 @@ type ClusterRoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleList.go
@@ -16,13 +16,13 @@ type ClusterRoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/pulumiTypes.go
@@ -150,13 +150,13 @@ func (o AggregationRulePtrOutput) ClusterRoleSelectors() metav1.LabelSelectorArr
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRoleType struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule *AggregationRule `pulumi:"aggregationRule"`
+	AggregationRule AggregationRule `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -176,13 +176,13 @@ type ClusterRoleTypeInput interface {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRoleTypeArgs struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrInput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleInput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -241,23 +241,23 @@ func (o ClusterRoleTypeOutput) ToClusterRoleTypeOutputWithContext(ctx context.Co
 }
 
 // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-func (o ClusterRoleTypeOutput) AggregationRule() AggregationRulePtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *AggregationRule { return v.AggregationRule }).(AggregationRulePtrOutput)
+func (o ClusterRoleTypeOutput) AggregationRule() AggregationRuleOutput {
+	return o.ApplyT(func(v ClusterRoleType) AggregationRule { return v.AggregationRule }).(AggregationRuleOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this ClusterRole
@@ -288,13 +288,13 @@ func (o ClusterRoleTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleTypeOutp
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -314,13 +314,13 @@ type ClusterRoleBindingTypeInput interface {
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -379,23 +379,23 @@ func (o ClusterRoleBindingTypeOutput) ToClusterRoleBindingTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -426,13 +426,13 @@ func (o ClusterRoleBindingTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleB
 // ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindings, and will no longer be served in v1.20.
 type ClusterRoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items []ClusterRoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleBindingListTypeInput is an input type that accepts ClusterRoleBindingListTypeArgs and ClusterRoleBindingListTypeOutput values.
@@ -450,13 +450,13 @@ type ClusterRoleBindingListTypeInput interface {
 // ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindings, and will no longer be served in v1.20.
 type ClusterRoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -487,8 +487,8 @@ func (o ClusterRoleBindingListTypeOutput) ToClusterRoleBindingListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoleBindings
@@ -497,25 +497,25 @@ func (o ClusterRoleBindingListTypeOutput) Items() ClusterRoleBindingTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
 type ClusterRoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items []ClusterRoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleListTypeInput is an input type that accepts ClusterRoleListTypeArgs and ClusterRoleListTypeOutput values.
@@ -533,13 +533,13 @@ type ClusterRoleListTypeInput interface {
 // ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
 type ClusterRoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleListTypeArgs) ElementType() reflect.Type {
@@ -570,8 +570,8 @@ func (o ClusterRoleListTypeOutput) ToClusterRoleListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoles
@@ -580,13 +580,13 @@ func (o ClusterRoleListTypeOutput) Items() ClusterRoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
@@ -730,11 +730,11 @@ func (o PolicyRuleArrayOutput) Index(i pulumi.IntInput) PolicyRuleOutput {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RoleType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -754,11 +754,11 @@ type RoleTypeInput interface {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RoleTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -817,18 +817,18 @@ func (o RoleTypeOutput) ToRoleTypeOutputWithContext(ctx context.Context) RoleTyp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this Role
@@ -859,13 +859,13 @@ func (o RoleTypeArrayOutput) Index(i pulumi.IntInput) RoleTypeOutput {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -885,13 +885,13 @@ type RoleBindingTypeInput interface {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -950,23 +950,23 @@ func (o RoleBindingTypeOutput) ToRoleBindingTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o RoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o RoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v RoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -997,13 +997,13 @@ func (o RoleBindingTypeArrayOutput) Index(i pulumi.IntInput) RoleBindingTypeOutp
 // RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
 type RoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items []RoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleBindingListTypeInput is an input type that accepts RoleBindingListTypeArgs and RoleBindingListTypeOutput values.
@@ -1021,13 +1021,13 @@ type RoleBindingListTypeInput interface {
 // RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
 type RoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -1058,8 +1058,8 @@ func (o RoleBindingListTypeOutput) ToRoleBindingListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of RoleBindings
@@ -1068,25 +1068,25 @@ func (o RoleBindingListTypeOutput) Items() RoleBindingTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleList is a collection of Roles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
 type RoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items []RoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleListTypeInput is an input type that accepts RoleListTypeArgs and RoleListTypeOutput values.
@@ -1104,13 +1104,13 @@ type RoleListTypeInput interface {
 // RoleList is a collection of Roles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
 type RoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleListTypeArgs) ElementType() reflect.Type {
@@ -1141,8 +1141,8 @@ func (o RoleListTypeOutput) ToRoleListTypeOutputWithContext(ctx context.Context)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of Roles
@@ -1151,23 +1151,23 @@ func (o RoleListTypeOutput) Items() RoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup *string `pulumi:"apiGroup"`
+	ApiGroup string `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // RoleRefInput is an input type that accepts RoleRefArgs and RoleRefOutput values.
@@ -1185,11 +1185,11 @@ type RoleRefInput interface {
 // RoleRef contains information that points to the role being used
 type RoleRefArgs struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
+	ApiGroup pulumi.StringInput `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (RoleRefArgs) ElementType() reflect.Type {
@@ -1272,18 +1272,18 @@ func (o RoleRefOutput) ToRoleRefPtrOutputWithContext(ctx context.Context) RoleRe
 }
 
 // APIGroup is the group for the resource being referenced
-func (o RoleRefOutput) ApiGroup() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.ApiGroup }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) ApiGroup() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.ApiGroup }).(pulumi.StringOutput)
 }
 
 // Kind is the type of resource being referenced
-func (o RoleRefOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name is the name of resource being referenced
-func (o RoleRefOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type RoleRefPtrOutput struct{ *pulumi.OutputState }
@@ -1310,7 +1310,7 @@ func (o RoleRefPtrOutput) ApiGroup() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ApiGroup
+		return &v.ApiGroup
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1320,7 +1320,7 @@ func (o RoleRefPtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1330,7 +1330,7 @@ func (o RoleRefPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1339,9 +1339,9 @@ type Subject struct {
 	// APIVersion holds the API group and version of the referenced subject. Defaults to "v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
 	ApiVersion *string `pulumi:"apiVersion"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace *string `pulumi:"namespace"`
 }
@@ -1363,9 +1363,9 @@ type SubjectArgs struct {
 	// APIVersion holds the API group and version of the referenced subject. Defaults to "v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
 	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
 }
@@ -1429,13 +1429,13 @@ func (o SubjectOutput) ApiVersion() pulumi.StringPtrOutput {
 }
 
 // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-func (o SubjectOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the object being referenced.
-func (o SubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.

--- a/sdk/go/kubernetes/rbac/v1alpha1/role.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/role.go
@@ -15,11 +15,11 @@ type Role struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleBinding.go
@@ -16,13 +16,13 @@ type RoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleBindingList.go
@@ -16,13 +16,13 @@ type RoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleList.go
@@ -16,13 +16,13 @@ type RoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRole.go
@@ -15,13 +15,13 @@ type ClusterRole struct {
 	pulumi.CustomResourceState
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrOutput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleOutput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBinding.go
@@ -16,13 +16,13 @@ type ClusterRoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingList.go
@@ -16,13 +16,13 @@ type ClusterRoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleList.go
@@ -16,13 +16,13 @@ type ClusterRoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewClusterRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/pulumiTypes.go
@@ -150,13 +150,13 @@ func (o AggregationRulePtrOutput) ClusterRoleSelectors() metav1.LabelSelectorArr
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRoleType struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule *AggregationRule `pulumi:"aggregationRule"`
+	AggregationRule AggregationRule `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -176,13 +176,13 @@ type ClusterRoleTypeInput interface {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRoleTypeArgs struct {
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-	AggregationRule AggregationRulePtrInput `pulumi:"aggregationRule"`
+	AggregationRule AggregationRuleInput `pulumi:"aggregationRule"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this ClusterRole
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -241,23 +241,23 @@ func (o ClusterRoleTypeOutput) ToClusterRoleTypeOutputWithContext(ctx context.Co
 }
 
 // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-func (o ClusterRoleTypeOutput) AggregationRule() AggregationRulePtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *AggregationRule { return v.AggregationRule }).(AggregationRulePtrOutput)
+func (o ClusterRoleTypeOutput) AggregationRule() AggregationRuleOutput {
+	return o.ApplyT(func(v ClusterRoleType) AggregationRule { return v.AggregationRule }).(AggregationRuleOutput)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this ClusterRole
@@ -288,13 +288,13 @@ func (o ClusterRoleTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleTypeOutp
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -314,13 +314,13 @@ type ClusterRoleBindingTypeInput interface {
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -379,23 +379,23 @@ func (o ClusterRoleBindingTypeOutput) ToClusterRoleBindingTypeOutputWithContext(
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o ClusterRoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o ClusterRoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v ClusterRoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -426,13 +426,13 @@ func (o ClusterRoleBindingTypeArrayOutput) Index(i pulumi.IntInput) ClusterRoleB
 // ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindingList, and will no longer be served in v1.20.
 type ClusterRoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items []ClusterRoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleBindingListTypeInput is an input type that accepts ClusterRoleBindingListTypeArgs and ClusterRoleBindingListTypeOutput values.
@@ -450,13 +450,13 @@ type ClusterRoleBindingListTypeInput interface {
 // ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindingList, and will no longer be served in v1.20.
 type ClusterRoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoleBindings
 	Items ClusterRoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -487,8 +487,8 @@ func (o ClusterRoleBindingListTypeOutput) ToClusterRoleBindingListTypeOutputWith
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoleBindings
@@ -497,25 +497,25 @@ func (o ClusterRoleBindingListTypeOutput) Items() ClusterRoleBindingTypeArrayOut
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
 type ClusterRoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items []ClusterRoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // ClusterRoleListTypeInput is an input type that accepts ClusterRoleListTypeArgs and ClusterRoleListTypeOutput values.
@@ -533,13 +533,13 @@ type ClusterRoleListTypeInput interface {
 // ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
 type ClusterRoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of ClusterRoles
 	Items ClusterRoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (ClusterRoleListTypeArgs) ElementType() reflect.Type {
@@ -570,8 +570,8 @@ func (o ClusterRoleListTypeOutput) ToClusterRoleListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of ClusterRoles
@@ -580,13 +580,13 @@ func (o ClusterRoleListTypeOutput) Items() ClusterRoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o ClusterRoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o ClusterRoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterRoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v ClusterRoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o ClusterRoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v ClusterRoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
@@ -730,11 +730,11 @@ func (o PolicyRuleArrayOutput) Index(i pulumi.IntInput) PolicyRuleOutput {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RoleType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules []PolicyRule `pulumi:"rules"`
 }
@@ -754,11 +754,11 @@ type RoleTypeInput interface {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RoleTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayInput `pulumi:"rules"`
 }
@@ -817,18 +817,18 @@ func (o RoleTypeOutput) ToRoleTypeOutputWithContext(ctx context.Context) RoleTyp
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Rules holds all the PolicyRules for this Role
@@ -859,13 +859,13 @@ func (o RoleTypeArrayOutput) Index(i pulumi.IntInput) RoleTypeOutput {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef *RoleRef `pulumi:"roleRef"`
+	RoleRef RoleRef `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `pulumi:"subjects"`
 }
@@ -885,13 +885,13 @@ type RoleBindingTypeInput interface {
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrInput `pulumi:"roleRef"`
+	RoleRef RoleRefInput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayInput `pulumi:"subjects"`
 }
@@ -950,23 +950,23 @@ func (o RoleBindingTypeOutput) ToRoleBindingTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o RoleBindingTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v RoleBindingType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-func (o RoleBindingTypeOutput) RoleRef() RoleRefPtrOutput {
-	return o.ApplyT(func(v RoleBindingType) *RoleRef { return v.RoleRef }).(RoleRefPtrOutput)
+func (o RoleBindingTypeOutput) RoleRef() RoleRefOutput {
+	return o.ApplyT(func(v RoleBindingType) RoleRef { return v.RoleRef }).(RoleRefOutput)
 }
 
 // Subjects holds references to the objects the role applies to.
@@ -997,13 +997,13 @@ func (o RoleBindingTypeArrayOutput) Index(i pulumi.IntInput) RoleBindingTypeOutp
 // RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
 type RoleBindingListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items []RoleBindingType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleBindingListTypeInput is an input type that accepts RoleBindingListTypeArgs and RoleBindingListTypeOutput values.
@@ -1021,13 +1021,13 @@ type RoleBindingListTypeInput interface {
 // RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
 type RoleBindingListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleBindingListTypeArgs) ElementType() reflect.Type {
@@ -1058,8 +1058,8 @@ func (o RoleBindingListTypeOutput) ToRoleBindingListTypeOutputWithContext(ctx co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of RoleBindings
@@ -1068,25 +1068,25 @@ func (o RoleBindingListTypeOutput) Items() RoleBindingTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleBindingListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleBindingListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleBindingListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleBindingListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleBindingListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleBindingListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleList is a collection of Roles Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
 type RoleListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items []RoleType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // RoleListTypeInput is an input type that accepts RoleListTypeArgs and RoleListTypeOutput values.
@@ -1104,13 +1104,13 @@ type RoleListTypeInput interface {
 // RoleList is a collection of Roles Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
 type RoleListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (RoleListTypeArgs) ElementType() reflect.Type {
@@ -1141,8 +1141,8 @@ func (o RoleListTypeOutput) ToRoleListTypeOutputWithContext(ctx context.Context)
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o RoleListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of Roles
@@ -1151,23 +1151,23 @@ func (o RoleListTypeOutput) Items() RoleTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o RoleListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata.
-func (o RoleListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v RoleListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o RoleListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v RoleListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup *string `pulumi:"apiGroup"`
+	ApiGroup string `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 }
 
 // RoleRefInput is an input type that accepts RoleRefArgs and RoleRefOutput values.
@@ -1185,11 +1185,11 @@ type RoleRefInput interface {
 // RoleRef contains information that points to the role being used
 type RoleRefArgs struct {
 	// APIGroup is the group for the resource being referenced
-	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
+	ApiGroup pulumi.StringInput `pulumi:"apiGroup"`
 	// Kind is the type of resource being referenced
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name is the name of resource being referenced
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 }
 
 func (RoleRefArgs) ElementType() reflect.Type {
@@ -1272,18 +1272,18 @@ func (o RoleRefOutput) ToRoleRefPtrOutputWithContext(ctx context.Context) RoleRe
 }
 
 // APIGroup is the group for the resource being referenced
-func (o RoleRefOutput) ApiGroup() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.ApiGroup }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) ApiGroup() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.ApiGroup }).(pulumi.StringOutput)
 }
 
 // Kind is the type of resource being referenced
-func (o RoleRefOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name is the name of resource being referenced
-func (o RoleRefOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v RoleRef) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o RoleRefOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v RoleRef) string { return v.Name }).(pulumi.StringOutput)
 }
 
 type RoleRefPtrOutput struct{ *pulumi.OutputState }
@@ -1310,7 +1310,7 @@ func (o RoleRefPtrOutput) ApiGroup() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.ApiGroup
+		return &v.ApiGroup
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1320,7 +1320,7 @@ func (o RoleRefPtrOutput) Kind() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Kind
+		return &v.Kind
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1330,7 +1330,7 @@ func (o RoleRefPtrOutput) Name() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Name
+		return &v.Name
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1339,9 +1339,9 @@ type Subject struct {
 	// APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	ApiGroup *string `pulumi:"apiGroup"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace *string `pulumi:"namespace"`
 }
@@ -1363,9 +1363,9 @@ type SubjectArgs struct {
 	// APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	ApiGroup pulumi.StringPtrInput `pulumi:"apiGroup"`
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Name of the object being referenced.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
 	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
 }
@@ -1429,13 +1429,13 @@ func (o SubjectOutput) ApiGroup() pulumi.StringPtrOutput {
 }
 
 // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-func (o SubjectOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Name of the object being referenced.
-func (o SubjectOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v Subject) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o SubjectOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v Subject) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.

--- a/sdk/go/kubernetes/rbac/v1beta1/role.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/role.go
@@ -15,11 +15,11 @@ type Role struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Rules holds all the PolicyRules for this Role
 	Rules PolicyRuleArrayOutput `pulumi:"rules"`
 }

--- a/sdk/go/kubernetes/rbac/v1beta1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleBinding.go
@@ -16,13 +16,13 @@ type RoleBinding struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef RoleRefPtrOutput `pulumi:"roleRef"`
+	RoleRef RoleRefOutput `pulumi:"roleRef"`
 	// Subjects holds references to the objects the role applies to.
 	Subjects SubjectArrayOutput `pulumi:"subjects"`
 }

--- a/sdk/go/kubernetes/rbac/v1beta1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleBindingList.go
@@ -16,13 +16,13 @@ type RoleBindingList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of RoleBindings
 	Items RoleBindingTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleBindingList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/rbac/v1beta1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleList.go
@@ -16,13 +16,13 @@ type RoleList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of Roles
 	Items RoleTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata.
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewRoleList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1/priorityClass.go
@@ -16,19 +16,19 @@ type PriorityClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrOutput `pulumi:"description"`
+	Description pulumi.StringOutput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrOutput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolOutput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrOutput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringOutput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrOutput `pulumi:"value"`
+	Value pulumi.IntOutput `pulumi:"value"`
 }
 
 // NewPriorityClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1/priorityClassList.go
@@ -16,13 +16,13 @@ type PriorityClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPriorityClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/scheduling/v1/pulumiTypes.go
@@ -14,19 +14,19 @@ import (
 // PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description *string `pulumi:"description"`
+	Description string `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault *bool `pulumi:"globalDefault"`
+	GlobalDefault bool `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy *string `pulumi:"preemptionPolicy"`
+	PreemptionPolicy string `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value *int `pulumi:"value"`
+	Value int `pulumi:"value"`
 }
 
 // PriorityClassTypeInput is an input type that accepts PriorityClassTypeArgs and PriorityClassTypeOutput values.
@@ -44,19 +44,19 @@ type PriorityClassTypeInput interface {
 // PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description pulumi.StringInput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrInput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolInput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrInput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringInput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrInput `pulumi:"value"`
+	Value pulumi.IntInput `pulumi:"value"`
 }
 
 func (PriorityClassTypeArgs) ElementType() reflect.Type {
@@ -113,38 +113,38 @@ func (o PriorityClassTypeOutput) ToPriorityClassTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-func (o PriorityClassTypeOutput) Description() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Description }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Description() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Description }).(pulumi.StringOutput)
 }
 
 // globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *bool { return v.GlobalDefault }).(pulumi.BoolPtrOutput)
+func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolOutput {
+	return o.ApplyT(func(v PriorityClassType) bool { return v.GlobalDefault }).(pulumi.BoolOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PriorityClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.PreemptionPolicy }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.PreemptionPolicy }).(pulumi.StringOutput)
 }
 
 // The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-func (o PriorityClassTypeOutput) Value() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *int { return v.Value }).(pulumi.IntPtrOutput)
+func (o PriorityClassTypeOutput) Value() pulumi.IntOutput {
+	return o.ApplyT(func(v PriorityClassType) int { return v.Value }).(pulumi.IntOutput)
 }
 
 type PriorityClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -170,13 +170,13 @@ func (o PriorityClassTypeArrayOutput) Index(i pulumi.IntInput) PriorityClassType
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items []PriorityClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PriorityClassListTypeInput is an input type that accepts PriorityClassListTypeArgs and PriorityClassListTypeOutput values.
@@ -194,13 +194,13 @@ type PriorityClassListTypeInput interface {
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PriorityClassListTypeArgs) ElementType() reflect.Type {
@@ -231,8 +231,8 @@ func (o PriorityClassListTypeOutput) ToPriorityClassListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of PriorityClasses
@@ -241,13 +241,13 @@ func (o PriorityClassListTypeOutput) Items() PriorityClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PriorityClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/scheduling/v1alpha1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/priorityClass.go
@@ -16,19 +16,19 @@ type PriorityClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrOutput `pulumi:"description"`
+	Description pulumi.StringOutput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrOutput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolOutput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrOutput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringOutput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrOutput `pulumi:"value"`
+	Value pulumi.IntOutput `pulumi:"value"`
 }
 
 // NewPriorityClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassList.go
@@ -16,13 +16,13 @@ type PriorityClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPriorityClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/pulumiTypes.go
@@ -14,19 +14,19 @@ import (
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description *string `pulumi:"description"`
+	Description string `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault *bool `pulumi:"globalDefault"`
+	GlobalDefault bool `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy *string `pulumi:"preemptionPolicy"`
+	PreemptionPolicy string `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value *int `pulumi:"value"`
+	Value int `pulumi:"value"`
 }
 
 // PriorityClassTypeInput is an input type that accepts PriorityClassTypeArgs and PriorityClassTypeOutput values.
@@ -44,19 +44,19 @@ type PriorityClassTypeInput interface {
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description pulumi.StringInput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrInput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolInput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrInput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringInput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrInput `pulumi:"value"`
+	Value pulumi.IntInput `pulumi:"value"`
 }
 
 func (PriorityClassTypeArgs) ElementType() reflect.Type {
@@ -113,38 +113,38 @@ func (o PriorityClassTypeOutput) ToPriorityClassTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-func (o PriorityClassTypeOutput) Description() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Description }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Description() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Description }).(pulumi.StringOutput)
 }
 
 // globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *bool { return v.GlobalDefault }).(pulumi.BoolPtrOutput)
+func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolOutput {
+	return o.ApplyT(func(v PriorityClassType) bool { return v.GlobalDefault }).(pulumi.BoolOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PriorityClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.PreemptionPolicy }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.PreemptionPolicy }).(pulumi.StringOutput)
 }
 
 // The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-func (o PriorityClassTypeOutput) Value() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *int { return v.Value }).(pulumi.IntPtrOutput)
+func (o PriorityClassTypeOutput) Value() pulumi.IntOutput {
+	return o.ApplyT(func(v PriorityClassType) int { return v.Value }).(pulumi.IntOutput)
 }
 
 type PriorityClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -170,13 +170,13 @@ func (o PriorityClassTypeArrayOutput) Index(i pulumi.IntInput) PriorityClassType
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items []PriorityClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PriorityClassListTypeInput is an input type that accepts PriorityClassListTypeArgs and PriorityClassListTypeOutput values.
@@ -194,13 +194,13 @@ type PriorityClassListTypeInput interface {
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PriorityClassListTypeArgs) ElementType() reflect.Type {
@@ -231,8 +231,8 @@ func (o PriorityClassListTypeOutput) ToPriorityClassListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of PriorityClasses
@@ -241,13 +241,13 @@ func (o PriorityClassListTypeOutput) Items() PriorityClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PriorityClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/scheduling/v1beta1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/priorityClass.go
@@ -16,19 +16,19 @@ type PriorityClass struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrOutput `pulumi:"description"`
+	Description pulumi.StringOutput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrOutput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolOutput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrOutput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringOutput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrOutput `pulumi:"value"`
+	Value pulumi.IntOutput `pulumi:"value"`
 }
 
 // NewPriorityClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1beta1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/priorityClassList.go
@@ -16,13 +16,13 @@ type PriorityClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPriorityClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/scheduling/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/pulumiTypes.go
@@ -14,19 +14,19 @@ import (
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description *string `pulumi:"description"`
+	Description string `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault *bool `pulumi:"globalDefault"`
+	GlobalDefault bool `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy *string `pulumi:"preemptionPolicy"`
+	PreemptionPolicy string `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value *int `pulumi:"value"`
+	Value int `pulumi:"value"`
 }
 
 // PriorityClassTypeInput is an input type that accepts PriorityClassTypeArgs and PriorityClassTypeOutput values.
@@ -44,19 +44,19 @@ type PriorityClassTypeInput interface {
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description pulumi.StringInput `pulumi:"description"`
 	// globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-	GlobalDefault pulumi.BoolPtrInput `pulumi:"globalDefault"`
+	GlobalDefault pulumi.BoolInput `pulumi:"globalDefault"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-	PreemptionPolicy pulumi.StringPtrInput `pulumi:"preemptionPolicy"`
+	PreemptionPolicy pulumi.StringInput `pulumi:"preemptionPolicy"`
 	// The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-	Value pulumi.IntPtrInput `pulumi:"value"`
+	Value pulumi.IntInput `pulumi:"value"`
 }
 
 func (PriorityClassTypeArgs) ElementType() reflect.Type {
@@ -113,38 +113,38 @@ func (o PriorityClassTypeOutput) ToPriorityClassTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-func (o PriorityClassTypeOutput) Description() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Description }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Description() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Description }).(pulumi.StringOutput)
 }
 
 // globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *bool { return v.GlobalDefault }).(pulumi.BoolPtrOutput)
+func (o PriorityClassTypeOutput) GlobalDefault() pulumi.BoolOutput {
+	return o.ApplyT(func(v PriorityClassType) bool { return v.GlobalDefault }).(pulumi.BoolOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PriorityClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PriorityClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
-func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *string { return v.PreemptionPolicy }).(pulumi.StringPtrOutput)
+func (o PriorityClassTypeOutput) PreemptionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassType) string { return v.PreemptionPolicy }).(pulumi.StringOutput)
 }
 
 // The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-func (o PriorityClassTypeOutput) Value() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v PriorityClassType) *int { return v.Value }).(pulumi.IntPtrOutput)
+func (o PriorityClassTypeOutput) Value() pulumi.IntOutput {
+	return o.ApplyT(func(v PriorityClassType) int { return v.Value }).(pulumi.IntOutput)
 }
 
 type PriorityClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -170,13 +170,13 @@ func (o PriorityClassTypeArrayOutput) Index(i pulumi.IntInput) PriorityClassType
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items []PriorityClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PriorityClassListTypeInput is an input type that accepts PriorityClassListTypeArgs and PriorityClassListTypeOutput values.
@@ -194,13 +194,13 @@ type PriorityClassListTypeInput interface {
 // PriorityClassList is a collection of priority classes.
 type PriorityClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of PriorityClasses
 	Items PriorityClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PriorityClassListTypeArgs) ElementType() reflect.Type {
@@ -231,8 +231,8 @@ func (o PriorityClassListTypeOutput) ToPriorityClassListTypeOutputWithContext(ct
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of PriorityClasses
@@ -241,13 +241,13 @@ func (o PriorityClassListTypeOutput) Items() PriorityClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PriorityClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PriorityClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PriorityClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PriorityClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PriorityClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PriorityClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 func init() {

--- a/sdk/go/kubernetes/settings/v1alpha1/podPreset.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/podPreset.go
@@ -15,11 +15,11 @@ type PodPreset struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrOutput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
-	Spec     PodPresetSpecPtrOutput     `pulumi:"spec"`
+	Kind     pulumi.StringOutput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
+	Spec     PodPresetSpecOutput     `pulumi:"spec"`
 }
 
 // NewPodPreset registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/settings/v1alpha1/podPresetList.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/podPresetList.go
@@ -16,13 +16,13 @@ type PodPresetList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items PodPresetTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewPodPresetList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/settings/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/pulumiTypes.go
@@ -15,11 +15,11 @@ import (
 // PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 type PodPresetType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     *string            `pulumi:"kind"`
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
-	Spec     *PodPresetSpec     `pulumi:"spec"`
+	Kind     string            `pulumi:"kind"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
+	Spec     PodPresetSpec     `pulumi:"spec"`
 }
 
 // PodPresetTypeInput is an input type that accepts PodPresetTypeArgs and PodPresetTypeOutput values.
@@ -37,11 +37,11 @@ type PodPresetTypeInput interface {
 // PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 type PodPresetTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind     pulumi.StringPtrInput     `pulumi:"kind"`
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
-	Spec     PodPresetSpecPtrInput     `pulumi:"spec"`
+	Kind     pulumi.StringInput     `pulumi:"kind"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
+	Spec     PodPresetSpecInput     `pulumi:"spec"`
 }
 
 func (PodPresetTypeArgs) ElementType() reflect.Type {
@@ -98,21 +98,21 @@ func (o PodPresetTypeOutput) ToPodPresetTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodPresetTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodPresetType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodPresetTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodPresetType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodPresetTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodPresetType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodPresetTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodPresetType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
-func (o PodPresetTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v PodPresetType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o PodPresetTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v PodPresetType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
-func (o PodPresetTypeOutput) Spec() PodPresetSpecPtrOutput {
-	return o.ApplyT(func(v PodPresetType) *PodPresetSpec { return v.Spec }).(PodPresetSpecPtrOutput)
+func (o PodPresetTypeOutput) Spec() PodPresetSpecOutput {
+	return o.ApplyT(func(v PodPresetType) PodPresetSpec { return v.Spec }).(PodPresetSpecOutput)
 }
 
 type PodPresetTypeArrayOutput struct{ *pulumi.OutputState }
@@ -138,13 +138,13 @@ func (o PodPresetTypeArrayOutput) Index(i pulumi.IntInput) PodPresetTypeOutput {
 // PodPresetList is a list of PodPreset objects.
 type PodPresetListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items []PodPresetType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // PodPresetListTypeInput is an input type that accepts PodPresetListTypeArgs and PodPresetListTypeOutput values.
@@ -162,13 +162,13 @@ type PodPresetListTypeInput interface {
 // PodPresetList is a list of PodPreset objects.
 type PodPresetListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is a list of schema objects.
 	Items PodPresetTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (PodPresetListTypeArgs) ElementType() reflect.Type {
@@ -199,8 +199,8 @@ func (o PodPresetListTypeOutput) ToPodPresetListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o PodPresetListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodPresetListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o PodPresetListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v PodPresetListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is a list of schema objects.
@@ -209,13 +209,13 @@ func (o PodPresetListTypeOutput) Items() PodPresetTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o PodPresetListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v PodPresetListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o PodPresetListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v PodPresetListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o PodPresetListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v PodPresetListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o PodPresetListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v PodPresetListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // PodPresetSpec is a description of a pod preset.

--- a/sdk/go/kubernetes/storage/v1/csidriver.go
+++ b/sdk/go/kubernetes/storage/v1/csidriver.go
@@ -16,13 +16,13 @@ type CSIDriver struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec CSIDriverSpecPtrOutput `pulumi:"spec"`
+	Spec CSIDriverSpecOutput `pulumi:"spec"`
 }
 
 // NewCSIDriver registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/csidriverList.go
+++ b/sdk/go/kubernetes/storage/v1/csidriverList.go
@@ -16,13 +16,13 @@ type CSIDriverList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items CSIDriverTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCSIDriverList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/csinode.go
+++ b/sdk/go/kubernetes/storage/v1/csinode.go
@@ -16,13 +16,13 @@ type CSINode struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec CSINodeSpecPtrOutput `pulumi:"spec"`
+	Spec CSINodeSpecOutput `pulumi:"spec"`
 }
 
 // NewCSINode registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/csinodeList.go
+++ b/sdk/go/kubernetes/storage/v1/csinodeList.go
@@ -16,13 +16,13 @@ type CSINodeList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items CSINodeTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCSINodeList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/storage/v1/pulumiTypes.go
@@ -15,13 +15,13 @@ import (
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec *CSIDriverSpec `pulumi:"spec"`
+	Spec CSIDriverSpec `pulumi:"spec"`
 }
 
 // CSIDriverTypeInput is an input type that accepts CSIDriverTypeArgs and CSIDriverTypeOutput values.
@@ -39,13 +39,13 @@ type CSIDriverTypeInput interface {
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec CSIDriverSpecPtrInput `pulumi:"spec"`
+	Spec CSIDriverSpecInput `pulumi:"spec"`
 }
 
 func (CSIDriverTypeArgs) ElementType() reflect.Type {
@@ -102,23 +102,23 @@ func (o CSIDriverTypeOutput) ToCSIDriverTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSIDriverTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSIDriverTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSIDriverTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSIDriverTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSIDriverTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CSIDriverTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CSIDriverType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the CSI Driver.
-func (o CSIDriverTypeOutput) Spec() CSIDriverSpecPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *CSIDriverSpec { return v.Spec }).(CSIDriverSpecPtrOutput)
+func (o CSIDriverTypeOutput) Spec() CSIDriverSpecOutput {
+	return o.ApplyT(func(v CSIDriverType) CSIDriverSpec { return v.Spec }).(CSIDriverSpecOutput)
 }
 
 type CSIDriverTypeArrayOutput struct{ *pulumi.OutputState }
@@ -144,13 +144,13 @@ func (o CSIDriverTypeArrayOutput) Index(i pulumi.IntInput) CSIDriverTypeOutput {
 // CSIDriverList is a collection of CSIDriver objects.
 type CSIDriverListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items []CSIDriverType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CSIDriverListTypeInput is an input type that accepts CSIDriverListTypeArgs and CSIDriverListTypeOutput values.
@@ -168,13 +168,13 @@ type CSIDriverListTypeInput interface {
 // CSIDriverList is a collection of CSIDriver objects.
 type CSIDriverListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items CSIDriverTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CSIDriverListTypeArgs) ElementType() reflect.Type {
@@ -205,8 +205,8 @@ func (o CSIDriverListTypeOutput) ToCSIDriverListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSIDriverListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSIDriverListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CSIDriver
@@ -215,13 +215,13 @@ func (o CSIDriverListTypeOutput) Items() CSIDriverTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSIDriverListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSIDriverListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSIDriverListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CSIDriverListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CSIDriverListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CSIDriverSpec is the specification of a CSIDriver.
@@ -413,13 +413,13 @@ func (o CSIDriverSpecPtrOutput) VolumeLifecycleModes() pulumi.StringArrayOutput 
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 type CSINodeType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec *CSINodeSpec `pulumi:"spec"`
+	Spec CSINodeSpec `pulumi:"spec"`
 }
 
 // CSINodeTypeInput is an input type that accepts CSINodeTypeArgs and CSINodeTypeOutput values.
@@ -437,13 +437,13 @@ type CSINodeTypeInput interface {
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 type CSINodeTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec CSINodeSpecPtrInput `pulumi:"spec"`
+	Spec CSINodeSpecInput `pulumi:"spec"`
 }
 
 func (CSINodeTypeArgs) ElementType() reflect.Type {
@@ -500,23 +500,23 @@ func (o CSINodeTypeOutput) ToCSINodeTypeOutputWithContext(ctx context.Context) C
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSINodeTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSINodeTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSINodeTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSINodeTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata.name must be the Kubernetes node name.
-func (o CSINodeTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CSINodeTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CSINodeType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec is the specification of CSINode
-func (o CSINodeTypeOutput) Spec() CSINodeSpecPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *CSINodeSpec { return v.Spec }).(CSINodeSpecPtrOutput)
+func (o CSINodeTypeOutput) Spec() CSINodeSpecOutput {
+	return o.ApplyT(func(v CSINodeType) CSINodeSpec { return v.Spec }).(CSINodeSpecOutput)
 }
 
 type CSINodeTypeArrayOutput struct{ *pulumi.OutputState }
@@ -544,9 +544,9 @@ type CSINodeDriver struct {
 	// allocatable represents the volume resources of a node that are available for scheduling. This field is beta.
 	Allocatable *VolumeNodeResources `pulumi:"allocatable"`
 	// This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-	NodeID *string `pulumi:"nodeID"`
+	NodeID string `pulumi:"nodeID"`
 	// topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
 	TopologyKeys []string `pulumi:"topologyKeys"`
 }
@@ -568,9 +568,9 @@ type CSINodeDriverArgs struct {
 	// allocatable represents the volume resources of a node that are available for scheduling. This field is beta.
 	Allocatable VolumeNodeResourcesPtrInput `pulumi:"allocatable"`
 	// This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-	NodeID pulumi.StringPtrInput `pulumi:"nodeID"`
+	NodeID pulumi.StringInput `pulumi:"nodeID"`
 	// topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
 	TopologyKeys pulumi.StringArrayInput `pulumi:"topologyKeys"`
 }
@@ -634,13 +634,13 @@ func (o CSINodeDriverOutput) Allocatable() VolumeNodeResourcesPtrOutput {
 }
 
 // This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-func (o CSINodeDriverOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeDriver) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CSINodeDriverOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeDriver) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-func (o CSINodeDriverOutput) NodeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeDriver) *string { return v.NodeID }).(pulumi.StringPtrOutput)
+func (o CSINodeDriverOutput) NodeID() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeDriver) string { return v.NodeID }).(pulumi.StringOutput)
 }
 
 // topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
@@ -671,13 +671,13 @@ func (o CSINodeDriverArrayOutput) Index(i pulumi.IntInput) CSINodeDriverOutput {
 // CSINodeList is a collection of CSINode objects.
 type CSINodeListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items []CSINodeType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CSINodeListTypeInput is an input type that accepts CSINodeListTypeArgs and CSINodeListTypeOutput values.
@@ -695,13 +695,13 @@ type CSINodeListTypeInput interface {
 // CSINodeList is a collection of CSINode objects.
 type CSINodeListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items CSINodeTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CSINodeListTypeArgs) ElementType() reflect.Type {
@@ -732,8 +732,8 @@ func (o CSINodeListTypeOutput) ToCSINodeListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSINodeListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSINodeListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CSINode
@@ -742,13 +742,13 @@ func (o CSINodeListTypeOutput) Items() CSINodeTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSINodeListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSINodeListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSINodeListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CSINodeListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CSINodeListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CSINodeSpec holds information about the specification of all CSI drivers installed on a node
@@ -892,25 +892,25 @@ func (o CSINodeSpecPtrOutput) Drivers() CSINodeDriverArrayOutput {
 // StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
 type StorageClassType struct {
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion *bool `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion bool `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies []corev1.TopologySelectorTerm `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions []string `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters map[string]string `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner *string `pulumi:"provisioner"`
+	Provisioner string `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy *string `pulumi:"reclaimPolicy"`
+	ReclaimPolicy string `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode *string `pulumi:"volumeBindingMode"`
+	VolumeBindingMode string `pulumi:"volumeBindingMode"`
 }
 
 // StorageClassTypeInput is an input type that accepts StorageClassTypeArgs and StorageClassTypeOutput values.
@@ -930,25 +930,25 @@ type StorageClassTypeInput interface {
 // StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
 type StorageClassTypeArgs struct {
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion pulumi.BoolPtrInput `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion pulumi.BoolInput `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies corev1.TopologySelectorTermArrayInput `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions pulumi.StringArrayInput `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters pulumi.StringMapInput `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner pulumi.StringPtrInput `pulumi:"provisioner"`
+	Provisioner pulumi.StringInput `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy pulumi.StringPtrInput `pulumi:"reclaimPolicy"`
+	ReclaimPolicy pulumi.StringInput `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode pulumi.StringPtrInput `pulumi:"volumeBindingMode"`
+	VolumeBindingMode pulumi.StringInput `pulumi:"volumeBindingMode"`
 }
 
 func (StorageClassTypeArgs) ElementType() reflect.Type {
@@ -1007,8 +1007,8 @@ func (o StorageClassTypeOutput) ToStorageClassTypeOutputWithContext(ctx context.
 }
 
 // AllowVolumeExpansion shows whether the storage class allow volume expand
-func (o StorageClassTypeOutput) AllowVolumeExpansion() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *bool { return v.AllowVolumeExpansion }).(pulumi.BoolPtrOutput)
+func (o StorageClassTypeOutput) AllowVolumeExpansion() pulumi.BoolOutput {
+	return o.ApplyT(func(v StorageClassType) bool { return v.AllowVolumeExpansion }).(pulumi.BoolOutput)
 }
 
 // Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
@@ -1017,18 +1017,18 @@ func (o StorageClassTypeOutput) AllowedTopologies() corev1.TopologySelectorTermA
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StorageClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StorageClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o StorageClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o StorageClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v StorageClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
@@ -1042,18 +1042,18 @@ func (o StorageClassTypeOutput) Parameters() pulumi.StringMapOutput {
 }
 
 // Provisioner indicates the type of the provisioner.
-func (o StorageClassTypeOutput) Provisioner() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.Provisioner }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) Provisioner() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.Provisioner }).(pulumi.StringOutput)
 }
 
 // Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-func (o StorageClassTypeOutput) ReclaimPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.ReclaimPolicy }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) ReclaimPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.ReclaimPolicy }).(pulumi.StringOutput)
 }
 
 // VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-func (o StorageClassTypeOutput) VolumeBindingMode() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.VolumeBindingMode }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) VolumeBindingMode() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.VolumeBindingMode }).(pulumi.StringOutput)
 }
 
 type StorageClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1079,13 +1079,13 @@ func (o StorageClassTypeArrayOutput) Index(i pulumi.IntInput) StorageClassTypeOu
 // StorageClassList is a collection of storage classes.
 type StorageClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items []StorageClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // StorageClassListTypeInput is an input type that accepts StorageClassListTypeArgs and StorageClassListTypeOutput values.
@@ -1103,13 +1103,13 @@ type StorageClassListTypeInput interface {
 // StorageClassList is a collection of storage classes.
 type StorageClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items StorageClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (StorageClassListTypeArgs) ElementType() reflect.Type {
@@ -1140,8 +1140,8 @@ func (o StorageClassListTypeOutput) ToStorageClassListTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StorageClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StorageClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of StorageClasses
@@ -1150,13 +1150,13 @@ func (o StorageClassListTypeOutput) Items() StorageClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StorageClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StorageClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v StorageClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
@@ -1164,15 +1164,15 @@ func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec *VolumeAttachmentSpec `pulumi:"spec"`
+	Spec VolumeAttachmentSpec `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status *VolumeAttachmentStatus `pulumi:"status"`
+	Status VolumeAttachmentStatus `pulumi:"status"`
 }
 
 // VolumeAttachmentTypeInput is an input type that accepts VolumeAttachmentTypeArgs and VolumeAttachmentTypeOutput values.
@@ -1192,15 +1192,15 @@ type VolumeAttachmentTypeInput interface {
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrInput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecInput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrInput `pulumi:"status"`
+	Status VolumeAttachmentStatusInput `pulumi:"status"`
 }
 
 func (VolumeAttachmentTypeArgs) ElementType() reflect.Type {
@@ -1259,28 +1259,28 @@ func (o VolumeAttachmentTypeOutput) ToVolumeAttachmentTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecPtrOutput)
+func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecOutput)
 }
 
 // Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusPtrOutput)
+func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusOutput)
 }
 
 type VolumeAttachmentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1306,13 +1306,13 @@ func (o VolumeAttachmentTypeArrayOutput) Index(i pulumi.IntInput) VolumeAttachme
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items []VolumeAttachmentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // VolumeAttachmentListTypeInput is an input type that accepts VolumeAttachmentListTypeArgs and VolumeAttachmentListTypeOutput values.
@@ -1330,13 +1330,13 @@ type VolumeAttachmentListTypeInput interface {
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (VolumeAttachmentListTypeArgs) ElementType() reflect.Type {
@@ -1367,8 +1367,8 @@ func (o VolumeAttachmentListTypeOutput) ToVolumeAttachmentListTypeOutputWithCont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of VolumeAttachments
@@ -1377,13 +1377,13 @@ func (o VolumeAttachmentListTypeOutput) Items() VolumeAttachmentTypeArrayOutput 
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
@@ -1544,11 +1544,11 @@ func (o VolumeAttachmentSourcePtrOutput) PersistentVolumeName() pulumi.StringPtr
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpec struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher *string `pulumi:"attacher"`
+	Attacher string `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName *string `pulumi:"nodeName"`
+	NodeName string `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source *VolumeAttachmentSource `pulumi:"source"`
+	Source VolumeAttachmentSource `pulumi:"source"`
 }
 
 // VolumeAttachmentSpecInput is an input type that accepts VolumeAttachmentSpecArgs and VolumeAttachmentSpecOutput values.
@@ -1566,11 +1566,11 @@ type VolumeAttachmentSpecInput interface {
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpecArgs struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher pulumi.StringPtrInput `pulumi:"attacher"`
+	Attacher pulumi.StringInput `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName pulumi.StringPtrInput `pulumi:"nodeName"`
+	NodeName pulumi.StringInput `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source VolumeAttachmentSourcePtrInput `pulumi:"source"`
+	Source VolumeAttachmentSourceInput `pulumi:"source"`
 }
 
 func (VolumeAttachmentSpecArgs) ElementType() reflect.Type {
@@ -1653,18 +1653,18 @@ func (o VolumeAttachmentSpecOutput) ToVolumeAttachmentSpecPtrOutputWithContext(c
 }
 
 // Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.Attacher }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.Attacher }).(pulumi.StringOutput)
 }
 
 // The node that the volume should be attached to.
-func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.NodeName }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.NodeName }).(pulumi.StringOutput)
 }
 
 // Source represents the volume that should be attached.
-func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourcePtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourcePtrOutput)
+func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourceOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourceOutput)
 }
 
 type VolumeAttachmentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1691,7 +1691,7 @@ func (o VolumeAttachmentSpecPtrOutput) Attacher() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attacher
+		return &v.Attacher
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1701,7 +1701,7 @@ func (o VolumeAttachmentSpecPtrOutput) NodeName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NodeName
+		return &v.NodeName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1711,7 +1711,7 @@ func (o VolumeAttachmentSpecPtrOutput) Source() VolumeAttachmentSourcePtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Source
+		return &v.Source
 	}).(VolumeAttachmentSourcePtrOutput)
 }
 
@@ -1720,7 +1720,7 @@ type VolumeAttachmentStatus struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError *VolumeError `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached *bool `pulumi:"attached"`
+	Attached bool `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata map[string]string `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -1744,7 +1744,7 @@ type VolumeAttachmentStatusArgs struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError VolumeErrorPtrInput `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached pulumi.BoolPtrInput `pulumi:"attached"`
+	Attached pulumi.BoolInput `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata pulumi.StringMapInput `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -1836,8 +1836,8 @@ func (o VolumeAttachmentStatusOutput) AttachError() VolumeErrorPtrOutput {
 }
 
 // Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentStatus) *bool { return v.Attached }).(pulumi.BoolPtrOutput)
+func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolOutput {
+	return o.ApplyT(func(v VolumeAttachmentStatus) bool { return v.Attached }).(pulumi.BoolOutput)
 }
 
 // Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
@@ -1884,7 +1884,7 @@ func (o VolumeAttachmentStatusPtrOutput) Attached() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attached
+		return &v.Attached
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/kubernetes/storage/v1/storageClass.go
+++ b/sdk/go/kubernetes/storage/v1/storageClass.go
@@ -19,25 +19,25 @@ type StorageClass struct {
 	pulumi.CustomResourceState
 
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion pulumi.BoolPtrOutput `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion pulumi.BoolOutput `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies corev1.TopologySelectorTermArrayOutput `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions pulumi.StringArrayOutput `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters pulumi.StringMapOutput `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner pulumi.StringPtrOutput `pulumi:"provisioner"`
+	Provisioner pulumi.StringOutput `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy pulumi.StringPtrOutput `pulumi:"reclaimPolicy"`
+	ReclaimPolicy pulumi.StringOutput `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode pulumi.StringPtrOutput `pulumi:"volumeBindingMode"`
+	VolumeBindingMode pulumi.StringOutput `pulumi:"volumeBindingMode"`
 }
 
 // NewStorageClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/storageClassList.go
+++ b/sdk/go/kubernetes/storage/v1/storageClassList.go
@@ -16,13 +16,13 @@ type StorageClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items StorageClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewStorageClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1/volumeAttachment.go
@@ -18,15 +18,15 @@ type VolumeAttachment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrOutput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecOutput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrOutput `pulumi:"status"`
+	Status VolumeAttachmentStatusOutput `pulumi:"status"`
 }
 
 // NewVolumeAttachment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1/volumeAttachmentList.go
@@ -16,13 +16,13 @@ type VolumeAttachmentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewVolumeAttachmentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1alpha1/pulumiTypes.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/pulumiTypes.go
@@ -17,15 +17,15 @@ import (
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec *VolumeAttachmentSpec `pulumi:"spec"`
+	Spec VolumeAttachmentSpec `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status *VolumeAttachmentStatus `pulumi:"status"`
+	Status VolumeAttachmentStatus `pulumi:"status"`
 }
 
 // VolumeAttachmentTypeInput is an input type that accepts VolumeAttachmentTypeArgs and VolumeAttachmentTypeOutput values.
@@ -45,15 +45,15 @@ type VolumeAttachmentTypeInput interface {
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrInput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecInput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrInput `pulumi:"status"`
+	Status VolumeAttachmentStatusInput `pulumi:"status"`
 }
 
 func (VolumeAttachmentTypeArgs) ElementType() reflect.Type {
@@ -112,28 +112,28 @@ func (o VolumeAttachmentTypeOutput) ToVolumeAttachmentTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecPtrOutput)
+func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecOutput)
 }
 
 // Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusPtrOutput)
+func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusOutput)
 }
 
 type VolumeAttachmentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -159,13 +159,13 @@ func (o VolumeAttachmentTypeArrayOutput) Index(i pulumi.IntInput) VolumeAttachme
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items []VolumeAttachmentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // VolumeAttachmentListTypeInput is an input type that accepts VolumeAttachmentListTypeArgs and VolumeAttachmentListTypeOutput values.
@@ -183,13 +183,13 @@ type VolumeAttachmentListTypeInput interface {
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (VolumeAttachmentListTypeArgs) ElementType() reflect.Type {
@@ -220,8 +220,8 @@ func (o VolumeAttachmentListTypeOutput) ToVolumeAttachmentListTypeOutputWithCont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of VolumeAttachments
@@ -230,13 +230,13 @@ func (o VolumeAttachmentListTypeOutput) Items() VolumeAttachmentTypeArrayOutput 
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
@@ -397,11 +397,11 @@ func (o VolumeAttachmentSourcePtrOutput) PersistentVolumeName() pulumi.StringPtr
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpec struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher *string `pulumi:"attacher"`
+	Attacher string `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName *string `pulumi:"nodeName"`
+	NodeName string `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source *VolumeAttachmentSource `pulumi:"source"`
+	Source VolumeAttachmentSource `pulumi:"source"`
 }
 
 // VolumeAttachmentSpecInput is an input type that accepts VolumeAttachmentSpecArgs and VolumeAttachmentSpecOutput values.
@@ -419,11 +419,11 @@ type VolumeAttachmentSpecInput interface {
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpecArgs struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher pulumi.StringPtrInput `pulumi:"attacher"`
+	Attacher pulumi.StringInput `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName pulumi.StringPtrInput `pulumi:"nodeName"`
+	NodeName pulumi.StringInput `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source VolumeAttachmentSourcePtrInput `pulumi:"source"`
+	Source VolumeAttachmentSourceInput `pulumi:"source"`
 }
 
 func (VolumeAttachmentSpecArgs) ElementType() reflect.Type {
@@ -506,18 +506,18 @@ func (o VolumeAttachmentSpecOutput) ToVolumeAttachmentSpecPtrOutputWithContext(c
 }
 
 // Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.Attacher }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.Attacher }).(pulumi.StringOutput)
 }
 
 // The node that the volume should be attached to.
-func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.NodeName }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.NodeName }).(pulumi.StringOutput)
 }
 
 // Source represents the volume that should be attached.
-func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourcePtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourcePtrOutput)
+func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourceOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourceOutput)
 }
 
 type VolumeAttachmentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -544,7 +544,7 @@ func (o VolumeAttachmentSpecPtrOutput) Attacher() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attacher
+		return &v.Attacher
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -554,7 +554,7 @@ func (o VolumeAttachmentSpecPtrOutput) NodeName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NodeName
+		return &v.NodeName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -564,7 +564,7 @@ func (o VolumeAttachmentSpecPtrOutput) Source() VolumeAttachmentSourcePtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Source
+		return &v.Source
 	}).(VolumeAttachmentSourcePtrOutput)
 }
 
@@ -573,7 +573,7 @@ type VolumeAttachmentStatus struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError *VolumeError `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached *bool `pulumi:"attached"`
+	Attached bool `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata map[string]string `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -597,7 +597,7 @@ type VolumeAttachmentStatusArgs struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError VolumeErrorPtrInput `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached pulumi.BoolPtrInput `pulumi:"attached"`
+	Attached pulumi.BoolInput `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata pulumi.StringMapInput `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -689,8 +689,8 @@ func (o VolumeAttachmentStatusOutput) AttachError() VolumeErrorPtrOutput {
 }
 
 // Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentStatus) *bool { return v.Attached }).(pulumi.BoolPtrOutput)
+func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolOutput {
+	return o.ApplyT(func(v VolumeAttachmentStatus) bool { return v.Attached }).(pulumi.BoolOutput)
 }
 
 // Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
@@ -737,7 +737,7 @@ func (o VolumeAttachmentStatusPtrOutput) Attached() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attached
+		return &v.Attached
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/kubernetes/storage/v1alpha1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/volumeAttachment.go
@@ -18,15 +18,15 @@ type VolumeAttachment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrOutput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecOutput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrOutput `pulumi:"status"`
+	Status VolumeAttachmentStatusOutput `pulumi:"status"`
 }
 
 // NewVolumeAttachment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentList.go
@@ -16,13 +16,13 @@ type VolumeAttachmentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewVolumeAttachmentList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/csidriver.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csidriver.go
@@ -16,13 +16,13 @@ type CSIDriver struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec CSIDriverSpecPtrOutput `pulumi:"spec"`
+	Spec CSIDriverSpecOutput `pulumi:"spec"`
 }
 
 // NewCSIDriver registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/csidriverList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csidriverList.go
@@ -16,13 +16,13 @@ type CSIDriverList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items CSIDriverTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCSIDriverList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/csinode.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csinode.go
@@ -16,13 +16,13 @@ type CSINode struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec CSINodeSpecPtrOutput `pulumi:"spec"`
+	Spec CSINodeSpecOutput `pulumi:"spec"`
 }
 
 // NewCSINode registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/csinodeList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csinodeList.go
@@ -16,13 +16,13 @@ type CSINodeList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items CSINodeTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewCSINodeList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/storage/v1beta1/pulumiTypes.go
@@ -15,13 +15,13 @@ import (
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec *CSIDriverSpec `pulumi:"spec"`
+	Spec CSIDriverSpec `pulumi:"spec"`
 }
 
 // CSIDriverTypeInput is an input type that accepts CSIDriverTypeArgs and CSIDriverTypeOutput values.
@@ -39,13 +39,13 @@ type CSIDriverTypeInput interface {
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the CSI Driver.
-	Spec CSIDriverSpecPtrInput `pulumi:"spec"`
+	Spec CSIDriverSpecInput `pulumi:"spec"`
 }
 
 func (CSIDriverTypeArgs) ElementType() reflect.Type {
@@ -102,23 +102,23 @@ func (o CSIDriverTypeOutput) ToCSIDriverTypeOutputWithContext(ctx context.Contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSIDriverTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSIDriverTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSIDriverTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSIDriverTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSIDriverTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CSIDriverTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CSIDriverType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the CSI Driver.
-func (o CSIDriverTypeOutput) Spec() CSIDriverSpecPtrOutput {
-	return o.ApplyT(func(v CSIDriverType) *CSIDriverSpec { return v.Spec }).(CSIDriverSpecPtrOutput)
+func (o CSIDriverTypeOutput) Spec() CSIDriverSpecOutput {
+	return o.ApplyT(func(v CSIDriverType) CSIDriverSpec { return v.Spec }).(CSIDriverSpecOutput)
 }
 
 type CSIDriverTypeArrayOutput struct{ *pulumi.OutputState }
@@ -144,13 +144,13 @@ func (o CSIDriverTypeArrayOutput) Index(i pulumi.IntInput) CSIDriverTypeOutput {
 // CSIDriverList is a collection of CSIDriver objects.
 type CSIDriverListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items []CSIDriverType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CSIDriverListTypeInput is an input type that accepts CSIDriverListTypeArgs and CSIDriverListTypeOutput values.
@@ -168,13 +168,13 @@ type CSIDriverListTypeInput interface {
 // CSIDriverList is a collection of CSIDriver objects.
 type CSIDriverListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CSIDriver
 	Items CSIDriverTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CSIDriverListTypeArgs) ElementType() reflect.Type {
@@ -205,8 +205,8 @@ func (o CSIDriverListTypeOutput) ToCSIDriverListTypeOutputWithContext(ctx contex
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSIDriverListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSIDriverListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CSIDriver
@@ -215,13 +215,13 @@ func (o CSIDriverListTypeOutput) Items() CSIDriverTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSIDriverListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSIDriverListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSIDriverListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSIDriverListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CSIDriverListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CSIDriverListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CSIDriverListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CSIDriverSpec is the specification of a CSIDriver.
@@ -413,13 +413,13 @@ func (o CSIDriverSpecPtrOutput) VolumeLifecycleModes() pulumi.StringArrayOutput 
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 type CSINodeType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec *CSINodeSpec `pulumi:"spec"`
+	Spec CSINodeSpec `pulumi:"spec"`
 }
 
 // CSINodeTypeInput is an input type that accepts CSINodeTypeArgs and CSINodeTypeOutput values.
@@ -437,13 +437,13 @@ type CSINodeTypeInput interface {
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 type CSINodeTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// metadata.name must be the Kubernetes node name.
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// spec is the specification of CSINode
-	Spec CSINodeSpecPtrInput `pulumi:"spec"`
+	Spec CSINodeSpecInput `pulumi:"spec"`
 }
 
 func (CSINodeTypeArgs) ElementType() reflect.Type {
@@ -500,23 +500,23 @@ func (o CSINodeTypeOutput) ToCSINodeTypeOutputWithContext(ctx context.Context) C
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSINodeTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSINodeTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSINodeTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSINodeTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // metadata.name must be the Kubernetes node name.
-func (o CSINodeTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o CSINodeTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v CSINodeType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // spec is the specification of CSINode
-func (o CSINodeTypeOutput) Spec() CSINodeSpecPtrOutput {
-	return o.ApplyT(func(v CSINodeType) *CSINodeSpec { return v.Spec }).(CSINodeSpecPtrOutput)
+func (o CSINodeTypeOutput) Spec() CSINodeSpecOutput {
+	return o.ApplyT(func(v CSINodeType) CSINodeSpec { return v.Spec }).(CSINodeSpecOutput)
 }
 
 type CSINodeTypeArrayOutput struct{ *pulumi.OutputState }
@@ -544,9 +544,9 @@ type CSINodeDriver struct {
 	// allocatable represents the volume resources of a node that are available for scheduling.
 	Allocatable *VolumeNodeResources `pulumi:"allocatable"`
 	// This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-	NodeID *string `pulumi:"nodeID"`
+	NodeID string `pulumi:"nodeID"`
 	// topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
 	TopologyKeys []string `pulumi:"topologyKeys"`
 }
@@ -568,9 +568,9 @@ type CSINodeDriverArgs struct {
 	// allocatable represents the volume resources of a node that are available for scheduling.
 	Allocatable VolumeNodeResourcesPtrInput `pulumi:"allocatable"`
 	// This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name pulumi.StringInput `pulumi:"name"`
 	// nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-	NodeID pulumi.StringPtrInput `pulumi:"nodeID"`
+	NodeID pulumi.StringInput `pulumi:"nodeID"`
 	// topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
 	TopologyKeys pulumi.StringArrayInput `pulumi:"topologyKeys"`
 }
@@ -634,13 +634,13 @@ func (o CSINodeDriverOutput) Allocatable() VolumeNodeResourcesPtrOutput {
 }
 
 // This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
-func (o CSINodeDriverOutput) Name() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeDriver) *string { return v.Name }).(pulumi.StringPtrOutput)
+func (o CSINodeDriverOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeDriver) string { return v.Name }).(pulumi.StringOutput)
 }
 
 // nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
-func (o CSINodeDriverOutput) NodeID() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeDriver) *string { return v.NodeID }).(pulumi.StringPtrOutput)
+func (o CSINodeDriverOutput) NodeID() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeDriver) string { return v.NodeID }).(pulumi.StringOutput)
 }
 
 // topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
@@ -671,13 +671,13 @@ func (o CSINodeDriverArrayOutput) Index(i pulumi.IntInput) CSINodeDriverOutput {
 // CSINodeList is a collection of CSINode objects.
 type CSINodeListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items []CSINodeType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // CSINodeListTypeInput is an input type that accepts CSINodeListTypeArgs and CSINodeListTypeOutput values.
@@ -695,13 +695,13 @@ type CSINodeListTypeInput interface {
 // CSINodeList is a collection of CSINode objects.
 type CSINodeListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// items is the list of CSINode
 	Items CSINodeTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (CSINodeListTypeArgs) ElementType() reflect.Type {
@@ -732,8 +732,8 @@ func (o CSINodeListTypeOutput) ToCSINodeListTypeOutputWithContext(ctx context.Co
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o CSINodeListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o CSINodeListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // items is the list of CSINode
@@ -742,13 +742,13 @@ func (o CSINodeListTypeOutput) Items() CSINodeTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o CSINodeListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o CSINodeListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v CSINodeListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o CSINodeListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v CSINodeListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o CSINodeListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v CSINodeListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // CSINodeSpec holds information about the specification of all CSI drivers installed on a node
@@ -892,25 +892,25 @@ func (o CSINodeSpecPtrOutput) Drivers() CSINodeDriverArrayOutput {
 // StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
 type StorageClassType struct {
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion *bool `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion bool `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies []corev1.TopologySelectorTerm `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions []string `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters map[string]string `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner *string `pulumi:"provisioner"`
+	Provisioner string `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy *string `pulumi:"reclaimPolicy"`
+	ReclaimPolicy string `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode *string `pulumi:"volumeBindingMode"`
+	VolumeBindingMode string `pulumi:"volumeBindingMode"`
 }
 
 // StorageClassTypeInput is an input type that accepts StorageClassTypeArgs and StorageClassTypeOutput values.
@@ -930,25 +930,25 @@ type StorageClassTypeInput interface {
 // StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
 type StorageClassTypeArgs struct {
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion pulumi.BoolPtrInput `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion pulumi.BoolInput `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies corev1.TopologySelectorTermArrayInput `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions pulumi.StringArrayInput `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters pulumi.StringMapInput `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner pulumi.StringPtrInput `pulumi:"provisioner"`
+	Provisioner pulumi.StringInput `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy pulumi.StringPtrInput `pulumi:"reclaimPolicy"`
+	ReclaimPolicy pulumi.StringInput `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode pulumi.StringPtrInput `pulumi:"volumeBindingMode"`
+	VolumeBindingMode pulumi.StringInput `pulumi:"volumeBindingMode"`
 }
 
 func (StorageClassTypeArgs) ElementType() reflect.Type {
@@ -1007,8 +1007,8 @@ func (o StorageClassTypeOutput) ToStorageClassTypeOutputWithContext(ctx context.
 }
 
 // AllowVolumeExpansion shows whether the storage class allow volume expand
-func (o StorageClassTypeOutput) AllowVolumeExpansion() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *bool { return v.AllowVolumeExpansion }).(pulumi.BoolPtrOutput)
+func (o StorageClassTypeOutput) AllowVolumeExpansion() pulumi.BoolOutput {
+	return o.ApplyT(func(v StorageClassType) bool { return v.AllowVolumeExpansion }).(pulumi.BoolOutput)
 }
 
 // Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
@@ -1017,18 +1017,18 @@ func (o StorageClassTypeOutput) AllowedTopologies() corev1.TopologySelectorTermA
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StorageClassTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StorageClassTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o StorageClassTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o StorageClassTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v StorageClassType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
@@ -1042,18 +1042,18 @@ func (o StorageClassTypeOutput) Parameters() pulumi.StringMapOutput {
 }
 
 // Provisioner indicates the type of the provisioner.
-func (o StorageClassTypeOutput) Provisioner() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.Provisioner }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) Provisioner() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.Provisioner }).(pulumi.StringOutput)
 }
 
 // Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-func (o StorageClassTypeOutput) ReclaimPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.ReclaimPolicy }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) ReclaimPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.ReclaimPolicy }).(pulumi.StringOutput)
 }
 
 // VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-func (o StorageClassTypeOutput) VolumeBindingMode() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassType) *string { return v.VolumeBindingMode }).(pulumi.StringPtrOutput)
+func (o StorageClassTypeOutput) VolumeBindingMode() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassType) string { return v.VolumeBindingMode }).(pulumi.StringOutput)
 }
 
 type StorageClassTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1079,13 +1079,13 @@ func (o StorageClassTypeArrayOutput) Index(i pulumi.IntInput) StorageClassTypeOu
 // StorageClassList is a collection of storage classes.
 type StorageClassListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items []StorageClassType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // StorageClassListTypeInput is an input type that accepts StorageClassListTypeArgs and StorageClassListTypeOutput values.
@@ -1103,13 +1103,13 @@ type StorageClassListTypeInput interface {
 // StorageClassList is a collection of storage classes.
 type StorageClassListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items StorageClassTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (StorageClassListTypeArgs) ElementType() reflect.Type {
@@ -1140,8 +1140,8 @@ func (o StorageClassListTypeOutput) ToStorageClassListTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o StorageClassListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o StorageClassListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of StorageClasses
@@ -1150,13 +1150,13 @@ func (o StorageClassListTypeOutput) Items() StorageClassTypeArrayOutput {
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o StorageClassListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o StorageClassListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v StorageClassListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v StorageClassListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v StorageClassListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
@@ -1164,15 +1164,15 @@ func (o StorageClassListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata metav1.ObjectMeta `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec *VolumeAttachmentSpec `pulumi:"spec"`
+	Spec VolumeAttachmentSpec `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status *VolumeAttachmentStatus `pulumi:"status"`
+	Status VolumeAttachmentStatus `pulumi:"status"`
 }
 
 // VolumeAttachmentTypeInput is an input type that accepts VolumeAttachmentTypeArgs and VolumeAttachmentTypeOutput values.
@@ -1192,15 +1192,15 @@ type VolumeAttachmentTypeInput interface {
 // VolumeAttachment objects are non-namespaced.
 type VolumeAttachmentTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaInput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrInput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecInput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrInput `pulumi:"status"`
+	Status VolumeAttachmentStatusInput `pulumi:"status"`
 }
 
 func (VolumeAttachmentTypeArgs) ElementType() reflect.Type {
@@ -1259,28 +1259,28 @@ func (o VolumeAttachmentTypeOutput) ToVolumeAttachmentTypeOutputWithContext(ctx 
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaPtrOutput)
+func (o VolumeAttachmentTypeOutput) Metadata() metav1.ObjectMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) metav1.ObjectMeta { return v.Metadata }).(metav1.ObjectMetaOutput)
 }
 
 // Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecPtrOutput)
+func (o VolumeAttachmentTypeOutput) Spec() VolumeAttachmentSpecOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentSpec { return v.Spec }).(VolumeAttachmentSpecOutput)
 }
 
 // Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentType) *VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusPtrOutput)
+func (o VolumeAttachmentTypeOutput) Status() VolumeAttachmentStatusOutput {
+	return o.ApplyT(func(v VolumeAttachmentType) VolumeAttachmentStatus { return v.Status }).(VolumeAttachmentStatusOutput)
 }
 
 type VolumeAttachmentTypeArrayOutput struct{ *pulumi.OutputState }
@@ -1306,13 +1306,13 @@ func (o VolumeAttachmentTypeArrayOutput) Index(i pulumi.IntInput) VolumeAttachme
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListType struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion *string `pulumi:"apiVersion"`
+	ApiVersion string `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items []VolumeAttachmentType `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind *string `pulumi:"kind"`
+	Kind string `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata *metav1.ListMeta `pulumi:"metadata"`
+	Metadata metav1.ListMeta `pulumi:"metadata"`
 }
 
 // VolumeAttachmentListTypeInput is an input type that accepts VolumeAttachmentListTypeArgs and VolumeAttachmentListTypeOutput values.
@@ -1330,13 +1330,13 @@ type VolumeAttachmentListTypeInput interface {
 // VolumeAttachmentList is a collection of VolumeAttachment objects.
 type VolumeAttachmentListTypeArgs struct {
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrInput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringInput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayInput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrInput `pulumi:"kind"`
+	Kind pulumi.StringInput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrInput `pulumi:"metadata"`
+	Metadata metav1.ListMetaInput `pulumi:"metadata"`
 }
 
 func (VolumeAttachmentListTypeArgs) ElementType() reflect.Type {
@@ -1367,8 +1367,8 @@ func (o VolumeAttachmentListTypeOutput) ToVolumeAttachmentListTypeOutputWithCont
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.ApiVersion }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) ApiVersion() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.ApiVersion }).(pulumi.StringOutput)
 }
 
 // Items is the list of VolumeAttachments
@@ -1377,13 +1377,13 @@ func (o VolumeAttachmentListTypeOutput) Items() VolumeAttachmentTypeArrayOutput 
 }
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *string { return v.Kind }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Kind() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) string { return v.Kind }).(pulumi.StringOutput)
 }
 
 // Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentListType) *metav1.ListMeta { return v.Metadata }).(metav1.ListMetaPtrOutput)
+func (o VolumeAttachmentListTypeOutput) Metadata() metav1.ListMetaOutput {
+	return o.ApplyT(func(v VolumeAttachmentListType) metav1.ListMeta { return v.Metadata }).(metav1.ListMetaOutput)
 }
 
 // VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
@@ -1544,11 +1544,11 @@ func (o VolumeAttachmentSourcePtrOutput) PersistentVolumeName() pulumi.StringPtr
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpec struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher *string `pulumi:"attacher"`
+	Attacher string `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName *string `pulumi:"nodeName"`
+	NodeName string `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source *VolumeAttachmentSource `pulumi:"source"`
+	Source VolumeAttachmentSource `pulumi:"source"`
 }
 
 // VolumeAttachmentSpecInput is an input type that accepts VolumeAttachmentSpecArgs and VolumeAttachmentSpecOutput values.
@@ -1566,11 +1566,11 @@ type VolumeAttachmentSpecInput interface {
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
 type VolumeAttachmentSpecArgs struct {
 	// Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-	Attacher pulumi.StringPtrInput `pulumi:"attacher"`
+	Attacher pulumi.StringInput `pulumi:"attacher"`
 	// The node that the volume should be attached to.
-	NodeName pulumi.StringPtrInput `pulumi:"nodeName"`
+	NodeName pulumi.StringInput `pulumi:"nodeName"`
 	// Source represents the volume that should be attached.
-	Source VolumeAttachmentSourcePtrInput `pulumi:"source"`
+	Source VolumeAttachmentSourceInput `pulumi:"source"`
 }
 
 func (VolumeAttachmentSpecArgs) ElementType() reflect.Type {
@@ -1653,18 +1653,18 @@ func (o VolumeAttachmentSpecOutput) ToVolumeAttachmentSpecPtrOutputWithContext(c
 }
 
 // Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.Attacher }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) Attacher() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.Attacher }).(pulumi.StringOutput)
 }
 
 // The node that the volume should be attached to.
-func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *string { return v.NodeName }).(pulumi.StringPtrOutput)
+func (o VolumeAttachmentSpecOutput) NodeName() pulumi.StringOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) string { return v.NodeName }).(pulumi.StringOutput)
 }
 
 // Source represents the volume that should be attached.
-func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourcePtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentSpec) *VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourcePtrOutput)
+func (o VolumeAttachmentSpecOutput) Source() VolumeAttachmentSourceOutput {
+	return o.ApplyT(func(v VolumeAttachmentSpec) VolumeAttachmentSource { return v.Source }).(VolumeAttachmentSourceOutput)
 }
 
 type VolumeAttachmentSpecPtrOutput struct{ *pulumi.OutputState }
@@ -1691,7 +1691,7 @@ func (o VolumeAttachmentSpecPtrOutput) Attacher() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attacher
+		return &v.Attacher
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1701,7 +1701,7 @@ func (o VolumeAttachmentSpecPtrOutput) NodeName() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.NodeName
+		return &v.NodeName
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1711,7 +1711,7 @@ func (o VolumeAttachmentSpecPtrOutput) Source() VolumeAttachmentSourcePtrOutput 
 		if v == nil {
 			return nil
 		}
-		return v.Source
+		return &v.Source
 	}).(VolumeAttachmentSourcePtrOutput)
 }
 
@@ -1720,7 +1720,7 @@ type VolumeAttachmentStatus struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError *VolumeError `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached *bool `pulumi:"attached"`
+	Attached bool `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata map[string]string `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -1744,7 +1744,7 @@ type VolumeAttachmentStatusArgs struct {
 	// The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachError VolumeErrorPtrInput `pulumi:"attachError"`
 	// Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-	Attached pulumi.BoolPtrInput `pulumi:"attached"`
+	Attached pulumi.BoolInput `pulumi:"attached"`
 	// Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
 	AttachmentMetadata pulumi.StringMapInput `pulumi:"attachmentMetadata"`
 	// The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
@@ -1836,8 +1836,8 @@ func (o VolumeAttachmentStatusOutput) AttachError() VolumeErrorPtrOutput {
 }
 
 // Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
-func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v VolumeAttachmentStatus) *bool { return v.Attached }).(pulumi.BoolPtrOutput)
+func (o VolumeAttachmentStatusOutput) Attached() pulumi.BoolOutput {
+	return o.ApplyT(func(v VolumeAttachmentStatus) bool { return v.Attached }).(pulumi.BoolOutput)
 }
 
 // Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
@@ -1884,7 +1884,7 @@ func (o VolumeAttachmentStatusPtrOutput) Attached() pulumi.BoolPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return v.Attached
+		return &v.Attached
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/kubernetes/storage/v1beta1/storageClass.go
+++ b/sdk/go/kubernetes/storage/v1beta1/storageClass.go
@@ -19,25 +19,25 @@ type StorageClass struct {
 	pulumi.CustomResourceState
 
 	// AllowVolumeExpansion shows whether the storage class allow volume expand
-	AllowVolumeExpansion pulumi.BoolPtrOutput `pulumi:"allowVolumeExpansion"`
+	AllowVolumeExpansion pulumi.BoolOutput `pulumi:"allowVolumeExpansion"`
 	// Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
 	AllowedTopologies corev1.TopologySelectorTermArrayOutput `pulumi:"allowedTopologies"`
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
 	MountOptions pulumi.StringArrayOutput `pulumi:"mountOptions"`
 	// Parameters holds the parameters for the provisioner that should create volumes of this storage class.
 	Parameters pulumi.StringMapOutput `pulumi:"parameters"`
 	// Provisioner indicates the type of the provisioner.
-	Provisioner pulumi.StringPtrOutput `pulumi:"provisioner"`
+	Provisioner pulumi.StringOutput `pulumi:"provisioner"`
 	// Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
-	ReclaimPolicy pulumi.StringPtrOutput `pulumi:"reclaimPolicy"`
+	ReclaimPolicy pulumi.StringOutput `pulumi:"reclaimPolicy"`
 	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
-	VolumeBindingMode pulumi.StringPtrOutput `pulumi:"volumeBindingMode"`
+	VolumeBindingMode pulumi.StringOutput `pulumi:"volumeBindingMode"`
 }
 
 // NewStorageClass registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/storageClassList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/storageClassList.go
@@ -16,13 +16,13 @@ type StorageClassList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of StorageClasses
 	Items StorageClassTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewStorageClassList registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1beta1/volumeAttachment.go
@@ -18,15 +18,15 @@ type VolumeAttachment struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ObjectMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ObjectMetaOutput `pulumi:"metadata"`
 	// Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-	Spec VolumeAttachmentSpecPtrOutput `pulumi:"spec"`
+	Spec VolumeAttachmentSpecOutput `pulumi:"spec"`
 	// Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
-	Status VolumeAttachmentStatusPtrOutput `pulumi:"status"`
+	Status VolumeAttachmentStatusOutput `pulumi:"status"`
 }
 
 // NewVolumeAttachment registers a new resource with the given unique name, arguments, and options.

--- a/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentList.go
@@ -16,13 +16,13 @@ type VolumeAttachmentList struct {
 	pulumi.CustomResourceState
 
 	// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-	ApiVersion pulumi.StringPtrOutput `pulumi:"apiVersion"`
+	ApiVersion pulumi.StringOutput `pulumi:"apiVersion"`
 	// Items is the list of VolumeAttachments
 	Items VolumeAttachmentTypeArrayOutput `pulumi:"items"`
 	// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Kind pulumi.StringOutput `pulumi:"kind"`
 	// Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	Metadata metav1.ListMetaPtrOutput `pulumi:"metadata"`
+	Metadata metav1.ListMetaOutput `pulumi:"metadata"`
 }
 
 // NewVolumeAttachmentList registers a new resource with the given unique name, arguments, and options.


### PR DESCRIPTION
A part of https://github.com/pulumi/pulumi-kubernetes/issues/1084
The .NET codegen is not replaced yet, but it's a step towards. The actual codegen required some changes in pulumi/pulumi.