### PR TITLE
[yaml] Treat an empty directory as unset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [sdk/python] Fix wait for metadata in `yaml._parse_yaml_object`. (https://github.com/pulumi/pulumi-kubernetes/pull/1675)
 - Fix diff logic for server-side apply mode (https://github.com/pulumi/pulumi-kubernetes/pull/1679)
 - Add option to disable Helm hook warnings (https://github.com/pulumi/pulumi-kubernetes/pull/1682)
+- For renderToYamlDirectory, treat an empty directory as unset (https://github.com/pulumi/pulumi-kubernetes/pull/1678)
 
 ## 3.6.0 (Auguest 4, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -448,7 +448,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 
 	renderYamlToDirectory := func() string {
 		// Read the config from the Provider.
-		if directory, exists := vars["kubernetes:config:renderYamlToDirectory"]; exists {
+		if directory, exists := vars["kubernetes:config:renderYamlToDirectory"]; exists && directory != "" {
 			return directory
 		}
 		return ""


### PR DESCRIPTION
If `renderYamlToDirectory` is set but is the empty string, treat it as
unset.