### PR TITLE
Use include-crds flags when using helm v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ install:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$(go env GOPATH)/bin" "v1.24.0"
 
     # Install Helm CLI. Do not install Tiller.
-    - curl -LO  https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz
-    - tar -xvf helm-v3.0.0-linux-amd64.tar.gz
+    - curl -LO  https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz
+    - tar -xvf helm-v3.2.1-linux-amd64.tar.gz
     - sudo mv linux-amd64/helm /usr/local/bin
     - helm repo add stable https://kubernetes-charts.storage.googleapis.com/
     - helm repo update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Support helm v3 `include-crds` argument. (https://github.com/pulumi/pulumi-kubernetes/pull/1102)
+
 ## 2.1.1 (May 8, 2020)
 
 -   Python and .NET packages failed to publish for 2.1.0, so bumping release version.

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -219,7 +219,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
                 // --include-crds is available in helm v3.1+ so check for a regex matching that version
-                let r = RegExp('(?:^|\W)v3.[1-9](?:$|\W)');
+                let r = RegExp('^v3\.[1-9]');
                 if (r.test(helmVer)) {
                     cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 } else {

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -218,8 +218,8 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Client: v2.16.7+g5f2584f
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
-                // We can reasonably assume helm v3 if the version starts with v3
-                let r = RegExp('^v3.[1-9]*');
+                // --include-crds is available in helm v3.1+ so check for a regex matching that version
+                let r = RegExp('(?:^|\W)v3.[1-9](?:$|\W)');
                 if (r.test(helmVer)) {
                     cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 } else {

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -206,7 +206,7 @@ export class Chart extends yaml.CollectionComponentResource {
                     : "";
 
                 // Check the helm version - v2 or v3
-                let helmVerCmd = `helm version --short`;
+                let helmVerCmd = `helm version --short || true`;
                 const helmVer = execSync(
                     helmVerCmd,
                     {
@@ -218,11 +218,12 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Client: v2.16.7+g5f2584f
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
-                // We can reasonably assume helm v2 if the version starts with Client
-                if (helmVer.startsWith("Client")) {
-                    cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
-                } else {
+                // We can reasonably assume helm v3 if the version starts with v3
+                let r = RegExp('^v3.[1-9]*');
+                if (r.test(helmVer)) {
                     cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+                } else {
+                    cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 }
 
                 const yamlStream = execSync(

--- a/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v2/helm.ts
@@ -214,16 +214,14 @@ export class Chart extends yaml.CollectionComponentResource {
                     },
                 ).toString();
 
+                cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 // Helm v2 returns version like this:
                 // Client: v2.16.7+g5f2584f
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
                 // --include-crds is available in helm v3.1+ so check for a regex matching that version
-                let r = RegExp('^v3\.[1-9]');
-                if (r.test(helmVer)) {
-                    cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
-                } else {
-                    cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+                if (RegExp('^v3\.[1-9]').test(helmVer)) {
+                    cmd += ` --include-crds`
                 }
 
                 const yamlStream = execSync(

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -5,6 +5,7 @@ import json
 import os.path
 import shutil
 import subprocess
+import re
 from tempfile import mkdtemp, mkstemp
 from typing import Any, Callable, List, Optional, TextIO, Tuple, Union
 
@@ -290,12 +291,11 @@ def _is_helm_v3() -> bool:
     """
     output = subprocess.run("helm version --short", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
-
-    """ 
-    We return the inverse: if the version string starts with "Client"
-    we are not helm v3
     """
-    return not version.startswith("Client")
+    --include-crds is available in helm v3.1+ so check for a regex matching that version
+    """
+    if re.search("^v3.[1-9]*", version):
+        return True
     
 
 

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -281,6 +281,8 @@ def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     return yaml_str
 
 def _is_helm_v3() -> bool:
+
+    cmd: List[str] = ['helm', 'version', '--short']
     
     """ 
     Helm v2 returns version like this:
@@ -289,14 +291,13 @@ def _is_helm_v3() -> bool:
     v3.1.2+gd878d4d
     We can reasonably assume helm v2 if the version starts with Client 
     """
-    output = subprocess.run("helm version --short", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
+    output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
     """
     --include-crds is available in helm v3.1+ so check for a regex matching that version
     """
-    if re.search("^v3.[1-9]*", version):
-        return True
-    
+    regexp = re.compile(r'(?:^|\W)v3.[1-9](?:$|\W)')
+    return(bool(regexp.search(version)))
 
 
 def _write_override_file(all_config: Tuple[TextIO, str]) -> None:

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -357,7 +357,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
     pulumi.Output.all(file, data).apply(_write_override_file)
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
-    crd_arg = [ '--include-crds' ] if _is_helm_v3 else []
+    crd_arg = [ '--include-crds' ] if _is_helm_v3() else []
 
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -289,14 +289,11 @@ def _is_helm_v3() -> bool:
     Client: v2.16.7+g5f2584f
     Helm v3 returns a version like this:
     v3.1.2+gd878d4d
-    We can reasonably assume helm v2 if the version starts with Client 
+    --include-crds is available in helm v3.1+ so check for a regex matching that version
     """
     output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
-    """
-    --include-crds is available in helm v3.1+ so check for a regex matching that version
-    """
-    regexp = re.compile(r'(?:^|\W)v3.[1-9](?:$|\W)')
+    regexp = re.compile(r'^v3.\[1-9]')
     return(bool(regexp.search(version)))
 
 

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -10,8 +10,6 @@ using System.Text.Json;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
 
-
-
 namespace Pulumi.Kubernetes.Helm
 {
     public abstract class ChartBase : CollectionComponentResource
@@ -87,9 +85,6 @@ namespace Pulumi.Kubernetes.Helm
                     var data = JsonSerializer.Serialize(cfgBase.Values);
                     File.WriteAllText(overrides, data);
 
-                    // Get helm version
-                    var helmv3 = IsHelmV3();
-
                     // Does not require Tiller. From the `helm template` documentation:
                     //
                     // >  Render chart templates locally and display the output.
@@ -117,7 +112,7 @@ namespace Pulumi.Kubernetes.Helm
                         flags.Add(cfgBase.Namespace);
                     }
 
-                    if (helmv3)
+                    if (IsHelmV3())
                     {
                         flags.Add("--include-crds");
                     }
@@ -154,9 +149,9 @@ namespace Pulumi.Kubernetes.Helm
             // Client: v2.16.7+g5f2584f
             // Helm v3 returns a version like this:
             // v3.1.2+gd878d4d
-            // We can reasonably assume helm v3 if the version starts with v3
+            // --include-crds is available in helm v3.1+ so check for a regex matching that version
             var version = Utilities.ExecuteCommand("helm", flags, env);
-            Regex r = new Regex(@"(?:^|\W)v3.[1-9](?:$|\W)");
+            Regex r = new Regex(@"^v3\.[1-9]");
             return r.IsMatch(version);
         }
 

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -156,7 +156,7 @@ namespace Pulumi.Kubernetes.Helm
             // v3.1.2+gd878d4d
             // We can reasonably assume helm v3 if the version starts with v3
             var version = Utilities.ExecuteCommand("helm", flags, env);
-            Regex r = new Regex(@"^v3.[1-9]*");
+            Regex r = new Regex(@"(?:^|\W)v3.[1-9](?:$|\W)");
             return r.IsMatch(version);
         }
 

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -5,9 +5,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
+
+
 
 namespace Pulumi.Kubernetes.Helm
 {
@@ -151,9 +154,10 @@ namespace Pulumi.Kubernetes.Helm
             // Client: v2.16.7+g5f2584f
             // Helm v3 returns a version like this:
             // v3.1.2+gd878d4d
-            // We can reasonably assume helm v2 if the version starts with Client
+            // We can reasonably assume helm v3 if the version starts with v3
             var version = Utilities.ExecuteCommand("helm", flags, env);
-            return !version.StartsWith("Client");
+            Regex r = new Regex(@"^v3.[1-9]*");
+            return r.IsMatch(version);
         }
 
         private void Fetch(string chart, ChartFetchArgsUnwrap opts)

--- a/sdk/go/kubernetes/helm/v2/chart.go
+++ b/sdk/go/kubernetes/helm/v2/chart.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 

--- a/sdk/go/kubernetes/helm/v2/chart.go
+++ b/sdk/go/kubernetes/helm/v2/chart.go
@@ -206,11 +206,11 @@ func yamlDecode(ctx *pulumi.Context, text, namespace string) ([]map[string]inter
 func isHelmV3() (bool, error) {
 
 	/*
-	   Helm v2 returns version like this:
-	   Client: v2.16.7+g5f2584f
-	   Helm v3 returns a version like this:
-	   v3.1.2+gd878d4d
-	   We can reasonably assume helm v2 if the version starts with Client
+		Helm v2 returns version like this:
+		Client: v2.16.7+g5f2584f
+		Helm v3 returns a version like this:
+		v3.1.2+gd878d4d
+		--include-crds is available in helm v3.1+ so check for a regex matching that version
 	*/
 	helmVerArgs := []string{"version", "--short"}
 	helmVerCmd := exec.Command("helm", helmVerArgs...)
@@ -223,7 +223,7 @@ func isHelmV3() (bool, error) {
 		return false, errors.Wrap(err, fmt.Sprintf("failed to check helm version: %s", stderr.String()))
 	}
 
-	matched, err := regexp.MatchString(`(?:^|\W)v3.[1-9](?:$|\W)`, string(version))
+	matched, err := regexp.MatchString(`^v3\.[1-9]`, string(version))
 	if err != nil {
 		return false, errors.Wrap(err, fmt.Sprintf("failed to perform regex match: %s", stderr.String()))
 	}

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -219,7 +219,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
                 // --include-crds is available in helm v3.1+ so check for a regex matching that version
-                let r = RegExp('(?:^|\W)v3.[1-9](?:$|\W)');
+                let r = RegExp('^v3\.[1-9]');
                 if (r.test(helmVer)) {
                     cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 } else {

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -218,8 +218,8 @@ export class Chart extends yaml.CollectionComponentResource {
                 // Client: v2.16.7+g5f2584f
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
-                // We can reasonably assume helm v3 if the version starts with v3
-                let r = RegExp('^v3.[1-9]*');
+                // --include-crds is available in helm v3.1+ so check for a regex matching that version
+                let r = RegExp('(?:^|\W)v3.[1-9](?:$|\W)');
                 if (r.test(helmVer)) {
                     cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 } else {

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -157,6 +157,7 @@ export class Chart extends yaml.CollectionComponentResource {
             try {
                 let chart: string;
                 let defaultValues: string;
+                let cmd: string;
                 if (isChartOpts(cfg)) {
                     // Fetch chart.
                     if (cfg.repo && cfg.repo.includes("http")) {
@@ -203,7 +204,28 @@ export class Chart extends yaml.CollectionComponentResource {
                 const namespaceArg = cfg.namespace
                     ? `--namespace ${shell.quote([cfg.namespace])}`
                     : "";
-                let cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+
+                // Check the helm version - v2 or v3
+                let helmVerCmd = `helm version --short`;
+                const helmVer = execSync(
+                    helmVerCmd,
+                    {
+                        env: {...process.env},
+                        maxBuffer: 512 * 1024 * 1024, // 512 MB
+                        stdio: ['pipe', 'pipe', 'ignore'], // Suppress tiller version error
+                    },
+                ).toString();
+
+                // Helm v2 returns version like this:
+                // Client: v2.16.7+g5f2584f
+                // Helm v3 returns a version like this:
+                // v3.1.2+gd878d4d
+                // We can reasonably assume helm v2 if the version starts with Client
+                if (helmVer.startsWith("Client")) {
+                    cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+                } else {
+                    cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+                }
 
                 const yamlStream = execSync(
                     cmd,

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -214,16 +214,14 @@ export class Chart extends yaml.CollectionComponentResource {
                     },
                 ).toString();
 
+                cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
                 // Helm v2 returns version like this:
                 // Client: v2.16.7+g5f2584f
                 // Helm v3 returns a version like this:
                 // v3.1.2+gd878d4d
                 // --include-crds is available in helm v3.1+ so check for a regex matching that version
-                let r = RegExp('^v3\.[1-9]');
-                if (r.test(helmVer)) {
-                    cmd = `helm template ${chart} --include-crds --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
-                } else {
-                    cmd = `helm template ${chart} --name-template ${release} --values ${defaultValues} --values ${values} ${apiVersionsArgs} ${namespaceArg}`;
+                if (RegExp('^v3\.[1-9]').test(helmVer)) {
+                    cmd += ` --include-crds`
                 }
 
                 const yamlStream = execSync(

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -5,6 +5,7 @@ import json
 import os.path
 import shutil
 import subprocess
+import re
 from tempfile import mkdtemp, mkstemp
 from typing import Any, Callable, List, Optional, TextIO, Tuple, Union
 
@@ -290,12 +291,11 @@ def _is_helm_v3() -> bool:
     """
     output = subprocess.run("helm version --short", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
-
-    """ 
-    We return the inverse: if the version string starts with "Client"
-    we are not helm v3
     """
-    return not version.startswith("Client")
+    --include-crds is available in helm v3.1+ so check for a regex matching that version
+    """
+    if re.search("^v3.[1-9]*", version):
+        return True
     
 
 

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -281,6 +281,8 @@ def _run_helm_cmd(all_config: Tuple[List[Union[str, bytes]], Any]) -> str:
     return yaml_str
 
 def _is_helm_v3() -> bool:
+
+    cmd: List[str] = ['helm', 'version', '--short']
     
     """ 
     Helm v2 returns version like this:
@@ -289,14 +291,13 @@ def _is_helm_v3() -> bool:
     v3.1.2+gd878d4d
     We can reasonably assume helm v2 if the version starts with Client 
     """
-    output = subprocess.run("helm version --short", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
+    output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
     """
     --include-crds is available in helm v3.1+ so check for a regex matching that version
     """
-    if re.search("^v3.[1-9]*", version):
-        return True
-    
+    regexp = re.compile(r'(?:^|\W)v3.[1-9](?:$|\W)')
+    return(bool(regexp.search(version)))
 
 
 def _write_override_file(all_config: Tuple[TextIO, str]) -> None:

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -357,7 +357,7 @@ def _parse_chart(all_config: Tuple[str, Union[ChartOpts, LocalChartOpts], pulumi
     pulumi.Output.all(file, data).apply(_write_override_file)
 
     namespace_arg = ['--namespace', config.namespace] if config.namespace else []
-    crd_arg = [ '--include-crds' ] if _is_helm_v3 else []
+    crd_arg = [ '--include-crds' ] if _is_helm_v3() else []
 
     # Use 'helm template' to create a combined YAML manifest.
     cmd = ['helm', 'template', chart, '--name-template', release_name,

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -289,14 +289,11 @@ def _is_helm_v3() -> bool:
     Client: v2.16.7+g5f2584f
     Helm v3 returns a version like this:
     v3.1.2+gd878d4d
-    We can reasonably assume helm v2 if the version starts with Client 
+    --include-crds is available in helm v3.1+ so check for a regex matching that version
     """
     output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True, check=True)
     version: str = output.stdout
-    """
-    --include-crds is available in helm v3.1+ so check for a regex matching that version
-    """
-    regexp = re.compile(r'(?:^|\W)v3.[1-9](?:$|\W)')
+    regexp = re.compile(r'^v3.\[1-9]')
     return(bool(regexp.search(version)))
 
 


### PR DESCRIPTION
This PR adds a mechanism to detect if helm v3 is being used when the
chart is rendered. If it is, it includes the `--include-crds` flag so
that the CRDs are rendered as part of the YAML stream.

Fixes #1023


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->