### PR TITLE
Fix hanging updates for deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add skipAwait option to helm.v3 SDKs. (https://github.com/pulumi/pulumi-kubernetes/pull/1603)
 - [sdk/go] `ConfigGroup` now respects explicit provider instances when parsing YAML. (https://github.com/pulumi/pulumi-kubernetes/pull/1601)
+- Fix hanging updates for deployment await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1596)
 
 ## 3.3.1 (June 8, 2021)
 

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -598,8 +598,13 @@ func (dia *deploymentInitAwaiter) processReplicaSetEvent(event watch.Event) {
 
 	logger.V(3).Infof("ReplicaSet %q is owned by %q", rs.GetName(), dia.config.currentInputs.GetName())
 
-	// If Pod was deleted, remove it from our aggregated checkers.
 	generation := rs.GetAnnotations()[revision]
+	if generation == "" {
+		// This should be unlikely but this is not a RS we want to process anyway if no revision is specified.
+		return
+	}
+
+	// If Pod was deleted, remove it from our aggregated checkers.
 	if event.Type == watch.Deleted {
 		delete(dia.replicaSets, generation)
 		return

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -156,8 +156,9 @@ func (dia *deploymentInitAwaiter) Await() error {
 	})
 	// If the required resource version is no longer available, reset tracked deployment state to the latest.
 	if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
+		var deployment *unstructured.Unstructured
 		// Get live versions of Deployment again.
-		deployment, err := deploymentClient.Get(context.TODO(),
+		deployment, err = deploymentClient.Get(context.TODO(),
 			dia.config.currentInputs.GetName(),
 			metav1.GetOptions{})
 		if err != nil {

--- a/tests/sdk/go/kustomize/main.go
+++ b/tests/sdk/go/kustomize/main.go
@@ -10,11 +10,16 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ns, err := corev1.NewNamespace(ctx, "test", &corev1.NamespaceArgs{})
+		if err != nil {
+			return err
+		}
 		provider, err := k8s.NewProvider(ctx, "k8s", &k8s.ProviderArgs{
 			Kubeconfig: pulumi.String("~/.kube/config"),
 			Namespace:  ns.Metadata.Name(),
 		})
-
+		if err != nil {
+			return err
+		}
 		_, err = kustomize.NewDirectory(ctx, "helloWorld",
 			kustomize.DirectoryArgs{Directory: pulumi.String("helloWorld")},
 			pulumi.Provider(provider),

--- a/tests/sdk/nodejs/istio/step1/index.ts
+++ b/tests/sdk/nodejs/istio/step1/index.ts
@@ -53,5 +53,6 @@ export const frontendIp = pulumi
     ])
     .apply(([status, spec]) => {
         const port = spec.ports.filter(p => p.name == "http2")[0].port;
-        return `${status.loadBalancer.ingress[0].ip}:${port}/productpage`;
+        const ingress = status.loadBalancer.ingress[0];
+        return `${ingress.hostname ?? ingress.ip}:${port}/productpage`;
     });

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -975,7 +975,7 @@ func TestSecrets(t *testing.T) {
 			"message": secretMessage,
 		},
 		ExpectRefreshChanges: true,
-		Quick: true,
+		Quick:                true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
 			state, err := json.Marshal(stackInfo.Deployment)


### PR DESCRIPTION
Fix for #1502 

In my investigation for the above issue, I was able to determine that there is a TOCTTOU style race in the state maintained by the await logic for deployments. Specifically, the initial state is seeded during Read() where information on replicaset generations, pods and PVCs are all populated. The watch is kicked off subsequently but based on the most recent resource version. The current await logic seems quite brittle against the potential for missed events. Indeed in my repro, I was able to determine that the await logic would hang forever waiting to see updates for an older generation of the `replicaset` (as referenced during the initial `Read()`) while the watch began with a state where the expected (old) `replicaset` was already deleted. This change seeds the watches to begin at the resource versions we initially read.

In some ways I am not thrilled with this approach since we are further perpetuating the current highly stateful nature of the await logic here. As part of the refactor/rearchitecture of the await logic for complex resources such as deployments we should definitely consider an approach where the strong consistency of the event stream is not necessary. The current biggest caveats with this approach:
1. With setting the resource revision for the watch, there is the possibility that the resource version to read from is no longer retained (`Await()` is significantly delayed from `Read()`) in which case we would get a `410` from the api server. I am not sure what we should do in that situation to recover.
2. The set resource version might cause an additional performance penalty.
3. Not entirely sure how best to test this. My repro environment was a bit convoluted though I will share the preliminary performance/load testing scaffold I used to track the issue (and verify fix) separately.