### PR TITLE
Update json-patch mod to fix hangs on pulumi update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bug Fixes
 
--   Fix server-side diff when immutable fields change. (https://github.com/pulumi/pulumi-kubernetes/pull/1223)
+-   Fix server-side diff when immutable fields change. (https://github.com/pulumi/pulumi-kubernetes/pull/988)
+-   Update json-patch mod to fix hangs on pulumi update. (https://github.com/pulumi/pulumi-kubernetes/pull/1223)
 
 ## 2.4.1 (July 24, 2020)
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,13 +4,13 @@ go 1.14
 
 require (
 	github.com/ahmetb/go-linq v3.0.0+incompatible
-	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/golang/protobuf v1.3.5
 	github.com/googleapis/gnostic v0.2.0
 	github.com/imdario/mergo v0.3.8
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/pulumi/json-patch v0.0.0-20200731230438-50deba092bc7
 	github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200702193010-d611740ab0fa
 	github.com/pulumi/pulumi/sdk/v2 v2.5.1-0.20200626210151-8961f5b0caae
 	github.com/stretchr/testify v1.6.1

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -568,6 +568,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/json-patch v0.0.0-20200731230438-50deba092bc7 h1:8qUt+Rx/e2r8ulfqTnTIEllY7qBXub0lg9yDEAaBRnM=
+github.com/pulumi/json-patch v0.0.0-20200731230438-50deba092bc7/go.mod h1:lHHSztMWUwjDNAtnPNx1/z24Cqx0E9rPhCemR+RL/As=
 github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200702193010-d611740ab0fa h1:iqnQ3kfZbK+KUXw+fqquS51xSjkJjh83u/COzQXGjjw=
 github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200702193010-d611740ab0fa/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=

--- a/provider/pkg/openapi/match.go
+++ b/provider/pkg/openapi/match.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/pulumi/json-patch"
 	"k8s.io/client-go/util/jsonpath"
 )
 

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/pulumi/json-patch"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v2/proto/go"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -28,10 +28,10 @@ import (
 	"strings"
 	"sync"
 
-	jsonpatch "github.com/pulumi/json-patch"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	pkgerrors "github.com/pkg/errors"
+	jsonpatch "github.com/pulumi/json-patch"
 	"github.com/pulumi/pulumi-kubernetes/provider/v2/pkg/await"
 	"github.com/pulumi/pulumi-kubernetes/provider/v2/pkg/clients"
 	"github.com/pulumi/pulumi-kubernetes/provider/v2/pkg/cluster"

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"sync"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/pulumi/json-patch"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	pkgerrors "github.com/pkg/errors"

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -609,6 +609,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/json-patch v0.0.0-20200731230438-50deba092bc7 h1:8qUt+Rx/e2r8ulfqTnTIEllY7qBXub0lg9yDEAaBRnM=
+github.com/pulumi/json-patch v0.0.0-20200731230438-50deba092bc7/go.mod h1:lHHSztMWUwjDNAtnPNx1/z24Cqx0E9rPhCemR+RL/As=
 github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200702193010-d611740ab0fa h1:iqnQ3kfZbK+KUXw+fqquS51xSjkJjh83u/COzQXGjjw=
 github.com/pulumi/pulumi/pkg/v2 v2.5.1-0.20200702193010-d611740ab0fa/go.mod h1:zfUm4/GH2dVRlHZ3Yeb9bRweCQM7icVBdplu6MUDRrQ=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0 h1:3VMXbEo3bqeaU+YDt8ufVBLD0WhLYE3tG3t/nIZ3Iac=


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
A performance bug was discovered that can cause CRD
diffs to fail. This bug is fixed in an open PR [1] to the upstream
repo, but has not been merged yet. In the meantime, I forked
the json-patch repo, and applied the fix [2]. This change will be
reverted once the upstream patch merges, and the module will
be updated to point at the fixed changeset.

[1] https://github.com/evanphx/json-patch/pull/108
[2] https://github.com/pulumi/json-patch
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1222 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
