### PR TITLE
Handle different namespaces for server-side diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update pulumi dependencies v3.5.1 (https://github.com/pulumi/pulumi-kubernetes/pull/1623)
 - Skip cluster connectivity check in yamlRenderMode (https://github.com/pulumi/pulumi-kubernetes/pull/1629)
+- Handle different namespaces for server-side diff (https://github.com/pulumi/pulumi-kubernetes/pull/1631)
 
 ## 3.4.0 (June 17, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2213,6 +2213,9 @@ func (k *kubeProvider) serverSidePatch(
 		newObject, err = client.Create(context.TODO(), newInputs, metav1.CreateOptions{
 			DryRun: []string{metav1.DryRunAll},
 		})
+		if err != nil {
+			return nil, nil, err
+		}
 	case err == nil:
 		newObject, err = client.Patch(context.TODO(), newInputs.GetName(), patchType, patch, metav1.PatchOptions{
 			DryRun: []string{metav1.DryRunAll},

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2201,12 +2201,20 @@ func (k *kubeProvider) serverSidePatch(
 	var newObject *unstructured.Unstructured
 	_, err = client.Get(context.TODO(), newInputs.GetName(), metav1.GetOptions{})
 	switch {
-	case err == nil:
-		newObject, err = client.Patch(context.TODO(), newInputs.GetName(), patchType, patch, metav1.PatchOptions{
-			DryRun: []string{metav1.DryRunAll},
-		})
 	case errors.IsNotFound(err):
 		newObject, err = client.Create(context.TODO(), newInputs, metav1.CreateOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+	case newInputs.GetNamespace() != oldInputs.GetNamespace():
+		client, err := k.clientSet.ResourceClient(newInputs.GroupVersionKind(), newInputs.GetNamespace())
+		if err != nil {
+			return nil, nil, err
+		}
+		newObject, err = client.Create(context.TODO(), newInputs, metav1.CreateOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+	case err == nil:
+		newObject, err = client.Patch(context.TODO(), newInputs.GetName(), patchType, patch, metav1.PatchOptions{
 			DryRun: []string{metav1.DryRunAll},
 		})
 	default:

--- a/tests/sdk/nodejs/dry-run/step1/index.ts
+++ b/tests/sdk/nodejs/dry-run/step1/index.ts
@@ -16,6 +16,9 @@ import * as k8s from "@pulumi/kubernetes";
 import * as random from "@pulumi/random";
 import * as pulumi from "@pulumi/pulumi";
 
+// This test creates a Provider with `enableDryRun` (server side apply) enabled. A namespace is also specified, which
+// causes the Deployment to be created in that namespace.
+
 // TODO(levi): Use auto-naming for namespace once https://github.com/pulumi/pulumi-kubernetes/issues/1632 is fixed.
 const suffix = new random.RandomString("suffix", {length: 7, special: false, upper: false}).result;
 const ns = new k8s.core.v1.Namespace("test", {metadata: {name: pulumi.interpolate`test-${suffix}`}});

--- a/tests/sdk/nodejs/dry-run/step1/package.json
+++ b/tests/sdk/nodejs/dry-run/step1/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "steps",
+    "name": "dry-run",
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/tests/sdk/nodejs/dry-run/step2/index.ts
+++ b/tests/sdk/nodejs/dry-run/step2/index.ts
@@ -19,7 +19,7 @@ import * as pulumi from "@pulumi/pulumi";
 // TODO(levi): Use auto-naming for namespace once https://github.com/pulumi/pulumi-kubernetes/issues/1632 is fixed.
 const suffix = new random.RandomString("suffix", {length: 7, special: false, upper: false}).result;
 const ns = new k8s.core.v1.Namespace("test", {metadata: {name: pulumi.interpolate`test-${suffix}`}});
-const provider = new k8s.Provider("k8s", {enableDryRun: true, namespace: ns.metadata.name});
+const provider = new k8s.Provider("k8s", {enableDryRun: true}); // Use the default namespace.
 
 const appLabels = { app: "nginx" };
 const deployment = new k8s.apps.v1.Deployment("nginx", {

--- a/tests/sdk/nodejs/dry-run/step2/index.ts
+++ b/tests/sdk/nodejs/dry-run/step2/index.ts
@@ -16,6 +16,9 @@ import * as k8s from "@pulumi/kubernetes";
 import * as random from "@pulumi/random";
 import * as pulumi from "@pulumi/pulumi";
 
+// This test creates a Provider with `enableDryRun` (server side apply) enabled. The namespace option is removed, which
+// causes the Deployment to be recreated in the default namespace.
+
 // TODO(levi): Use auto-naming for namespace once https://github.com/pulumi/pulumi-kubernetes/issues/1632 is fixed.
 const suffix = new random.RandomString("suffix", {length: 7, special: false, upper: false}).result;
 const ns = new k8s.core.v1.Namespace("test", {metadata: {name: pulumi.interpolate`test-${suffix}`}});

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -451,6 +451,12 @@ func TestDeploymentRollout(t *testing.T) {
 func TestDryRun(t *testing.T) {
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir: filepath.Join("dry-run", "step1"),
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      filepath.Join("dry-run", "step2"),
+				Additive: true,
+			},
+		},
 	})
 	integration.ProgramTest(t, &test)
 }


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The server-side diff logic previously tried to use the
same k8s client for calculating the patch. In the case
where the namespace of a resource changed, this
diff would fail because the client was for the old
namespace.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #683 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
