### PR TITLE
Change await logic client to use target apiVersion on update

### DIFF
--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package await
 import (
 	"context"
 	"fmt"
+
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/clients"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/cluster"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/kinds"
@@ -353,7 +354,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 	// - [ ] Support server-side apply, when it comes out.
 	//
 
-	client, err := c.ClientSet.ResourceClient(c.Previous.GroupVersionKind(), c.Previous.GetNamespace())
+	client, err := c.ClientSet.ResourceClient(c.Inputs.GroupVersionKind(), c.Inputs.GetNamespace())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the await logic used the previous apiVersion of a
resource to issue requests to the API server. In the case of
API changes, this could cause errors. Newer apiVersions should
be backward compatible, so switch to using the target apiVersion
of a resource instead.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
