### PR TITLE
Fix diff logic for CRD kinds with the same name as a built-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
+
 - Add env variable lookup for k8s client settings (https://github.com/pulumi/pulumi-kubernetes/pull/1777)
+- Fix diff logic for CRD kinds with the same name as a built-in (https://github.com/pulumi/pulumi-kubernetes/pull/1779)
 
 ## 3.8.2 (October 18, 2021)
 

--- a/provider/pkg/gen/kinds/kinds.tmpl
+++ b/provider/pkg/gen/kinds/kinds.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package kinds
 import (
 	"strings"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -117,3 +118,10 @@ func toGVK(gv groupVersion, kind Kind) schema.GroupVersionKind {
 		Kind:    string(kind),
 	}
 }
+
+// KnownGroupVersions is the set of built-in GroupVersions / ApiVersions. GVs defined by a CRD are not part of this set.
+var KnownGroupVersions = codegen.NewStringSet(
+{{- range .GroupVersions}}
+	"{{.}}",
+{{- end}}
+)

--- a/provider/pkg/gen/kinds/kinds.tmpl
+++ b/provider/pkg/gen/kinds/kinds.tmpl
@@ -124,4 +124,5 @@ var KnownGroupVersions = codegen.NewStringSet(
 {{- range .GroupVersions}}
 	"{{.}}",
 {{- end}}
+    "v1", // alias for "core/v1"
 )

--- a/provider/pkg/kinds/kinds.go
+++ b/provider/pkg/kinds/kinds.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package kinds
 import (
 	"strings"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -269,3 +270,57 @@ func toGVK(gv groupVersion, kind Kind) schema.GroupVersionKind {
 		Kind:    string(kind),
 	}
 }
+
+// KnownGroupVersions is the set of built-in GroupVersions / ApiVersions. GVs defined by a CRD are not part of this set.
+var KnownGroupVersions = codegen.NewStringSet(
+	"admissionregistration.k8s.io/v1",
+	"admissionregistration.k8s.io/v1beta1",
+	"apiextensions.k8s.io/v1",
+	"apiextensions.k8s.io/v1beta1",
+	"apiregistration.k8s.io/v1",
+	"apiregistration.k8s.io/v1beta1",
+	"apps/v1",
+	"apps/v1beta1",
+	"apps/v1beta2",
+	"auditregistration.k8s.io/v1alpha1",
+	"authentication.k8s.io/v1",
+	"authentication.k8s.io/v1beta1",
+	"authorization.k8s.io/v1",
+	"authorization.k8s.io/v1beta1",
+	"autoscaling/v1",
+	"autoscaling/v2beta1",
+	"autoscaling/v2beta2",
+	"batch/v1",
+	"batch/v1beta1",
+	"batch/v2alpha1",
+	"certificates.k8s.io/v1",
+	"certificates.k8s.io/v1beta1",
+	"coordination.k8s.io/v1",
+	"coordination.k8s.io/v1beta1",
+	"core/v1",
+	"discovery.k8s.io/v1",
+	"discovery.k8s.io/v1beta1",
+	"events.k8s.io/v1",
+	"events.k8s.io/v1beta1",
+	"extensions/v1beta1",
+	"flowcontrol.apiserver.k8s.io/v1alpha1",
+	"flowcontrol.apiserver.k8s.io/v1beta1",
+	"meta/v1",
+	"networking.k8s.io/v1",
+	"networking.k8s.io/v1beta1",
+	"node.k8s.io/v1",
+	"node.k8s.io/v1alpha1",
+	"node.k8s.io/v1beta1",
+	"policy/v1",
+	"policy/v1beta1",
+	"rbac.authorization.k8s.io/v1",
+	"rbac.authorization.k8s.io/v1alpha1",
+	"rbac.authorization.k8s.io/v1beta1",
+	"scheduling.k8s.io/v1",
+	"scheduling.k8s.io/v1alpha1",
+	"scheduling.k8s.io/v1beta1",
+	"settings.k8s.io/v1alpha1",
+	"storage.k8s.io/v1",
+	"storage.k8s.io/v1alpha1",
+	"storage.k8s.io/v1beta1",
+)

--- a/provider/pkg/kinds/kinds.go
+++ b/provider/pkg/kinds/kinds.go
@@ -323,4 +323,5 @@ var KnownGroupVersions = codegen.NewStringSet(
 	"storage.k8s.io/v1",
 	"storage.k8s.io/v1alpha1",
 	"storage.k8s.io/v1beta1",
+	"v1", // alias for "core/v1"
 )

--- a/provider/pkg/openapi/openapi.go
+++ b/provider/pkg/openapi/openapi.go
@@ -93,9 +93,8 @@ func PatchForResourceUpdate(
 		return nil, "", nil, err
 	}
 
-	// Use kinds.Namespaced() to determine if kind is unknown, such as for CRD Kinds.
-	kind := kinds.Kind(lastSubmitted.GetKind())
-	if knownKind, _ := kind.Namespaced(); !knownKind {
+	// CRD GroupVersions are not included in the known set.
+	if knownGV := kinds.KnownGroupVersions.Has(lastSubmitted.GetAPIVersion()); !knownGV {
 		// Use a JSON merge patch for CRD Kinds.
 		patch, patchType, err = MergePatch(
 			lastSubmitted, lastSubmittedJSON, currentSubmittedJSON, liveOldJSON,


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The diff logic was incorrectly treating CRD kinds with a name
matching a built-in kind as known (e.g., Service). In these cases,
the patch behavior was erroneously set to strategic merge rather
than JSON merge.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1774
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
