### PR TITLE
Add replaceOnUpdate annotation to force resource replacement

### DIFF
--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -31,6 +31,7 @@ const (
 	AnnotationSkipAwait         = AnnotationPrefix + "skipAwait"
 	AnnotationTimeoutSeconds    = AnnotationPrefix + "timeoutSeconds"
 	AnnotationInitialAPIVersion = AnnotationPrefix + "initialApiVersion"
+	AnnotationReplaceOnUpdate   = AnnotationPrefix + "replaceOnUpdate"
 
 	AnnotationHelmHook = "helm.sh/hook"
 )

--- a/provider/pkg/metadata/overrides.go
+++ b/provider/pkg/metadata/overrides.go
@@ -26,6 +26,11 @@ func SkipAwaitLogic(obj *unstructured.Unstructured) bool {
 	return IsAnnotationTrue(obj, AnnotationSkipAwait)
 }
 
+// ReplaceOnUpdate returns true if the `pulumi.com/replaceOnUpdate` annotation is "true", false otherwise.
+func ReplaceOnUpdate(obj *unstructured.Unstructured) bool {
+	return IsAnnotationTrue(obj, AnnotationReplaceOnUpdate)
+}
+
 // TimeoutDuration returns the resource timeout duration. There are a number of things it can do here in this order
 // 1. Return the timeout as specified in the customResource options
 // 2. Return the timeout as specified in `pulumi.com/timeoutSeconds` annotation,

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1382,6 +1382,12 @@ func (k *kubeProvider) Diff(
 			// object in a new namespace and then deleting the old one).
 			newInputs.GetNamespace() == oldInputs.GetNamespace()
 
+	// If the replaceOnUpdate annotation is "true", then schedule the resource for replacement.
+	if metadata.ReplaceOnUpdate(newInputs) {
+		hasChanges = pulumirpc.DiffResponse_DIFF_SOME
+		replaces = append(replaces, `.metadata.annotations["pulumi.com/replaceOnUpdate"]`)
+	}
+
 	return &pulumirpc.DiffResponse{
 		Changes:             hasChanges,
 		Replaces:            replaces,


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Setting `pulumi.com/replaceOnUpdate` to "true" will cause the resource
to be replaced on subsequent updates.

Reviewer note:
I still need to add tests, but wanted to make sure the overall approach makes sense.

Here's an example of what this looks like in the CLI with the annotation set.
<img width="444" alt="Screen Shot 2021-05-04 at 3 52 03 PM" src="https://user-images.githubusercontent.com/9253463/117074523-ae388400-acf0-11eb-8880-39fec54d01ef.png">

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1007 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
