### PR TITLE
Fix Makefile to set Python SDK version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ python_sdk::
 	cd ${PACKDIR}/python/ && \
 		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e "s/\$${VERSION}/$(PYPI_VERSION)/g" -e "s/\$${PLUGIN_VERSION}/$(VERSION)/g" ./bin/setup.py && \
+		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
 		rm ./bin/setup.py.bak && \
 		cd ./bin && python3 setup.py build sdist
 


### PR DESCRIPTION
A [recent change](https://github.com/pulumi/pulumi/pull/7479) to the codegen has changed the way `setup.py` is emitted that requires an update to the `Makefile` to set the version.

We'll need this change merged before we release another version.