### PR TITLE
postpone AdmissionregistrationV1B1 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Postpone the removal of admissionregistration/v1beta1, which has been retargeted at 1.22 (https://github.com/pulumi/pulumi-kubernetes/pull/1474)
+
 ## 2.8.1 (February 12, 2021)
 
 -   Skip Helm test hook resources by default (https://github.com/pulumi/pulumi-kubernetes/pull/1467)
@@ -215,7 +217,7 @@ not be affected by this change.
     - Fixed the type of some properties in `JSONSchemaPropsArgs` (there's no need to have 2nd-level inputs there):
         - `InputList<InputJson>` -> `InputList<JsonElement>`
         - `InputMap<Union<TArgs, InputList<string>>>` -> `InputMap<Union<TArgs, ImmutableArray<string>>>`
-        
+
 ### Bug Fixes
 
 -   Fix incorrect schema consts for apiVersion and kind (https://github.com/pulumi/pulumi-kubernetes/pull/1153)

--- a/provider/pkg/kinds/deprecated.go
+++ b/provider/pkg/kinds/deprecated.go
@@ -48,7 +48,7 @@ import (
 // extensions/v1beta1/Ingress / 1.14 / 1.18
 // https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.14.md#deprecations
 //
-// admissionregistration/v1beta1/* / 1.16 / 1.19
+// admissionregistration/v1beta1/* / 1.16 / 1.22 (Previously 1.19, see https://github.com/kubernetes/kubernetes/issues/82021#issuecomment-636873001)
 // apiextensions/v1beta1/CustomResourceDefinition / 1.16 / 1.22 (Previously 1.19)
 // https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals
 //
@@ -234,7 +234,7 @@ func RemovedInVersion(gvk schema.GroupVersionKind) *cluster.ServerVersion {
 
 	switch gv {
 	case AdmissionregistrationV1B1:
-		return &v119
+		return &v122
 	case ApiextensionsV1B1:
 		return &v122
 	case AuthenticationV1B1:

--- a/provider/pkg/kinds/deprecated_test.go
+++ b/provider/pkg/kinds/deprecated_test.go
@@ -192,7 +192,7 @@ func TestRemovedInVersion(t *testing.T) {
 		gvk         GroupVersionKind
 		wantVersion *cluster.ServerVersion
 	}{
-		{toGVK(AdmissionregistrationV1B1, MutatingWebhookConfiguration), &v119},
+		{toGVK(AdmissionregistrationV1B1, MutatingWebhookConfiguration), &v122},
 		{toGVK(ApiextensionsV1B1, CustomResourceDefinition), &v122},
 		{toGVK(AppsV1B1, Deployment), &v116},
 		{toGVK(AppsV1B2, Deployment), &v116},


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Per [the comment](https://github.com/kubernetes/kubernetes/issues/82021#issuecomment-636873001), the removal of  `admissionregistration/v1beta1` has been retargeted at 1.22.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Fixes #1388.