### PR TITLE
[sdk/python] yaml. _parse_yaml_object wait only for metadata name and namespace instead of all metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- [sdk/python] Fix wait for metadata in `yaml._parse_yaml_object`. (https://github.com/pulumi/pulumi-kubernetes/pull/1675)
+
 ## 3.6.0 (Auguest 4, 2021)
 
 The following breaking changes are part of the Kubernetes v1.22 update:

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -480,8 +480,8 @@ def _parse_yaml_object(
     spec = obj.get("spec")
     identifier: pulumi.Output = pulumi.Output.from_input(metadata["name"])
     if "namespace" in metadata:
-        identifier = pulumi.Output.from_input(metadata).apply(
-            lambda metadata: f"{metadata['namespace']}/{metadata['name']}")
+        identifier = pulumi.Output.all(metadata["namespace"], metadata["name"]).apply(
+            lambda x: f"{x[0]}/{x[1]}")
     if resource_prefix:
         identifier = pulumi.Output.from_input(identifier).apply(
             lambda identifier: f"{resource_prefix}-{identifier}")

--- a/sdk/python/pulumi_kubernetes/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml.py
@@ -480,8 +480,8 @@ def _parse_yaml_object(
     spec = obj.get("spec")
     identifier: pulumi.Output = pulumi.Output.from_input(metadata["name"])
     if "namespace" in metadata:
-        identifier = pulumi.Output.from_input(metadata).apply(
-            lambda metadata: f"{metadata['namespace']}/{metadata['name']}")
+        identifier = pulumi.Output.all(metadata["namespace"], metadata["name"]).apply(
+            lambda x: f"{x[0]}/{x[1]}")
     if resource_prefix:
         identifier = pulumi.Output.from_input(identifier).apply(
             lambda identifier: f"{resource_prefix}-{identifier}")


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Use `Output.all` only on metadata.name and namespace instead of all metadata in `yaml._parse_yaml_object`

### Related issues (optional)

Fix #1674 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
