### PR TITLE
Fix bug with Go Helm v3 transformation marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 -   Upgrade helm and k8s deps (https://github.com/pulumi/pulumi-kubernetes/pull/1414)
+-   Fix bug with Go Helm v3 transformation marshaling (https://github.com/pulumi/pulumi-kubernetes/pull/1420)
 
 ## 2.7.5 (December 16, 2020)
 

--- a/provider/pkg/gen/go-templates/helm/v3/pulumiTypes.tmpl
+++ b/provider/pkg/gen/go-templates/helm/v3/pulumiTypes.tmpl
@@ -146,11 +146,12 @@ type ChartArgs struct {
 }
 
 // chartArgs is a copy of ChartArgs but without using TInput in types.
+// Note that Transformations are omitted in JSON marshaling because functions are not serializable.
 type chartArgs struct {
 	APIVersions     []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
 	Namespace       string                 `json:"namespace,omitempty" pulumi:"namespace"`
 	Values          map[string]interface{} `json:"values,omitempty" pulumi:"values"`
-	Transformations []yaml.Transformation  `json:"transformations,omitempty" pulumi:"transformations"`
+	Transformations []yaml.Transformation  `json:"-" pulumi:"transformations"`
 	ResourcePrefix  string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
 	Repo            string                 `json:"repo,omitempty" pulumi:"repo"`
 	Chart           string                 `json:"chart,omitempty" pulumi:"chart"`

--- a/sdk/go/kubernetes/helm/v3/pulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v3/pulumiTypes.go
@@ -146,6 +146,7 @@ type ChartArgs struct {
 }
 
 // chartArgs is a copy of ChartArgs but without using TInput in types.
+// Note that Transformations are omitted in JSON marshaling because functions are not serializable.
 type chartArgs struct {
 	APIVersions     []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
 	Namespace       string                 `json:"namespace,omitempty" pulumi:"namespace"`

--- a/sdk/go/kubernetes/helm/v3/pulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v3/pulumiTypes.go
@@ -150,7 +150,7 @@ type chartArgs struct {
 	APIVersions     []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
 	Namespace       string                 `json:"namespace,omitempty" pulumi:"namespace"`
 	Values          map[string]interface{} `json:"values,omitempty" pulumi:"values"`
-	Transformations []yaml.Transformation  `json:"transformations,omitempty" pulumi:"transformations"`
+	Transformations []yaml.Transformation  `json:"-" pulumi:"transformations"`
 	ResourcePrefix  string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
 	Repo            string                 `json:"repo,omitempty" pulumi:"repo"`
 	Chart           string                 `json:"chart,omitempty" pulumi:"chart"`


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The Helm v3 code was incorrectly trying to marshal transformation functions into JSON before invoking the provider's Helm support. The transformations only execute in the context of the SDK, so the correct behavior is to omit those in the marshaled JSON.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1369 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
