### PR TITLE
Fix helm chart resolution issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix bug where rendering manifests results in files being overwritten by subsequent resources with the same kind and name, but different namespace (https://github.com/pulumi/pulumi-kubernetes/pull/1429)
 - Update pulumi dependency to fix python Resource.get() functions (https://github.com/pulumi/pulumi-kubernetes/pull/1480)
 - Upgrade to Go1.16 (https://github.com/pulumi/pulumi-kubernetes/pull/1486)
+- Fix bug preventing helm chart being located in bitnami repo (https://github.com/pulumi/pulumi-kubernetes/pull/1491)
 
 ## 2.8.2 (February 23, 2021)
 

--- a/provider/pkg/provider/invoke_helm_template_test.go
+++ b/provider/pkg/provider/invoke_helm_template_test.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestNormalizeChartRef(t *testing.T) {
+	check := func(repoName string, repoUrl string, originalChartRef string, expect string) {
+		actual := normalizeChartRef(repoName, repoUrl, originalChartRef)
+		if actual != expect {
+			t.Errorf("Expected normalizeChartRef(%s, %s, %s) to be %s but got %s",
+				repoName, repoUrl, originalChartRef, expect, actual)
+		}
+	}
+
+	check("bitnami", "https://charts.bitnami.com/bitnami", "apache", "apache")
+	check("bitnami", "", "apache", "bitnami/apache")
+	check("bitnami", "", "bitnami/apache", "bitnami/apache")
+}


### PR DESCRIPTION
### Proposed changes

Fixes issue with helm chart not found. Originally showed up in examples repo for helm. 

### Related issues

*  https://github.com/pulumi/examples/issues/938

### Test/debug notes

I was reproducing https://github.com/pulumi/examples/issues/938 with a custom-built pulumi-resource-kubernetes (from master) that included instrumentation to spew out the failing Chart parameter, this is what I got:

```
(*provider.chart)(0xc000603c80)({
 opts: (provider.HelmChartOpts) {
  HelmFetchOpts: (provider.HelmFetchOpts) {
   CAFile: (string) "",
   CertFile: (string) "",
   Destination: (string) "",
   Devel: (bool) false,
   Home: (string) "",
   KeyFile: (string) "",
   Keyring: (string) "",
   Password: (string) "",
   Prov: (bool) false,
   Repo: (string) (len=34) "https://charts.bitnami.com/bitnami",
   UntarDir: (string) "",
   Username: (string) "",
   Verify: (bool) false,
   Version: (string) ""
  },
  APIVersions: ([]string) <nil>,
  Chart: (string) (len=6) "apache",
  IncludeTestHookResources: (bool) false,
  Namespace: (string) "",
  Path: (string) "",
  ReleaseName: (string) (len=6) "apache",
  Repo: (string) (len=7) "bitnami",
  Values: (map[string]interface {}) <nil>,
  Version: (string) (len=5) "1.0.0"
 },
 chartDir: (string) (len=8) "chartdir",
 helmHome: (*string)(<nil>)
})
```

So presumably the client was passing Repo=bitnami and also HelmFetchOpts.Repo=https://charts.bitnami.com/bitnami together. 

Is this a client fault or the pulumi-resource-kubernetes fault? The PR assumes the input is valid but pulumi-reosurce-kubernetes should process it differently. If the input is invalid, let us instead fix the client and harden pulumi-resource-kubernetes to warn appropriately.



