### PR TITLE
Mark Secret inputs as secret in schema

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/googleapis/gnostic v0.2.0
 	github.com/imdario/mergo v0.3.8
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c
+	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5
 	github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.28.0

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -563,8 +563,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c h1:O72rbiQ16xwJ1h7lnmhbxQIMeASHPrs0xBOUFru8R98=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5 h1:eZwzn4BxGoWANUNzCp0nsLA80GSdljNdDTrMkfE/6mY=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
 github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae h1:KuvWPTsPuiRTnYIShcjzoksbF8XQPAxnxa89m9+Lqj0=
 github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae/go.mod h1:llk6tmXss8kJrt3vEXAkwiwgZOuINEFmKIfMveVIwO8=

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -324,6 +324,12 @@ func genPropertySpec(p Property, resourceGV string, resourceKind string) pschema
 			}),
 		}
 	}
+	if resourceKind == "Secret" {
+		switch p.Name() {
+		case "data", "stringData":
+			propertySpec.Secret = true
+		}
+	}
 	return propertySpec
 }
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/pulumi/pulumi-kubernetes/provider/v2 v2.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c
+	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5
 	github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae
 	github.com/stretchr/testify v1.6.1
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -604,8 +604,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c h1:O72rbiQ16xwJ1h7lnmhbxQIMeASHPrs0xBOUFru8R98=
-github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701195026-956d362d8b4c/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5 h1:eZwzn4BxGoWANUNzCp0nsLA80GSdljNdDTrMkfE/6mY=
+github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200701201749-137f39151bb5/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0 h1:3VMXbEo3bqeaU+YDt8ufVBLD0WhLYE3tG3t/nIZ3Iac=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
 github.com/pulumi/pulumi/sdk/v2 v2.2.2-0.20200514204320-e677c7d6dca3 h1:uCVadlcmLexcm6WHJv1EFB3E9PKqWQt/+zVuNC+WpjM=


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The "data" and "stringData" fields should be treated
as secret in the core.v1.Secret resource.
<!--Give us a brief description of what you've done and what it solves. -->

This produces the following schema:
```json
"kubernetes:core/v1:Secret": {
    "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.\n\nNote: While Pulumi automatically encrypts the 'data' and 'stringData'\nfields, this encryption only applies to Pulumi's context, including the state file, \nthe Service, the CLI, etc. Kubernetes does not encrypt Secret resources by default,\nand the contents are visible to users with access to the Secret in Kubernetes using\ntools like 'kubectl'.\n\nFor more information on securing Kubernetes Secrets, see the following links:\nhttps://kubernetes.io/docs/concepts/configuration/secret/#security-properties\nhttps://kubernetes.io/docs/concepts/configuration/secret/#risks",
    "properties": {
        "apiVersion": {
            "type": "string",
            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
            "const": "v1"
        },
        "data": {
            "type": "object",
            "additionalProperties": {
                "type": "string"
            },
            "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
            "secret": true
        },
...
        "stringData": {
            "type": "object",
            "additionalProperties": {
                "type": "string"
            },
            "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.",
            "secret": true
        },
...
    },
},
```

### Related issues (optional)
Related to https://github.com/pulumi/pulumi-kubernetes/issues/1188
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
