### PR TITLE
Print warning for Helm resources using unsupported hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Print warning for Helm resources using unsupported hooks (https://github.com/pulumi/pulumi-kubernetes/pull/1460)
+
 ## 2.7.8 (January 27, 2021)
 
 -   Update pulumi dependency to remove unused Go types (https://github.com/pulumi/pulumi-kubernetes/pull/1450)

--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -31,6 +31,8 @@ const (
 	AnnotationSkipAwait         = AnnotationPrefix + "skipAwait"
 	AnnotationTimeoutSeconds    = AnnotationPrefix + "timeoutSeconds"
 	AnnotationInitialAPIVersion = AnnotationPrefix + "initialApiVersion"
+
+	AnnotationHelmHook = "helm.sh/hook"
 )
 
 // Annotations for internal Pulumi use only.
@@ -45,6 +47,11 @@ func IsInternalAnnotation(key string) bool {
 	}
 
 	return false
+}
+
+// IsHelmHookAnnotation returns true if the specified annotation has the `helm.sh/hook` prefix, false otherwise.
+func IsHelmHookAnnotation(key string) bool {
+	return strings.HasPrefix(key, AnnotationHelmHook)
 }
 
 // SetAnnotation sets the specified key, value annotation on the provided Unstructured object.

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1034,12 +1034,23 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 
 	var failures []*pulumirpc.CheckFailure
 
-	// If annotations with a reserved internal prefix exist, ignore them.
+	hasHelmHook := false
 	for key := range newInputs.GetAnnotations() {
+		// If annotations with a reserved internal prefix exist, ignore them.
 		if metadata.IsInternalAnnotation(key) {
 			_ = k.host.Log(ctx, diag.Warning, urn,
 				fmt.Sprintf("ignoring user-specified value for internal annotation %q", key))
 		}
+
+		// If the Helm hook annotation is found, set the hasHelmHook flag.
+		if has := metadata.IsHelmHookAnnotation(key); has {
+			hasHelmHook = hasHelmHook || has
+		}
+	}
+	if hasHelmHook {
+		_ = k.host.Log(ctx, diag.Warning, urn,
+			"this resource contains helm hooks that are not currently supported. " +
+			"This feature is tracked at https://github.com/pulumi/pulumi-kubernetes/issues/555")
 	}
 
 	annotatedInputs, err := legacyInitialAPIVersion(oldInputs, newInputs)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1049,8 +1049,9 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 	}
 	if hasHelmHook {
 		_ = k.host.Log(ctx, diag.Warning, urn,
-			"this resource contains helm hooks that are not currently supported. " +
-			"This feature is tracked at https://github.com/pulumi/pulumi-kubernetes/issues/555")
+			"This resource contains Helm hooks that are not currently supported by Pulumi. The resource will"+
+				"be created, but any hooks will not be executed. Hooks support is tracked at "+
+				"https://github.com/pulumi/pulumi-kubernetes/issues/555")
 	}
 
 	annotatedInputs, err := legacyInitialAPIVersion(oldInputs, newInputs)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/pulumi/pulumi-kubernetes/provider/v2 v2.0.0
 	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.4.3
-	github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90
-	github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90
+	github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529
+	github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529
 	github.com/stretchr/testify v1.6.1
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -899,11 +899,11 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90 h1:LMnNWqFTmVKJQIfNwCJ9jlcs+hMuN00fMJVtHpsZwGQ=
-github.com/pulumi/pulumi/pkg/v2 v2.18.1-0.20210120203508-ef66287b7b90/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
+github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529 h1:eWGiFS3P+Nw/gG/MSlOiAsRT/ssEi/fh/q1KS9qe8Q8=
+github.com/pulumi/pulumi/pkg/v2 v2.18.3-0.20210126224412-216fd2bed529/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
 github.com/pulumi/pulumi/sdk/v2 v2.2.1/go.mod h1:QNbWpL4gvf3X0lUFT7TXA2Jo1ff/Ti2l97AyFGYwvW4=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90 h1:WisNgaTEbSpCsFm3UD3jgXMbLsIMgata17Og/wGW1Cc=
-github.com/pulumi/pulumi/sdk/v2 v2.18.1-0.20210120203508-ef66287b7b90/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529 h1:PKX++TRfU+a8tG0MajO/ghxEU0DxC8vpc+q9jsXkts4=
+github.com/pulumi/pulumi/sdk/v2 v2.18.3-0.20210126224412-216fd2bed529/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1521,7 +1521,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-helm.sh/helm/v3 v3.5.0/go.mod h1:bjwXfmGAF+SEuJZ2AtN1xmTuz4FqaNYOJrXP+vtj6Tw=
+helm.sh/helm/v3 v3.5.1/go.mod h1:bjwXfmGAF+SEuJZ2AtN1xmTuz4FqaNYOJrXP+vtj6Tw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tests/sdk/python/python_test.go
+++ b/tests/sdk/python/python_test.go
@@ -58,7 +58,7 @@ func TestGet(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	for _, dir := range []string{ "get-old"} {
+	for _, dir := range []string{"get-old"} {
 		t.Run(dir, func(t *testing.T) {
 			options := baseOptions.With(integration.ProgramTestOptions{
 				ExpectRefreshChanges: true, // CRD changes on refresh


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Here's an example of how this looks:
```
kubernetes:traefik.containo.us/v1alpha1:IngressRoute (traefik-dashboard):
    warning: This resource contains Helm hooks that are not currently supported by Pulumi. The resource willbe created, but any hooks will not be executed. Hooks support is tracked at https://github.com/pulumi/pulumi-kubernetes/issues/555
```

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1454 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
