### PR TITLE
[crd2pulumi] Drop darwin-386 support from Makefile

### DIFF
--- a/provider/cmd/crd2pulumi/Makefile
+++ b/provider/cmd/crd2pulumi/Makefile
@@ -12,8 +12,6 @@ build::
 release: rel-darwin rel-linux rel-windows
 
 rel-darwin::
-	GOOS=darwin GOARCH=386 $(GO) build -o releases/crd2pulumi-darwin-386/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-darwin-368.tar.gz releases/crd2pulumi-darwin-386
 	GOOS=darwin GOARCH=amd64 $(GO) build -o releases/crd2pulumi-darwin-amd64/crd2pulumi $(PROJECT)
 	tar -zcvf releases/crd2pulumi-darwin-amd64.tar.gz releases/crd2pulumi-darwin-amd64
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
[Go 1.15 dropped support for Darwin 32-bit architectures](https://golang.org/doc/go1.15#darwin), so we will no longer provide `darwin-386` release binaries. You can compile the code from source using Go 1.14 if you still need this support.
<!--Give us a brief description of what you've done and what it solves. -->


