### PR TITLE
Error on delete if cluster is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Error on delete if cluster is unreachable (https://github.com/pulumi/pulumi-kubernetes/pull/1379)
+
 ## 2.7.0 (November 12, 2020)
 
 -   Add support for previewing Create and Update operations for API servers that support dry-run (https://github.com/pulumi/pulumi-kubernetes/pull/1355)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1956,10 +1956,10 @@ func (k *kubeProvider) Delete(
 	label := fmt.Sprintf("%s.Delete(%s)", k.label(), urn)
 	logger.V(9).Infof("%s executing", label)
 
-	// If the cluster is unreachable, consider the resource deleted and inform the user.
 	if k.clusterUnreachable {
-		_ = k.host.Log(ctx, diag.Warning, urn, fmt.Sprintf("configured Kubernetes cluster is unreachable: %s", k.clusterUnreachableReason))
-		return &pbempty.Empty{}, nil
+		return nil, fmt.Errorf("configured Kubernetes cluster is unreachable: %s\n"+
+			"If the cluster has been deleted, you can edit the pulumi state to remove this resource",
+			k.clusterUnreachableReason)
 	}
 
 	// TODO(hausdorff): Propagate other options, like grace period through flags.


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
We previously considered a resource to be deleted if the
cluster is unreachable during an update. The intent was to
gracefully handle cases where the underlying cluster was
deleted (perhaps as part of another stack). Unfortunately,
this change led to cases where resources were erroneously
deleted from the state due to network partitions.

This change reverts that behavior so that an error is returned
for resource deletion if the cluster is unreachable.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1013 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
