### PR TITLE
[helm] Don't pass opts to child resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
-_(none)_
+
+- In Python helmv2 and helmv3, and Node.js helmv3, no longer pass `Chart` resource options to child resources explicitly.
+  (https://github.com/pulumi/pulumi-kubernetes/pull/1539)
 
 ## 3.0.0 (April 19, 2021)
 

--- a/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
@@ -155,13 +155,13 @@ export class Chart extends yaml.CollectionComponentResource {
         });
 
         this.resources = allConfig.apply(cfg => {
-            return this.parseChart(cfg, releaseName, opts)
+            return this.parseChart(cfg, releaseName)
         });
 
         this.ready = this.resources.apply(m => Object.values(m));
     }
 
-    parseChart(config: ChartOpts | LocalChartOpts, releaseName: string, opts?: pulumi.ComponentResourceOptions) {
+    parseChart(config: ChartOpts | LocalChartOpts, releaseName: string) {
         const blob = {
             ...config,
             releaseName,
@@ -226,7 +226,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: config.transformations || [],
             },
-            { ...opts, parent: this }
+            { parent: this }
         ));
     }
 }

--- a/provider/pkg/gen/python-templates/helm/v2/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v2/helm.py
@@ -173,12 +173,7 @@ class Chart(pulumi.ComponentResource):
             __props__,
             opts)
 
-        if opts is not None:
-            opts.parent = self
-        else:
-            opts = pulumi.ResourceOptions(parent=self)
-
-        all_config = pulumi.Output.from_input((release_name, config, opts))
+        all_config = pulumi.Output.from_input((release_name, config, pulumi.ResourceOptions(parent=self)))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -174,8 +174,7 @@ class Chart(pulumi.ComponentResource):
 
         config.release_name = release_name
 
-        opts.parent = self
-        all_config = pulumi.Output.from_input((config, opts))
+        all_config = pulumi.Output.from_input((config, pulumi.ResourceOptions(parent=self)))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the

--- a/sdk/nodejs/helm/v3/helm.ts
+++ b/sdk/nodejs/helm/v3/helm.ts
@@ -155,13 +155,13 @@ export class Chart extends yaml.CollectionComponentResource {
         });
 
         this.resources = allConfig.apply(cfg => {
-            return this.parseChart(cfg, releaseName, opts)
+            return this.parseChart(cfg, releaseName)
         });
 
         this.ready = this.resources.apply(m => Object.values(m));
     }
 
-    parseChart(config: ChartOpts | LocalChartOpts, releaseName: string, opts?: pulumi.ComponentResourceOptions) {
+    parseChart(config: ChartOpts | LocalChartOpts, releaseName: string) {
         const blob = {
             ...config,
             releaseName,
@@ -226,7 +226,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: config.transformations || [],
             },
-            { ...opts, parent: this }
+            { parent: this }
         ));
     }
 }

--- a/sdk/python/pulumi_kubernetes/helm/v2/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v2/helm.py
@@ -173,12 +173,7 @@ class Chart(pulumi.ComponentResource):
             __props__,
             opts)
 
-        if opts is not None:
-            opts.parent = self
-        else:
-            opts = pulumi.ResourceOptions(parent=self)
-
-        all_config = pulumi.Output.from_input((release_name, config, opts))
+        all_config = pulumi.Output.from_input((release_name, config, pulumi.ResourceOptions(parent=self)))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -174,8 +174,7 @@ class Chart(pulumi.ComponentResource):
 
         config.release_name = release_name
 
-        opts.parent = self
-        all_config = pulumi.Output.from_input((config, opts))
+        all_config = pulumi.Output.from_input((config, pulumi.ResourceOptions(parent=self)))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the


### PR DESCRIPTION
The `opts` passed to a component should be passed to its `super` call, but not to its children.  Child resources automatically inherit those options that they should from their parent - so the resource options applied to a parent should not also be passed down to children explicitly.

In 3 of the 8 implementations of Helm Chart in this codebase, we were passing the component opts to the children.  In the other 5 we were (correctly) not passing them.

Fixes #1538
