### PR TITLE
Fix bug rendering Helm v3 resources that include hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Fix bug rendering Helm v3 resources that include hooks (https://github.com/pulumi/pulumi-kubernetes/pull/1458)
+
 ## 2.7.8 (January 27, 2021)
 
 -   Update pulumi dependency to remove unused Go types (https://github.com/pulumi/pulumi-kubernetes/pull/1450)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (Unreleased)
 
--   Fix bug rendering Helm v3 resources that include hooks (https://github.com/pulumi/pulumi-kubernetes/pull/1458)
+-   Fix bug rendering Helm v3 resources that include hooks (https://github.com/pulumi/pulumi-kubernetes/pull/1459)
 
 ## 2.7.8 (January 27, 2021)
 

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -222,6 +222,12 @@ func (c *chart) template() (string, error) {
 	if err != nil {
 		return "", pkgerrors.Wrap(err, "failed to create chart from template")
 	}
+	manifests := strings.Builder{}
+	manifests.WriteString(rel.Manifest)
+	for _, hook := range rel.Hooks {
+		manifests.WriteString("\n---\n")
+		manifests.WriteString(hook.Manifest)
+	}
 
-	return rel.Manifest, nil
+	return manifests.String(), nil
 }


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This bug caused any resource that includes a hook annotation to
be skipped, which is an unintended behavior change from the v2 SDK.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/1335
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
