### PR TITLE
[sdk/ts] Update CustomResource to match current codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Ensure using `PULUMI_KUBERNETES_MANAGED_BY_LABEL` doesn't cause diffs on further stack updates (https://github.com/pulumi/pulumi-kubernetes/pull/1508)
+- [sdk/ts] Update CustomResource to match current codegen (https://github.com/pulumi/pulumi-kubernetes/pull/1510)
 
 ## 2.8.3 (March 17, 2021)
 

--- a/provider/pkg/gen/nodejs-templates/apiextensions/customResource.ts
+++ b/provider/pkg/gen/nodejs-templates/apiextensions/customResource.ts
@@ -18,7 +18,7 @@
 import * as pulumi from "@pulumi/pulumi"
 import * as inputs from "../types/input";
 import * as outputs from "../types/output";
-import { getVersion } from "../utilities";
+import * as utilities from "../utilities";
 
 /**
  * CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the
@@ -74,18 +74,21 @@ export class CustomResource extends pulumi.CustomResource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(name: string, args: CustomResourceArgs, opts?: pulumi.CustomResourceOptions) {
-        const props: pulumi.Inputs = {};
-        for (const key of Object.keys(args)) {
-            props[key] = (args as any)[key];
-        }
-
-        if (!opts) {
-            opts = {}
+        let inputs: pulumi.Inputs = {};
+        opts = opts || {};
+        if (!opts.id) {
+            for (const key of Object.keys(args)) {
+                inputs[key] = (args as any)[key];
+            }
+        } else {
+            for (const key of Object.keys(args)) {
+                inputs[key] = undefined;
+            }
         }
         if (!opts.version) {
-            opts.version = getVersion();
+            opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});
         }
-        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, props, opts);
+        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, inputs, opts);
         this.__inputs = args;
     }
 }

--- a/sdk/nodejs/apiextensions/customResource.ts
+++ b/sdk/nodejs/apiextensions/customResource.ts
@@ -18,7 +18,7 @@
 import * as pulumi from "@pulumi/pulumi"
 import * as inputs from "../types/input";
 import * as outputs from "../types/output";
-import { getVersion } from "../utilities";
+import * as utilities from "../utilities";
 
 /**
  * CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the
@@ -74,18 +74,21 @@ export class CustomResource extends pulumi.CustomResource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(name: string, args: CustomResourceArgs, opts?: pulumi.CustomResourceOptions) {
-        const props: pulumi.Inputs = {};
-        for (const key of Object.keys(args)) {
-            props[key] = (args as any)[key];
-        }
-
-        if (!opts) {
-            opts = {}
+        let inputs: pulumi.Inputs = {};
+        opts = opts || {};
+        if (!opts.id) {
+            for (const key of Object.keys(args)) {
+                inputs[key] = (args as any)[key];
+            }
+        } else {
+            for (const key of Object.keys(args)) {
+                inputs[key] = undefined;
+            }
         }
         if (!opts.version) {
-            opts.version = getVersion();
+            opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});
         }
-        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, props, opts);
+        super(`kubernetes:${args.apiVersion}:${args.kind}`, name, inputs, opts);
         this.__inputs = args;
     }
 }


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The CustomResource is an overlay (not generated from schema),
so we missed an upstream codegen change. Applying this fix
manually to avoid mutating the opts structure.

Related to https://github.com/pulumi/pulumi/issues/6293
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
