### PR TITLE
Fix panic resulting from passing kubeconfig as object during provider creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Add support for previewing Create and Update operations for API servers that support dry-run (https://github.com/pulumi/pulumi-kubernetes/pull/1355)
 -   Fix panic introduced in #1355 (https://github.com/pulumi/pulumi-kubernetes/pull/1368)
 -   Update Helm to v3.4.0 and client-go to v1.19.2 (https://github.com/pulumi/pulumi-kubernetes/pull/1360)
+-   Fix panic when provider is given kubeconfig as an object instead of string (https://github.com/pulumi/pulumi-kubernetes/pull/1373)
 
 ## 2.6.3 (October 12, 2020)
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1231

You can successfully create a provider by specifying `kubeconfig` as an object, even though the SDKs are typed as a string. Any subsequent updates will fail in the DiffConfig path when it tries to parse the existing kubeconfig (it appears that there's no workaround for this at the moment once you've gotten yourself into the situation. 

This change adds support for parsing kubeconfig specified as either a map or a string to bypass the panic. Any other types will fail, and malformed kubeconfig maps will continue to fail on this path. I did not update the client SDK types of kubeconfig as the goal of this fix was to get rid of the panic.

How do you get into this situation? [EKS](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cluster.ts#L140) specifies `kubeconfig` as `Output<any>`, so this is quite an easy mistake to make if the kubeconfig comes back as an object as it does in the following example:

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";
import * as awsx from "@pulumi/awsx";
import * as eks from "@pulumi/eks";
import * as k8s from "@pulumi/kubernetes";

import * as bcrypt from "bcryptjs";

const vpc = new awsx.ec2.Vpc("lbriggs", {
    subnets: [
        { type: "public", tags: { "kubernetes.io/cluster/lbriggs": "shared", "kubernetes.io/role/elb": "1" } },
        { type: "private", tags: { "kubernetes.io/cluster/lbriggs": "shared", "kubernetes.io/role/internal-elb": "1" }  },
    ]
})

export const vpcId = vpc.id
export const privateSubnets = vpc.privateSubnetIds
export const publicSubnets = vpc.publicSubnetIds

const cluster = new eks.Cluster("lbriggs", {
    name: "lbriggs",
    vpcId: vpcId,
    privateSubnetIds: privateSubnets,
    publicSubnetIds: publicSubnets,
    createOidcProvider: true,
})

export const clusterName = cluster.eksCluster.name
export const kubeconfig = cluster.kubeconfig
export const clusterOidcProvider = cluster.core.oidcProvider?.url
export const clusterOidcProviderArn = cluster.core.oidcProvider?.arn

const provider = new k8s.Provider("k8s", { kubeconfig: kubeconfig });


// TODO: make this a secret and set as a config value
const password = bcrypt.hashSync("changeme", 10)

const argocd = new k8s.helm.v3.Chart("argocd",
    {
        namespace: "default",
        chart: "argo-cd",
        fetchOpts: { repo: "https://argoproj.github.io/argo-helm" },
        values: {
            installCRDs: false,
            configs: {
                secret: {
                    argocdServerAdminPassword: password,
                },
            },
            server: {
                service: {
                    type: 'LoadBalancer',
                },
            }
        },
        // The helm chart is using a deprecated apiVersion,
        // So let's transform it
        // transformations: [
        //     (obj: any) => {
        //         if (obj.apiVersion == "extensions/v1beta1")  {
        //             obj.apiVersion = "networking.k8s.io/v1beta1"
        //         }
        //     },
        // ],
    },
    {provider: provider },
);

export const url = argocd.getResourceProperty("v1/Service", "default/argocd-server", "status").apply(((status: any) => status.loadBalancer.ingress[0].hostname))
```

On the first update, the code runs fine and resources are created. On subsequent runs, it panics with the error message in the linked issue. The panic is no longer triggered after this change. It is unclear to me if the  `any` typing of eks `kubeconfig` is intentional or a bug, will follow up on that separately. 