### PR TITLE
Ensure using a Kubernetes provider with an incompatible resource doesn't panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 -   Skip Helm test hook resources by default (https://github.com/pulumi/pulumi-kubernetes/pull/1467)
+-   Ensure no panic when a kubernetes provider is used with an incompatible resource type (https://github.com/pulumi/pulumi-kubernetes/pull/1469)
 
 ## 2.8.0 (February 3, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2092,7 +2092,10 @@ func (k *kubeProvider) label() string {
 }
 
 func (k *kubeProvider) gvkFromURN(urn resource.URN) (schema.GroupVersionKind, error) {
-	contract.Assertf(string(urn.Type().Package()) == k.providerPackage, "Kubernetes GVK is: %q", string(urn))
+	if string(urn.Type().Package()) != k.providerPackage {
+		return schema.GroupVersionKind{}, fmt.Errorf("unrecognized resource type: %q for this provider",
+			urn.Type())
+	}
 
 	// Emit GVK.
 	kind := string(urn.Type().Name())


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/3224

With the following code:

```
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";
import * as k8s from "@pulumi/kubernetes";

const wrongProvider = new k8s.Provider("wrong-provider")

const x = new aws.s3.Bucket("test", {}, {
    provider: wrongProvider,
})

```

Before:

```
▶ pulumi up
Previewing update (dev)

     Type                            Name                     Plan       Info
 +   pulumi:pulumi:Stack             test-panic-provider-dev  create     24 messages
 +   ├─ pulumi:providers:kubernetes  wrong-provider           create
     └─ aws:s3:Bucket                test                                1 error

Diagnostics:
  pulumi:pulumi:Stack (test-panic-provider-dev):
    panic: fatal: An assertion has failed: Kubernetes GVK is: "urn:pulumi:dev::test-panic-provider::aws:s3/bucket:Bucket::test"
    goroutine 87 [running]:
    github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.failfast(...)
    	/Users/stack72/code/go/pkg/mod/github.com/pulumi/pulumi/sdk/v2@v2.18.3-0.20210126224412-216fd2bed529/go/common/util/contract/failfast.go:23
    github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.Assertf(0xc0004da900, 0x5d29d14, 0x15, 0xc000149490, 0x1, 0x1)
    	/Users/stack72/code/go/pkg/mod/github.com/pulumi/pulumi/sdk/v2@v2.18.3-0.20210126224412-216fd2bed529/go/common/util/contract/assert.go:33 +0x1a5
    github.com/pulumi/pulumi-kubernetes/provider/v2/pkg/provider.(*kubeProvider).gvkFromURN(0xc0008630e0, 0xc0004da940, 0x3f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0000c0510, ...)
    	/Users/stack72/code/go/src/github.com/pulumi/pulumi-kubernetes/provider/pkg/provider/provider.go:2095 +0x145
    github.com/pulumi/pulumi-kubernetes/provider/v2/pkg/provider.(*kubeProvider).Check(0xc0008630e0, 0x6040a60, 0xc0004cd1d0, 0xc0007e0680, 0xc0008630e0, 0x5a6a001, 0xc0007e06c0)
    	/Users/stack72/code/go/src/github.com/pulumi/pulumi-kubernetes/provider/pkg/provider/provider.go:1103 +0x98c
    github.com/pulumi/pulumi/sdk/v2/proto/go._ResourceProvider_Check_Handler.func1(0x6040a60, 0xc0004cd1d0, 0x5bf4ce0, 0xc0007e0680, 0x5c22340, 0x70115c0, 0x6040a60, 0xc0004cd1d0)
    	/Users/stack72/code/go/pkg/mod/github.com/pulumi/pulumi/sdk/v2@v2.18.3-0.20210126224412-216fd2bed529/proto/go/provider.pb.go:2233 +0x89
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1(0x6040a60, 0xc0004cd140, 0x5bf4ce0, 0xc0007e0680, 0xc0003dbc60, 0xc0003dbc80, 0x0, 0x0, 0x5fe2780, 0xc000814590)
    	/Users/stack72/code/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x2f6
    github.com/pulumi/pulumi/sdk/v2/proto/go._ResourceProvider_Check_Handler(0x5c9b840, 0xc0008630e0, 0x6040a60, 0xc0004cd140, 0xc0002d2e40, 0xc00031bd00, 0x6040a60, 0xc0004cd140, 0xc0005a7220, 0x45)
    	/Users/stack72/code/go/pkg/mod/github.com/pulumi/pulumi/sdk/v2@v2.18.3-0.20210126224412-216fd2bed529/proto/go/provider.pb.go:2235 +0x150
    google.golang.org/grpc.(*Server).processUnaryRPC(0xc000411520, 0x605c6e0, 0xc000502780, 0xc00069ae00, 0xc000799cb0, 0x6fade18, 0x0, 0x0, 0x0)
    	/Users/stack72/code/go/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1082 +0x522
    google.golang.org/grpc.(*Server).handleStream(0xc000411520, 0x605c6e0, 0xc000502780, 0xc00069ae00, 0x0)
    	/Users/stack72/code/go/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1405 +0xcc5
    google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0007d6020, 0xc000411520, 0x605c6e0, 0xc000502780, 0xc00069ae00)
    	/Users/stack72/code/go/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:746 +0xa5
    created by google.golang.org/grpc.(*Server).serveStreams.func1
    	/Users/stack72/code/go/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:744 +0xa5

  aws:s3:Bucket (test):
    error: transport is closing
```

After:

```
▶ pulumi up
Previewing update (dev)

     Type                            Name                     Plan       Info
 +   pulumi:pulumi:Stack             test-panic-provider-dev  create
 +   ├─ pulumi:providers:kubernetes  wrong-provider           create
     └─ aws:s3:Bucket                test                                1 error

Diagnostics:
  aws:s3:Bucket (test):
    error: unrecognized resource type: "aws:s3/bucket:Bucket" for this provider
```