### PR TITLE
Allow control of managed-by label through use of environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Skip Helm test hook resources by default (https://github.com/pulumi/pulumi-kubernetes/pull/1467)
 -   Ensure no panic when a kubernetes provider is used with an incompatible resource type (https://github.com/pulumi/pulumi-kubernetes/pull/1469)
+-   Allow users to set `PULUMI_KUBERNETES_MANAGED_BY_LABEL` environment variable to control `app.kubernetes.io/managed-by` label (https://github.com/pulumi/pulumi-kubernetes/pull/1471)
 
 ## 2.8.0 (February 3, 2021)
 

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -90,7 +91,12 @@ func GetLabel(obj *unstructured.Unstructured, key string) interface{} {
 // (e.g.) the underlying object is mistyped. In particular, TrySetLabel will fail if the underlying
 // object has a Pulumi computed value.
 func TrySetManagedByLabel(obj *unstructured.Unstructured) (bool, error) {
-	return TrySetLabel(obj, managedByLabel, "pulumi")
+	managedBy := "pulumi"
+	labelVal, exists := os.LookupEnv("PULUMI_KUBERNETES_MANAGED_BY_LABEL")
+	if exists {
+		managedBy = labelVal
+	}
+	return TrySetLabel(obj, managedByLabel, managedBy)
 }
 
 // HasManagedByLabel returns true if the object has the `app.kubernetes.io/managed-by` label set to `pulumi`,


### PR DESCRIPTION
Related: #1357

This allows the label to be controlled in a simple way for now

```
▶ PULUMI_KUBERNETES_MANAGED_BY_LABEL=mycompany pulumi up
Previewing update (dev)
     Type                             Name                      Plan
 +   pulumi:pulumi:Stack              testing-new-workflow-dev  create
 +   └─ kubernetes:core/v1:Namespace  nginx                     create
Resources:
    + 2 to create
Do you want to perform this update? details
+ pulumi:pulumi:Stack: (create)
    [urn=urn:pulumi:dev::testing-new-workflow::pulumi:pulumi:Stack::testing-new-workflow-dev]
    + kubernetes:core/v1:Namespace: (create)
        [urn=urn:pulumi:dev::testing-new-workflow::kubernetes:core/v1:Namespace::nginx]
        [provider=urn:pulumi:dev::testing-new-workflow::pulumi:providers:kubernetes::default_2_8_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9]
        apiVersion: "v1"
        kind      : "Namespace"
        metadata  : {
            labels: {
                app.kubernetes.io/managed-by: "mycompany"
            }
            name  : "testing"
        }
```


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->