### PR TITLE
Fix incorrect schema consts for apiVersion and kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
     - Fixed the type of some properties in `JSONSchemaPropsArgs` (there's no need to have 2nd-level inputs there):
         - `InputList<InputJson>` -> `InputList<JsonElement>`
         - `InputMap<Union<TArgs, InputList<string>>>` -> `InputMap<Union<TArgs, ImmutableArray<string>>>`
+        
+### Bug Fixes
+
+-   Fix incorrect schema consts for apiVersion and kind (https://github.com/pulumi/pulumi-kubernetes/pull/1153)
 
 ## 2.2.2 (May 27, 2020)
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -234,15 +234,9 @@ func genPropertySpec(p Property, resourceGV string, resourceKind string) pschema
 	contract.Assert(err == nil)
 
 	constValue := func() *string {
-		if p.name == "apiVersion" {
-			if strings.HasPrefix(resourceGV, "core/") {
-				dv := strings.TrimPrefix(resourceGV, "core/")
-				return &dv
-			}
-			return &resourceGV
-		}
-		if p.name == "kind" {
-			return &resourceKind
+		cv := p.ConstValue()
+		if len(cv) != 0 {
+			return &cv
 		}
 
 		return nil

--- a/sdk/dotnet/Meta/V1/Status.cs
+++ b/sdk/dotnet/Meta/V1/Status.cs
@@ -87,7 +87,7 @@ namespace Pulumi.Kubernetes.Meta.V1
         private static Pulumi.Kubernetes.Types.Inputs.Meta.V1.StatusArgs? MakeArgs(Pulumi.Kubernetes.Types.Inputs.Meta.V1.StatusArgs? args)
         {
             args ??= new Pulumi.Kubernetes.Types.Inputs.Meta.V1.StatusArgs();
-            args.ApiVersion = "meta/v1";
+            args.ApiVersion = "v1";
             args.Kind = "Status";
             return args;
         }

--- a/sdk/go/kubernetes/meta/v1/status.go
+++ b/sdk/go/kubernetes/meta/v1/status.go
@@ -37,7 +37,7 @@ func NewStatus(ctx *pulumi.Context,
 	if args == nil {
 		args = &StatusArgs{}
 	}
-	args.ApiVersion = pulumi.StringPtr("meta/v1")
+	args.ApiVersion = pulumi.StringPtr("v1")
 	args.Kind = pulumi.StringPtr("Status")
 	var resource Status
 	err := ctx.RegisterResource("kubernetes:meta/v1:Status", name, args, &resource, opts...)


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The logic for setting constant values in the schema was
incorrect for the apiVersion and kind properties. This fix
changes one incorrect apiVersion in the C# and Go SDKs.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1152
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
