### PR TITLE
Docs build calls schema Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ openapi_file::
 k8sgen::
 	(cd provider && go build -a -o $(WORKING_DIR)/bin/${CODEGEN} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/$(CODEGEN))
 
-schema::
+schema:: k8sgen
 	@echo "Generating Pulumi schema..."
 	$(WORKING_DIR)/bin/${CODEGEN} schema $(OPENAPI_FILE) $(CURDIR)
 	@echo "Finished generating schema."


### PR DESCRIPTION
This requires codegen to be built otherwise we get the following
error:

```
Generating Pulumi schema...
/home/runner/work/docs/docs/pulumi-kubernetes/bin/pulumi-gen-kubernetes schema provider/pkg/gen/openapi-specs/swagger-v1.19.0.json /home/runner/work/docs/docs/pulumi-kubernetes
make: /home/runner/work/docs/docs/pulumi-kubernetes/bin/pulumi-gen-kubernetes: Command not found
make: *** [schema] Error 127
Makefile:33: recipe for target 'schema' failed
```


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->