### PR TITLE
Update pulumi dependency to remove unused Go types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Update pulumi dependency to remove unused Go types (https://github.com/pulumi/pulumi-kubernetes/pull/1450)
+
 ## 2.7.7 (January 20, 2021)
 
 -   Expand allowed Python pyyaml dependency versions (https://github.com/pulumi/pulumi-kubernetes/pull/1435)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90
-	github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90
+	github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529
+	github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.29.1
 	helm.sh/helm/v3 v3.5.0

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -927,11 +927,11 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90 h1:LMnNWqFTmVKJQIfNwCJ9jlcs+hMuN00fMJVtHpsZwGQ=
-github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
+github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529 h1:eWGiFS3P+Nw/gG/MSlOiAsRT/ssEi/fh/q1KS9qe8Q8=
+github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
 github.com/pulumi/pulumi/sdk/v2 v2.2.1/go.mod h1:QNbWpL4gvf3X0lUFT7TXA2Jo1ff/Ti2l97AyFGYwvW4=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90 h1:WisNgaTEbSpCsFm3UD3jgXMbLsIMgata17Og/wGW1Cc=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529 h1:PKX++TRfU+a8tG0MajO/ghxEU0DxC8vpc+q9jsXkts4=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90
+	github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -165,8 +165,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90 h1:WisNgaTEbSpCsFm3UD3jgXMbLsIMgata17Og/wGW1Cc=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529 h1:PKX++TRfU+a8tG0MajO/ghxEU0DxC8vpc+q9jsXkts4=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The upstream pulumi dependency made a breaking change [1]
to remove a bunch of unused types from the core Go SDK.
This should significantly reduce the memory requirements
for compiling Go programs using the k8s provider as well
as shinking the resulting binary size.

[1] https://github.com/pulumi/pulumi/pull/6143
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Related to https://github.com/pulumi/pulumi-kubernetes/issues/1445
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
