### PR TITLE
Suppress header-supplied warnings by default

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -502,7 +502,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 			k.clusterUnreachableReason = fmt.Sprintf(
 				"unable to load Kubernetes client configuration from kubeconfig file: %v", err)
 		} else {
-			k.config = config
+			warningConfig := rest.CopyConfig(config)
+			warningConfig.WarningHandler = rest.NoWarnings{}
+			k.config = warningConfig
 		}
 	}
 


### PR DESCRIPTION
Kubernetes v1.19 and above [send warnings][1] to clients via headers, and clients by default log them to stderr. This has the effect in Pulumi of them being picked up as diagnostics, some of which conflict with the suppression of deprecation warnings defined in provider config.

This became apparent when EKS changed the default version from 1.18 to 1.19, as several diagnostic messages which cannot otherwise be removed are produced.

This commit uses the `NoWarnings` handler to suppress them. Ultimately it might be better to catch warnings as diagnostics, and include things like resource deprecations behind the the config flag.

[1]: https://kubernetes.io/blog/2020/09/03/warnings/