### PR TITLE
fix(customresources): use a 3-way merge patch instead of strategic merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+-   fix(customresources): use a 3-way merge patch instead of strategic merge. (https://github.com/pulumi/pulumi-kubernetes/pull/1095)
 -   Fix required input props in Go SDK. (https://github.com/pulumi/pulumi-kubernetes/pull/1090)
 -   Update Go SDK using latest codegen packages. (https://github.com/pulumi/pulumi-kubernetes/pull/1089)
 -   Fix schema type for Fields and RawExtension. (https://github.com/pulumi/pulumi-kubernetes/pull/1086)

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -188,6 +188,35 @@ func TestAccHelmLocal(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccPrometheusOperator(t *testing.T) {
+	skipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         path.Join(getCwd(t), "prometheus-operator"),
+			SkipRefresh: true,
+			ExtraRuntimeValidation: func(
+				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+			) {
+				assert.NotNil(t, stackInfo.Deployment)
+				assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
+			},
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      path.Join(getCwd(t), "prometheus-operator", "steps"),
+					Additive: true,
+					ExtraRuntimeValidation: func(
+						t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+					) {
+						assert.NotNil(t, stackInfo.Deployment)
+						assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
+					},
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccMariadb(t *testing.T) {
 	skipIfShort(t)
 	test := getBaseOptions(t).

--- a/tests/examples/prometheus-operator/Pulumi.yaml
+++ b/tests/examples/prometheus-operator/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: prometheus-operator
+description: The CoreOS Prometheus Operator
+runtime: nodejs

--- a/tests/examples/prometheus-operator/index.ts
+++ b/tests/examples/prometheus-operator/index.ts
@@ -1,0 +1,78 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// PrometheusOperatorArgs are the options to configure on the CoreOS
+// PrometheusOperator.
+interface PrometheusOperatorArgs {
+    namespace: pulumi.Input<string>;
+    version?: string;
+}
+
+// PrometheusOperator implements the CoreOS Prometheus Operator.
+export class PrometheusOperator extends pulumi.ComponentResource {
+    public readonly configFile: k8s.yaml.ConfigFile;
+    constructor(
+        name: string,
+        args: PrometheusOperatorArgs,
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('pulumi:monitoring/v1:PrometheusOperator', name, {}, opts);
+
+        this.configFile = new k8s.yaml.ConfigFile(
+            name,
+            {
+                file: `https://github.com/coreos/prometheus-operator/raw/release-${args.version || '0.38'}/bundle.yaml`,
+                transformations: [
+                    obj => {
+                        if (obj.metadata.namespace) {
+                            obj.metadata.namespace = args.namespace;
+                        }
+                        if (obj.kind === 'ClusterRoleBinding') {
+                            obj.subjects[0].namespace = args.namespace;
+                        }
+                    },
+                ],
+            }, { parent: this });
+    }
+}
+
+// Create the Prometheus Operator.
+const prometheusOperator = new PrometheusOperator("prometheus", {
+    namespace: "default",
+});
+
+// Create the Prometheus Operator ServiceMonitor.
+const myMonitoring = new k8s.apiextensions.CustomResource('my-monitoring', {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    spec: {
+        selector: {
+            matchLabels: { app: 'my-app' },
+        },
+        endpoints: [
+            {
+                port: 'http',
+                interval: '65s',
+                // start with the following
+                relabelings: [
+                    {
+                        regex: '(.*)',
+                        targetLabel: 'stackdriver',
+                        replacement: 'true',
+                        action: 'replace'
+                    }
+                ],
+                // try to add the following in replacement of above in steps/step1.ts
+                // metricRelabelings: [
+                //   {
+                //     sourceLabels: ['__name__'],
+                //     regex: 'typhoon_(.*)',
+                //     targetLabel: 'stackdriver',
+                //     replacement: 'true',
+                //     action: 'replace'
+                //   }
+                // ]
+            },
+        ],
+    },
+}, {dependsOn: prometheusOperator});

--- a/tests/examples/prometheus-operator/package.json
+++ b/tests/examples/prometheus-operator/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "prometheus-operator",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/examples/prometheus-operator/step1/index.ts
+++ b/tests/examples/prometheus-operator/step1/index.ts
@@ -1,0 +1,78 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// PrometheusOperatorArgs are the options to configure on the CoreOS
+// PrometheusOperator.
+interface PrometheusOperatorArgs {
+    namespace: pulumi.Input<string>;
+    version?: string;
+}
+
+// PrometheusOperator implements the CoreOS Prometheus Operator.
+export class PrometheusOperator extends pulumi.ComponentResource {
+    public readonly configFile: k8s.yaml.ConfigFile;
+    constructor(
+        name: string,
+        args: PrometheusOperatorArgs,
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('pulumi:monitoring/v1:PrometheusOperator', name, {}, opts);
+
+        this.configFile = new k8s.yaml.ConfigFile(
+            name,
+            {
+                file: `https://github.com/coreos/prometheus-operator/raw/release-${args.version || '0.38'}/bundle.yaml`,
+                transformations: [
+                    obj => {
+                        if (obj.metadata.namespace) {
+                            obj.metadata.namespace = args.namespace;
+                        }
+                        if (obj.kind === 'ClusterRoleBinding') {
+                            obj.subjects[0].namespace = args.namespace;
+                        }
+                    },
+                ],
+            }, { parent: this });
+    }
+}
+
+// Create the Prometheus Operator.
+const prometheusOperator = new PrometheusOperator("prometheus", {
+    namespace: "default",
+});
+
+// Create the Prometheus Operator ServiceMonitor.
+const myMonitoring = new k8s.apiextensions.CustomResource('my-monitoring', {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    spec: {
+        selector: {
+            matchLabels: { app: 'my-app' },
+        },
+        endpoints: [
+            {
+                port: 'http',
+                interval: '65s',
+                // removing the following in index.ts in favor of below 
+                // relabelings: [
+                //   {
+                //     regex: '(.*)',
+                //     targetLabel: 'stackdriver',
+                //     replacement: 'true',
+                //     action: 'replace'
+                //   }
+                // ],
+                // add the following in replacement of above in index.ts
+                metricRelabelings: [
+                    {
+                        sourceLabels: ['__name__'],
+                        regex: 'typhoon_(.*)',
+                        targetLabel: 'stackdriver',
+                        replacement: 'true',
+                        action: 'replace'
+                    }
+                ]
+            },
+        ],
+    },
+}, {dependsOn: prometheusOperator});

--- a/tests/examples/prometheus-operator/tsconfig.json
+++ b/tests/examples/prometheus-operator/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

CustomResources do not support [JSON strategic merges](https://tools.ietf.org/html/rfc6902) on patch updates.

Instead, they require a [JSON 3-way merge patch](https://tools.ietf.org/html/rfc7386) to properly apply the patch.

CustomResource kinds now are treated separately from other known k8s kinds in
order to apply the proper patch.

A new [CoreOS prometheus-operator](https://github.com/coreos/prometheus-operator) test with a step update is included to validate this update path.
### Related issues (optional)

Fixes #1061
