### PR TITLE
Update Makefile

### DIFF
--- a/provider/cmd/crd2pulumi/Makefile
+++ b/provider/cmd/crd2pulumi/Makefile
@@ -13,16 +13,17 @@ release: rel-darwin rel-linux rel-windows
 
 rel-darwin::
 	GOOS=darwin GOARCH=amd64 $(GO) build -o releases/crd2pulumi-darwin-amd64/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-darwin-amd64.tar.gz releases/crd2pulumi-darwin-amd64
+	tar -zcvf releases/crd2pulumi-darwin-amd64.tar.gz -C releases/crd2pulumi-darwin-amd64 .
 
 rel-linux::
 	GOOS=linux GOARCH=386 $(GO) build -o releases/crd2pulumi-linux-386/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-linux-386.tar.gz releases/crd2pulumi-linux-386
+	tar -zcvf releases/crd2pulumi-linux-386.tar.gz -C releases/crd2pulumi-linux-386 .
 	GOOS=linux GOARCH=amd64 $(GO) build -o releases/crd2pulumi-linux-amd64/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-linux-amd64.tar.gz releases/crd2pulumi-linux-amd64
+	tar -zcvf releases/crd2pulumi-linux-amd64.tar.gz -C releases/crd2pulumi-linux-amd64 .
 
 rel-windows::
-	GOOS=windows GOARCH=386 $(GO) build -o releases/crd2pulumi-windows-386/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-windows-386.tar.gz releases/crd2pulumi-windows-386
-	GOOS=windows GOARCH=amd64 $(GO) build -o releases/crd2pulumi-windows-amd64/crd2pulumi $(PROJECT)
-	tar -zcvf releases/crd2pulumi-windows-amd64.tar.gz releases/crd2pulumi-windows-amd64
+	GOOS=windows GOARCH=386 $(GO) build -o releases/crd2pulumi-windows-386/crd2pulumi.exe $(PROJECT)
+	zip -j releases/crd2pulumi-windows-386.zip releases/crd2pulumi-windows-386/crd2pulumi.exe
+	GOOS=windows GOARCH=amd64 $(GO) build -o releases/crd2pulumi-windows-amd64/crd2pulumi.exe $(PROJECT)
+	zip -j releases/crd2pulumi-windows-amd64.zip releases/crd2pulumi-windows-amd64/crd2pulumi.exe
+	


### PR DESCRIPTION
A user suggested to compress the Windows binaries using .zip instead of .tar.gz and to remove the folder structure (it was `releases/crd2pulumi-darwin-amd64/crd2pulumi, etc...` before)