### PR TITLE
Add option to disable Helm hook warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [sdk/python] Fix wait for metadata in `yaml._parse_yaml_object`. (https://github.com/pulumi/pulumi-kubernetes/pull/1675)
 - Fix diff logic for server-side apply mode (https://github.com/pulumi/pulumi-kubernetes/pull/1679)
+- Add option to disable Helm hook warnings (https://github.com/pulumi/pulumi-kubernetes/pull/1682)
 
 ## 3.6.0 (Auguest 4, 2021)
 

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -42,6 +42,10 @@
             "suppressDeprecationWarnings": {
                 "type": "boolean",
                 "description": "If present and set to true, suppress apiVersion deprecation warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressDeprecationWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS` environment variable."
+            },
+            "suppressHelmHookWarnings": {
+                "type": "boolean",
+                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable."
             }
         }
     },
@@ -29616,6 +29620,15 @@
                 "defaultInfo": {
                     "environment": [
                         "PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS"
+                    ]
+                }
+            },
+            "suppressHelmHookWarnings": {
+                "type": "boolean",
+                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
+                "defaultInfo": {
+                    "environment": [
+                        "PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS"
                     ]
                 }
             }

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -70,6 +70,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					Description: "If present and set to true, suppress apiVersion deprecation warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressDeprecationWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
+				"suppressHelmHookWarnings": {
+					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 			},
 		},
 
@@ -125,6 +129,15 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 						},
 					},
 					Description: "If present and set to true, suppress apiVersion deprecation warnings from the CLI.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
+				"suppressHelmHookWarnings": {
+					DefaultInfo: &pschema.DefaultSpec{
+						Environment: []string{
+							"PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS",
+						},
+					},
+					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 			},

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1203,7 +1203,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 }
 
 // helmHookWarning logs a warning if a Chart contains unsupported hooks. The warning can be disabled by setting
-// the PULUMI_DISABLE_HELM_HOOK_WARNING environment variable.
+// the suppressHelmHookWarnings provider flag or related ENV var.
 func (k *kubeProvider) helmHookWarning(ctx context.Context, newInputs *unstructured.Unstructured, urn resource.URN) {
 	hasHelmHook := false
 	for key, value := range newInputs.GetAnnotations() {

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -123,5 +123,19 @@ namespace Pulumi.Kubernetes
             set => _suppressDeprecationWarnings.Set(value);
         }
 
+        private static readonly __Value<bool?> _suppressHelmHookWarnings = new __Value<bool?>(() => __config.GetBoolean("suppressHelmHookWarnings"));
+        /// <summary>
+        /// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+        /// 
+        /// This config can be specified in the following ways, using this precedence:
+        /// 1. This `suppressHelmHookWarnings` parameter.
+        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        /// </summary>
+        public static bool? SuppressHelmHookWarnings
+        {
+            get => _suppressHelmHookWarnings.Get();
+            set => _suppressHelmHookWarnings.Set(value);
+        }
+
     }
 }

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -101,11 +101,22 @@ namespace Pulumi.Kubernetes
         [Input("suppressDeprecationWarnings", json: true)]
         public Input<bool>? SuppressDeprecationWarnings { get; set; }
 
+        /// <summary>
+        /// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+        /// 
+        /// This config can be specified in the following ways, using this precedence:
+        /// 1. This `suppressHelmHookWarnings` parameter.
+        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        /// </summary>
+        [Input("suppressHelmHookWarnings", json: true)]
+        public Input<bool>? SuppressHelmHookWarnings { get; set; }
+
         public ProviderArgs()
         {
             EnableDryRun = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN");
             KubeConfig = Utilities.GetEnv("KUBECONFIG");
             SuppressDeprecationWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS");
+            SuppressHelmHookWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS");
         }
     }
 }

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -63,3 +63,12 @@ func GetRenderYamlToDirectory(ctx *pulumi.Context) string {
 func GetSuppressDeprecationWarnings(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:suppressDeprecationWarnings")
 }
+
+// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+//
+// This config can be specified in the following ways, using this precedence:
+// 1. This `suppressHelmHookWarnings` parameter.
+// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+func GetSuppressHelmHookWarnings(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:suppressHelmHookWarnings")
+}

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -31,6 +31,9 @@ func NewProvider(ctx *pulumi.Context,
 	if args.SuppressDeprecationWarnings == nil {
 		args.SuppressDeprecationWarnings = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS").(bool))
 	}
+	if args.SuppressHelmHookWarnings == nil {
+		args.SuppressHelmHookWarnings = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS").(bool))
+	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:kubernetes", name, args, &resource, opts...)
 	if err != nil {
@@ -67,6 +70,12 @@ type providerArgs struct {
 	RenderYamlToDirectory *string `pulumi:"renderYamlToDirectory"`
 	// If present and set to true, suppress apiVersion deprecation warnings from the CLI.
 	SuppressDeprecationWarnings *bool `pulumi:"suppressDeprecationWarnings"`
+	// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+	//
+	// This config can be specified in the following ways, using this precedence:
+	// 1. This `suppressHelmHookWarnings` parameter.
+	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+	SuppressHelmHookWarnings *bool `pulumi:"suppressHelmHookWarnings"`
 }
 
 // The set of arguments for constructing a Provider resource.
@@ -98,6 +107,12 @@ type ProviderArgs struct {
 	RenderYamlToDirectory pulumi.StringPtrInput
 	// If present and set to true, suppress apiVersion deprecation warnings from the CLI.
 	SuppressDeprecationWarnings pulumi.BoolPtrInput
+	// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+	//
+	// This config can be specified in the following ways, using this precedence:
+	// 1. This `suppressHelmHookWarnings` parameter.
+	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+	SuppressHelmHookWarnings pulumi.BoolPtrInput
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -41,6 +41,7 @@ export class Provider extends pulumi.ProviderResource {
             inputs["namespace"] = args ? args.namespace : undefined;
             inputs["renderYamlToDirectory"] = args ? args.renderYamlToDirectory : undefined;
             inputs["suppressDeprecationWarnings"] = pulumi.output((args ? args.suppressDeprecationWarnings : undefined) ?? <any>utilities.getEnvBoolean("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS")).apply(JSON.stringify);
+            inputs["suppressHelmHookWarnings"] = pulumi.output((args ? args.suppressHelmHookWarnings : undefined) ?? <any>utilities.getEnvBoolean("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS")).apply(JSON.stringify);
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});
@@ -94,4 +95,12 @@ export interface ProviderArgs {
      * If present and set to true, suppress apiVersion deprecation warnings from the CLI.
      */
     suppressDeprecationWarnings?: pulumi.Input<boolean>;
+    /**
+     * If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+     *
+     * This config can be specified in the following ways, using this precedence:
+     * 1. This `suppressHelmHookWarnings` parameter.
+     * 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+     */
+    suppressHelmHookWarnings?: pulumi.Input<boolean>;
 }

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -19,7 +19,8 @@ class ProviderArgs:
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
-                 suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None):
+                 suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
+                 suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a Provider resource.
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
@@ -42,6 +43,11 @@ class ProviderArgs:
                and may result in an error if they are referenced by other resources. Also note that any secret values
                used in these resources will be rendered in plaintext to the resulting YAML.
         :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to true, suppress apiVersion deprecation warnings from the CLI.
+        :param pulumi.Input[bool] suppress_helm_hook_warnings: If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+               
+               This config can be specified in the following ways, using this precedence:
+               1. This `suppressHelmHookWarnings` parameter.
+               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
         """
         if cluster is not None:
             pulumi.set(__self__, "cluster", cluster)
@@ -63,6 +69,10 @@ class ProviderArgs:
             suppress_deprecation_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS')
         if suppress_deprecation_warnings is not None:
             pulumi.set(__self__, "suppress_deprecation_warnings", suppress_deprecation_warnings)
+        if suppress_helm_hook_warnings is None:
+            suppress_helm_hook_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS')
+        if suppress_helm_hook_warnings is not None:
+            pulumi.set(__self__, "suppress_helm_hook_warnings", suppress_helm_hook_warnings)
 
     @property
     @pulumi.getter
@@ -161,6 +171,22 @@ class ProviderArgs:
     def suppress_deprecation_warnings(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "suppress_deprecation_warnings", value)
 
+    @property
+    @pulumi.getter(name="suppressHelmHookWarnings")
+    def suppress_helm_hook_warnings(self) -> Optional[pulumi.Input[bool]]:
+        """
+        If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+
+        This config can be specified in the following ways, using this precedence:
+        1. This `suppressHelmHookWarnings` parameter.
+        2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        """
+        return pulumi.get(self, "suppress_helm_hook_warnings")
+
+    @suppress_helm_hook_warnings.setter
+    def suppress_helm_hook_warnings(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "suppress_helm_hook_warnings", value)
+
 
 class Provider(pulumi.ProviderResource):
     @overload
@@ -174,6 +200,7 @@ class Provider(pulumi.ProviderResource):
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
                  suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
+                 suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         The provider type for the kubernetes package.
@@ -200,6 +227,11 @@ class Provider(pulumi.ProviderResource):
                and may result in an error if they are referenced by other resources. Also note that any secret values
                used in these resources will be rendered in plaintext to the resulting YAML.
         :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to true, suppress apiVersion deprecation warnings from the CLI.
+        :param pulumi.Input[bool] suppress_helm_hook_warnings: If present and set to true, suppress unsupported Helm hook warnings from the CLI.
+               
+               This config can be specified in the following ways, using this precedence:
+               1. This `suppressHelmHookWarnings` parameter.
+               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
         """
         ...
     @overload
@@ -232,6 +264,7 @@ class Provider(pulumi.ProviderResource):
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
                  suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
+                 suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
@@ -257,6 +290,9 @@ class Provider(pulumi.ProviderResource):
             if suppress_deprecation_warnings is None:
                 suppress_deprecation_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS')
             __props__.__dict__["suppress_deprecation_warnings"] = pulumi.Output.from_input(suppress_deprecation_warnings).apply(pulumi.runtime.to_json) if suppress_deprecation_warnings is not None else None
+            if suppress_helm_hook_warnings is None:
+                suppress_helm_hook_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS')
+            __props__.__dict__["suppress_helm_hook_warnings"] = pulumi.Output.from_input(suppress_helm_hook_warnings).apply(pulumi.runtime.to_json) if suppress_helm_hook_warnings is not None else None
         super(Provider, __self__).__init__(
             'kubernetes',
             resource_name,


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The warning for unsupported Helm hooks can now be disabled
using the suppressHelmHookWarnings Provider option, or by setting 
the `PULUMI_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Related: https://github.com/pulumi/pulumi-kubernetes/issues/555
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
