### PR TITLE
Ensure sdk/go/kubernetes/providers is updated to pulumi v3

### DIFF
--- a/sdk/go/kubernetes/providers/provider.go
+++ b/sdk/go/kubernetes/providers/provider.go
@@ -6,7 +6,7 @@ package providers
 import (
 	"reflect"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // The provider type for the kubernetes package.


### PR DESCRIPTION
Fixes: #1528

This was causing the usage of the Go SDK to try and pull Pulumi v2
as a dependency