### PR TITLE
Change k8s API removals from error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+-   Change k8s API removals from error to warning (https://github.com/pulumi/pulumi-kubernetes/pull/1475)
+
 ## 2.8.1 (February 12, 2021)
 
 -   Skip Helm test hook resources by default (https://github.com/pulumi/pulumi-kubernetes/pull/1467)


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The provider checks for deprecated and removed API
versions of k8s resources to provide clearer messages
for affected APIs. These messages are intended to be
informational, and should not block the deployment of
a resource if the cluster accepts it. To avoid inadvertently
failing a deployment when the upstream removal version
has changed, print a warning rather than returning an error.
<!--Give us a brief description of what you've done and what it solves. -->

Here's what this looks like now for a removed API:

Preview
```
warning: apiVersion "extensions/v1beta1/Deployment" was removed in Kubernetes 1.16. Use "apps/v1/Deployment" instead.
See https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals for more information.
```

(This previously would have returned an error)

Update
```
error: resource scale-test was not successfully created by the Kubernetes API server : apiVersion "extensions/v1beta1/Deployment" was removed in Kubernetes 1.16. Use "apps/v1/Deployment" instead.
See https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals for more information.
```

(An error is returned, but it's only after the cluster reported that the resource was not available.)

### Related issues (optional)
Related to #1388 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
