### PR TITLE
[sdk/go] Fix plugin versioning for invoke calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- [sdk/go] Fix plugin versioning for invoke calls (https://github.com/pulumi/pulumi-kubernetes/pull/1520)
+
 ## 2.8.4 (March 29, 2021)
 
 - Ensure using `PULUMI_KUBERNETES_MANAGED_BY_LABEL` doesn't cause diffs on further stack updates (https://github.com/pulumi/pulumi-kubernetes/pull/1508)

--- a/provider/pkg/gen/go-templates/helm/v3/chart.tmpl
+++ b/provider/pkg/gen/go-templates/helm/v3/chart.tmpl
@@ -292,10 +292,7 @@ func helmTemplate(ctx *pulumi.Context, jsonOpts string) ([]map[string]interface{
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-    // TODO: Rather than hardcoding, try to parse a version from a go.mod
-    // https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1") // Pin invoke to 2.6.1 so that the helm:template function is available
-	if err := ctx.Invoke("kubernetes:helm:template", &args, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:helm:template", &args, &ret); err != nil {
 		return nil, errors.Wrap(err, "failed to invoke helm template")
 	}
 	return ret.Result, nil

--- a/provider/pkg/gen/go-templates/kustomize/directory.tmpl
+++ b/provider/pkg/gen/go-templates/kustomize/directory.tmpl
@@ -181,10 +181,7 @@ func parseDirectory(ctx *pulumi.Context, name string, args directoryArgs, opts .
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-    // TODO: Rather than hardcoding, try to parse a version from a go.mod
-    // https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1")
-	if err := ctx.Invoke("kubernetes:kustomize:directory", &invokeArgs, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:kustomize:directory", &invokeArgs, &ret); err != nil {
 		return nil, errors.Wrap(err, "kustomize invoke failed")
 	}
 

--- a/provider/pkg/gen/go-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/go-templates/yaml/yaml.tmpl
@@ -102,10 +102,7 @@ func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption)
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-    // TODO: Rather than hardcoding, try to parse a version from a go.mod
-    // https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1")
-	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret); err != nil {
 		return nil, err
 	}
 	return ret.Result, nil

--- a/sdk/go/kubernetes/helm/v3/chart.go
+++ b/sdk/go/kubernetes/helm/v3/chart.go
@@ -292,10 +292,7 @@ func helmTemplate(ctx *pulumi.Context, jsonOpts string) ([]map[string]interface{
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-	// TODO: Rather than hardcoding, try to parse a version from a go.mod
-	// https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1") // Pin invoke to 2.6.1 so that the helm:template function is available
-	if err := ctx.Invoke("kubernetes:helm:template", &args, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:helm:template", &args, &ret); err != nil {
 		return nil, errors.Wrap(err, "failed to invoke helm template")
 	}
 	return ret.Result, nil

--- a/sdk/go/kubernetes/kustomize/directory.go
+++ b/sdk/go/kubernetes/kustomize/directory.go
@@ -181,10 +181,7 @@ func parseDirectory(ctx *pulumi.Context, name string, args directoryArgs, opts .
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-	// TODO: Rather than hardcoding, try to parse a version from a go.mod
-	// https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1")
-	if err := ctx.Invoke("kubernetes:kustomize:directory", &invokeArgs, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:kustomize:directory", &invokeArgs, &ret); err != nil {
 		return nil, errors.Wrap(err, "kustomize invoke failed")
 	}
 

--- a/sdk/go/kubernetes/yaml/yaml.go
+++ b/sdk/go/kubernetes/yaml/yaml.go
@@ -147,10 +147,7 @@ func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption)
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-	// TODO: Rather than hardcoding, try to parse a version from a go.mod
-	// https://github.com/pulumi/pulumi-kubernetes/issues/1324
-	versionOpt := pulumi.Version("2.6.1")
-	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret, versionOpt); err != nil {
+	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret); err != nil {
 		return nil, err
 	}
 	return ret.Result, nil


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Hardcoding to v2.6.1 was causing problems for
users that didn't have this version of the plugin
installed. Since the Go SDK always uses the
same version of the plugin as the selected
module, it should be safe to drop the version
requirement.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1487 
Fix #1451 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
