### PR TITLE
Ensure provider InvokeOption is passed to functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- `ConfigGroup` now respects explicit provider instances when parsing YAML.
+
 ## 3.3.0 (May 26, 2021)
 
 - Automatically mark Secret data as Pulumi secrets. (https://github.com/pulumi/pulumi-kubernetes/pull/1577)

--- a/provider/pkg/gen/_go-templates/yaml/configGroup.go
+++ b/provider/pkg/gen/_go-templates/yaml/configGroup.go
@@ -264,7 +264,8 @@ func NewConfigGroup(ctx *pulumi.Context,
 		}
 
 		// Parse and decode the YAML files.
-		rs, err := parseDecodeYamlFiles(ctx, args, true, pulumi.Parent(configGroup))
+		parseOpts := append(opts, pulumi.Parent(configGroup))
+		rs, err := parseDecodeYamlFiles(ctx, args, true, parseOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/pkg/gen/_go-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/_go-templates/yaml/yaml.tmpl
@@ -79,10 +79,18 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 		}
 	}
 
+  // Find options which are also Invoke options, and prepare them to pass to Invoke functions
+	var invokeOpts []pulumi.InvokeOption
+	for _, opt := range opts {
+		if invokeOpt, ok := opt.(pulumi.InvokeOption); ok {
+			invokeOpts = append(invokeOpts, invokeOpt)
+		}
+	}
+
 	// Next parse all YAML documents into objects.
 	for _, yaml := range yamls {
 		// Parse the resulting YAML bytes and turn them into raw Kubernetes objects.
-		dec, err := yamlDecode(ctx, yaml, opts...)
+		dec, err := yamlDecode(ctx, yaml, invokeOpts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "decoding YAML")
 		}
@@ -94,7 +102,7 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 }
 
 // yamlDecode invokes the function to decode a single YAML file and decompose it into object structures.
-func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption) ([]map[string]interface{}, error) {
+func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.InvokeOption) ([]map[string]interface{}, error) {
 	args := struct {
 		Text string `pulumi:"text"`
 	}{Text: text}
@@ -102,7 +110,7 @@ func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption)
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret); err != nil {
+	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret, opts...); err != nil {
 		return nil, err
 	}
 	return ret.Result, nil

--- a/sdk/go/kubernetes/yaml/configGroup.go
+++ b/sdk/go/kubernetes/yaml/configGroup.go
@@ -264,7 +264,8 @@ func NewConfigGroup(ctx *pulumi.Context,
 		}
 
 		// Parse and decode the YAML files.
-		rs, err := parseDecodeYamlFiles(ctx, args, true, pulumi.Parent(configGroup))
+		parseOpts := append(opts, pulumi.Parent(configGroup))
+		rs, err := parseDecodeYamlFiles(ctx, args, true, parseOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/kubernetes/yaml/yaml.go
+++ b/sdk/go/kubernetes/yaml/yaml.go
@@ -126,10 +126,18 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 		}
 	}
 
+	// Find options which are also Invoke options, and prepare them to pass to Invoke functions
+	var invokeOpts []pulumi.InvokeOption
+	for _, opt := range opts {
+		if invokeOpt, ok := opt.(pulumi.InvokeOption); ok {
+			invokeOpts = append(invokeOpts, invokeOpt)
+		}
+	}
+
 	// Next parse all YAML documents into objects.
 	for _, yaml := range yamls {
 		// Parse the resulting YAML bytes and turn them into raw Kubernetes objects.
-		dec, err := yamlDecode(ctx, yaml, opts...)
+		dec, err := yamlDecode(ctx, yaml, invokeOpts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "decoding YAML")
 		}
@@ -141,7 +149,7 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 }
 
 // yamlDecode invokes the function to decode a single YAML file and decompose it into object structures.
-func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption) ([]map[string]interface{}, error) {
+func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.InvokeOption) ([]map[string]interface{}, error) {
 	args := struct {
 		Text string `pulumi:"text"`
 	}{Text: text}
@@ -149,7 +157,7 @@ func yamlDecode(ctx *pulumi.Context, text string, opts ...pulumi.ResourceOption)
 		Result []map[string]interface{} `pulumi:"result"`
 	}
 
-	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret); err != nil {
+	if err := ctx.Invoke("kubernetes:yaml:decode", &args, &ret, opts...); err != nil {
 		return nil, err
 	}
 	return ret.Result, nil


### PR DESCRIPTION
This commit ensure that provider options specified are passed to the YAML Decoding function if supplied to a ConfigGroup. This prevents the unnecessary instantiation of a default provider where this is used in a mode where only explicitly created providers are otherwise in play.