### PR TITLE
Error on refresh for an unreachable cluster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Fix refresh for render-yaml resources (https://github.com/pulumi/pulumi-kubernetes/pull/1523)
+- Behavior change: Error on refresh for an unreachable cluster. (https://github.com/pulumi/pulumi-kubernetes/pull/1522)
 
 ## 2.9.0 (April 8, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1594,7 +1594,7 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 	label := fmt.Sprintf("%s.Read(%s)", k.label(), urn)
 	logger.V(9).Infof("%s executing", label)
 
-	// If the cluster is unreachable, consider the resource deleted and inform the user.
+	// If the cluster is unreachable, return an error.
 	if k.clusterUnreachable {
 		_ = k.host.Log(ctx, diag.Warning, urn, fmt.Sprintf(
 			"configured Kubernetes cluster is unreachable: %s", k.clusterUnreachableReason))

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1598,7 +1598,8 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 	if k.clusterUnreachable {
 		_ = k.host.Log(ctx, diag.Warning, urn, fmt.Sprintf(
 			"configured Kubernetes cluster is unreachable: %s", k.clusterUnreachableReason))
-		return deleteResponse, nil
+		return nil, fmt.Errorf("failed to read resource state due to unreachable cluster. " +
+			"If the cluster has been deleted, you can edit the pulumi state to remove this resource")
 	}
 
 	// Obtain new properties, create a Kubernetes `unstructured.Unstructured` that we can pass to the


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the refresh action would assume that an unreachable
cluster meant that the resources had been deleted out of band,
and would delete them from the state with a warning. This deletion
only affected the Pulumi state, not the actual k8s resource, and
could be repaired by reverting to the previous checkpoint.

Unfortunately, this behavior can lead to unintended state changes
in the case of a network partition, especially if the refresh operation
is running as part of an automated job.

This commit changes the default behavior of refresh to return an
error in the case of an unreachable cluster. This change means that
the state may have to be updated manually if the cluster was actually
deleted, but this seems like a preferable alternative to unexpected
state changes.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1485 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
