### PR TITLE
Handle auto-named namespaces for server-side diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Skip cluster connectivity check in yamlRenderMode (https://github.com/pulumi/pulumi-kubernetes/pull/1629)
 - Handle different namespaces for server-side diff (https://github.com/pulumi/pulumi-kubernetes/pull/1631)
 - Handle auto-named namespaces for server-side diff (https://github.com/pulumi/pulumi-kubernetes/pull/1633)
+- *Revert* Fix hanging updates for deployment await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1596)
 
 ## 3.4.1 (June 24, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 - Update pulumi dependencies v3.5.1 (https://github.com/pulumi/pulumi-kubernetes/pull/1623)
 - Skip cluster connectivity check in yamlRenderMode (https://github.com/pulumi/pulumi-kubernetes/pull/1629)
 - Handle different namespaces for server-side diff (https://github.com/pulumi/pulumi-kubernetes/pull/1631)
-- *Revert* Fix hanging updates for deployment await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1596)
+- Handle auto-named namespaces for server-side diff (https://github.com/pulumi/pulumi-kubernetes/pull/1633)
 
 ## 3.4.1 (June 24, 2021)
+
 - *Revert* Fix hanging updates for deployment await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1596)
 
 ## 3.4.0 (June 17, 2021)

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -179,13 +179,17 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 
 			outputs, err = client.Create(context.TODO(), c.Inputs, options)
 			if err != nil {
+				// If the namespace hasn't been created yet, the preview will always fail.
+				if c.DryRun && IsNamespaceNotFoundErr(err) {
+					return &namespaceError{c.Inputs}
+				}
+
 				_ = c.Host.LogStatus(c.Context, diag.Info, c.URN, fmt.Sprintf(
 					"Retry #%d; creation failed: %v", i, err))
 				return err
 			}
 
-			// TODO(levi): return nil here to be more explicit (early returns on any error)
-			return err
+			return nil
 
 		}).
 		WithMaxRetries(5).

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1529,15 +1529,13 @@ func (k *kubeProvider) Create(
 	initialized, awaitErr := await.Creation(config)
 	if awaitErr != nil {
 		if req.GetPreview() {
-			failedPreview := func() bool {
-				_, isPreviewErr := awaitErr.(await.PreviewError)
-				if k.isDryRunDisabledError(err) || isPreviewErr {
-					return true
-				}
-
-				return false
+			failedPreview := false
+			_, isPreviewErr := awaitErr.(await.PreviewError)
+			if k.isDryRunDisabledError(err) || isPreviewErr {
+				failedPreview = true
 			}
-			if failedPreview() {
+
+			if failedPreview {
 				logger.V(9).Infof("could not preview Create(%v): %v", urn, err)
 				return &pulumirpc.CreateResponse{Id: "", Properties: req.GetProperties()}, nil
 			}

--- a/tests/sdk/nodejs/dry-run/step1/index.ts
+++ b/tests/sdk/nodejs/dry-run/step1/index.ts
@@ -13,15 +13,11 @@
 // limitations under the License.
 
 import * as k8s from "@pulumi/kubernetes";
-import * as random from "@pulumi/random";
-import * as pulumi from "@pulumi/pulumi";
 
 // This test creates a Provider with `enableDryRun` (server side apply) enabled. A namespace is also specified, which
 // causes the Deployment to be created in that namespace.
 
-// TODO(levi): Use auto-naming for namespace once https://github.com/pulumi/pulumi-kubernetes/issues/1632 is fixed.
-const suffix = new random.RandomString("suffix", {length: 7, special: false, upper: false}).result;
-const ns = new k8s.core.v1.Namespace("test", {metadata: {name: pulumi.interpolate`test-${suffix}`}});
+const ns = new k8s.core.v1.Namespace("test");
 const provider = new k8s.Provider("k8s", {enableDryRun: true, namespace: ns.metadata.name});
 
 const appLabels = { app: "nginx" };

--- a/tests/sdk/nodejs/dry-run/step1/package.json
+++ b/tests/sdk/nodejs/dry-run/step1/package.json
@@ -2,8 +2,7 @@
     "name": "dry-run",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/random": "latest"
+        "@pulumi/pulumi": "latest"
     },
     "devDependencies": {
     },

--- a/tests/sdk/nodejs/dry-run/step2/index.ts
+++ b/tests/sdk/nodejs/dry-run/step2/index.ts
@@ -13,15 +13,11 @@
 // limitations under the License.
 
 import * as k8s from "@pulumi/kubernetes";
-import * as random from "@pulumi/random";
-import * as pulumi from "@pulumi/pulumi";
 
 // This test creates a Provider with `enableDryRun` (server side apply) enabled. The namespace option is removed, which
 // causes the Deployment to be recreated in the default namespace.
 
-// TODO(levi): Use auto-naming for namespace once https://github.com/pulumi/pulumi-kubernetes/issues/1632 is fixed.
-const suffix = new random.RandomString("suffix", {length: 7, special: false, upper: false}).result;
-const ns = new k8s.core.v1.Namespace("test", {metadata: {name: pulumi.interpolate`test-${suffix}`}});
+const ns = new k8s.core.v1.Namespace("test");
 const provider = new k8s.Provider("k8s", {enableDryRun: true}); // Use the default namespace.
 
 const appLabels = { app: "nginx" };


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This fixes a bug with server-side diff support where auto-named
namespaces would cause resources using that namespace to
fail during preview. This was caused by configuring the k8s client
to run a server-side preview on a namespace that didn't yet exist.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1632
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
