### PR TITLE
Allow overwriting property types from the schema.

### DIFF
--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1,0 +1,23 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import pschema "github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+
+// typeOverlays augment the types defined by the kubernetes schema.
+var typeOverlays = map[string]pschema.ComplexTypeSpec{}
+
+// resourceOverlays augment the resources defined by the kubernetes schema.
+var resourceOverlays = map[string]pschema.ResourceSpec{}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -145,6 +145,11 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 
 	definitions := swagger["definitions"].(map[string]interface{})
 	groupsSlice := createGroups(definitions)
+
+	// Make a copy of the overlay types and resources
+	overlayTypes := pkg.Types
+	overlayResources := pkg.Resources
+
 	for _, group := range groupsSlice {
 		if group.Group() == "apiserverinternal" {
 			continue
@@ -175,6 +180,22 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				}
 				objectSpec.Language["nodejs"] = rawMessage(map[string][]string{"requiredOutputs": propNames})
 
+				// Check if the current type exists in the overlays and overwrite types accordingly
+				if overlaySpec, hasType := overlayTypes[tok]; hasType {
+					for propName, overlayProp := range overlaySpec.Properties {
+						// If overlay prop types are defined, overwrite the k8s schema prop type.
+						if len(overlayProp.OneOf) > 1 {
+							if k8sProp, propExists := objectSpec.Properties[propName]; propExists {
+								k8sProp.OneOf = overlayProp.OneOf
+								k8sProp.Ref = ""
+								k8sProp.Type = ""
+
+								objectSpec.Properties[propName] = k8sProp
+							}
+						}
+					}
+				}
+
 				pkg.Types[tok] = pschema.ComplexTypeSpec{
 					ObjectTypeSpec: objectSpec,
 				}
@@ -199,6 +220,22 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				for _, t := range kind.Aliases() {
 					aliasedType := t
 					resourceSpec.Aliases = append(resourceSpec.Aliases, pschema.AliasSpec{Type: &aliasedType})
+				}
+
+				// Check if the current resource exists in the overlays and overwrite types accordingly
+				if overlaySpec, hasResource := overlayResources[tok]; hasResource {
+					for propName, overlayProp := range overlaySpec.InputProperties {
+						// If overlay prop types are defined, overwrite the k8s schema prop type.
+						if len(overlayProp.OneOf) > 1 {
+							if k8sProp, propExists := objectSpec.Properties[propName]; propExists {
+								k8sProp.OneOf = overlayProp.OneOf
+								k8sProp.Ref = ""
+								k8sProp.Type = ""
+
+								resourceSpec.InputProperties[propName] = k8sProp
+							}
+						}
+					}
 				}
 
 				pkg.Resources[tok] = resourceSpec

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,10 +146,6 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 	definitions := swagger["definitions"].(map[string]interface{})
 	groupsSlice := createGroups(definitions)
 
-	// Make a copy of the overlay types and resources
-	overlayTypes := pkg.Types
-	overlayResources := pkg.Resources
-
 	for _, group := range groupsSlice {
 		if group.Group() == "apiserverinternal" {
 			continue
@@ -180,8 +176,8 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				}
 				objectSpec.Language["nodejs"] = rawMessage(map[string][]string{"requiredOutputs": propNames})
 
-				// Check if the current type exists in the overlays and overwrite types accordingly
-				if overlaySpec, hasType := overlayTypes[tok]; hasType {
+				// Check if the current type exists in the overlays and overwrite types accordingly.
+				if overlaySpec, hasType := typeOverlays[tok]; hasType {
 					for propName, overlayProp := range overlaySpec.Properties {
 						// If overlay prop types are defined, overwrite the k8s schema prop type.
 						if len(overlayProp.OneOf) > 1 {
@@ -222,8 +218,8 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					resourceSpec.Aliases = append(resourceSpec.Aliases, pschema.AliasSpec{Type: &aliasedType})
 				}
 
-				// Check if the current resource exists in the overlays and overwrite types accordingly
-				if overlaySpec, hasResource := overlayResources[tok]; hasResource {
+				// Check if the current resource exists in the overlays and overwrite types accordingly.
+				if overlaySpec, hasResource := resourceOverlays[tok]; hasResource {
 					for propName, overlayProp := range overlaySpec.InputProperties {
 						// If overlay prop types are defined, overwrite the k8s schema prop type.
 						if len(overlayProp.OneOf) > 1 {
@@ -239,6 +235,13 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				}
 
 				pkg.Resources[tok] = resourceSpec
+			}
+		}
+
+		// If there are types in the overlays that do not exist in the schema (i.e. enum types), add them.
+		for tok, overlayType := range typeOverlays {
+			if _, typeExists := pkg.Types[tok]; !typeExists {
+				pkg.Types[tok] = overlayType
 			}
 		}
 	}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The changes will let us specify enums and their related properties in `pschema.PackageSpec` to overwrite the types specified in the k8s schema. Check out the [example PR](https://github.com/pulumi/pulumi-kubernetes/pull/1408/files) based on these changes.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
