### PR TITLE
Add support for Create/Update previews.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.3 (October 12, 2020)
 
+-   Add support for previewing Create and Update operations for API servers that support dry-run (https://github.com/pulumi/pulumi-kubernetes/pull/1355)
 -   Revert Helm v2 deprecation warnings (https://github.com/pulumi/pulumi-kubernetes/pull/1352)
 
 ## 2.6.2 (October 7, 2020)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v2 v2.10.2
-	github.com/pulumi/pulumi/sdk/v2 v2.10.2
+	github.com/pulumi/pulumi/pkg/v2 v2.11.3-0.20201012185126-156aa9862e15
+	github.com/pulumi/pulumi/sdk/v2 v2.11.3-0.20201012185126-156aa9862e15
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.29.1
 	helm.sh/helm/v3 v3.3.3

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -881,9 +881,13 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi/pkg/v2 v2.10.2 h1:fmqbtsf+GR9DKJjB8dVYzu5b9J5C1ZPCKpmY+hGjSnc=
 github.com/pulumi/pulumi/pkg/v2 v2.10.2/go.mod h1:zQWe2D4tYJDeXNzSclqNmP8/SMSKOh8k22AbWg3+mVc=
+github.com/pulumi/pulumi/pkg/v2 v2.11.3-0.20201012185126-156aa9862e15 h1:N4+VC5U8weg6k9DeJhX2GdOTaxgzjzG5JU0BjRIDlnM=
+github.com/pulumi/pulumi/pkg/v2 v2.11.3-0.20201012185126-156aa9862e15/go.mod h1:7NmgAy555Lk7v4Ddb6HF1BVAhdyT3012h47vz/hLD2k=
 github.com/pulumi/pulumi/sdk/v2 v2.2.1/go.mod h1:QNbWpL4gvf3X0lUFT7TXA2Jo1ff/Ti2l97AyFGYwvW4=
 github.com/pulumi/pulumi/sdk/v2 v2.10.2 h1:NPB5bs1b6ta/LEKQKh0hVIRUxczI4MTrEfAeymls5xY=
 github.com/pulumi/pulumi/sdk/v2 v2.10.2/go.mod h1:EED7KCDOohYIewUppsav5KHTFTmfYGqUFib1uRvYdWQ=
+github.com/pulumi/pulumi/sdk/v2 v2.11.3-0.20201012185126-156aa9862e15 h1:ivePIkhn9MsrBSJFqYVJKf03BxWVWN5WrSLQL7SJ9zM=
+github.com/pulumi/pulumi/sdk/v2 v2.11.3-0.20201012185126-156aa9862e15/go.mod h1:WQ4WaHMA7mduVHAJi87iIqbWvqsuBUYccBiKK+FrayI=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
Implement support for the recently-added "provider preview" feature of
the Pulumi plugin interface that allows a resource provider to return
known values from a call to Create or Update during a preview. This
feature improves the usability of previews by allowing more values to be
treated as known.

When previewing a Create or Update operation, the Kuberentes provider
will either return the result of a dry-run performed by the API server
or will return the inputs as-is. The dry-run is preferred, but is only
possible when all of the inputs to the resource are known, the API
server supports dry-running the resource in question, and the user has
explicitly enabled the feature using the `enableDryRun` configuration
property. Returning the inputs as-is matches the behavior previously
implemented by the Pulumi engine.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
