### PR TITLE
Don't replace PVCs when resources change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
-(None)
+
+- Don't replace PVC on .spec.resources.requests change. (https://github.com/pulumi/pulumi-kubernetes/pull/1705)
 
 ## 3.7.0 (September 3, 2021)
 - Add initial support for a Helm release resource - `kubernetes:helm.sh/v3:Release. Currently available in Beta (https://github.com/pulumi/pulumi-kubernetes/pull/1677)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## HEAD (Unreleased)
 
-- Don't replace PVC on .spec.resources.requests change. (https://github.com/pulumi/pulumi-kubernetes/pull/1705)
-    - *NOTE*: User's will now need to use need to use the `replaceOnChanges` resource option for PVCs if modifying the size
+- Don't replace PVC on .spec.resources.requests or .limits change. (https://github.com/pulumi/pulumi-kubernetes/pull/1705)
+    - *NOTE*: User's will now need to use the `replaceOnChanges` resource option for PVCs if modifying requests or limits to trigger replacement
 
 ## 3.7.0 (September 3, 2021)
 - Add initial support for a Helm release resource - `kubernetes:helm.sh/v3:Release. Currently available in Beta (https://github.com/pulumi/pulumi-kubernetes/pull/1677)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Don't replace PVC on .spec.resources.requests change. (https://github.com/pulumi/pulumi-kubernetes/pull/1705)
+    - *NOTE*: User's will now need to use need to use the `replaceOnChanges` resource option for PVCs if modifying the size
 
 ## 3.7.0 (September 3, 2021)
 - Add initial support for a Helm release resource - `kubernetes:helm.sh/v3:Release. Currently available in Beta (https://github.com/pulumi/pulumi-kubernetes/pull/1677)

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -109,7 +109,6 @@ var core = _versions{
 				".spec.accessModes",
 				".spec.resources",
 				".spec.resources.limits",
-				".spec.resources.requests",
 				".spec.selector",
 				".spec.storageClassName",
 				".spec.volumeName",

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -105,10 +105,7 @@ var core = _versions{
 			}),
 		"PersistentVolumeClaim": append(
 			properties{
-				".spec",
 				".spec.accessModes",
-				".spec.resources",
-				".spec.resources.limits",
 				".spec.selector",
 				".spec.storageClassName",
 				".spec.volumeName",

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -164,7 +164,7 @@ func TestPatchToDiff(t *testing.T) {
 			old: object{"spec": object{"resources": object{"requests": object{"storage": "10Gi"}}}},
 			new: object{"spec": object{"resources": object{"requests": object{"storage": "20Gi"}}}},
 			expected: expected{
-				"spec.resources.requests.storage": UR,
+				"spec.resources.requests.storage": U,
 			},
 		},
 	}

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -159,10 +159,10 @@ func TestPatchToDiff(t *testing.T) {
 			expected:  expected{},
 		},
 		{
-			name: `PVC resources don't trigger a replace.`,
+			name:  `PVC resources don't trigger a replace.`,
 			group: "core", version: "v1", kind: "PersistentVolumeClaim",
-			old: 	object{"spec": object{"resources": object{"requests": object{"storage": "10Gi"}}}},
-			new: 	object{"spec": object{"resources": object{"requests": object{"storage": "20Gi"}}}},
+			old: object{"spec": object{"resources": object{"requests": object{"storage": "10Gi"}}}},
+			new: object{"spec": object{"resources": object{"requests": object{"storage": "20Gi"}}}},
 			expected: expected{
 				"spec.resources.requests.storage": UR,
 			},

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -158,6 +158,15 @@ func TestPatchToDiff(t *testing.T) {
 			oldInputs: object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},
 			expected:  expected{},
 		},
+		{
+			name: `PVC resources don't trigger a replace.`,
+			group: "core", version: "v1", kind: "PersistentVolumeClaim",
+			old: 	object{"spec": object{"resources": object{"requests": object{"storage": "10Gi"}}}},
+			new: 	object{"spec": object{"resources": object{"requests": object{"storage": "20Gi"}}}},
+			expected: expected{
+				"spec.resources.requests.storage": UR,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
PVCs often contain critical data that users don't want to lose.

Having the resources field trigger a replace can mean that users can't take advantage of volume resizing.

This allows users to resize volumes and update the field without worrying about a triggering of replacements

### Related issues (optional)

fixes #1665
