### PR TITLE
Skip Helm test hook resources by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Skip Helm test hook resources by default (https://github.com/pulumi/pulumi-kubernetes/pull/1467)
+
 ## 2.8.0 (February 3, 2021)
 
 Note: This release fixes a bug with the Helm v3 SDK that omitted any chart resources that included a hook annotation.

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ test_all::
 generate_schema:: schema
 
 install_dotnet_sdk::
+	rm -rf $(WORKING_DIR)/nuget/$(NUGET_PKG_NAME).*.nupkg
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} ${WORKING_DIR}/nuget \;
 

--- a/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
@@ -404,6 +404,12 @@ namespace Pulumi.Kubernetes.Helm
         }
 
         /// <summary>
+        /// By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+        /// this flag to true to include these resources.
+        /// </summary>
+        public Input<bool>? IncludeTestHookResources { get; set; }
+
+        /// <summary>
         /// The optional namespace to install chart resources into.
         /// </summary>
         public Input<string>? Namespace { get; set; }

--- a/provider/pkg/gen/dotnet-templates/helm/Unwraps.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/Unwraps.cs
@@ -24,6 +24,7 @@ namespace Pulumi.Kubernetes.Helm
     internal class BaseChartArgsUnwrap
     {
         public ImmutableArray<string> ApiVersions { get; set; }
+        public bool? IncludeTestHookResources { get; set; }
         public string? Namespace { get; set; }
         public ImmutableDictionary<string, object> Values { get; set; } = null!;
         public List<TransformationAction> Transformations { get; set; } = null!;
@@ -67,27 +68,29 @@ namespace Pulumi.Kubernetes.Helm
         public static Output<Union<ChartArgsUnwrap, LocalChartArgsUnwrap>> Unwrap(this Union<ChartArgs, LocalChartArgs> options)
         {
             return options.Match(
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap()).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap()).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT0(
                         new ChartArgsUnwrap
                         {
                             ApiVersions = vs.Item1,
-                            Namespace = vs.Item2,
-                            Values = vs.Item3,
+                            IncludeTestHookResources = vs.Item2,
+                            Namespace = vs.Item3,
+                            Values = vs.Item4,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
-                            Repo = vs.Item4,
-                            Chart = vs.Item5,
-                            Version = vs.Item6,
-                            FetchOptions = vs.Item7
+                            Repo = vs.Item5,
+                            Chart = vs.Item6,
+                            Version = vs.Item7,
+                            FetchOptions = vs.Item8
                         })),
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.Namespace.ToNullable(), v.Values).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT1(
                         new LocalChartArgsUnwrap
                         {
                             ApiVersions = vs.Item1,
-                            Namespace = vs.Item2,
-                            Values = vs.Item3,
+                            IncludeTestHookResources = vs.Item2,
+                            Namespace = vs.Item3,
+                            Values = vs.Item4,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
                             Path = v.Path

--- a/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
@@ -309,6 +309,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                 jsonOpts = new JsonOpts
                 {
                     ApiVersions = cfgBase.ApiVersions,
+                    IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -345,6 +346,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                 jsonOpts = new JsonOpts
                 {
                     ApiVersions = cfgBase.ApiVersions,
+                    IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,

--- a/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
@@ -372,6 +372,8 @@ namespace Pulumi.Kubernetes.Helm.V3
         {
             [JsonPropertyName("api_versions")]
             public ImmutableArray<string> ApiVersions { get; set; }
+            [JsonPropertyName("include_test_hook_resources")]
+            public bool? IncludeTestHookResources { get; set; }
             [JsonPropertyName("namespace")]
             public string? Namespace { get; set; }
             [JsonPropertyName("values")]

--- a/provider/pkg/gen/go-templates/helm/v3/pulumiTypes.tmpl
+++ b/provider/pkg/gen/go-templates/helm/v3/pulumiTypes.tmpl
@@ -117,6 +117,9 @@ func (o FetchArgsOutput) ToFetchArgsOutputWithContext(ctx context.Context) Fetch
 type ChartArgs struct {
 	// The optional Kubernetes API versions used for Capabilities.APIVersions.
 	APIVersions pulumi.StringArrayInput
+	// By default, Helm resources with the `test`, `test-success`, and `test-failure` hooks are not installed. Set
+	// this flag to true to include these resources.
+	IncludeTestHookResources pulumi.BoolInput
 	// The optional namespace to install chart resources into.
 	Namespace pulumi.StringInput
 	// Overrides for chart values.
@@ -148,16 +151,17 @@ type ChartArgs struct {
 // chartArgs is a copy of ChartArgs but without using TInput in types.
 // Note that Transformations are omitted in JSON marshaling because functions are not serializable.
 type chartArgs struct {
-	APIVersions     []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
-	Namespace       string                 `json:"namespace,omitempty" pulumi:"namespace"`
-	Values          map[string]interface{} `json:"values,omitempty" pulumi:"values"`
-	Transformations []yaml.Transformation  `json:"-" pulumi:"transformations"`
-	ResourcePrefix  string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
-	Repo            string                 `json:"repo,omitempty" pulumi:"repo"`
-	Chart           string                 `json:"chart,omitempty" pulumi:"chart"`
-	Version         string                 `json:"version,omitempty" pulumi:"version"`
-	FetchArgs       fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
-	Path            string                 `json:"path,omitempty" pulumi:"path"`
+	APIVersions              []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
+	IncludeTestHookResources bool                   `json:"include_test_hook_resources,omitempty" pulumi:"includeTestHookResources"`
+	Namespace                string                 `json:"namespace,omitempty" pulumi:"namespace"`
+	Values                   map[string]interface{} `json:"values,omitempty" pulumi:"values"`
+	Transformations          []yaml.Transformation  `json:"-" pulumi:"transformations"`
+	ResourcePrefix           string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
+	Repo                     string                 `json:"repo,omitempty" pulumi:"repo"`
+	Chart                    string                 `json:"chart,omitempty" pulumi:"chart"`
+	Version                  string                 `json:"version,omitempty" pulumi:"version"`
+	FetchArgs                fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
+	Path                     string                 `json:"path,omitempty" pulumi:"path"`
 }
 
 type ChartArgsInput interface {

--- a/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
@@ -187,6 +187,10 @@ export class Chart extends yaml.CollectionComponentResource {
                                 obj["fetch_opts"] = value;
                                 break;
                             }
+                            case "includeTestHookResources": {
+                                obj["include_test_hook_resources"] = value;
+                                break;
+                            }
                             case "releaseName": {
                                 obj["release_name"] = value;
                                 break;
@@ -232,6 +236,11 @@ interface BaseChartOpts {
      * The optional kubernetes api versions used for Capabilities.APIVersions.
      */
     apiVersions?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * By default, Helm resources with the `test`, `test-success`, and `test-failure` hooks are not installed. Set
+     * this flag to true to include these resources.
+     */
+    includeTestHookResources?: boolean;
     /**
      * The optional namespace to install chart resources into.
      */

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -361,12 +361,6 @@ class BaseChartOpts:
     Optional namespace to install chart resources into.
     """
 
-    include_test_hook_resources: Optional[pulumi.Input[bool]]
-    """
-    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
-    this flag to true to include these resources.
-    """
-
     values: Optional[pulumi.Inputs]
     """
     Optional overrides for chart values.
@@ -389,18 +383,21 @@ class BaseChartOpts:
     Optional kubernetes api versions used for Capabilities.APIVersions.
     """
 
+    include_test_hook_resources: Optional[pulumi.Input[bool]]
+    """
+    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+    this flag to true to include these resources.
+    """
+
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
-                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
-        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
-               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
-               resources.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
         :param Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] transformations: Optional list
                of transformations to apply to resources that will be created by this chart prior to creation.
@@ -409,6 +406,9 @@ class BaseChartOpts:
                Example: A resource created with resource_prefix="foo" would produce a resource named "foo-resourceName".
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
         self.namespace = namespace
         self.include_test_hook_resources = include_test_hook_resources
@@ -459,7 +459,8 @@ class ChartOpts(BaseChartOpts):
                  repo: Optional[pulumi.Input[str]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  fetch_opts: Optional[pulumi.Input[FetchOpts]] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] chart: The name of the chart to deploy.  If `repo` is provided, this chart name
                will be prefixed by the repo name.
@@ -480,8 +481,12 @@ class ChartOpts(BaseChartOpts):
                fetching of the Helm chart.
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
-        super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions)
+        super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
+                                        include_test_hook_resources)
         self.chart = chart
         self.repo = repo
         self.version = version
@@ -504,7 +509,8 @@ class LocalChartOpts(BaseChartOpts):
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] path: The path to the chart directory which contains the
                `Chart.yaml` file.
@@ -517,9 +523,13 @@ class LocalChartOpts(BaseChartOpts):
                Example: A resource created with resource_prefix="foo" would produce a resource named "foo-resourceName".
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
 
-        super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions)
+        super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
+                                             include_test_hook_resources)
         self.path = path
 
 

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -361,6 +361,12 @@ class BaseChartOpts:
     Optional namespace to install chart resources into.
     """
 
+    include_test_hook_resources: Optional[pulumi.Input[bool]]
+    """
+    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+    this flag to true to include these resources.
+    """
+
     values: Optional[pulumi.Inputs]
     """
     Optional overrides for chart values.
@@ -385,12 +391,16 @@ class BaseChartOpts:
 
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
         :param Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] transformations: Optional list
                of transformations to apply to resources that will be created by this chart prior to creation.
@@ -401,6 +411,7 @@ class BaseChartOpts:
                Capabilities.APIVersions.
         """
         self.namespace = namespace
+        self.include_test_hook_resources = include_test_hook_resources
         self.values = values
         self.transformations = transformations
         self.resource_prefix = resource_prefix

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	pkgerrors "github.com/pkg/errors"
+	logger "github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -231,6 +232,7 @@ func (c *chart) template() (string, error) {
 	for _, hook := range rel.Hooks {
 		switch {
 		case !c.opts.IncludeTestHookResources && testHookAnnotation.MatchString(hook.Manifest):
+			logger.V(9).Infof("Skipping Helm resource with test hook: %s", hook.Name)
 			// Skip test hook.
 		default:
 			manifests.WriteString("\n---\n")

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -55,14 +55,15 @@ type HelmFetchOpts struct {
 type HelmChartOpts struct {
 	HelmFetchOpts `json:"fetch_opts,omitempty"`
 
-	APIVersions []string               `json:"api_versions,omitempty"`
-	Chart       string                 `json:"chart,omitempty"`
-	Namespace   string                 `json:"namespace,omitempty"`
-	Path        string                 `json:"path,omitempty"`
-	ReleaseName string                 `json:"release_name,omitempty"`
-	Repo        string                 `json:"repo,omitempty"`
-	Values      map[string]interface{} `json:"values,omitempty"`
-	Version     string                 `json:"version,omitempty"`
+	APIVersions              []string               `json:"api_versions,omitempty"`
+	Chart                    string                 `json:"chart,omitempty"`
+	IncludeTestHookResources bool                   `json:"include_test_hook_resources,omitempty"`
+	Namespace                string                 `json:"namespace,omitempty"`
+	Path                     string                 `json:"path,omitempty"`
+	ReleaseName              string                 `json:"release_name,omitempty"`
+	Repo                     string                 `json:"repo,omitempty"`
+	Values                   map[string]interface{} `json:"values,omitempty"`
+	Version                  string                 `json:"version,omitempty"`
 }
 
 // helmTemplate performs Helm fetch/pull + template operations and returns the resulting YAML manifest based on the
@@ -229,8 +230,7 @@ func (c *chart) template() (string, error) {
 	manifests.WriteString(rel.Manifest)
 	for _, hook := range rel.Hooks {
 		switch {
-		case testAnnotation.MatchString(hook.Manifest):
-			// TODO: allow user to opt out via flag
+		case !c.opts.IncludeTestHookResources && testAnnotation.MatchString(hook.Manifest):
 			// Skip test hook.
 		default:
 			manifests.WriteString("\n---\n")

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -32,8 +32,8 @@ import (
 	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
-// testAnnotation matches test-related Helm hook annotations (test, test-success, test-failure)
-var testAnnotation = regexp.MustCompile(`"?helm.sh\/hook"?:.*test`)
+// testHookAnnotation matches test-related Helm hook annotations (test, test-success, test-failure)
+var testHookAnnotation = regexp.MustCompile(`"?helm.sh\/hook"?:.*test`)
 
 type HelmFetchOpts struct {
 	CAFile      string `json:"ca_file,omitempty"`
@@ -230,7 +230,7 @@ func (c *chart) template() (string, error) {
 	manifests.WriteString(rel.Manifest)
 	for _, hook := range rel.Hooks {
 		switch {
-		case !c.opts.IncludeTestHookResources && testAnnotation.MatchString(hook.Manifest):
+		case !c.opts.IncludeTestHookResources && testHookAnnotation.MatchString(hook.Manifest):
 			// Skip test hook.
 		default:
 			manifests.WriteString("\n---\n")

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1044,12 +1044,13 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 
 		// If the Helm hook annotation is found, set the hasHelmHook flag.
 		if has := metadata.IsHelmHookAnnotation(key); has {
+			// TODO: except for test
 			hasHelmHook = hasHelmHook || has
 		}
 	}
 	if hasHelmHook {
 		_ = k.host.Log(ctx, diag.Warning, urn,
-			"This resource contains Helm hooks that are not currently supported by Pulumi. The resource will"+
+			"This resource contains Helm hooks that are not currently supported by Pulumi. The resource will "+
 				"be created, but any hooks will not be executed. Hooks support is tracked at "+
 				"https://github.com/pulumi/pulumi-kubernetes/issues/555")
 	}

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -404,6 +404,12 @@ namespace Pulumi.Kubernetes.Helm
         }
 
         /// <summary>
+        /// By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+        /// this flag to true to include these resources.
+        /// </summary>
+        public Input<bool>? IncludeTestHookResources { get; set; }
+
+        /// <summary>
         /// The optional namespace to install chart resources into.
         /// </summary>
         public Input<string>? Namespace { get; set; }

--- a/sdk/dotnet/Helm/Unwraps.cs
+++ b/sdk/dotnet/Helm/Unwraps.cs
@@ -24,6 +24,7 @@ namespace Pulumi.Kubernetes.Helm
     internal class BaseChartArgsUnwrap
     {
         public ImmutableArray<string> ApiVersions { get; set; }
+        public bool? IncludeTestHookResources { get; set; }
         public string? Namespace { get; set; }
         public ImmutableDictionary<string, object> Values { get; set; } = null!;
         public List<TransformationAction> Transformations { get; set; } = null!;
@@ -67,27 +68,29 @@ namespace Pulumi.Kubernetes.Helm
         public static Output<Union<ChartArgsUnwrap, LocalChartArgsUnwrap>> Unwrap(this Union<ChartArgs, LocalChartArgs> options)
         {
             return options.Match(
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap()).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap()).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT0(
                         new ChartArgsUnwrap
                         {
                             ApiVersions = vs.Item1,
-                            Namespace = vs.Item2,
-                            Values = vs.Item3,
+                            IncludeTestHookResources = vs.Item2,
+                            Namespace = vs.Item3,
+                            Values = vs.Item4,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
-                            Repo = vs.Item4,
-                            Chart = vs.Item5,
-                            Version = vs.Item6,
-                            FetchOptions = vs.Item7
+                            Repo = vs.Item5,
+                            Chart = vs.Item6,
+                            Version = vs.Item7,
+                            FetchOptions = vs.Item8
                         })),
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.Namespace.ToNullable(), v.Values).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT1(
                         new LocalChartArgsUnwrap
                         {
                             ApiVersions = vs.Item1,
-                            Namespace = vs.Item2,
-                            Values = vs.Item3,
+                            IncludeTestHookResources = vs.Item2,
+                            Namespace = vs.Item3,
+                            Values = vs.Item4,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
                             Path = v.Path

--- a/sdk/dotnet/Helm/V3/Chart.cs
+++ b/sdk/dotnet/Helm/V3/Chart.cs
@@ -309,6 +309,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                 jsonOpts = new JsonOpts
                 {
                     ApiVersions = cfgBase.ApiVersions,
+                    IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -345,6 +346,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                 jsonOpts = new JsonOpts
                 {
                     ApiVersions = cfgBase.ApiVersions,
+                    IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,

--- a/sdk/dotnet/Helm/V3/Chart.cs
+++ b/sdk/dotnet/Helm/V3/Chart.cs
@@ -372,6 +372,8 @@ namespace Pulumi.Kubernetes.Helm.V3
         {
             [JsonPropertyName("api_versions")]
             public ImmutableArray<string> ApiVersions { get; set; }
+            [JsonPropertyName("include_test_hook_resources")]
+            public bool? IncludeTestHookResources { get; set; }
             [JsonPropertyName("namespace")]
             public string? Namespace { get; set; }
             [JsonPropertyName("values")]

--- a/sdk/go/kubernetes/helm/v3/pulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v3/pulumiTypes.go
@@ -117,6 +117,9 @@ func (o FetchArgsOutput) ToFetchArgsOutputWithContext(ctx context.Context) Fetch
 type ChartArgs struct {
 	// The optional Kubernetes API versions used for Capabilities.APIVersions.
 	APIVersions pulumi.StringArrayInput
+	// By default, Helm resources with the `test`, `test-success`, and `test-failure` hooks are not installed. Set
+	// this flag to true to include these resources.
+	IncludeTestHookResources pulumi.BoolInput
 	// The optional namespace to install chart resources into.
 	Namespace pulumi.StringInput
 	// Overrides for chart values.
@@ -148,16 +151,17 @@ type ChartArgs struct {
 // chartArgs is a copy of ChartArgs but without using TInput in types.
 // Note that Transformations are omitted in JSON marshaling because functions are not serializable.
 type chartArgs struct {
-	APIVersions     []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
-	Namespace       string                 `json:"namespace,omitempty" pulumi:"namespace"`
-	Values          map[string]interface{} `json:"values,omitempty" pulumi:"values"`
-	Transformations []yaml.Transformation  `json:"-" pulumi:"transformations"`
-	ResourcePrefix  string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
-	Repo            string                 `json:"repo,omitempty" pulumi:"repo"`
-	Chart           string                 `json:"chart,omitempty" pulumi:"chart"`
-	Version         string                 `json:"version,omitempty" pulumi:"version"`
-	FetchArgs       fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
-	Path            string                 `json:"path,omitempty" pulumi:"path"`
+	APIVersions              []string               `json:"api_versions,omitempty" pulumi:"apiVersions"`
+	IncludeTestHookResources bool                   `json:"include_test_hook_resources,omitempty" pulumi:"includeTestHookResources"`
+	Namespace                string                 `json:"namespace,omitempty" pulumi:"namespace"`
+	Values                   map[string]interface{} `json:"values,omitempty" pulumi:"values"`
+	Transformations          []yaml.Transformation  `json:"-" pulumi:"transformations"`
+	ResourcePrefix           string                 `json:"resource_prefix,omitempty" pulumi:"resourcePrefix"`
+	Repo                     string                 `json:"repo,omitempty" pulumi:"repo"`
+	Chart                    string                 `json:"chart,omitempty" pulumi:"chart"`
+	Version                  string                 `json:"version,omitempty" pulumi:"version"`
+	FetchArgs                fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
+	Path                     string                 `json:"path,omitempty" pulumi:"path"`
 }
 
 type ChartArgsInput interface {

--- a/sdk/nodejs/helm/v3/helm.ts
+++ b/sdk/nodejs/helm/v3/helm.ts
@@ -187,6 +187,10 @@ export class Chart extends yaml.CollectionComponentResource {
                                 obj["fetch_opts"] = value;
                                 break;
                             }
+                            case "includeTestHookResources": {
+                                obj["include_test_hook_resources"] = value;
+                                break;
+                            }
                             case "releaseName": {
                                 obj["release_name"] = value;
                                 break;
@@ -232,6 +236,11 @@ interface BaseChartOpts {
      * The optional kubernetes api versions used for Capabilities.APIVersions.
      */
     apiVersions?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * By default, Helm resources with the `test`, `test-success`, and `test-failure` hooks are not installed. Set
+     * this flag to true to include these resources.
+     */
+    includeTestHookResources?: boolean;
     /**
      * The optional namespace to install chart resources into.
      */

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -361,12 +361,6 @@ class BaseChartOpts:
     Optional namespace to install chart resources into.
     """
 
-    include_test_hook_resources: Optional[pulumi.Input[bool]]
-    """
-    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
-    this flag to true to include these resources.
-    """
-
     values: Optional[pulumi.Inputs]
     """
     Optional overrides for chart values.
@@ -389,18 +383,21 @@ class BaseChartOpts:
     Optional kubernetes api versions used for Capabilities.APIVersions.
     """
 
+    include_test_hook_resources: Optional[pulumi.Input[bool]]
+    """
+    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+    this flag to true to include these resources.
+    """
+
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
-                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
-        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
-               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
-               resources.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
         :param Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] transformations: Optional list
                of transformations to apply to resources that will be created by this chart prior to creation.
@@ -409,6 +406,9 @@ class BaseChartOpts:
                Example: A resource created with resource_prefix="foo" would produce a resource named "foo-resourceName".
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
         self.namespace = namespace
         self.include_test_hook_resources = include_test_hook_resources
@@ -459,7 +459,8 @@ class ChartOpts(BaseChartOpts):
                  repo: Optional[pulumi.Input[str]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  fetch_opts: Optional[pulumi.Input[FetchOpts]] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] chart: The name of the chart to deploy.  If `repo` is provided, this chart name
                will be prefixed by the repo name.
@@ -480,8 +481,12 @@ class ChartOpts(BaseChartOpts):
                fetching of the Helm chart.
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
-        super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions)
+        super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
+                                        include_test_hook_resources)
         self.chart = chart
         self.repo = repo
         self.version = version
@@ -504,7 +509,8 @@ class LocalChartOpts(BaseChartOpts):
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
-                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
+                 api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] path: The path to the chart directory which contains the
                `Chart.yaml` file.
@@ -517,9 +523,13 @@ class LocalChartOpts(BaseChartOpts):
                Example: A resource created with resource_prefix="foo" would produce a resource named "foo-resourceName".
         :param Optional[Sequence[pulumi.Input[str]]] api_versions: Optional kubernetes api versions used for
                Capabilities.APIVersions.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         """
 
-        super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions)
+        super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
+                                             include_test_hook_resources)
         self.path = path
 
 

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -361,6 +361,12 @@ class BaseChartOpts:
     Optional namespace to install chart resources into.
     """
 
+    include_test_hook_resources: Optional[pulumi.Input[bool]]
+    """
+    By default, Helm resources with the 'test', 'test-success', and 'test-failure' hooks are not installed. Set
+    this flag to true to include these resources.
+    """
+
     values: Optional[pulumi.Inputs]
     """
     Optional overrides for chart values.
@@ -385,12 +391,16 @@ class BaseChartOpts:
 
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
+                 include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Inputs] = None,
                  transformations: Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] = None,
                  resource_prefix: Optional[str] = None,
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
+        :param Optional[pulumi.Input[bool]] include_test_hook_resources: By default, Helm resources with the 'test',
+               'test-success', and 'test-failure' hooks are not installed. Set this flag to true to include these
+               resources.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
         :param Optional[Sequence[Callable[[Any, pulumi.ResourceOptions], None]]] transformations: Optional list
                of transformations to apply to resources that will be created by this chart prior to creation.
@@ -401,6 +411,7 @@ class BaseChartOpts:
                Capabilities.APIVersions.
         """
         self.namespace = namespace
+        self.include_test_hook_resources = include_test_hook_resources
         self.values = values
         self.transformations = transformations
         self.resource_prefix = resource_prefix


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Many Helm charts include test hooks that can be
used by the "helm test" command to validate an
installation, but should not be included as part of
a default chart installation. This change disables
the creation of test resources by default, and includes
a new Chart parameter that can be used to override
this default and install the test resources.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Related to #665 