### PR TITLE
[python] Rename yaml.Config file_id parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Bug Fixes
+
+-   Rename Python's yaml.ConfigFile file_id parameter to file. (https://github.com/pulumi/pulumi-kubernetes/pull/1248)
+
 ### Improvements
 
 -   Remove the ComponentStatus resource type. (https://github.com/pulumi/pulumi-kubernetes/pull/1234)

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -219,7 +219,7 @@ class ConfigFile(pulumi.ComponentResource):
     Kubernetes resources contained in this ConfigFile.
     """
 
-    def __init__(self, name, file, opts=None, transformations=None, resource_prefix=None, file_id=None):
+    def __init__(self, name, file=None, opts=None, transformations=None, resource_prefix=None, file_id=None):
         """
         ConfigFile creates a set of Kubernetes resources from a Kubernetes YAML file.
 
@@ -298,6 +298,8 @@ class ConfigFile(pulumi.ComponentResource):
         if file_id is not None:
             warnings.warn("explicit use of file_id is deprecated, use 'file' instead", DeprecationWarning)
             file = file_id
+        if file is None:
+            raise TypeError("Missing file argument")
 
         if _is_url(file):
             text = _read_url(file)

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -93,7 +93,7 @@ class ConfigGroup(pulumi.ComponentResource):
         ### YAML with Transformations
 
         ```python
-        from pulumi_kubernetes.yaml import ConfigFile
+        from pulumi_kubernetes.yaml import ConfigGroup
 
         # Make every service private to the cluster, i.e., turn all services into ClusterIP instead of LoadBalancer.
         def make_service_private(obj, opts):
@@ -219,7 +219,7 @@ class ConfigFile(pulumi.ComponentResource):
     Kubernetes resources contained in this ConfigFile.
     """
 
-    def __init__(self, name, file_id, opts=None, transformations=None, resource_prefix=None):
+    def __init__(self, name, file, opts=None, transformations=None, resource_prefix=None, file_id=None):
         """
         ConfigFile creates a set of Kubernetes resources from a Kubernetes YAML file.
 
@@ -231,7 +231,7 @@ class ConfigFile(pulumi.ComponentResource):
 
         example = ConfigFile(
             "example",
-            file_id="foo.yaml",
+            file="foo.yaml",
         )
         ```
         ### YAML with Transformations
@@ -265,13 +265,13 @@ class ConfigFile(pulumi.ComponentResource):
 
         example = ConfigFile(
             "example",
-            file_id="foo.yaml",
+            file="foo.yaml",
             transformations=[make_service_private, alias, omit_resource],
         )
         ```
 
         :param str name: A name for a resource.
-        :param str file_id: Path or a URL that uniquely identifies a file.
+        :param str file: Path or a URL that uniquely identifies a file.
         :param Optional[pulumi.ResourceOptions] opts: A bag of optional settings that control a resource's behavior.
         :param Optional[List[Tuple[Callable, Optional[pulumi.ResourceOptions]]]] transformations: A set of
                transformations to apply to Kubernetes resource definitions before registering with engine.
@@ -295,10 +295,14 @@ class ConfigFile(pulumi.ComponentResource):
             __props__,
             opts)
 
-        if _is_url(file_id):
-            text = _read_url(file_id)
+        if file_id is not None:
+            warnings.warn("explicit use of file_id is deprecated, use 'file' instead", DeprecationWarning)
+            file = file_id
+
+        if _is_url(file):
+            text = _read_url(file)
         else:
-            text = _read_file(file_id)
+            text = _read_file(file)
 
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
 

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -2,6 +2,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 from copy import copy
 from glob import glob
 from inspect import getargspec

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -219,7 +219,7 @@ class ConfigFile(pulumi.ComponentResource):
     Kubernetes resources contained in this ConfigFile.
     """
 
-    def __init__(self, name, file, opts=None, transformations=None, resource_prefix=None, file_id=None):
+    def __init__(self, name, file=None, opts=None, transformations=None, resource_prefix=None, file_id=None):
         """
         ConfigFile creates a set of Kubernetes resources from a Kubernetes YAML file.
 
@@ -298,6 +298,8 @@ class ConfigFile(pulumi.ComponentResource):
         if file_id is not None:
             warnings.warn("explicit use of file_id is deprecated, use 'file' instead", DeprecationWarning)
             file = file_id
+        if file is None:
+            raise TypeError("Missing file argument")
 
         if _is_url(file):
             text = _read_url(file)

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -93,7 +93,7 @@ class ConfigGroup(pulumi.ComponentResource):
         ### YAML with Transformations
 
         ```python
-        from pulumi_kubernetes.yaml import ConfigFile
+        from pulumi_kubernetes.yaml import ConfigGroup
 
         # Make every service private to the cluster, i.e., turn all services into ClusterIP instead of LoadBalancer.
         def make_service_private(obj, opts):
@@ -219,7 +219,7 @@ class ConfigFile(pulumi.ComponentResource):
     Kubernetes resources contained in this ConfigFile.
     """
 
-    def __init__(self, name, file_id, opts=None, transformations=None, resource_prefix=None):
+    def __init__(self, name, file, opts=None, transformations=None, resource_prefix=None, file_id=None):
         """
         ConfigFile creates a set of Kubernetes resources from a Kubernetes YAML file.
 
@@ -231,7 +231,7 @@ class ConfigFile(pulumi.ComponentResource):
 
         example = ConfigFile(
             "example",
-            file_id="foo.yaml",
+            file="foo.yaml",
         )
         ```
         ### YAML with Transformations
@@ -265,13 +265,13 @@ class ConfigFile(pulumi.ComponentResource):
 
         example = ConfigFile(
             "example",
-            file_id="foo.yaml",
+            file="foo.yaml",
             transformations=[make_service_private, alias, omit_resource],
         )
         ```
 
         :param str name: A name for a resource.
-        :param str file_id: Path or a URL that uniquely identifies a file.
+        :param str file: Path or a URL that uniquely identifies a file.
         :param Optional[pulumi.ResourceOptions] opts: A bag of optional settings that control a resource's behavior.
         :param Optional[List[Tuple[Callable, Optional[pulumi.ResourceOptions]]]] transformations: A set of
                transformations to apply to Kubernetes resource definitions before registering with engine.
@@ -295,10 +295,14 @@ class ConfigFile(pulumi.ComponentResource):
             __props__,
             opts)
 
-        if _is_url(file_id):
-            text = _read_url(file_id)
+        if file_id is not None:
+            warnings.warn("explicit use of file_id is deprecated, use 'file' instead", DeprecationWarning)
+            file = file_id
+
+        if _is_url(file):
+            text = _read_url(file)
         else:
-            text = _read_file(file_id)
+            text = _read_file(file)
 
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
 

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -2,6 +2,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 from copy import copy
 from glob import glob
 from inspect import getargspec


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
All of the other SDKs call this parameter `file`,
so rename it from `file_id` with deprecated
support for the old name.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1247 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
