### PR TITLE
Stop publishing tarballs to eng.pulumi.com in publish_tgz.sh.

### DIFF
--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -13,19 +13,6 @@ if [ ! -f $PUBLISH ]; then
     exit 1
 fi
 
-echo "Publishing SDK build to s3://eng.pulumi.com/:"
-for OS in "${PUBLISH_GOOS[@]}"
-do
-    for ARCH in "${PUBLISH_GOARCH[@]}"
-    do
-        export GOOS=${OS}
-        export GOARCH=${ARCH}
-
-        RELEASE_INFO=($($(dirname $0)/make_release.sh))
-        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
-    done
-done
-
 echo "Publishing Plugin archive to s3://rel.pulumi.com/:"
 for OS in "${PUBLISH_GOOS[@]}"
 do

--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -3,15 +3,8 @@
 set -o nounset -o errexit -o pipefail
 
 ROOT=$(dirname $0)/..
-PUBLISH=$GOPATH/src/github.com/pulumi/scripts/ci/publish.sh
 PUBLISH_GOOS=("linux" "windows" "darwin")
 PUBLISH_GOARCH=("amd64")
-PUBLISH_PROJECT="pulumi-kubernetes"
-
-if [ ! -f $PUBLISH ]; then
-    >&2 echo "error: Missing publish script at $PUBLISH"
-    exit 1
-fi
 
 echo "Publishing Plugin archive to s3://rel.pulumi.com/:"
 for OS in "${PUBLISH_GOOS[@]}"


### PR DESCRIPTION
With #1141 the AWS creds were changed to use a tighter-scoped one. That caused the `master` branch build to fail with the following error:

```
./scripts/publish_tgz.sh

Publishing SDK build to s3://eng.pulumi.com/:

Publishing pulumi-kubernetes/linux/amd64@50c4d31260ec2164b3e662064150ac31a202561f to: s3://eng.pulumi.com/releases/pulumi-kubernetes/linux/amd64/50c4d31260ec2164b3e662064150ac31a202561f.tgz

upload failed: ../../../../../../../tmp/50c4d31260ec2164b3e662064150ac31a202561f.tgz to s3://eng.pulumi.com/releases/pulumi-kubernetes/linux/amd64/50c4d31260ec2164b3e662064150ac31a202561f.tgz An error occurred (AccessDenied) when calling the CreateMultipartUpload operation: Access Denied

Makefile:103: recipe for target 'publish_tgz' failed
```

It looks like this is a difference in how the publish step works in other repos. And looking at the history of this script in some of the [other repos](https://pulumi.slack.com/archives/C5J0XFWRJ/p1590080692091100?thread_ts=1590079618.087400&cid=C5J0XFWRJ), we seem to have stopped publishing the tarballs to `eng.pulumi.com` almost 2 years ago in those other repos whereas this repo was still publishing the SDKs there, as well as publishing to the respective language's canonical package repository site.

This PR removes the part that publishes the SDKs to the `eng.pulumi.com` bucket as well.