### PR TITLE
Fix misleading message for disable Helm hook warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+## 3.6.2 (August 19, 2021)
+
+- Fix environment variable name in disable Helm hook warnings message (https://github.com/pulumi/pulumi-kubernetes/pull/1683)
+
 ## 3.6.1 (August 19, 2021)
 
 - [sdk/python] Fix wait for metadata in `yaml._parse_yaml_object`. (https://github.com/pulumi/pulumi-kubernetes/pull/1675)

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -45,7 +45,7 @@
             },
             "suppressHelmHookWarnings": {
                 "type": "boolean",
-                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable."
+                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable."
             }
         }
     },
@@ -29625,7 +29625,7 @@
             },
             "suppressHelmHookWarnings": {
                 "type": "boolean",
-                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
+                "description": "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.",
                 "defaultInfo": {
                     "environment": [
                         "PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS"

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -71,7 +71,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"suppressHelmHookWarnings": {
-					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
+					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 			},
@@ -137,7 +137,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 							"PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS",
 						},
 					},
-					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.",
+					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 			},

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1226,7 +1226,7 @@ func (k *kubeProvider) helmHookWarning(ctx context.Context, newInputs *unstructu
 			"This resource contains Helm hooks that are not currently supported by Pulumi. The resource will "+
 				"be created, but any hooks will not be executed. Hooks support is tracked at "+
 				"https://github.com/pulumi/pulumi-kubernetes/issues/555 -- This warning can be disabled by setting "+
-				"the PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING environment variable")
+				"the PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS environment variable")
 	}
 }
 

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -129,7 +129,7 @@ namespace Pulumi.Kubernetes
         /// 
         /// This config can be specified in the following ways, using this precedence:
         /// 1. This `suppressHelmHookWarnings` parameter.
-        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
         /// </summary>
         public static bool? SuppressHelmHookWarnings
         {

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -106,7 +106,7 @@ namespace Pulumi.Kubernetes
         /// 
         /// This config can be specified in the following ways, using this precedence:
         /// 1. This `suppressHelmHookWarnings` parameter.
-        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        /// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
         /// </summary>
         [Input("suppressHelmHookWarnings", json: true)]
         public Input<bool>? SuppressHelmHookWarnings { get; set; }

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -68,7 +68,7 @@ func GetSuppressDeprecationWarnings(ctx *pulumi.Context) bool {
 //
 // This config can be specified in the following ways, using this precedence:
 // 1. This `suppressHelmHookWarnings` parameter.
-// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
 func GetSuppressHelmHookWarnings(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:suppressHelmHookWarnings")
 }

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -74,7 +74,7 @@ type providerArgs struct {
 	//
 	// This config can be specified in the following ways, using this precedence:
 	// 1. This `suppressHelmHookWarnings` parameter.
-	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
 	SuppressHelmHookWarnings *bool `pulumi:"suppressHelmHookWarnings"`
 }
 
@@ -111,7 +111,7 @@ type ProviderArgs struct {
 	//
 	// This config can be specified in the following ways, using this precedence:
 	// 1. This `suppressHelmHookWarnings` parameter.
-	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+	// 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
 	SuppressHelmHookWarnings pulumi.BoolPtrInput
 }
 

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -100,7 +100,7 @@ export interface ProviderArgs {
      *
      * This config can be specified in the following ways, using this precedence:
      * 1. This `suppressHelmHookWarnings` parameter.
-     * 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+     * 2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
      */
     suppressHelmHookWarnings?: pulumi.Input<boolean>;
 }

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -47,7 +47,7 @@ class ProviderArgs:
                
                This config can be specified in the following ways, using this precedence:
                1. This `suppressHelmHookWarnings` parameter.
-               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
         """
         if cluster is not None:
             pulumi.set(__self__, "cluster", cluster)
@@ -179,7 +179,7 @@ class ProviderArgs:
 
         This config can be specified in the following ways, using this precedence:
         1. This `suppressHelmHookWarnings` parameter.
-        2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+        2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
         """
         return pulumi.get(self, "suppress_helm_hook_warnings")
 
@@ -231,7 +231,7 @@ class Provider(pulumi.ProviderResource):
                
                This config can be specified in the following ways, using this precedence:
                1. This `suppressHelmHookWarnings` parameter.
-               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNING` environment variable.
+               2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.
         """
         ...
     @overload


### PR DESCRIPTION
### Proposed changes

Fix the misleading message added in #1682, in schema it uses `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS`, but message missed the tailing `S`.

### Related issues (optional)

Related: #1682