### PR TITLE
feat: service types from k8s corev1

### DIFF
--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -39,10 +39,10 @@ var serviceSpecType = pschema.ComplexTypeSpec{
 		Type: "string",
 	},
 	Enum: []pschema.EnumValueSpec{
-			{Value: v1.ServiceTypeExternalName},
-			{Value: v1.ServiceTypeClusterIP},
-			{Value: v1.ServiceTypeNodePort},
-			{Value: v1.ServiceTypeLoadBalancer},
+		{Value: v1.ServiceTypeExternalName},
+		{Value: v1.ServiceTypeClusterIP},
+		{Value: v1.ServiceTypeNodePort},
+		{Value: v1.ServiceTypeLoadBalancer},
 	},
 }
 


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.dev>

Use the `Service` types from the k8s API.

If this is a good start, I can start slowly adding the missing constants.