### PR TITLE
[Python] Support annotations on transformation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 -   Update Go Helm v3 to use native client. (https://github.com/pulumi/pulumi-kubernetes/pull/1296)
+-   Python: Allow type annotations on transformation functions. (https://github.com/pulumi/pulumi-kubernetes/pull/1298)
 
 ## 2.5.1 (September 2, 2020)
 

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -5,7 +5,7 @@ import json
 import warnings
 from copy import copy
 from glob import glob
-from inspect import getargspec
+from inspect import getfullargspec
 from typing import Any, Callable, Dict, List, Optional
 
 import pulumi
@@ -420,7 +420,7 @@ def _parse_yaml_object(
     # Allow users to change API objects before any validation.
     if transformations is not None:
         for t in transformations:
-            if len(getargspec(t)[0]) == 2:
+            if len(getfullargspec(t)[0]) == 2:
                 t(obj, opts)
             else:
                 t(obj)

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -5,7 +5,7 @@ import json
 import warnings
 from copy import copy
 from glob import glob
-from inspect import getargspec
+from inspect import getfullargspec
 from typing import Any, Callable, Dict, List, Optional
 
 import pulumi
@@ -420,7 +420,7 @@ def _parse_yaml_object(
     # Allow users to change API objects before any validation.
     if transformations is not None:
         for t in transformations:
-            if len(getargspec(t)[0]) == 2:
+            if len(getfullargspec(t)[0]) == 2:
                 t(obj, opts)
             else:
                 t(obj)

--- a/tests/sdk/python/kustomize/__main__.py
+++ b/tests/sdk/python/kustomize/__main__.py
@@ -14,11 +14,13 @@
 
 import pulumi_kubernetes as k8s
 
+from typing import Any
+
 ns = k8s.core.v1.Namespace("ns")
 
 
 def set_namespace(namespace):
-    def f(obj):
+    def f(obj: Any):
         if "metadata" in obj:
             obj["metadata"]["namespace"] = namespace.metadata["name"]
         else:


### PR DESCRIPTION
Replace use of the deprecated `inspect.getargspec` with `inspect.getfullargspec`, which works when there are type annotations on the function parameters.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1163