### PR TITLE
fix: include namespace in renderedYaml filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Fix bug where rendering manifests results in files being overwritten by subsequent resources with the same kind and name, but different namespace (https://github.com/pulumi/pulumi-kubernetes/pull/1429)
+
 ## 2.8.2 (February 23, 2021)
 
 -   Postpone the removal of admissionregistration/v1beta1, which has been retargeted at 1.22 (https://github.com/pulumi/pulumi-kubernetes/pull/1474)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2764,7 +2764,12 @@ func renderPathForResource(resource *unstructured.Unstructured, yamlDirectory st
 	crdDirectory := filepath.Join(yamlDirectory, "0-crd")
 	manifestDirectory := filepath.Join(yamlDirectory, "1-manifest")
 
-	fileName := fmt.Sprintf("%s-%s-%s.yaml", strings.ToLower(resource.GetKind()), resource.GetNamespace(), resource.GetName())
+	namespace := "default"
+	if "" != resource.GetNamespace() {
+		namespace = resource.GetNamespace()
+	}
+
+	fileName := fmt.Sprintf("%s-%s-%s.yaml", strings.ToLower(resource.GetKind()), namespace, resource.GetName())
 	filepath.Join(yamlDirectory, fileName)
 
 	var path string

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2764,7 +2764,7 @@ func renderPathForResource(resource *unstructured.Unstructured, yamlDirectory st
 	crdDirectory := filepath.Join(yamlDirectory, "0-crd")
 	manifestDirectory := filepath.Join(yamlDirectory, "1-manifest")
 
-	fileName := fmt.Sprintf("%s-%s.yaml", strings.ToLower(resource.GetKind()), resource.GetName())
+	fileName := fmt.Sprintf("%s-%s-%s.yaml", strings.ToLower(resource.GetKind()), resource.GetNamespace(), resource.GetName())
 	filepath.Join(yamlDirectory, fileName)
 
 	var path string


### PR DESCRIPTION
This fixes a problem when resources have the same name/kind, but live in different namespaces. This caused the first file written to be overwritten by the later resources.