### PR TITLE
Ensure PULUMI_KUBERNETES_MANAGED_BY_LABEL doesn't cause diffs on updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Ensure using `PULUMI_KUBERNETES_MANAGED_BY_LABEL` doesn't cause diffs on further stack updates (https://github.com/pulumi/pulumi-kubernetes/pull/1508)
+
 ## 2.8.3 (March 17, 2021)
 
 - Fix bug where rendering manifests results in files being overwritten by subsequent resources with the same kind and name, but different namespace (https://github.com/pulumi/pulumi-kubernetes/pull/1429)

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -99,12 +99,18 @@ func TrySetManagedByLabel(obj *unstructured.Unstructured) (bool, error) {
 	return TrySetLabel(obj, managedByLabel, managedBy)
 }
 
-// HasManagedByLabel returns true if the object has the `app.kubernetes.io/managed-by` label set to `pulumi`,
-// or is a computed value.
+// HasManagedByLabel returns true if the object has the `app.kubernetes.io/managed-by` label set to the value
+// of `PULUMI_KUBERNETES_MANAGED_BY_LABEL` EnvVar, `pulumi`, or is a computed value.
 func HasManagedByLabel(obj *unstructured.Unstructured) bool {
 	val := GetLabel(obj, managedByLabel)
 	if isComputedValue(val) {
 		return true
+	}
+	// now we should check to see if the user has specified a label via EnvVar
+	// we should also check to see if that value is the same as what is in the metadata
+	labelVal, exists := os.LookupEnv("PULUMI_KUBERNETES_MANAGED_BY_LABEL")
+	if exists {
+		return labelVal == val.(string)
 	}
 	str, ok := val.(string)
 	return ok && str == "pulumi"


### PR DESCRIPTION
Fixes: #1357

Before:

```
▶ PULUMI_KUBERNETES_MANAGED_BY_LABEL=mycompany pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/stack72/test-kubernetes-go/dev/previews/9f709e63-1719-4493-8ed5-515882fcc70b

     Type                              Name                    Plan       Info
     pulumi:pulumi:Stack               test-kubernetes-go-dev
 ~   └─ kubernetes:apps/v1:Deployment  app-dep                 update     [diff: ~metadata]

Resources:
    ~ 1 to update
    1 unchanged

Do you want to perform this update? no
confirmation declined, not proceeding with the update
```

After:

```
▶ PULUMI_KUBERNETES_MANAGED_BY_LABEL=mycompany pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/stack72/test-kubernetes-go/dev/previews/91ef271f-3000-472f-b41e-b5470d4cca25

     Type                 Name                    Plan
     pulumi:pulumi:Stack  test-kubernetes-go-dev

Resources:
    2 unchanged
```


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->