### PR TITLE
Remove deprecation warnings from SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### Bug Fixes
 
 -   Fix error parsing Helm version (https://github.com/pulumi/pulumi-kubernetes/pull/1170)
+-   Fix prometheus-operator test to wait for the CRD to be ready before use (https://github.com/pulumi/pulumi-kubernetes/pull/1172)
+-   Fix suppress deprecation warnings flag (https://github.com/pulumi/pulumi-kubernetes/pull/1189)
 
 ### Improvements
 
--   Fix prometheus-operator test to wait for the CRD to be ready before use (https://github.com/pulumi/pulumi-kubernetes/pull/1172)
 -   Set supported environment variables in SDK Provider classes (https://github.com/pulumi/pulumi-kubernetes/pull/1166)
 -   Python SDK updated to align with other Pulumi Python SDKs. (https://github.com/pulumi/pulumi-kubernetes/pull/1160)
 -   Add support for Kustomize. (https://github.com/pulumi/pulumi-kubernetes/pull/1178)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/googleapis/gnostic v0.2.0
 	github.com/imdario/mergo v0.3.8
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa
+	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c
 	github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.28.0

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -563,8 +563,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa h1:Jhm3xGFG1gCx56AMfjM4Pzm+N3wZ8ZlO0GVl7yZh0Ek=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c h1:O72rbiQ16xwJ1h7lnmhbxQIMeASHPrs0xBOUFru8R98=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
 github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae h1:KuvWPTsPuiRTnYIShcjzoksbF8XQPAxnxa89m9+Lqj0=
 github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae/go.mod h1:llk6tmXss8kJrt3vEXAkwiwgZOuINEFmKIfMveVIwO8=

--- a/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta1/ControllerRevision.ts
@@ -21,7 +21,6 @@ export class ControllerRevision extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): ControllerRevision {
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         return new ControllerRevision(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class ControllerRevision extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: ControllerRevisionArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
             if (!args || args.revision === undefined) {
                 throw new Error("Missing required property 'revision'");

--- a/sdk/nodejs/apps/v1beta1/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta1/Deployment.ts
@@ -43,7 +43,6 @@ export class Deployment extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): Deployment {
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         return new Deployment(name, undefined, { ...opts, id: id });
     }
 
@@ -91,7 +90,6 @@ export class Deployment extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: DeploymentArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta1";
         inputs["kind"] = "Deployment";

--- a/sdk/nodejs/apps/v1beta1/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta1/StatefulSet.ts
@@ -37,7 +37,6 @@ export class StatefulSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): StatefulSet {
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         return new StatefulSet(name, undefined, { ...opts, id: id });
     }
 
@@ -82,7 +81,6 @@ export class StatefulSet extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: StatefulSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta1";
         inputs["kind"] = "StatefulSet";

--- a/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
+++ b/sdk/nodejs/apps/v1beta2/ControllerRevision.ts
@@ -21,7 +21,6 @@ export class ControllerRevision extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): ControllerRevision {
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         return new ControllerRevision(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class ControllerRevision extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: ControllerRevisionArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
             if (!args || args.revision === undefined) {
                 throw new Error("Missing required property 'revision'");

--- a/sdk/nodejs/apps/v1beta2/DaemonSet.ts
+++ b/sdk/nodejs/apps/v1beta2/DaemonSet.ts
@@ -21,7 +21,6 @@ export class DaemonSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): DaemonSet {
-        pulumi.log.warn("DaemonSet is deprecated: apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         return new DaemonSet(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class DaemonSet extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: DaemonSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("DaemonSet is deprecated: apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta2";
         inputs["kind"] = "DaemonSet";

--- a/sdk/nodejs/apps/v1beta2/Deployment.ts
+++ b/sdk/nodejs/apps/v1beta2/Deployment.ts
@@ -43,7 +43,6 @@ export class Deployment extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): Deployment {
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         return new Deployment(name, undefined, { ...opts, id: id });
     }
 
@@ -91,7 +90,6 @@ export class Deployment extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: DeploymentArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta2";
         inputs["kind"] = "Deployment";

--- a/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
+++ b/sdk/nodejs/apps/v1beta2/ReplicaSet.ts
@@ -21,7 +21,6 @@ export class ReplicaSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): ReplicaSet {
-        pulumi.log.warn("ReplicaSet is deprecated: apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         return new ReplicaSet(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class ReplicaSet extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: ReplicaSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("ReplicaSet is deprecated: apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta2";
         inputs["kind"] = "ReplicaSet";

--- a/sdk/nodejs/apps/v1beta2/StatefulSet.ts
+++ b/sdk/nodejs/apps/v1beta2/StatefulSet.ts
@@ -37,7 +37,6 @@ export class StatefulSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): StatefulSet {
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         return new StatefulSet(name, undefined, { ...opts, id: id });
     }
 
@@ -82,7 +81,6 @@ export class StatefulSet extends pulumi.CustomResource {
      */
     /** @deprecated apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: StatefulSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "apps/v1beta2";
         inputs["kind"] = "StatefulSet";

--- a/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/DaemonSet.ts
@@ -21,7 +21,6 @@ export class DaemonSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): DaemonSet {
-        pulumi.log.warn("DaemonSet is deprecated: extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         return new DaemonSet(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class DaemonSet extends pulumi.CustomResource {
      */
     /** @deprecated extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: DaemonSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("DaemonSet is deprecated: extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "extensions/v1beta1";
         inputs["kind"] = "DaemonSet";

--- a/sdk/nodejs/extensions/v1beta1/Deployment.ts
+++ b/sdk/nodejs/extensions/v1beta1/Deployment.ts
@@ -43,7 +43,6 @@ export class Deployment extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): Deployment {
-        pulumi.log.warn("Deployment is deprecated: extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         return new Deployment(name, undefined, { ...opts, id: id });
     }
 
@@ -91,7 +90,6 @@ export class Deployment extends pulumi.CustomResource {
      */
     /** @deprecated extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: DeploymentArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("Deployment is deprecated: extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "extensions/v1beta1";
         inputs["kind"] = "Deployment";

--- a/sdk/nodejs/extensions/v1beta1/Ingress.ts
+++ b/sdk/nodejs/extensions/v1beta1/Ingress.ts
@@ -35,7 +35,6 @@ export class Ingress extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): Ingress {
-        pulumi.log.warn("Ingress is deprecated: extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.")
         return new Ingress(name, undefined, { ...opts, id: id });
     }
 
@@ -83,7 +82,6 @@ export class Ingress extends pulumi.CustomResource {
      */
     /** @deprecated extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters. */
     constructor(name: string, args?: IngressArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("Ingress is deprecated: extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "extensions/v1beta1";
         inputs["kind"] = "Ingress";

--- a/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
+++ b/sdk/nodejs/extensions/v1beta1/ReplicaSet.ts
@@ -21,7 +21,6 @@ export class ReplicaSet extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): ReplicaSet {
-        pulumi.log.warn("ReplicaSet is deprecated: extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         return new ReplicaSet(name, undefined, { ...opts, id: id });
     }
 
@@ -69,7 +68,6 @@ export class ReplicaSet extends pulumi.CustomResource {
      */
     /** @deprecated extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters. */
     constructor(name: string, args?: ReplicaSetArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("ReplicaSet is deprecated: extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         let inputs: pulumi.Inputs = {};
         inputs["apiVersion"] = "extensions/v1beta1";
         inputs["kind"] = "ReplicaSet";

--- a/sdk/nodejs/storage/v1beta1/CSINode.ts
+++ b/sdk/nodejs/storage/v1beta1/CSINode.ts
@@ -21,7 +21,6 @@ export class CSINode extends pulumi.CustomResource {
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
     public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): CSINode {
-        pulumi.log.warn("CSINode is deprecated: storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode.")
         return new CSINode(name, undefined, { ...opts, id: id });
     }
 
@@ -65,7 +64,6 @@ export class CSINode extends pulumi.CustomResource {
      */
     /** @deprecated storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode. */
     constructor(name: string, args?: CSINodeArgs, opts?: pulumi.CustomResourceOptions) {
-        pulumi.log.warn("CSINode is deprecated: storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode.")
         let inputs: pulumi.Inputs = {};
             if (!args || args.spec === undefined) {
                 throw new Error("Missing required property 'spec'");

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class ControllerRevision(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class ControllerRevision(pulumi.CustomResource):
     """
     Revision indicates the revision of the state represented by Data.
     """
-    warnings.warn("apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, data=None, kind=None, metadata=None, revision=None, __props__=None, __name__=None, __opts__=None):
         """
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
@@ -46,7 +42,6 @@ class ControllerRevision(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[float] revision: Revision indicates the revision of the state represented by Data.
         """
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta1/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class Deployment(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class Deployment(pulumi.CustomResource):
     """
     Most recently observed status of the Deployment.
     """
-    warnings.warn("apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -67,7 +63,6 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object metadata.
         :param pulumi.Input[dict] spec: Specification of the desired behavior of the Deployment.
         """
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class StatefulSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -29,8 +27,6 @@ class StatefulSet(pulumi.CustomResource):
     """
     Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
     """
-    warnings.warn("apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -57,7 +53,6 @@ class StatefulSet(pulumi.CustomResource):
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[dict] spec: Spec defines the desired identities of pods in this set.
         """
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta1/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class ControllerRevision(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class ControllerRevision(pulumi.CustomResource):
     """
     Revision indicates the revision of the state represented by Data.
     """
-    warnings.warn("apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, data=None, kind=None, metadata=None, revision=None, __props__=None, __name__=None, __opts__=None):
         """
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
@@ -46,7 +42,6 @@ class ControllerRevision(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[float] revision: Revision indicates the revision of the state represented by Data.
         """
-        pulumi.log.warn("ControllerRevision is deprecated: apps/v1beta2/ControllerRevision is deprecated by apps/v1/ControllerRevision and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class DaemonSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class DaemonSet(pulumi.CustomResource):
     """
     The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
     """
-    warnings.warn("apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         DaemonSet represents the configuration of a daemon set.
@@ -45,7 +41,6 @@ class DaemonSet(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[dict] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
-        pulumi.log.warn("DaemonSet is deprecated: apps/v1beta2/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class Deployment(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class Deployment(pulumi.CustomResource):
     """
     Most recently observed status of the Deployment.
     """
-    warnings.warn("apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -67,7 +63,6 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object metadata.
         :param pulumi.Input[dict] spec: Specification of the desired behavior of the Deployment.
         """
-        pulumi.log.warn("Deployment is deprecated: apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class ReplicaSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class ReplicaSet(pulumi.CustomResource):
     """
     Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
     """
-    warnings.warn("apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -45,7 +41,6 @@ class ReplicaSet(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[dict] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
-        pulumi.log.warn("ReplicaSet is deprecated: apps/v1beta2/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class StatefulSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -29,8 +27,6 @@ class StatefulSet(pulumi.CustomResource):
     """
     Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
     """
-    warnings.warn("apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -57,7 +53,6 @@ class StatefulSet(pulumi.CustomResource):
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[dict] spec: Spec defines the desired identities of pods in this set.
         """
-        pulumi.log.warn("StatefulSet is deprecated: apps/v1beta2/StatefulSet is deprecated by apps/v1/StatefulSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class DaemonSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class DaemonSet(pulumi.CustomResource):
     """
     The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
     """
-    warnings.warn("extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         DaemonSet represents the configuration of a daemon set.
@@ -45,7 +41,6 @@ class DaemonSet(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[dict] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
-        pulumi.log.warn("DaemonSet is deprecated: extensions/v1beta1/DaemonSet is deprecated by apps/v1/DaemonSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class Deployment(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class Deployment(pulumi.CustomResource):
     """
     Most recently observed status of the Deployment.
     """
-    warnings.warn("extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -67,7 +63,6 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object metadata.
         :param pulumi.Input[dict] spec: Specification of the desired behavior of the Deployment.
         """
-        pulumi.log.warn("Deployment is deprecated: extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.", DeprecationWarning)
-
 
 class Ingress(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class Ingress(pulumi.CustomResource):
     """
     Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
     """
-    warnings.warn("extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
@@ -59,7 +55,6 @@ class Ingress(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[dict] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
-        pulumi.log.warn("Ingress is deprecated: extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
 
 class ReplicaSet(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -32,8 +30,6 @@ class ReplicaSet(pulumi.CustomResource):
     """
     Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
     """
-    warnings.warn("extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -45,7 +41,6 @@ class ReplicaSet(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[dict] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
-        pulumi.log.warn("ReplicaSet is deprecated: extensions/v1beta1/ReplicaSet is deprecated by apps/v1/ReplicaSet and not supported by Kubernetes v1.16+ clusters.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -8,8 +8,6 @@ import pulumi.runtime
 from typing import Union
 from ... import utilities, tables
 
-warnings.warn("storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode.", DeprecationWarning)
-
 
 class CSINode(pulumi.CustomResource):
     api_version: pulumi.Output[str]
@@ -28,8 +26,6 @@ class CSINode(pulumi.CustomResource):
     """
     spec is the specification of CSINode
     """
-    warnings.warn("storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode.", DeprecationWarning)
-
     def __init__(__self__, resource_name, opts=None, api_version=None, kind=None, metadata=None, spec=None, __props__=None, __name__=None, __opts__=None):
         """
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
@@ -41,7 +37,6 @@ class CSINode(pulumi.CustomResource):
         :param pulumi.Input[dict] metadata: metadata.name must be the Kubernetes node name.
         :param pulumi.Input[dict] spec: spec is the specification of CSINode
         """
-        pulumi.log.warn("CSINode is deprecated: storage/v1beta1/CSINode is deprecated by storage.k8s.io/v1/CSINode.")
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
             resource_name = __name__

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/pulumi/pulumi-kubernetes/provider/v2 v2.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa
+	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c
 	github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae
 	github.com/stretchr/testify v1.6.1
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -604,8 +604,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa h1:Jhm3xGFG1gCx56AMfjM4Pzm+N3wZ8ZlO0GVl7yZh0Ek=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200630221921-92cb042aeeaa/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c h1:O72rbiQ16xwJ1h7lnmhbxQIMeASHPrs0xBOUFru8R98=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0 h1:3VMXbEo3bqeaU+YDt8ufVBLD0WhLYE3tG3t/nIZ3Iac=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
 github.com/pulumi/pulumi/sdk/v2 v2.2.2-0.20200514204320-e677c7d6dca3 h1:uCVadlcmLexcm6WHJv1EFB3E9PKqWQt/+zVuNC+WpjM=


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The provider already logs warnings for deprecated
resources, and includes a flag to disable these
warnings, so don't log at the SDK layer.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1150 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
