### PR TITLE
Handle kubeconfig contents or path in provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+-   Handle kubeconfig contents or path in provider. (https://github.com/pulumi/pulumi-kubernetes/pull/1255)
+
 ## 2.4.3 (August 14, 2020)
 
 ### Bug Fixes

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -24,7 +24,7 @@
             },
             "kubeconfig": {
                 "type": "string",
-                "description": "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
+                "description": "The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
                 "language": {
                     "csharp": {
                         "name": "KubeConfig"
@@ -26398,7 +26398,7 @@
             },
             "kubeconfig": {
                 "type": "string",
-                "description": "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
+                "description": "The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
                 "defaultInfo": {
                     "environment": [
                         "KUBECONFIG"

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -37,8 +37,9 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 		Config: pschema.ConfigSpec{
 			Variables: map[string]pschema.PropertySpec{
 				"kubeconfig": {
-					Description: "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
-					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Description: "The contents of a kubeconfig file or the path to a kubeconfig file. If this is set," +
+						" this config will be used instead of $KUBECONFIG.",
+					TypeSpec: pschema.TypeSpec{Type: "string"},
 					Language: map[string]json.RawMessage{
 						"csharp": rawMessage(map[string]interface{}{
 							"name": "KubeConfig",
@@ -84,8 +85,9 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 							"KUBECONFIG",
 						},
 					},
-					Description: "The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
-					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Description: "The contents of a kubeconfig file or the path to a kubeconfig file. If this is set," +
+						" this config will be used instead of $KUBECONFIG.",
+					TypeSpec: pschema.TypeSpec{Type: "string"},
 					Language: map[string]json.RawMessage{
 						"csharp": rawMessage(map[string]interface{}{
 							"name": "KubeConfig",

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -29,7 +29,7 @@ namespace Pulumi.Kubernetes
         public static bool? EnableDryRun { get; set; } = __config.GetBoolean("enableDryRun");
 
         /// <summary>
-        /// The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+        /// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
         /// </summary>
         public static string? KubeConfig { get; set; } = __config.Get("kubeconfig");
 

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -69,7 +69,7 @@ namespace Pulumi.Kubernetes
         public Input<bool>? EnableDryRun { get; set; }
 
         /// <summary>
-        /// The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+        /// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
         /// </summary>
         [Input("kubeconfig")]
         public Input<string>? KubeConfig { get; set; }

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -28,7 +28,7 @@ func GetEnableDryRun(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:enableDryRun")
 }
 
-// The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
 func GetKubeconfig(ctx *pulumi.Context) string {
 	return config.Get(ctx, "kubernetes:kubeconfig")
 }

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -49,7 +49,7 @@ type providerArgs struct {
 	// 1. This `enableDryRun` parameter.
 	// 2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable.
 	EnableDryRun *bool `pulumi:"enableDryRun"`
-	// The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+	// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
 	Kubeconfig *string `pulumi:"kubeconfig"`
 	// If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
 	//
@@ -88,7 +88,7 @@ type ProviderArgs struct {
 	// 1. This `enableDryRun` parameter.
 	// 2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable.
 	EnableDryRun pulumi.BoolPtrInput
-	// The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+	// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
 	Kubeconfig pulumi.StringPtrInput
 	// If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
 	//

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -74,7 +74,7 @@ export interface ProviderArgs {
      */
     readonly enableDryRun?: pulumi.Input<boolean>;
     /**
-     * The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+     * The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
      */
     readonly kubeconfig?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -25,7 +25,7 @@ class Provider(pulumi.ProviderResource):
                This config can be specified in the following ways, using this precedence:
                1. This `enableDryRun` parameter.
                2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable.
-        :param pulumi.Input[str] kubeconfig: The contents of a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
+        :param pulumi.Input[str] kubeconfig: The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
         :param pulumi.Input[str] namespace: If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
                
                A namespace can be specified in multiple places, and the precedence is as follows:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	github.com/pulumi/pulumi-kubernetes/provider/v2 v2.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.0.0
+	github.com/pulumi/pulumi-kubernetes/provider/v2 v2.0.0
+	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.4.3
 	github.com/pulumi/pulumi/pkg/v2 v2.8.2
 	github.com/pulumi/pulumi/sdk/v2 v2.8.2
 	github.com/stretchr/testify v1.6.1

--- a/tests/integration/provider/provider_test.go
+++ b/tests/integration/provider/provider_test.go
@@ -34,17 +34,20 @@ func TestProvider(t *testing.T) {
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 8, len(stackInfo.Deployment.Resources))
+			assert.Equal(t, 10, len(stackInfo.Deployment.Resources))
 
 			tests.SortResourcesByURN(stackInfo)
 
-			stackRes := stackInfo.Deployment.Resources[7]
+			stackRes := stackInfo.Deployment.Resources[9]
 			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 
-			k8sProvider := stackInfo.Deployment.Resources[6]
-			assert.True(t, providers.IsProviderType(k8sProvider.URN.Type()))
+			k8sPathProvider := stackInfo.Deployment.Resources[8]
+			assert.True(t, providers.IsProviderType(k8sPathProvider.URN.Type()))
 
-			defaultProvider := stackInfo.Deployment.Resources[5]
+			k8sContentsProvider := stackInfo.Deployment.Resources[7]
+			assert.True(t, providers.IsProviderType(k8sContentsProvider.URN.Type()))
+
+			defaultProvider := stackInfo.Deployment.Resources[6]
 			assert.True(t, providers.IsProviderType(defaultProvider.URN.Type()))
 
 			// Assert the provider default Namespace (ns1) was created
@@ -64,10 +67,16 @@ func TestProvider(t *testing.T) {
 			assert.NotEqual(t, nsName.(string), providerNsName.(string))
 
 			// Assert the first Pod was created in the provider default namespace.
-			pod := stackInfo.Deployment.Resources[4]
-			assert.Equal(t, "nginx", string(pod.URN.Name()))
-			podNamespace, _ := openapi.Pluck(pod.Outputs, "metadata", "namespace")
-			assert.Equal(t, providerNsName.(string), podNamespace.(string))
+			pod1 := stackInfo.Deployment.Resources[4]
+			assert.Equal(t, "nginx1", string(pod1.URN.Name()))
+			podNamespace1, _ := openapi.Pluck(pod1.Outputs, "metadata", "namespace")
+			assert.Equal(t, providerNsName.(string), podNamespace1.(string))
+
+			// Assert the second Pod was created in the provider default namespace.
+			pod2 := stackInfo.Deployment.Resources[5]
+			assert.Equal(t, "nginx2", string(pod2.URN.Name()))
+			podNamespace2, _ := openapi.Pluck(pod2.Outputs, "metadata", "namespace")
+			assert.Equal(t, providerNsName.(string), podNamespace2.(string))
 
 			// Assert the Pod was created in the specified namespace rather than the provider default namespace.
 			namespacedPod := stackInfo.Deployment.Resources[3]

--- a/tests/integration/provider/step1/index.ts
+++ b/tests/integration/provider/step1/index.ts
@@ -17,21 +17,18 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-// Use the existing ~/.kube/config kubeconfig
-const kubeconfigPath = path.join(os.homedir(), ".kube", "config");
-
 const ns1 = new k8s.core.v1.Namespace("ns1");
 const ns2 = new k8s.core.v1.Namespace("ns2");
 
 // Create a new provider using the contents of a k8s config.
 const kubeconfigContentsProvider = new k8s.Provider("kubeconfigContentsProvider", {
-    kubeconfig: fs.readFileSync(kubeconfigPath).toString(),
+    kubeconfig: fs.readFileSync(path.join(os.homedir(), ".kube", "config")).toString(),
     namespace: ns1.metadata.name,
 });
 
 // Create a new provider using the path to a k8s config.
 const kubeconfigPathProvider = new k8s.Provider("kubeconfigPathProvider", {
-    kubeconfig: kubeconfigPath,
+    kubeconfig: "~/.kube/config",
     namespace: ns1.metadata.name,
 });
 
@@ -59,7 +56,7 @@ new k8s.core.v1.Pod("nginx2", {
     },
 }, { provider: kubeconfigPathProvider });
 
-// Create a Pod using the contents provider with a specified default namespace.
+// Create a Pod using the contents provider with a specified namespace.
 // The namespace should not be overridden by the provider default.
 new k8s.core.v1.Pod("namespaced-nginx", {
     metadata: { namespace: ns2.metadata.name },

--- a/tests/integration/provider/step1/index.ts
+++ b/tests/integration/provider/step1/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,26 @@ import * as os from "os";
 import * as path from "path";
 
 // Use the existing ~/.kube/config kubeconfig
-const kubeconfig = fs.readFileSync(path.join(os.homedir(), ".kube", "config")).toString();
+const kubeconfigPath = path.join(os.homedir(), ".kube", "config");
 
 const ns1 = new k8s.core.v1.Namespace("ns1");
 const ns2 = new k8s.core.v1.Namespace("ns2");
 
-// Create a new provider
-const myk8s = new k8s.Provider("myk8s", {
-    kubeconfig: kubeconfig,
+// Create a new provider using the contents of a k8s config.
+const kubeconfigContentsProvider = new k8s.Provider("kubeconfigContentsProvider", {
+    kubeconfig: fs.readFileSync(kubeconfigPath).toString(),
     namespace: ns1.metadata.name,
 });
 
-// Create a Pod using the custom provider.
+// Create a new provider using the path to a k8s config.
+const kubeconfigPathProvider = new k8s.Provider("kubeconfigPathProvider", {
+    kubeconfig: kubeconfigPath,
+    namespace: ns1.metadata.name,
+});
+
+// Create a Pod using the contents provider.
 // The namespace should be automatically set by the provider default.
-new k8s.core.v1.Pod("nginx", {
+new k8s.core.v1.Pod("nginx1", {
     spec: {
         containers: [{
             image: "nginx:1.7.9",
@@ -39,9 +45,21 @@ new k8s.core.v1.Pod("nginx", {
             ports: [{ containerPort: 80 }],
         }],
     },
-}, { provider: myk8s });
+}, { provider: kubeconfigContentsProvider });
 
-// Create a Pod using the custom provider with a specified default namespace.
+// Create a Pod using the path provider.
+// The namespace should be automatically set by the provider default.
+new k8s.core.v1.Pod("nginx2", {
+    spec: {
+        containers: [{
+            image: "nginx:1.7.9",
+            name: "nginx",
+            ports: [{ containerPort: 80 }],
+        }],
+    },
+}, { provider: kubeconfigPathProvider });
+
+// Create a Pod using the contents provider with a specified default namespace.
 // The namespace should not be overridden by the provider default.
 new k8s.core.v1.Pod("namespaced-nginx", {
     metadata: { namespace: ns2.metadata.name },
@@ -52,10 +70,10 @@ new k8s.core.v1.Pod("namespaced-nginx", {
             ports: [{ containerPort: 80 }],
         }],
     },
-}, { provider: myk8s });
+}, { provider: kubeconfigContentsProvider });
 
-// Create a Namespace using the custom provider
+// Create a Namespace using the contents provider
 // The namespace should not be affected by the provider override since it is a cluster-scoped kind.
 new k8s.core.v1.Namespace("other-ns",
     {},
-    { provider: myk8s });
+    { provider: kubeconfigContentsProvider });


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, we only handled the contents of a kubeconfig
as configuration for the k8s provivder. This change now
additionally supports passing in the path to a kubeconfig.
An error is only returned if both of these options fail to
load a valid k8s configuration.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1252 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
