### PR TITLE
Fix C# schema and $-properties

### DIFF
--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -41,6 +41,11 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				"kubeconfig": {
 					Description: "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Language: map[string]json.RawMessage{
+						"csharp": rawMessage(map[string]interface{}{
+							"name": "KubeConfig",
+						}),
+					},
 				},
 				"context": {
 					Description: "If present, the name of the kubeconfig context to use.",
@@ -78,6 +83,11 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				"kubeconfig": {
 					Description: "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Language: map[string]json.RawMessage{
+						"csharp": rawMessage(map[string]interface{}{
+							"name": "KubeConfig",
+						}),
+					},
 				},
 				"context": {
 					Description: "If present, the name of the kubeconfig context to use.",
@@ -122,12 +132,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 	groupsSlice := createGroups(definitions, schemaOpts())
 	for _, group := range groupsSlice {
 		for _, version := range group.Versions() {
-			mod := version.gv.String()
-			csharpNamespaces[mod] = fmt.Sprintf("%s.%s", pascalCase(group.Group()), pascalCase(version.Version()))
-
 			for _, kind := range version.Kinds() {
 				tok := fmt.Sprintf(`kubernetes:%s:%s`, kind.canonicalGV, kind.kind)
 
+				csharpNamespaces[kind.canonicalGV] = fmt.Sprintf("%s.%s", pascalCase(group.Group()), pascalCase(version.Version()))
 				modToPkg[kind.canonicalGV] = kind.schemaPkgName
 				pkgImportAliases[fmt.Sprintf("%s/%s", goImportPath, kind.schemaPkgName)] = strings.Replace(
 					kind.schemaPkgName, "/", "", -1)
@@ -139,11 +147,6 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				}
 
 				for _, p := range kind.Properties() {
-					// JSONSchema type includes `$ref` and `$schema` properties, and $ is an invalid character in
-					// the generated names.
-					if strings.HasPrefix(p.name, "$") {
-						p.name = "t_" + p.name[1:]
-					}
 					objectSpec.Properties[p.name] = genPropertySpec(p, kind.canonicalGV, kind.kind)
 				}
 				for _, p := range kind.RequiredInputProperties() {
@@ -181,7 +184,8 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 
 	pkg.Language["csharp"] = rawMessage(map[string]interface{}{
 		"packageReferences": map[string]string{
-			"Pulumi":                       "2.0.0-beta.2",
+			"Glob":                         "1.1.5",
+			"Pulumi":                       "2.*",
 			"System.Collections.Immutable": "1.6.0",
 		},
 		"namespaces": csharpNamespaces,
@@ -255,6 +259,24 @@ func genPropertySpec(p Property, resourceGV string, resourceKind string) pschema
 	}
 	if dv := defaultValue(); dv != nil {
 		propertySpec.Default = *dv
+	}
+	languageName := strings.ToUpper(p.name[:1]) + p.name[1:]
+	if languageName == resourceKind {
+		// .NET does not allow properties to be the same as the enclosing class - so special case these
+		propertySpec.Language = map[string]json.RawMessage{
+			"csharp": rawMessage(map[string]interface{}{
+				"name": languageName + "Value",
+			}),
+		}
+	}
+	// JSONSchema type includes `$ref` and `$schema` properties, and $ is an invalid character in
+	// the generated names. Replace them with `Ref` and `Schema`.
+	if strings.HasPrefix(p.name, "$") {
+		propertySpec.Language = map[string]json.RawMessage{
+			"csharp": rawMessage(map[string]interface{}{
+				"name": strings.ToUpper(p.name[1:2]) + p.name[2:],
+			}),
+		}
 	}
 	return propertySpec
 }

--- a/sdk/go/kubernetes/apiextensions/v1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiextensions/v1/pulumiTypes.go
@@ -2068,6 +2068,8 @@ func (o ExternalDocumentationPtrOutput) Url() pulumi.StringPtrOutput {
 
 // JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
 type JSONSchemaProps struct {
+	Ref                  *string           `pulumi:"$ref"`
+	Schema               *string           `pulumi:"$schema"`
 	AdditionalItems      interface{}       `pulumi:"additionalItems"`
 	AdditionalProperties interface{}       `pulumi:"additionalProperties"`
 	AllOf                []JSONSchemaProps `pulumi:"allOf"`
@@ -2104,8 +2106,6 @@ type JSONSchemaProps struct {
 	PatternProperties map[string]JSONSchemaProps `pulumi:"patternProperties"`
 	Properties        map[string]JSONSchemaProps `pulumi:"properties"`
 	Required          []string                   `pulumi:"required"`
-	T_ref             *string                    `pulumi:"t_ref"`
-	T_schema          *string                    `pulumi:"t_schema"`
 	Title             *string                    `pulumi:"title"`
 	Type              *string                    `pulumi:"type"`
 	UniqueItems       *bool                      `pulumi:"uniqueItems"`
@@ -2170,6 +2170,8 @@ type JSONSchemaPropsInput interface {
 
 // JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
 type JSONSchemaPropsArgs struct {
+	Ref                  pulumi.StringPtrInput     `pulumi:"$ref"`
+	Schema               pulumi.StringPtrInput     `pulumi:"$schema"`
 	AdditionalItems      pulumi.Input              `pulumi:"additionalItems"`
 	AdditionalProperties pulumi.Input              `pulumi:"additionalProperties"`
 	AllOf                JSONSchemaPropsArrayInput `pulumi:"allOf"`
@@ -2206,8 +2208,6 @@ type JSONSchemaPropsArgs struct {
 	PatternProperties JSONSchemaPropsMapInput   `pulumi:"patternProperties"`
 	Properties        JSONSchemaPropsMapInput   `pulumi:"properties"`
 	Required          pulumi.StringArrayInput   `pulumi:"required"`
-	T_ref             pulumi.StringPtrInput     `pulumi:"t_ref"`
-	T_schema          pulumi.StringPtrInput     `pulumi:"t_schema"`
 	Title             pulumi.StringPtrInput     `pulumi:"title"`
 	Type              pulumi.StringPtrInput     `pulumi:"type"`
 	UniqueItems       pulumi.BoolPtrInput       `pulumi:"uniqueItems"`
@@ -2388,6 +2388,14 @@ func (o JSONSchemaPropsOutput) ToJSONSchemaPropsPtrOutputWithContext(ctx context
 		return &v
 	}).(JSONSchemaPropsPtrOutput)
 }
+func (o JSONSchemaPropsOutput) Ref() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Ref }).(pulumi.StringPtrOutput)
+}
+
+func (o JSONSchemaPropsOutput) Schema() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Schema }).(pulumi.StringPtrOutput)
+}
+
 func (o JSONSchemaPropsOutput) AdditionalItems() pulumi.AnyOutput {
 	return o.ApplyT(func(v JSONSchemaProps) interface{} { return v.AdditionalItems }).(pulumi.AnyOutput)
 }
@@ -2520,14 +2528,6 @@ func (o JSONSchemaPropsOutput) Required() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v JSONSchemaProps) []string { return v.Required }).(pulumi.StringArrayOutput)
 }
 
-func (o JSONSchemaPropsOutput) T_ref() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JSONSchemaProps) *string { return v.T_ref }).(pulumi.StringPtrOutput)
-}
-
-func (o JSONSchemaPropsOutput) T_schema() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JSONSchemaProps) *string { return v.T_schema }).(pulumi.StringPtrOutput)
-}
-
 func (o JSONSchemaPropsOutput) Title() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Title }).(pulumi.StringPtrOutput)
 }
@@ -2619,6 +2619,24 @@ func (o JSONSchemaPropsPtrOutput) ToJSONSchemaPropsPtrOutputWithContext(ctx cont
 
 func (o JSONSchemaPropsPtrOutput) Elem() JSONSchemaPropsOutput {
 	return o.ApplyT(func(v *JSONSchemaProps) JSONSchemaProps { return *v }).(JSONSchemaPropsOutput)
+}
+
+func (o JSONSchemaPropsPtrOutput) Ref() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *JSONSchemaProps) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Ref
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o JSONSchemaPropsPtrOutput) Schema() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *JSONSchemaProps) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Schema
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o JSONSchemaPropsPtrOutput) AdditionalItems() pulumi.AnyOutput {
@@ -2911,24 +2929,6 @@ func (o JSONSchemaPropsPtrOutput) Required() pulumi.StringArrayOutput {
 		}
 		return v.Required
 	}).(pulumi.StringArrayOutput)
-}
-
-func (o JSONSchemaPropsPtrOutput) T_ref() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *JSONSchemaProps) *string {
-		if v == nil {
-			return nil
-		}
-		return v.T_ref
-	}).(pulumi.StringPtrOutput)
-}
-
-func (o JSONSchemaPropsPtrOutput) T_schema() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *JSONSchemaProps) *string {
-		if v == nil {
-			return nil
-		}
-		return v.T_schema
-	}).(pulumi.StringPtrOutput)
 }
 
 func (o JSONSchemaPropsPtrOutput) Title() pulumi.StringPtrOutput {

--- a/sdk/go/kubernetes/apiextensions/v1beta1/pulumiTypes.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/pulumiTypes.go
@@ -2165,6 +2165,8 @@ func (o ExternalDocumentationPtrOutput) Url() pulumi.StringPtrOutput {
 
 // JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
 type JSONSchemaProps struct {
+	Ref                  *string           `pulumi:"$ref"`
+	Schema               *string           `pulumi:"$schema"`
 	AdditionalItems      interface{}       `pulumi:"additionalItems"`
 	AdditionalProperties interface{}       `pulumi:"additionalProperties"`
 	AllOf                []JSONSchemaProps `pulumi:"allOf"`
@@ -2201,8 +2203,6 @@ type JSONSchemaProps struct {
 	PatternProperties map[string]JSONSchemaProps `pulumi:"patternProperties"`
 	Properties        map[string]JSONSchemaProps `pulumi:"properties"`
 	Required          []string                   `pulumi:"required"`
-	T_ref             *string                    `pulumi:"t_ref"`
-	T_schema          *string                    `pulumi:"t_schema"`
 	Title             *string                    `pulumi:"title"`
 	Type              *string                    `pulumi:"type"`
 	UniqueItems       *bool                      `pulumi:"uniqueItems"`
@@ -2267,6 +2267,8 @@ type JSONSchemaPropsInput interface {
 
 // JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
 type JSONSchemaPropsArgs struct {
+	Ref                  pulumi.StringPtrInput     `pulumi:"$ref"`
+	Schema               pulumi.StringPtrInput     `pulumi:"$schema"`
 	AdditionalItems      pulumi.Input              `pulumi:"additionalItems"`
 	AdditionalProperties pulumi.Input              `pulumi:"additionalProperties"`
 	AllOf                JSONSchemaPropsArrayInput `pulumi:"allOf"`
@@ -2303,8 +2305,6 @@ type JSONSchemaPropsArgs struct {
 	PatternProperties JSONSchemaPropsMapInput   `pulumi:"patternProperties"`
 	Properties        JSONSchemaPropsMapInput   `pulumi:"properties"`
 	Required          pulumi.StringArrayInput   `pulumi:"required"`
-	T_ref             pulumi.StringPtrInput     `pulumi:"t_ref"`
-	T_schema          pulumi.StringPtrInput     `pulumi:"t_schema"`
 	Title             pulumi.StringPtrInput     `pulumi:"title"`
 	Type              pulumi.StringPtrInput     `pulumi:"type"`
 	UniqueItems       pulumi.BoolPtrInput       `pulumi:"uniqueItems"`
@@ -2485,6 +2485,14 @@ func (o JSONSchemaPropsOutput) ToJSONSchemaPropsPtrOutputWithContext(ctx context
 		return &v
 	}).(JSONSchemaPropsPtrOutput)
 }
+func (o JSONSchemaPropsOutput) Ref() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Ref }).(pulumi.StringPtrOutput)
+}
+
+func (o JSONSchemaPropsOutput) Schema() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Schema }).(pulumi.StringPtrOutput)
+}
+
 func (o JSONSchemaPropsOutput) AdditionalItems() pulumi.AnyOutput {
 	return o.ApplyT(func(v JSONSchemaProps) interface{} { return v.AdditionalItems }).(pulumi.AnyOutput)
 }
@@ -2617,14 +2625,6 @@ func (o JSONSchemaPropsOutput) Required() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v JSONSchemaProps) []string { return v.Required }).(pulumi.StringArrayOutput)
 }
 
-func (o JSONSchemaPropsOutput) T_ref() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JSONSchemaProps) *string { return v.T_ref }).(pulumi.StringPtrOutput)
-}
-
-func (o JSONSchemaPropsOutput) T_schema() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v JSONSchemaProps) *string { return v.T_schema }).(pulumi.StringPtrOutput)
-}
-
 func (o JSONSchemaPropsOutput) Title() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v JSONSchemaProps) *string { return v.Title }).(pulumi.StringPtrOutput)
 }
@@ -2716,6 +2716,24 @@ func (o JSONSchemaPropsPtrOutput) ToJSONSchemaPropsPtrOutputWithContext(ctx cont
 
 func (o JSONSchemaPropsPtrOutput) Elem() JSONSchemaPropsOutput {
 	return o.ApplyT(func(v *JSONSchemaProps) JSONSchemaProps { return *v }).(JSONSchemaPropsOutput)
+}
+
+func (o JSONSchemaPropsPtrOutput) Ref() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *JSONSchemaProps) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Ref
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o JSONSchemaPropsPtrOutput) Schema() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *JSONSchemaProps) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Schema
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o JSONSchemaPropsPtrOutput) AdditionalItems() pulumi.AnyOutput {
@@ -3008,24 +3026,6 @@ func (o JSONSchemaPropsPtrOutput) Required() pulumi.StringArrayOutput {
 		}
 		return v.Required
 	}).(pulumi.StringArrayOutput)
-}
-
-func (o JSONSchemaPropsPtrOutput) T_ref() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *JSONSchemaProps) *string {
-		if v == nil {
-			return nil
-		}
-		return v.T_ref
-	}).(pulumi.StringPtrOutput)
-}
-
-func (o JSONSchemaPropsPtrOutput) T_schema() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *JSONSchemaProps) *string {
-		if v == nil {
-			return nil
-		}
-		return v.T_schema
-	}).(pulumi.StringPtrOutput)
 }
 
 func (o JSONSchemaPropsPtrOutput) Title() pulumi.StringPtrOutput {


### PR DESCRIPTION
- Fix C# namespace map
- Fix C# `KubeConfig` casing
- Special-case C# property names
- Stop encoding `$ref` and `$schema` as `t_*` (applies to Go too)