### PR TITLE
Fix Helm v3 default namespace handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Fix Python type hints for lists (https://github.com/pulumi/pulumi-kubernetes/pull/1313)
 -   Fix Python type hints for integers (https://github.com/pulumi/pulumi-kubernetes/pull/1317)
+-   Fix Helm v3 default namespace handling (https://github.com/pulumi/pulumi-kubernetes/pull/1323)
 
 ### Improvements
 

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -182,7 +182,7 @@ func (c *chart) template() (string, error) {
 
 	// If the namespace isn't set, explicitly set it to "default".
 	if len(c.opts.Namespace) == 0 {
-		c.opts.Namespace = "default"
+		c.opts.Namespace = "default" // nolint: goconst
 	}
 
 	installAction := action.NewInstall(cfg)

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -180,12 +180,18 @@ func (c *chart) template() (string, error) {
 		cfg.Capabilities.APIVersions = append(cfg.Capabilities.APIVersions, c.opts.APIVersions...)
 	}
 
+	// If the namespace isn't set, explicitly set it to "default".
+	if len(c.opts.Namespace) == 0 {
+		c.opts.Namespace = "default"
+	}
+
 	installAction := action.NewInstall(cfg)
 	installAction.APIVersions = c.opts.APIVersions
 	installAction.ClientOnly = true
 	installAction.DryRun = true
 	installAction.IncludeCRDs = true // TODO: handle this conditionally?
 	installAction.Namespace = c.opts.Namespace
+	installAction.NameTemplate = c.opts.ReleaseName
 	installAction.ReleaseName = c.opts.ReleaseName
 	installAction.Version = c.opts.Version
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
During the switch to native Helm v3 support, the behavior
for resources without a specified namespace was changed
inadvertently. Rather than specifying the "default" namespace,
no namespace was being set. This change correctly sets the
namespace in all cases.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1321 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
