### PR TITLE
cleanup(Makefile): rm unused publish_tgz to S3 as we publish to npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,6 @@ check_clean_worktree:
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: only_build check_clean_worktree publish_tgz only_test publish_packages
+travis_push: only_build check_clean_worktree only_test publish_packages
 travis_pull_request: only_build check_clean_worktree only_test
 travis_api: all


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

cleanup(Makefile): rm unused publish_tgz to S3 as we publish to npm

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
