### PR TITLE
Fix prometheus-operator test to wait for the CRD to be ready before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+-   Fix prometheus-operator test to wait for the CRD to be ready before use (https://github.com/pulumi/pulumi-kubernetes/pull/1172)
+
 ## 2.3.1 (June 17, 2020)
 
 ### Improvements

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -188,35 +188,34 @@ func TestAccHelmLocal(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-// TODO: uncomment once https://github.com/pulumi/pulumi-kubernetes/issues/1137 is fixed.
-//func TestAccPrometheusOperator(t *testing.T) {
-//	skipIfShort(t)
-//	test := getBaseOptions(t).
-//		With(integration.ProgramTestOptions{
-//			Dir:         path.Join(getCwd(t), "prometheus-operator"),
-//			SkipRefresh: true,
-//			ExtraRuntimeValidation: func(
-//				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
-//			) {
-//				assert.NotNil(t, stackInfo.Deployment)
-//				assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
-//			},
-//			EditDirs: []integration.EditDir{
-//				{
-//					Dir:      path.Join(getCwd(t), "prometheus-operator", "steps"),
-//					Additive: true,
-//					ExtraRuntimeValidation: func(
-//						t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
-//					) {
-//						assert.NotNil(t, stackInfo.Deployment)
-//						assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
-//					},
-//				},
-//			},
-//		})
-//
-//	integration.ProgramTest(t, &test)
-//}
+func TestAccPrometheusOperator(t *testing.T) {
+	skipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         path.Join(getCwd(t), "prometheus-operator"),
+			SkipRefresh: true,
+			ExtraRuntimeValidation: func(
+				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+			) {
+				assert.NotNil(t, stackInfo.Deployment)
+				assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
+			},
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      path.Join(getCwd(t), "prometheus-operator", "steps"),
+					Additive: true,
+					ExtraRuntimeValidation: func(
+						t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+					) {
+						assert.NotNil(t, stackInfo.Deployment)
+						assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
+					},
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
 
 func TestAccMariadb(t *testing.T) {
 	skipIfShort(t)

--- a/tests/examples/prometheus-operator/step1/index.ts
+++ b/tests/examples/prometheus-operator/step1/index.ts
@@ -4,13 +4,13 @@ import * as pulumi from "@pulumi/pulumi";
 // PrometheusOperatorArgs are the options to configure on the CoreOS
 // PrometheusOperator.
 interface PrometheusOperatorArgs {
-    namespace: pulumi.Input<string>;
     version?: string;
 }
 
 // PrometheusOperator implements the CoreOS Prometheus Operator.
-export class PrometheusOperator extends pulumi.ComponentResource {
+class PrometheusOperator extends pulumi.ComponentResource {
     public readonly configFile: k8s.yaml.ConfigFile;
+    public readonly service: pulumi.Output<k8s.core.v1.Service>;
     constructor(
         name: string,
         args: PrometheusOperatorArgs,
@@ -18,61 +18,52 @@ export class PrometheusOperator extends pulumi.ComponentResource {
     ) {
         super('pulumi:monitoring/v1:PrometheusOperator', name, {}, opts);
 
-        this.configFile = new k8s.yaml.ConfigFile(
-            name,
-            {
-                file: `https://github.com/coreos/prometheus-operator/raw/release-${args.version || '0.38'}/bundle.yaml`,
-                transformations: [
-                    obj => {
-                        if (obj.metadata.namespace) {
-                            obj.metadata.namespace = args.namespace;
-                        }
-                        if (obj.kind === 'ClusterRoleBinding') {
-                            obj.subjects[0].namespace = args.namespace;
-                        }
-                    },
-                ],
-            }, { parent: this });
+        this.configFile = new k8s.yaml.ConfigFile(name, {
+            file: `https://github.com/coreos/prometheus-operator/raw/release-${args.version || '0.38'}/bundle.yaml`,
+        }, {parent: this});
+
+        this.service = this.configFile.getResource("v1/Service", "default", "prometheus-operator");
     }
 }
 
 // Create the Prometheus Operator.
-const prometheusOperator = new PrometheusOperator("prometheus", {
-    namespace: "default",
-});
+const prometheusOperator = new PrometheusOperator("prometheus", {});
 
 // Create the Prometheus Operator ServiceMonitor.
-const myMonitoring = new k8s.apiextensions.CustomResource('my-monitoring', {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'ServiceMonitor',
-    spec: {
-        selector: {
-            matchLabels: { app: 'my-app' },
-        },
-        endpoints: [
-            {
-                port: 'http',
-                interval: '65s',
-                // removing the following in index.ts in favor of below 
-                // relabelings: [
-                //   {
-                //     regex: '(.*)',
-                //     targetLabel: 'stackdriver',
-                //     replacement: 'true',
-                //     action: 'replace'
-                //   }
-                // ],
-                // add the following in replacement of above in index.ts
-                metricRelabelings: [
-                    {
-                        sourceLabels: ['__name__'],
-                        regex: 'typhoon_(.*)',
-                        targetLabel: 'stackdriver',
-                        replacement: 'true',
-                        action: 'replace'
-                    }
-                ]
+const myMonitoring = prometheusOperator.service.apply(service => {
+    return new k8s.apiextensions.CustomResource('my-monitoring', {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'ServiceMonitor',
+        spec: {
+            selector: {
+                matchLabels: { app: 'my-app' },
             },
-        ],
-    },
-}, {dependsOn: prometheusOperator});
+            endpoints: [
+                {
+                    port: 'http',
+                    interval: '65s',
+                    // removing the following in index.ts in favor of below
+                    // relabelings: [
+                    //   {
+                    //     regex: '(.*)',
+                    //     targetLabel: 'stackdriver',
+                    //     replacement: 'true',
+                    //     action: 'replace'
+                    //   }
+                    // ],
+                    // add the following in replacement of above in index.ts
+                    metricRelabelings: [
+                        {
+                            sourceLabels: ['__name__'],
+                            regex: 'typhoon_(.*)',
+                            targetLabel: 'stackdriver',
+                            replacement: 'true',
+                            action: 'replace'
+                        }
+                    ]
+                },
+            ],
+        },
+    }, {dependsOn: service});
+})
+export const myMonitoringName = myMonitoring.id;


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Fix prometheus-operator test to wait for the CRD to be ready before use

### Related issues (optional)

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1137
