### PR TITLE
Fix auto-naming bug for computed names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add skipAwait option to YAML SDKs. (https://github.com/pulumi/pulumi-kubernetes/pull/1610)
 - [sdk/go] `ConfigGroup` now respects explicit provider instances when parsing YAML. (https://github.com/pulumi/pulumi-kubernetes/pull/1601)
 - Fix hanging updates for deployment await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1596)
+- Fix auto-naming bug for computed names (https://github.com/pulumi/pulumi-kubernetes/pull/1618)
 
 ## 3.3.1 (June 8, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1093,7 +1093,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 			}
 		}
 	} else {
-		metadata.AssignNameIfAutonamable(newInputs, urn.Name())
+		metadata.AssignNameIfAutonamable(newInputs, news, urn.Name())
 
 		// Set a "managed-by: pulumi" label on all created k8s resources.
 		_, err = metadata.TrySetManagedByLabel(newInputs)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This fixes a bug where a resource would be incorrectly auto-named
during preview if the `.metadata.name` value was a computed value.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1617 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
