### PR TITLE
Minor improvements to the .NET Helm/Yaml code

### DIFF
--- a/provider/pkg/gen/dotnet-templates/yaml/ConfigGroup.cs
+++ b/provider/pkg/gen/dotnet-templates/yaml/ConfigGroup.cs
@@ -200,7 +200,7 @@ namespace Pulumi.Kubernetes.Yaml
         /// Create a ConfigGroup resource with the given unique name, arguments, and options.
         /// </summary>
         /// <param name="name">The unique name of the resource</param>
-        /// <param name="args">The arguments used to populate this resource's properties</param>
+        /// <param name="config">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ConfigGroup(string name, ConfigGroupArgs config, ComponentResourceOptions? options = null)
             : base("kubernetes:yaml:ConfigGroup", name, options)

--- a/provider/pkg/gen/dotnet-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/dotnet-templates/yaml/yaml.tmpl
@@ -161,7 +161,8 @@ namespace Pulumi.Kubernetes.Yaml
 
         }
 
-        internal static bool IsUrl(string s) => s.StartsWith("http://") || s.StartsWith("https://");
+        internal static bool IsUrl(string s)
+            => s.StartsWith("http://", StringComparison.Ordinal) || s.StartsWith("https://", StringComparison.Ordinal);
 
         internal static Output<ImmutableDictionary<string, KubernetesResource>> ParseYamlDocument(ParseArgs config,
             ComponentResourceOptions? options = null)

--- a/sdk/dotnet/Yaml/ConfigGroup.cs
+++ b/sdk/dotnet/Yaml/ConfigGroup.cs
@@ -200,7 +200,7 @@ namespace Pulumi.Kubernetes.Yaml
         /// Create a ConfigGroup resource with the given unique name, arguments, and options.
         /// </summary>
         /// <param name="name">The unique name of the resource</param>
-        /// <param name="args">The arguments used to populate this resource's properties</param>
+        /// <param name="config">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ConfigGroup(string name, ConfigGroupArgs config, ComponentResourceOptions? options = null)
             : base("kubernetes:yaml:ConfigGroup", name, options)

--- a/sdk/dotnet/Yaml/Yaml.cs
+++ b/sdk/dotnet/Yaml/Yaml.cs
@@ -361,7 +361,8 @@ namespace Pulumi.Kubernetes.Yaml
 
         }
 
-        internal static bool IsUrl(string s) => s.StartsWith("http://") || s.StartsWith("https://");
+        internal static bool IsUrl(string s)
+            => s.StartsWith("http://", StringComparison.Ordinal) || s.StartsWith("https://", StringComparison.Ordinal);
 
         internal static Output<ImmutableDictionary<string, KubernetesResource>> ParseYamlDocument(ParseArgs config,
             ComponentResourceOptions? options = null)


### PR DESCRIPTION
Addresses minor nitpicks I noticed:

- Specify `StringComparison.Ordinal` for string comparisons (which will be faster and is more correct in these cases, per [string best practices](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings)).
- Avoid unnecessary string, array, and dictionary allocations.
- Fix compiler warning about an issue in an XML doc comment.