### PR TITLE
Set `usesIOClasses` for Python in the schema

### DIFF
--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -263,6 +263,7 @@ Use the navigation below to see detailed documentation for each of the supported
 		},
 		"moduleNameOverrides": modToPkg,
 		"compatibility":       kubernetes20,
+		"usesIOClasses":       true,
 		"readme": `The Kubernetes provider package offers support for all Kubernetes resources and their properties.
 Resources are exposed as types from modules based on Kubernetes API groups such as 'apps', 'core',
 'rbac', and 'storage', among many others. Additionally, support for deploying Helm charts ('helm')


### PR DESCRIPTION
Looks like we missed setting this for the Kubernetes provider. This option indicates that input/output classes should be used in generated examples and resource doc gen.