### PR TITLE
Use a 1.15.x GKE cluster for CI

### DIFF
--- a/tests/ci-cluster/gke.ts
+++ b/tests/ci-cluster/gke.ts
@@ -26,11 +26,11 @@ export class GkeCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("pulumi-kubernetes:ci:GkeCluster", name, {}, opts);
 
-        // Find the latest engine version.
+        // Find the latest 1.15.x engine version.
         const engineVersion = gcp.container.getEngineVersions({
             location: config.gcpLocation,
             project: config.gcpProject,
-        }).then(v => v.latestMasterVersion);
+        }).then(v => v.validMasterVersions.filter(v => v.startsWith("1.15"))[0]);
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("ephemeral-ci-cluster", {


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
A bunch of k8s resource APIs were removed in v1.16. Some
of our tests are using resources with these APIs, so pin clusters
to 1.15 releases.

<!--Give us a brief description of what you've done and what it solves. -->
