### PR TITLE
Set DisplayName, Publisher and tags in the Pulumi schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- [sdk/go] Update pulumi dependencies to register input types (https://github.com/pulumi/pulumi-kubernetes/pull/1783)
+
 ## 3.8.3 (October 29, 2021)
 
 - Add env variable lookup for k8s client settings (https://github.com/pulumi/pulumi-kubernetes/pull/1777)
@@ -8,7 +10,7 @@
 ## 3.8.2 (October 18, 2021)
 
 - [sdk/python] Relax PyYaml dependency to allow upgrade to PyYaml 6.0 (https://github.com/pulumi/pulumi-kubernetes/pull/1768)
-- [go/sdk] Add missing types for deprecated Provider (https://github.com/pulumi/pulumi-kubernetes/pull/1771)
+- [sdk/go] Add missing types for deprecated Provider (https://github.com/pulumi/pulumi-kubernetes/pull/1771)
 
 ## 3.8.1 (October 8, 2021)
 

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -1,13 +1,17 @@
 {
     "name": "kubernetes",
+    "displayName": "Kubernetes",
     "description": "A Pulumi package for creating and managing Kubernetes resources.",
     "keywords": [
         "pulumi",
-        "kubernetes"
+        "kubernetes",
+        "category/cloud",
+        "kind/native"
     ],
     "homepage": "https://pulumi.com",
     "license": "Apache-2.0",
     "repository": "https://github.com/pulumi/pulumi-kubernetes",
+    "publisher": "Pulumi",
     "config": {
         "variables": {
             "cluster": {

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b
-	github.com/pulumi/pulumi/sdk/v3 v3.14.0
+	github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424
+	github.com/pulumi/pulumi/sdk/v3 v3.16.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	google.golang.org/grpc v1.38.0

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -946,10 +946,10 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b h1:3ZM4P/K+2lsvNLq/cHxpVdjcC4iTn0xgY5vUITdy2nY=
-github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b/go.mod h1:0w8C+JDP+OuihIgj/TNljRJdNHyW1vNiH1zzbeB4xeM=
-github.com/pulumi/pulumi/sdk/v3 v3.14.0 h1:UXLRHGQCsO1tLWdv4IO3IQOXrUoZUHhDtDXFoGMmAtA=
-github.com/pulumi/pulumi/sdk/v3 v3.14.0/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
+github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424 h1:MB7LHWmVlMx5XRqOg2Vm9TXfY99VFqhg9I6lZpe+TMw=
+github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424/go.mod h1:jiNNl7RjXQSqkfVA2EJrfwoDVWhuDPVFjOqJ8q+CquA=
+github.com/pulumi/pulumi/sdk/v3 v3.16.0 h1:yqGysCf1LqlkengBnYqcbl5JI6JGySPN67+g60dMieU=
+github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -35,10 +35,12 @@ var resourceOverlays = map[string]pschema.ResourceSpec{}
 func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 	pkg := pschema.PackageSpec{
 		Name:        "kubernetes",
+		DisplayName: "Kubernetes",
 		Description: "A Pulumi package for creating and managing Kubernetes resources.",
 		License:     "Apache-2.0",
-		Keywords:    []string{"pulumi", "kubernetes"},
+		Keywords:    []string{"pulumi", "kubernetes", "category/cloud", "kind/native"},
 		Homepage:    "https://pulumi.com",
+		Publisher:   "Pulumi",
 		Repository:  "https://github.com/pulumi/pulumi-kubernetes",
 
 		Config: pschema.ConfigSpec{

--- a/sdk/dotnet/Pulumi.Kubernetes.csproj
+++ b/sdk/dotnet/Pulumi.Kubernetes.csproj
@@ -45,6 +45,9 @@
   </ItemGroup>
 
   <ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="logo.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>

--- a/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfiguration.go
@@ -285,6 +285,10 @@ func (o MutatingWebhookConfigurationMapOutput) MapIndex(k pulumi.StringInput) Mu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationInput)(nil)).Elem(), &MutatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationPtrInput)(nil)).Elem(), &MutatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationArrayInput)(nil)).Elem(), MutatingWebhookConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationMapInput)(nil)).Elem(), MutatingWebhookConfigurationMap{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationList.go
@@ -283,6 +283,10 @@ func (o MutatingWebhookConfigurationListMapOutput) MapIndex(k pulumi.StringInput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListInput)(nil)).Elem(), &MutatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListPtrInput)(nil)).Elem(), &MutatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListArrayInput)(nil)).Elem(), MutatingWebhookConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListMapInput)(nil)).Elem(), MutatingWebhookConfigurationListMap{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfiguration.go
@@ -285,6 +285,10 @@ func (o ValidatingWebhookConfigurationMapOutput) MapIndex(k pulumi.StringInput) 
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationInput)(nil)).Elem(), &ValidatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationPtrInput)(nil)).Elem(), &ValidatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationArrayInput)(nil)).Elem(), ValidatingWebhookConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationMapInput)(nil)).Elem(), ValidatingWebhookConfigurationMap{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationList.go
@@ -283,6 +283,10 @@ func (o ValidatingWebhookConfigurationListMapOutput) MapIndex(k pulumi.StringInp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListInput)(nil)).Elem(), &ValidatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListPtrInput)(nil)).Elem(), &ValidatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListArrayInput)(nil)).Elem(), ValidatingWebhookConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListMapInput)(nil)).Elem(), ValidatingWebhookConfigurationListMap{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfiguration.go
@@ -285,6 +285,10 @@ func (o MutatingWebhookConfigurationMapOutput) MapIndex(k pulumi.StringInput) Mu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationInput)(nil)).Elem(), &MutatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationPtrInput)(nil)).Elem(), &MutatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationArrayInput)(nil)).Elem(), MutatingWebhookConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationMapInput)(nil)).Elem(), MutatingWebhookConfigurationMap{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationList.go
@@ -283,6 +283,10 @@ func (o MutatingWebhookConfigurationListMapOutput) MapIndex(k pulumi.StringInput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListInput)(nil)).Elem(), &MutatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListPtrInput)(nil)).Elem(), &MutatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListArrayInput)(nil)).Elem(), MutatingWebhookConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*MutatingWebhookConfigurationListMapInput)(nil)).Elem(), MutatingWebhookConfigurationListMap{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(MutatingWebhookConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfiguration.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfiguration.go
@@ -285,6 +285,10 @@ func (o ValidatingWebhookConfigurationMapOutput) MapIndex(k pulumi.StringInput) 
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationInput)(nil)).Elem(), &ValidatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationPtrInput)(nil)).Elem(), &ValidatingWebhookConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationArrayInput)(nil)).Elem(), ValidatingWebhookConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationMapInput)(nil)).Elem(), ValidatingWebhookConfigurationMap{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationList.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationList.go
@@ -283,6 +283,10 @@ func (o ValidatingWebhookConfigurationListMapOutput) MapIndex(k pulumi.StringInp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListInput)(nil)).Elem(), &ValidatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListPtrInput)(nil)).Elem(), &ValidatingWebhookConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListArrayInput)(nil)).Elem(), ValidatingWebhookConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ValidatingWebhookConfigurationListMapInput)(nil)).Elem(), ValidatingWebhookConfigurationListMap{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(ValidatingWebhookConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/apiextensions/v1/customResourceDefinition.go
+++ b/sdk/go/kubernetes/apiextensions/v1/customResourceDefinition.go
@@ -291,6 +291,10 @@ func (o CustomResourceDefinitionMapOutput) MapIndex(k pulumi.StringInput) Custom
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionInput)(nil)).Elem(), &CustomResourceDefinition{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionPtrInput)(nil)).Elem(), &CustomResourceDefinition{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionArrayInput)(nil)).Elem(), CustomResourceDefinitionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionMapInput)(nil)).Elem(), CustomResourceDefinitionMap{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionPtrOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionArrayOutput{})

--- a/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionList.go
+++ b/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionList.go
@@ -283,6 +283,10 @@ func (o CustomResourceDefinitionListMapOutput) MapIndex(k pulumi.StringInput) Cu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListInput)(nil)).Elem(), &CustomResourceDefinitionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListPtrInput)(nil)).Elem(), &CustomResourceDefinitionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListArrayInput)(nil)).Elem(), CustomResourceDefinitionListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListMapInput)(nil)).Elem(), CustomResourceDefinitionListMap{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListPtrOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListArrayOutput{})

--- a/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinition.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinition.go
@@ -288,6 +288,10 @@ func (o CustomResourceDefinitionMapOutput) MapIndex(k pulumi.StringInput) Custom
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionInput)(nil)).Elem(), &CustomResourceDefinition{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionPtrInput)(nil)).Elem(), &CustomResourceDefinition{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionArrayInput)(nil)).Elem(), CustomResourceDefinitionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionMapInput)(nil)).Elem(), CustomResourceDefinitionMap{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionPtrOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionArrayOutput{})

--- a/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionList.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionList.go
@@ -280,6 +280,10 @@ func (o CustomResourceDefinitionListMapOutput) MapIndex(k pulumi.StringInput) Cu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListInput)(nil)).Elem(), &CustomResourceDefinitionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListPtrInput)(nil)).Elem(), &CustomResourceDefinitionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListArrayInput)(nil)).Elem(), CustomResourceDefinitionListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CustomResourceDefinitionListMapInput)(nil)).Elem(), CustomResourceDefinitionListMap{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListPtrOutput{})
 	pulumi.RegisterOutputType(CustomResourceDefinitionListArrayOutput{})

--- a/sdk/go/kubernetes/apiregistration/v1/apiservice.go
+++ b/sdk/go/kubernetes/apiregistration/v1/apiservice.go
@@ -293,6 +293,10 @@ func (o APIServiceMapOutput) MapIndex(k pulumi.StringInput) APIServiceOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceInput)(nil)).Elem(), &APIService{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServicePtrInput)(nil)).Elem(), &APIService{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceArrayInput)(nil)).Elem(), APIServiceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceMapInput)(nil)).Elem(), APIServiceMap{})
 	pulumi.RegisterOutputType(APIServiceOutput{})
 	pulumi.RegisterOutputType(APIServicePtrOutput{})
 	pulumi.RegisterOutputType(APIServiceArrayOutput{})

--- a/sdk/go/kubernetes/apiregistration/v1/apiserviceList.go
+++ b/sdk/go/kubernetes/apiregistration/v1/apiserviceList.go
@@ -289,6 +289,10 @@ func (o APIServiceListMapOutput) MapIndex(k pulumi.StringInput) APIServiceListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListInput)(nil)).Elem(), &APIServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListPtrInput)(nil)).Elem(), &APIServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListArrayInput)(nil)).Elem(), APIServiceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListMapInput)(nil)).Elem(), APIServiceListMap{})
 	pulumi.RegisterOutputType(APIServiceListOutput{})
 	pulumi.RegisterOutputType(APIServiceListPtrOutput{})
 	pulumi.RegisterOutputType(APIServiceListArrayOutput{})

--- a/sdk/go/kubernetes/apiregistration/v1beta1/apiservice.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/apiservice.go
@@ -290,6 +290,10 @@ func (o APIServiceMapOutput) MapIndex(k pulumi.StringInput) APIServiceOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceInput)(nil)).Elem(), &APIService{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServicePtrInput)(nil)).Elem(), &APIService{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceArrayInput)(nil)).Elem(), APIServiceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceMapInput)(nil)).Elem(), APIServiceMap{})
 	pulumi.RegisterOutputType(APIServiceOutput{})
 	pulumi.RegisterOutputType(APIServicePtrOutput{})
 	pulumi.RegisterOutputType(APIServiceArrayOutput{})

--- a/sdk/go/kubernetes/apiregistration/v1beta1/apiserviceList.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/apiserviceList.go
@@ -283,6 +283,10 @@ func (o APIServiceListMapOutput) MapIndex(k pulumi.StringInput) APIServiceListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListInput)(nil)).Elem(), &APIServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListPtrInput)(nil)).Elem(), &APIServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListArrayInput)(nil)).Elem(), APIServiceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*APIServiceListMapInput)(nil)).Elem(), APIServiceListMap{})
 	pulumi.RegisterOutputType(APIServiceListOutput{})
 	pulumi.RegisterOutputType(APIServiceListPtrOutput{})
 	pulumi.RegisterOutputType(APIServiceListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevision.go
@@ -298,6 +298,10 @@ func (o ControllerRevisionMapOutput) MapIndex(k pulumi.StringInput) ControllerRe
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionPtrInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionArrayInput)(nil)).Elem(), ControllerRevisionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionMapInput)(nil)).Elem(), ControllerRevisionMap{})
 	pulumi.RegisterOutputType(ControllerRevisionOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevisionList.go
@@ -283,6 +283,10 @@ func (o ControllerRevisionListMapOutput) MapIndex(k pulumi.StringInput) Controll
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListPtrInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListArrayInput)(nil)).Elem(), ControllerRevisionListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListMapInput)(nil)).Elem(), ControllerRevisionListMap{})
 	pulumi.RegisterOutputType(ControllerRevisionListOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/daemonSet.go
+++ b/sdk/go/kubernetes/apps/v1/daemonSet.go
@@ -290,6 +290,10 @@ func (o DaemonSetMapOutput) MapIndex(k pulumi.StringInput) DaemonSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetPtrInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetArrayInput)(nil)).Elem(), DaemonSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetMapInput)(nil)).Elem(), DaemonSetMap{})
 	pulumi.RegisterOutputType(DaemonSetOutput{})
 	pulumi.RegisterOutputType(DaemonSetPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/daemonSetList.go
+++ b/sdk/go/kubernetes/apps/v1/daemonSetList.go
@@ -283,6 +283,10 @@ func (o DaemonSetListMapOutput) MapIndex(k pulumi.StringInput) DaemonSetListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListPtrInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListArrayInput)(nil)).Elem(), DaemonSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListMapInput)(nil)).Elem(), DaemonSetListMap{})
 	pulumi.RegisterOutputType(DaemonSetListOutput{})
 	pulumi.RegisterOutputType(DaemonSetListPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/deployment.go
+++ b/sdk/go/kubernetes/apps/v1/deployment.go
@@ -315,6 +315,10 @@ func (o DeploymentMapOutput) MapIndex(k pulumi.StringInput) DeploymentOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentPtrInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentArrayInput)(nil)).Elem(), DeploymentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentMapInput)(nil)).Elem(), DeploymentMap{})
 	pulumi.RegisterOutputType(DeploymentOutput{})
 	pulumi.RegisterOutputType(DeploymentPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1/deploymentList.go
@@ -283,6 +283,10 @@ func (o DeploymentListMapOutput) MapIndex(k pulumi.StringInput) DeploymentListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListPtrInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListArrayInput)(nil)).Elem(), DeploymentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListMapInput)(nil)).Elem(), DeploymentListMap{})
 	pulumi.RegisterOutputType(DeploymentListOutput{})
 	pulumi.RegisterOutputType(DeploymentListPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/replicaSet.go
+++ b/sdk/go/kubernetes/apps/v1/replicaSet.go
@@ -290,6 +290,10 @@ func (o ReplicaSetMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetPtrInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetArrayInput)(nil)).Elem(), ReplicaSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetMapInput)(nil)).Elem(), ReplicaSetMap{})
 	pulumi.RegisterOutputType(ReplicaSetOutput{})
 	pulumi.RegisterOutputType(ReplicaSetPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/replicaSetList.go
+++ b/sdk/go/kubernetes/apps/v1/replicaSetList.go
@@ -283,6 +283,10 @@ func (o ReplicaSetListMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListPtrInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListArrayInput)(nil)).Elem(), ReplicaSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListMapInput)(nil)).Elem(), ReplicaSetListMap{})
 	pulumi.RegisterOutputType(ReplicaSetListOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1/statefulSet.go
@@ -306,6 +306,10 @@ func (o StatefulSetMapOutput) MapIndex(k pulumi.StringInput) StatefulSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetPtrInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetArrayInput)(nil)).Elem(), StatefulSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetMapInput)(nil)).Elem(), StatefulSetMap{})
 	pulumi.RegisterOutputType(StatefulSetOutput{})
 	pulumi.RegisterOutputType(StatefulSetPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1/statefulSetList.go
@@ -283,6 +283,10 @@ func (o StatefulSetListMapOutput) MapIndex(k pulumi.StringInput) StatefulSetList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListPtrInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListArrayInput)(nil)).Elem(), StatefulSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListMapInput)(nil)).Elem(), StatefulSetListMap{})
 	pulumi.RegisterOutputType(StatefulSetListOutput{})
 	pulumi.RegisterOutputType(StatefulSetListPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevision.go
@@ -300,6 +300,10 @@ func (o ControllerRevisionMapOutput) MapIndex(k pulumi.StringInput) ControllerRe
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionPtrInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionArrayInput)(nil)).Elem(), ControllerRevisionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionMapInput)(nil)).Elem(), ControllerRevisionMap{})
 	pulumi.RegisterOutputType(ControllerRevisionOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevisionList.go
@@ -283,6 +283,10 @@ func (o ControllerRevisionListMapOutput) MapIndex(k pulumi.StringInput) Controll
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListPtrInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListArrayInput)(nil)).Elem(), ControllerRevisionListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListMapInput)(nil)).Elem(), ControllerRevisionListMap{})
 	pulumi.RegisterOutputType(ControllerRevisionListOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/deployment.go
+++ b/sdk/go/kubernetes/apps/v1beta1/deployment.go
@@ -317,6 +317,10 @@ func (o DeploymentMapOutput) MapIndex(k pulumi.StringInput) DeploymentOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentPtrInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentArrayInput)(nil)).Elem(), DeploymentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentMapInput)(nil)).Elem(), DeploymentMap{})
 	pulumi.RegisterOutputType(DeploymentOutput{})
 	pulumi.RegisterOutputType(DeploymentPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/deploymentList.go
@@ -283,6 +283,10 @@ func (o DeploymentListMapOutput) MapIndex(k pulumi.StringInput) DeploymentListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListPtrInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListArrayInput)(nil)).Elem(), DeploymentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListMapInput)(nil)).Elem(), DeploymentListMap{})
 	pulumi.RegisterOutputType(DeploymentListOutput{})
 	pulumi.RegisterOutputType(DeploymentListPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1beta1/statefulSet.go
@@ -305,6 +305,10 @@ func (o StatefulSetMapOutput) MapIndex(k pulumi.StringInput) StatefulSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetPtrInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetArrayInput)(nil)).Elem(), StatefulSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetMapInput)(nil)).Elem(), StatefulSetMap{})
 	pulumi.RegisterOutputType(StatefulSetOutput{})
 	pulumi.RegisterOutputType(StatefulSetPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta1/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta1/statefulSetList.go
@@ -277,6 +277,10 @@ func (o StatefulSetListMapOutput) MapIndex(k pulumi.StringInput) StatefulSetList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListPtrInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListArrayInput)(nil)).Elem(), StatefulSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListMapInput)(nil)).Elem(), StatefulSetListMap{})
 	pulumi.RegisterOutputType(StatefulSetListOutput{})
 	pulumi.RegisterOutputType(StatefulSetListPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevision.go
@@ -300,6 +300,10 @@ func (o ControllerRevisionMapOutput) MapIndex(k pulumi.StringInput) ControllerRe
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionPtrInput)(nil)).Elem(), &ControllerRevision{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionArrayInput)(nil)).Elem(), ControllerRevisionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionMapInput)(nil)).Elem(), ControllerRevisionMap{})
 	pulumi.RegisterOutputType(ControllerRevisionOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevisionList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevisionList.go
@@ -283,6 +283,10 @@ func (o ControllerRevisionListMapOutput) MapIndex(k pulumi.StringInput) Controll
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListPtrInput)(nil)).Elem(), &ControllerRevisionList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListArrayInput)(nil)).Elem(), ControllerRevisionListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ControllerRevisionListMapInput)(nil)).Elem(), ControllerRevisionListMap{})
 	pulumi.RegisterOutputType(ControllerRevisionListOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListPtrOutput{})
 	pulumi.RegisterOutputType(ControllerRevisionListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/daemonSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/daemonSet.go
@@ -292,6 +292,10 @@ func (o DaemonSetMapOutput) MapIndex(k pulumi.StringInput) DaemonSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetPtrInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetArrayInput)(nil)).Elem(), DaemonSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetMapInput)(nil)).Elem(), DaemonSetMap{})
 	pulumi.RegisterOutputType(DaemonSetOutput{})
 	pulumi.RegisterOutputType(DaemonSetPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/daemonSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/daemonSetList.go
@@ -283,6 +283,10 @@ func (o DaemonSetListMapOutput) MapIndex(k pulumi.StringInput) DaemonSetListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListPtrInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListArrayInput)(nil)).Elem(), DaemonSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListMapInput)(nil)).Elem(), DaemonSetListMap{})
 	pulumi.RegisterOutputType(DaemonSetListOutput{})
 	pulumi.RegisterOutputType(DaemonSetListPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/deployment.go
+++ b/sdk/go/kubernetes/apps/v1beta2/deployment.go
@@ -317,6 +317,10 @@ func (o DeploymentMapOutput) MapIndex(k pulumi.StringInput) DeploymentOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentPtrInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentArrayInput)(nil)).Elem(), DeploymentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentMapInput)(nil)).Elem(), DeploymentMap{})
 	pulumi.RegisterOutputType(DeploymentOutput{})
 	pulumi.RegisterOutputType(DeploymentPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/deploymentList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/deploymentList.go
@@ -283,6 +283,10 @@ func (o DeploymentListMapOutput) MapIndex(k pulumi.StringInput) DeploymentListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListPtrInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListArrayInput)(nil)).Elem(), DeploymentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListMapInput)(nil)).Elem(), DeploymentListMap{})
 	pulumi.RegisterOutputType(DeploymentListOutput{})
 	pulumi.RegisterOutputType(DeploymentListPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/replicaSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/replicaSet.go
@@ -292,6 +292,10 @@ func (o ReplicaSetMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetPtrInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetArrayInput)(nil)).Elem(), ReplicaSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetMapInput)(nil)).Elem(), ReplicaSetMap{})
 	pulumi.RegisterOutputType(ReplicaSetOutput{})
 	pulumi.RegisterOutputType(ReplicaSetPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/replicaSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/replicaSetList.go
@@ -283,6 +283,10 @@ func (o ReplicaSetListMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListPtrInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListArrayInput)(nil)).Elem(), ReplicaSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListMapInput)(nil)).Elem(), ReplicaSetListMap{})
 	pulumi.RegisterOutputType(ReplicaSetListOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/statefulSet.go
+++ b/sdk/go/kubernetes/apps/v1beta2/statefulSet.go
@@ -305,6 +305,10 @@ func (o StatefulSetMapOutput) MapIndex(k pulumi.StringInput) StatefulSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetPtrInput)(nil)).Elem(), &StatefulSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetArrayInput)(nil)).Elem(), StatefulSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetMapInput)(nil)).Elem(), StatefulSetMap{})
 	pulumi.RegisterOutputType(StatefulSetOutput{})
 	pulumi.RegisterOutputType(StatefulSetPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetArrayOutput{})

--- a/sdk/go/kubernetes/apps/v1beta2/statefulSetList.go
+++ b/sdk/go/kubernetes/apps/v1beta2/statefulSetList.go
@@ -277,6 +277,10 @@ func (o StatefulSetListMapOutput) MapIndex(k pulumi.StringInput) StatefulSetList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListPtrInput)(nil)).Elem(), &StatefulSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListArrayInput)(nil)).Elem(), StatefulSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatefulSetListMapInput)(nil)).Elem(), StatefulSetListMap{})
 	pulumi.RegisterOutputType(StatefulSetListOutput{})
 	pulumi.RegisterOutputType(StatefulSetListPtrOutput{})
 	pulumi.RegisterOutputType(StatefulSetListArrayOutput{})

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/auditSink.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/auditSink.go
@@ -276,6 +276,10 @@ func (o AuditSinkMapOutput) MapIndex(k pulumi.StringInput) AuditSinkOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkInput)(nil)).Elem(), &AuditSink{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkPtrInput)(nil)).Elem(), &AuditSink{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkArrayInput)(nil)).Elem(), AuditSinkArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkMapInput)(nil)).Elem(), AuditSinkMap{})
 	pulumi.RegisterOutputType(AuditSinkOutput{})
 	pulumi.RegisterOutputType(AuditSinkPtrOutput{})
 	pulumi.RegisterOutputType(AuditSinkArrayOutput{})

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkList.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkList.go
@@ -280,6 +280,10 @@ func (o AuditSinkListMapOutput) MapIndex(k pulumi.StringInput) AuditSinkListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkListInput)(nil)).Elem(), &AuditSinkList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkListPtrInput)(nil)).Elem(), &AuditSinkList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkListArrayInput)(nil)).Elem(), AuditSinkListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AuditSinkListMapInput)(nil)).Elem(), AuditSinkListMap{})
 	pulumi.RegisterOutputType(AuditSinkListOutput{})
 	pulumi.RegisterOutputType(AuditSinkListPtrOutput{})
 	pulumi.RegisterOutputType(AuditSinkListArrayOutput{})

--- a/sdk/go/kubernetes/authentication/v1/tokenRequest.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenRequest.go
@@ -285,6 +285,10 @@ func (o TokenRequestMapOutput) MapIndex(k pulumi.StringInput) TokenRequestOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenRequestInput)(nil)).Elem(), &TokenRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenRequestPtrInput)(nil)).Elem(), &TokenRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenRequestArrayInput)(nil)).Elem(), TokenRequestArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenRequestMapInput)(nil)).Elem(), TokenRequestMap{})
 	pulumi.RegisterOutputType(TokenRequestOutput{})
 	pulumi.RegisterOutputType(TokenRequestPtrOutput{})
 	pulumi.RegisterOutputType(TokenRequestArrayOutput{})

--- a/sdk/go/kubernetes/authentication/v1/tokenReview.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenReview.go
@@ -291,6 +291,10 @@ func (o TokenReviewMapOutput) MapIndex(k pulumi.StringInput) TokenReviewOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewInput)(nil)).Elem(), &TokenReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewPtrInput)(nil)).Elem(), &TokenReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewArrayInput)(nil)).Elem(), TokenReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewMapInput)(nil)).Elem(), TokenReviewMap{})
 	pulumi.RegisterOutputType(TokenReviewOutput{})
 	pulumi.RegisterOutputType(TokenReviewPtrOutput{})
 	pulumi.RegisterOutputType(TokenReviewArrayOutput{})

--- a/sdk/go/kubernetes/authentication/v1beta1/tokenReview.go
+++ b/sdk/go/kubernetes/authentication/v1beta1/tokenReview.go
@@ -288,6 +288,10 @@ func (o TokenReviewMapOutput) MapIndex(k pulumi.StringInput) TokenReviewOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewInput)(nil)).Elem(), &TokenReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewPtrInput)(nil)).Elem(), &TokenReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewArrayInput)(nil)).Elem(), TokenReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TokenReviewMapInput)(nil)).Elem(), TokenReviewMap{})
 	pulumi.RegisterOutputType(TokenReviewOutput{})
 	pulumi.RegisterOutputType(TokenReviewPtrOutput{})
 	pulumi.RegisterOutputType(TokenReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1/localSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/localSubjectAccessReview.go
@@ -291,6 +291,10 @@ func (o LocalSubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) LocalS
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewInput)(nil)).Elem(), &LocalSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewPtrInput)(nil)).Elem(), &LocalSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewArrayInput)(nil)).Elem(), LocalSubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewMapInput)(nil)).Elem(), LocalSubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReview.go
@@ -291,6 +291,10 @@ func (o SelfSubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) SelfSub
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewInput)(nil)).Elem(), &SelfSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewPtrInput)(nil)).Elem(), &SelfSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewArrayInput)(nil)).Elem(), SelfSubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewMapInput)(nil)).Elem(), SelfSubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReview.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReview.go
@@ -291,6 +291,10 @@ func (o SelfSubjectRulesReviewMapOutput) MapIndex(k pulumi.StringInput) SelfSubj
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewInput)(nil)).Elem(), &SelfSubjectRulesReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewPtrInput)(nil)).Elem(), &SelfSubjectRulesReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewArrayInput)(nil)).Elem(), SelfSubjectRulesReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewMapInput)(nil)).Elem(), SelfSubjectRulesReviewMap{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewOutput{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewPtrOutput{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1/subjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1/subjectAccessReview.go
@@ -291,6 +291,10 @@ func (o SubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) SubjectAcce
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewInput)(nil)).Elem(), &SubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewPtrInput)(nil)).Elem(), &SubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewArrayInput)(nil)).Elem(), SubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewMapInput)(nil)).Elem(), SubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(SubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(SubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(SubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReview.go
@@ -288,6 +288,10 @@ func (o LocalSubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) LocalS
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewInput)(nil)).Elem(), &LocalSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewPtrInput)(nil)).Elem(), &LocalSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewArrayInput)(nil)).Elem(), LocalSubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LocalSubjectAccessReviewMapInput)(nil)).Elem(), LocalSubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(LocalSubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReview.go
@@ -288,6 +288,10 @@ func (o SelfSubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) SelfSub
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewInput)(nil)).Elem(), &SelfSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewPtrInput)(nil)).Elem(), &SelfSubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewArrayInput)(nil)).Elem(), SelfSubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectAccessReviewMapInput)(nil)).Elem(), SelfSubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(SelfSubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReview.go
@@ -288,6 +288,10 @@ func (o SelfSubjectRulesReviewMapOutput) MapIndex(k pulumi.StringInput) SelfSubj
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewInput)(nil)).Elem(), &SelfSubjectRulesReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewPtrInput)(nil)).Elem(), &SelfSubjectRulesReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewArrayInput)(nil)).Elem(), SelfSubjectRulesReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SelfSubjectRulesReviewMapInput)(nil)).Elem(), SelfSubjectRulesReviewMap{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewOutput{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewPtrOutput{})
 	pulumi.RegisterOutputType(SelfSubjectRulesReviewArrayOutput{})

--- a/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReview.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReview.go
@@ -288,6 +288,10 @@ func (o SubjectAccessReviewMapOutput) MapIndex(k pulumi.StringInput) SubjectAcce
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewInput)(nil)).Elem(), &SubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewPtrInput)(nil)).Elem(), &SubjectAccessReview{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewArrayInput)(nil)).Elem(), SubjectAccessReviewArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubjectAccessReviewMapInput)(nil)).Elem(), SubjectAccessReviewMap{})
 	pulumi.RegisterOutputType(SubjectAccessReviewOutput{})
 	pulumi.RegisterOutputType(SubjectAccessReviewPtrOutput{})
 	pulumi.RegisterOutputType(SubjectAccessReviewArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscaler.go
@@ -290,6 +290,10 @@ func (o HorizontalPodAutoscalerMapOutput) MapIndex(k pulumi.StringInput) Horizon
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerPtrInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerArrayInput)(nil)).Elem(), HorizontalPodAutoscalerArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerMapInput)(nil)).Elem(), HorizontalPodAutoscalerMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerList.go
@@ -283,6 +283,10 @@ func (o HorizontalPodAutoscalerListMapOutput) MapIndex(k pulumi.StringInput) Hor
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListPtrInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListArrayInput)(nil)).Elem(), HorizontalPodAutoscalerListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListMapInput)(nil)).Elem(), HorizontalPodAutoscalerListMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscaler.go
@@ -290,6 +290,10 @@ func (o HorizontalPodAutoscalerMapOutput) MapIndex(k pulumi.StringInput) Horizon
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerPtrInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerArrayInput)(nil)).Elem(), HorizontalPodAutoscalerArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerMapInput)(nil)).Elem(), HorizontalPodAutoscalerMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerList.go
@@ -283,6 +283,10 @@ func (o HorizontalPodAutoscalerListMapOutput) MapIndex(k pulumi.StringInput) Hor
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListPtrInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListArrayInput)(nil)).Elem(), HorizontalPodAutoscalerListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListMapInput)(nil)).Elem(), HorizontalPodAutoscalerListMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscaler.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscaler.go
@@ -290,6 +290,10 @@ func (o HorizontalPodAutoscalerMapOutput) MapIndex(k pulumi.StringInput) Horizon
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerPtrInput)(nil)).Elem(), &HorizontalPodAutoscaler{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerArrayInput)(nil)).Elem(), HorizontalPodAutoscalerArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerMapInput)(nil)).Elem(), HorizontalPodAutoscalerMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerArrayOutput{})

--- a/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerList.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerList.go
@@ -283,6 +283,10 @@ func (o HorizontalPodAutoscalerListMapOutput) MapIndex(k pulumi.StringInput) Hor
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListPtrInput)(nil)).Elem(), &HorizontalPodAutoscalerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListArrayInput)(nil)).Elem(), HorizontalPodAutoscalerListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*HorizontalPodAutoscalerListMapInput)(nil)).Elem(), HorizontalPodAutoscalerListMap{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListPtrOutput{})
 	pulumi.RegisterOutputType(HorizontalPodAutoscalerListArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1/cronJob.go
+++ b/sdk/go/kubernetes/batch/v1/cronJob.go
@@ -290,6 +290,10 @@ func (o CronJobMapOutput) MapIndex(k pulumi.StringInput) CronJobOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobPtrInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobArrayInput)(nil)).Elem(), CronJobArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobMapInput)(nil)).Elem(), CronJobMap{})
 	pulumi.RegisterOutputType(CronJobOutput{})
 	pulumi.RegisterOutputType(CronJobPtrOutput{})
 	pulumi.RegisterOutputType(CronJobArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1/cronJobList.go
+++ b/sdk/go/kubernetes/batch/v1/cronJobList.go
@@ -283,6 +283,10 @@ func (o CronJobListMapOutput) MapIndex(k pulumi.StringInput) CronJobListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListPtrInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListArrayInput)(nil)).Elem(), CronJobListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListMapInput)(nil)).Elem(), CronJobListMap{})
 	pulumi.RegisterOutputType(CronJobListOutput{})
 	pulumi.RegisterOutputType(CronJobListPtrOutput{})
 	pulumi.RegisterOutputType(CronJobListArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1/job.go
+++ b/sdk/go/kubernetes/batch/v1/job.go
@@ -301,6 +301,10 @@ func (o JobMapOutput) MapIndex(k pulumi.StringInput) JobOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*JobInput)(nil)).Elem(), &Job{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobPtrInput)(nil)).Elem(), &Job{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobArrayInput)(nil)).Elem(), JobArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobMapInput)(nil)).Elem(), JobMap{})
 	pulumi.RegisterOutputType(JobOutput{})
 	pulumi.RegisterOutputType(JobPtrOutput{})
 	pulumi.RegisterOutputType(JobArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1/jobList.go
+++ b/sdk/go/kubernetes/batch/v1/jobList.go
@@ -283,6 +283,10 @@ func (o JobListMapOutput) MapIndex(k pulumi.StringInput) JobListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*JobListInput)(nil)).Elem(), &JobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobListPtrInput)(nil)).Elem(), &JobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobListArrayInput)(nil)).Elem(), JobListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*JobListMapInput)(nil)).Elem(), JobListMap{})
 	pulumi.RegisterOutputType(JobListOutput{})
 	pulumi.RegisterOutputType(JobListPtrOutput{})
 	pulumi.RegisterOutputType(JobListArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1beta1/cronJob.go
+++ b/sdk/go/kubernetes/batch/v1beta1/cronJob.go
@@ -290,6 +290,10 @@ func (o CronJobMapOutput) MapIndex(k pulumi.StringInput) CronJobOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobPtrInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobArrayInput)(nil)).Elem(), CronJobArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobMapInput)(nil)).Elem(), CronJobMap{})
 	pulumi.RegisterOutputType(CronJobOutput{})
 	pulumi.RegisterOutputType(CronJobPtrOutput{})
 	pulumi.RegisterOutputType(CronJobArrayOutput{})

--- a/sdk/go/kubernetes/batch/v1beta1/cronJobList.go
+++ b/sdk/go/kubernetes/batch/v1beta1/cronJobList.go
@@ -283,6 +283,10 @@ func (o CronJobListMapOutput) MapIndex(k pulumi.StringInput) CronJobListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListPtrInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListArrayInput)(nil)).Elem(), CronJobListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListMapInput)(nil)).Elem(), CronJobListMap{})
 	pulumi.RegisterOutputType(CronJobListOutput{})
 	pulumi.RegisterOutputType(CronJobListPtrOutput{})
 	pulumi.RegisterOutputType(CronJobListArrayOutput{})

--- a/sdk/go/kubernetes/batch/v2alpha1/cronJob.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/cronJob.go
@@ -290,6 +290,10 @@ func (o CronJobMapOutput) MapIndex(k pulumi.StringInput) CronJobOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobPtrInput)(nil)).Elem(), &CronJob{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobArrayInput)(nil)).Elem(), CronJobArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobMapInput)(nil)).Elem(), CronJobMap{})
 	pulumi.RegisterOutputType(CronJobOutput{})
 	pulumi.RegisterOutputType(CronJobPtrOutput{})
 	pulumi.RegisterOutputType(CronJobArrayOutput{})

--- a/sdk/go/kubernetes/batch/v2alpha1/cronJobList.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/cronJobList.go
@@ -283,6 +283,10 @@ func (o CronJobListMapOutput) MapIndex(k pulumi.StringInput) CronJobListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListPtrInput)(nil)).Elem(), &CronJobList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListArrayInput)(nil)).Elem(), CronJobListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CronJobListMapInput)(nil)).Elem(), CronJobListMap{})
 	pulumi.RegisterOutputType(CronJobListOutput{})
 	pulumi.RegisterOutputType(CronJobListPtrOutput{})
 	pulumi.RegisterOutputType(CronJobListArrayOutput{})

--- a/sdk/go/kubernetes/certificates/v1/certificateSigningRequest.go
+++ b/sdk/go/kubernetes/certificates/v1/certificateSigningRequest.go
@@ -294,6 +294,10 @@ func (o CertificateSigningRequestMapOutput) MapIndex(k pulumi.StringInput) Certi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestInput)(nil)).Elem(), &CertificateSigningRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestPtrInput)(nil)).Elem(), &CertificateSigningRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestArrayInput)(nil)).Elem(), CertificateSigningRequestArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestMapInput)(nil)).Elem(), CertificateSigningRequestMap{})
 	pulumi.RegisterOutputType(CertificateSigningRequestOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestPtrOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestArrayOutput{})

--- a/sdk/go/kubernetes/certificates/v1/certificateSigningRequestList.go
+++ b/sdk/go/kubernetes/certificates/v1/certificateSigningRequestList.go
@@ -280,6 +280,10 @@ func (o CertificateSigningRequestListMapOutput) MapIndex(k pulumi.StringInput) C
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListInput)(nil)).Elem(), &CertificateSigningRequestList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListPtrInput)(nil)).Elem(), &CertificateSigningRequestList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListArrayInput)(nil)).Elem(), CertificateSigningRequestListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListMapInput)(nil)).Elem(), CertificateSigningRequestListMap{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListPtrOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListArrayOutput{})

--- a/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequest.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequest.go
@@ -284,6 +284,10 @@ func (o CertificateSigningRequestMapOutput) MapIndex(k pulumi.StringInput) Certi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestInput)(nil)).Elem(), &CertificateSigningRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestPtrInput)(nil)).Elem(), &CertificateSigningRequest{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestArrayInput)(nil)).Elem(), CertificateSigningRequestArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestMapInput)(nil)).Elem(), CertificateSigningRequestMap{})
 	pulumi.RegisterOutputType(CertificateSigningRequestOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestPtrOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestArrayOutput{})

--- a/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestList.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestList.go
@@ -276,6 +276,10 @@ func (o CertificateSigningRequestListMapOutput) MapIndex(k pulumi.StringInput) C
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListInput)(nil)).Elem(), &CertificateSigningRequestList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListPtrInput)(nil)).Elem(), &CertificateSigningRequestList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListArrayInput)(nil)).Elem(), CertificateSigningRequestListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CertificateSigningRequestListMapInput)(nil)).Elem(), CertificateSigningRequestListMap{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListPtrOutput{})
 	pulumi.RegisterOutputType(CertificateSigningRequestListArrayOutput{})

--- a/sdk/go/kubernetes/coordination/v1/lease.go
+++ b/sdk/go/kubernetes/coordination/v1/lease.go
@@ -285,6 +285,10 @@ func (o LeaseMapOutput) MapIndex(k pulumi.StringInput) LeaseOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseInput)(nil)).Elem(), &Lease{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeasePtrInput)(nil)).Elem(), &Lease{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseArrayInput)(nil)).Elem(), LeaseArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseMapInput)(nil)).Elem(), LeaseMap{})
 	pulumi.RegisterOutputType(LeaseOutput{})
 	pulumi.RegisterOutputType(LeasePtrOutput{})
 	pulumi.RegisterOutputType(LeaseArrayOutput{})

--- a/sdk/go/kubernetes/coordination/v1/leaseList.go
+++ b/sdk/go/kubernetes/coordination/v1/leaseList.go
@@ -283,6 +283,10 @@ func (o LeaseListMapOutput) MapIndex(k pulumi.StringInput) LeaseListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListInput)(nil)).Elem(), &LeaseList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListPtrInput)(nil)).Elem(), &LeaseList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListArrayInput)(nil)).Elem(), LeaseListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListMapInput)(nil)).Elem(), LeaseListMap{})
 	pulumi.RegisterOutputType(LeaseListOutput{})
 	pulumi.RegisterOutputType(LeaseListPtrOutput{})
 	pulumi.RegisterOutputType(LeaseListArrayOutput{})

--- a/sdk/go/kubernetes/coordination/v1beta1/lease.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/lease.go
@@ -285,6 +285,10 @@ func (o LeaseMapOutput) MapIndex(k pulumi.StringInput) LeaseOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseInput)(nil)).Elem(), &Lease{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeasePtrInput)(nil)).Elem(), &Lease{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseArrayInput)(nil)).Elem(), LeaseArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseMapInput)(nil)).Elem(), LeaseMap{})
 	pulumi.RegisterOutputType(LeaseOutput{})
 	pulumi.RegisterOutputType(LeasePtrOutput{})
 	pulumi.RegisterOutputType(LeaseArrayOutput{})

--- a/sdk/go/kubernetes/coordination/v1beta1/leaseList.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/leaseList.go
@@ -283,6 +283,10 @@ func (o LeaseListMapOutput) MapIndex(k pulumi.StringInput) LeaseListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListInput)(nil)).Elem(), &LeaseList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListPtrInput)(nil)).Elem(), &LeaseList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListArrayInput)(nil)).Elem(), LeaseListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LeaseListMapInput)(nil)).Elem(), LeaseListMap{})
 	pulumi.RegisterOutputType(LeaseListOutput{})
 	pulumi.RegisterOutputType(LeaseListPtrOutput{})
 	pulumi.RegisterOutputType(LeaseListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/binding.go
+++ b/sdk/go/kubernetes/core/v1/binding.go
@@ -283,6 +283,10 @@ func (o BindingMapOutput) MapIndex(k pulumi.StringInput) BindingOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*BindingInput)(nil)).Elem(), &Binding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*BindingPtrInput)(nil)).Elem(), &Binding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*BindingArrayInput)(nil)).Elem(), BindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*BindingMapInput)(nil)).Elem(), BindingMap{})
 	pulumi.RegisterOutputType(BindingOutput{})
 	pulumi.RegisterOutputType(BindingPtrOutput{})
 	pulumi.RegisterOutputType(BindingArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/configMap.go
+++ b/sdk/go/kubernetes/core/v1/configMap.go
@@ -291,6 +291,10 @@ func (o ConfigMapMapOutput) MapIndex(k pulumi.StringInput) ConfigMapOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapInput)(nil)).Elem(), &ConfigMap{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapPtrInput)(nil)).Elem(), &ConfigMap{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapArrayInput)(nil)).Elem(), ConfigMapArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapMapInput)(nil)).Elem(), ConfigMapMap{})
 	pulumi.RegisterOutputType(ConfigMapOutput{})
 	pulumi.RegisterOutputType(ConfigMapPtrOutput{})
 	pulumi.RegisterOutputType(ConfigMapArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/configMapList.go
+++ b/sdk/go/kubernetes/core/v1/configMapList.go
@@ -283,6 +283,10 @@ func (o ConfigMapListMapOutput) MapIndex(k pulumi.StringInput) ConfigMapListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapListInput)(nil)).Elem(), &ConfigMapList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapListPtrInput)(nil)).Elem(), &ConfigMapList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapListArrayInput)(nil)).Elem(), ConfigMapListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ConfigMapListMapInput)(nil)).Elem(), ConfigMapListMap{})
 	pulumi.RegisterOutputType(ConfigMapListOutput{})
 	pulumi.RegisterOutputType(ConfigMapListPtrOutput{})
 	pulumi.RegisterOutputType(ConfigMapListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/endpoints.go
+++ b/sdk/go/kubernetes/core/v1/endpoints.go
@@ -290,6 +290,10 @@ func (o EndpointsMapOutput) MapIndex(k pulumi.StringInput) EndpointsOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsInput)(nil)).Elem(), &Endpoints{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsPtrInput)(nil)).Elem(), &Endpoints{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsArrayInput)(nil)).Elem(), EndpointsArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsMapInput)(nil)).Elem(), EndpointsMap{})
 	pulumi.RegisterOutputType(EndpointsOutput{})
 	pulumi.RegisterOutputType(EndpointsPtrOutput{})
 	pulumi.RegisterOutputType(EndpointsArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/endpointsList.go
+++ b/sdk/go/kubernetes/core/v1/endpointsList.go
@@ -283,6 +283,10 @@ func (o EndpointsListMapOutput) MapIndex(k pulumi.StringInput) EndpointsListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsListInput)(nil)).Elem(), &EndpointsList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsListPtrInput)(nil)).Elem(), &EndpointsList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsListArrayInput)(nil)).Elem(), EndpointsListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointsListMapInput)(nil)).Elem(), EndpointsListMap{})
 	pulumi.RegisterOutputType(EndpointsListOutput{})
 	pulumi.RegisterOutputType(EndpointsListPtrOutput{})
 	pulumi.RegisterOutputType(EndpointsListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/event.go
+++ b/sdk/go/kubernetes/core/v1/event.go
@@ -373,6 +373,10 @@ func (o EventMapOutput) MapIndex(k pulumi.StringInput) EventOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventPtrInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventArrayInput)(nil)).Elem(), EventArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventMapInput)(nil)).Elem(), EventMap{})
 	pulumi.RegisterOutputType(EventOutput{})
 	pulumi.RegisterOutputType(EventPtrOutput{})
 	pulumi.RegisterOutputType(EventArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/eventList.go
+++ b/sdk/go/kubernetes/core/v1/eventList.go
@@ -283,6 +283,10 @@ func (o EventListMapOutput) MapIndex(k pulumi.StringInput) EventListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListPtrInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListArrayInput)(nil)).Elem(), EventListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListMapInput)(nil)).Elem(), EventListMap{})
 	pulumi.RegisterOutputType(EventListOutput{})
 	pulumi.RegisterOutputType(EventListPtrOutput{})
 	pulumi.RegisterOutputType(EventListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/limitRange.go
+++ b/sdk/go/kubernetes/core/v1/limitRange.go
@@ -279,6 +279,10 @@ func (o LimitRangeMapOutput) MapIndex(k pulumi.StringInput) LimitRangeOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeInput)(nil)).Elem(), &LimitRange{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangePtrInput)(nil)).Elem(), &LimitRange{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeArrayInput)(nil)).Elem(), LimitRangeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeMapInput)(nil)).Elem(), LimitRangeMap{})
 	pulumi.RegisterOutputType(LimitRangeOutput{})
 	pulumi.RegisterOutputType(LimitRangePtrOutput{})
 	pulumi.RegisterOutputType(LimitRangeArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/limitRangeList.go
+++ b/sdk/go/kubernetes/core/v1/limitRangeList.go
@@ -283,6 +283,10 @@ func (o LimitRangeListMapOutput) MapIndex(k pulumi.StringInput) LimitRangeListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeListInput)(nil)).Elem(), &LimitRangeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeListPtrInput)(nil)).Elem(), &LimitRangeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeListArrayInput)(nil)).Elem(), LimitRangeListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LimitRangeListMapInput)(nil)).Elem(), LimitRangeListMap{})
 	pulumi.RegisterOutputType(LimitRangeListOutput{})
 	pulumi.RegisterOutputType(LimitRangeListPtrOutput{})
 	pulumi.RegisterOutputType(LimitRangeListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/namespace.go
+++ b/sdk/go/kubernetes/core/v1/namespace.go
@@ -281,6 +281,10 @@ func (o NamespaceMapOutput) MapIndex(k pulumi.StringInput) NamespaceOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceInput)(nil)).Elem(), &Namespace{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespacePtrInput)(nil)).Elem(), &Namespace{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceArrayInput)(nil)).Elem(), NamespaceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceMapInput)(nil)).Elem(), NamespaceMap{})
 	pulumi.RegisterOutputType(NamespaceOutput{})
 	pulumi.RegisterOutputType(NamespacePtrOutput{})
 	pulumi.RegisterOutputType(NamespaceArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/namespaceList.go
+++ b/sdk/go/kubernetes/core/v1/namespaceList.go
@@ -283,6 +283,10 @@ func (o NamespaceListMapOutput) MapIndex(k pulumi.StringInput) NamespaceListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceListInput)(nil)).Elem(), &NamespaceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceListPtrInput)(nil)).Elem(), &NamespaceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceListArrayInput)(nil)).Elem(), NamespaceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NamespaceListMapInput)(nil)).Elem(), NamespaceListMap{})
 	pulumi.RegisterOutputType(NamespaceListOutput{})
 	pulumi.RegisterOutputType(NamespaceListPtrOutput{})
 	pulumi.RegisterOutputType(NamespaceListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/node.go
+++ b/sdk/go/kubernetes/core/v1/node.go
@@ -281,6 +281,10 @@ func (o NodeMapOutput) MapIndex(k pulumi.StringInput) NodeOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeInput)(nil)).Elem(), &Node{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodePtrInput)(nil)).Elem(), &Node{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeArrayInput)(nil)).Elem(), NodeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeMapInput)(nil)).Elem(), NodeMap{})
 	pulumi.RegisterOutputType(NodeOutput{})
 	pulumi.RegisterOutputType(NodePtrOutput{})
 	pulumi.RegisterOutputType(NodeArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/nodeList.go
+++ b/sdk/go/kubernetes/core/v1/nodeList.go
@@ -283,6 +283,10 @@ func (o NodeListMapOutput) MapIndex(k pulumi.StringInput) NodeListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeListInput)(nil)).Elem(), &NodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeListPtrInput)(nil)).Elem(), &NodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeListArrayInput)(nil)).Elem(), NodeListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NodeListMapInput)(nil)).Elem(), NodeListMap{})
 	pulumi.RegisterOutputType(NodeListOutput{})
 	pulumi.RegisterOutputType(NodeListPtrOutput{})
 	pulumi.RegisterOutputType(NodeListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/persistentVolume.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolume.go
@@ -281,6 +281,10 @@ func (o PersistentVolumeMapOutput) MapIndex(k pulumi.StringInput) PersistentVolu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeInput)(nil)).Elem(), &PersistentVolume{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumePtrInput)(nil)).Elem(), &PersistentVolume{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeArrayInput)(nil)).Elem(), PersistentVolumeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeMapInput)(nil)).Elem(), PersistentVolumeMap{})
 	pulumi.RegisterOutputType(PersistentVolumeOutput{})
 	pulumi.RegisterOutputType(PersistentVolumePtrOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/persistentVolumeClaim.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeClaim.go
@@ -281,6 +281,10 @@ func (o PersistentVolumeClaimMapOutput) MapIndex(k pulumi.StringInput) Persisten
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimInput)(nil)).Elem(), &PersistentVolumeClaim{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimPtrInput)(nil)).Elem(), &PersistentVolumeClaim{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimArrayInput)(nil)).Elem(), PersistentVolumeClaimArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimMapInput)(nil)).Elem(), PersistentVolumeClaimMap{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimPtrOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/persistentVolumeClaimList.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeClaimList.go
@@ -283,6 +283,10 @@ func (o PersistentVolumeClaimListMapOutput) MapIndex(k pulumi.StringInput) Persi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimListInput)(nil)).Elem(), &PersistentVolumeClaimList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimListPtrInput)(nil)).Elem(), &PersistentVolumeClaimList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimListArrayInput)(nil)).Elem(), PersistentVolumeClaimListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeClaimListMapInput)(nil)).Elem(), PersistentVolumeClaimListMap{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimListOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimListPtrOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeClaimListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/persistentVolumeList.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeList.go
@@ -283,6 +283,10 @@ func (o PersistentVolumeListMapOutput) MapIndex(k pulumi.StringInput) Persistent
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeListInput)(nil)).Elem(), &PersistentVolumeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeListPtrInput)(nil)).Elem(), &PersistentVolumeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeListArrayInput)(nil)).Elem(), PersistentVolumeListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PersistentVolumeListMapInput)(nil)).Elem(), PersistentVolumeListMap{})
 	pulumi.RegisterOutputType(PersistentVolumeListOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeListPtrOutput{})
 	pulumi.RegisterOutputType(PersistentVolumeListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/pod.go
+++ b/sdk/go/kubernetes/core/v1/pod.go
@@ -296,6 +296,10 @@ func (o PodMapOutput) MapIndex(k pulumi.StringInput) PodOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodInput)(nil)).Elem(), &Pod{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPtrInput)(nil)).Elem(), &Pod{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodArrayInput)(nil)).Elem(), PodArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodMapInput)(nil)).Elem(), PodMap{})
 	pulumi.RegisterOutputType(PodOutput{})
 	pulumi.RegisterOutputType(PodPtrOutput{})
 	pulumi.RegisterOutputType(PodArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/podList.go
+++ b/sdk/go/kubernetes/core/v1/podList.go
@@ -283,6 +283,10 @@ func (o PodListMapOutput) MapIndex(k pulumi.StringInput) PodListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodListInput)(nil)).Elem(), &PodList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodListPtrInput)(nil)).Elem(), &PodList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodListArrayInput)(nil)).Elem(), PodListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodListMapInput)(nil)).Elem(), PodListMap{})
 	pulumi.RegisterOutputType(PodListOutput{})
 	pulumi.RegisterOutputType(PodListPtrOutput{})
 	pulumi.RegisterOutputType(PodListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/podTemplate.go
+++ b/sdk/go/kubernetes/core/v1/podTemplate.go
@@ -279,6 +279,10 @@ func (o PodTemplateMapOutput) MapIndex(k pulumi.StringInput) PodTemplateOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateInput)(nil)).Elem(), &PodTemplate{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplatePtrInput)(nil)).Elem(), &PodTemplate{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateArrayInput)(nil)).Elem(), PodTemplateArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateMapInput)(nil)).Elem(), PodTemplateMap{})
 	pulumi.RegisterOutputType(PodTemplateOutput{})
 	pulumi.RegisterOutputType(PodTemplatePtrOutput{})
 	pulumi.RegisterOutputType(PodTemplateArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/podTemplateList.go
+++ b/sdk/go/kubernetes/core/v1/podTemplateList.go
@@ -283,6 +283,10 @@ func (o PodTemplateListMapOutput) MapIndex(k pulumi.StringInput) PodTemplateList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateListInput)(nil)).Elem(), &PodTemplateList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateListPtrInput)(nil)).Elem(), &PodTemplateList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateListArrayInput)(nil)).Elem(), PodTemplateListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodTemplateListMapInput)(nil)).Elem(), PodTemplateListMap{})
 	pulumi.RegisterOutputType(PodTemplateListOutput{})
 	pulumi.RegisterOutputType(PodTemplateListPtrOutput{})
 	pulumi.RegisterOutputType(PodTemplateListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/pulumiEnums.go
+++ b/sdk/go/kubernetes/core/v1/pulumiEnums.go
@@ -177,6 +177,8 @@ func (in *serviceSpecTypePtr) ToServiceSpecTypePtrOutputWithContext(ctx context.
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceSpecTypeInput)(nil)).Elem(), ServiceSpecType("ExternalName"))
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceSpecTypePtrInput)(nil)).Elem(), ServiceSpecType("ExternalName"))
 	pulumi.RegisterOutputType(ServiceSpecTypeOutput{})
 	pulumi.RegisterOutputType(ServiceSpecTypePtrOutput{})
 }

--- a/sdk/go/kubernetes/core/v1/replicationController.go
+++ b/sdk/go/kubernetes/core/v1/replicationController.go
@@ -281,6 +281,10 @@ func (o ReplicationControllerMapOutput) MapIndex(k pulumi.StringInput) Replicati
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerInput)(nil)).Elem(), &ReplicationController{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerPtrInput)(nil)).Elem(), &ReplicationController{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerArrayInput)(nil)).Elem(), ReplicationControllerArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerMapInput)(nil)).Elem(), ReplicationControllerMap{})
 	pulumi.RegisterOutputType(ReplicationControllerOutput{})
 	pulumi.RegisterOutputType(ReplicationControllerPtrOutput{})
 	pulumi.RegisterOutputType(ReplicationControllerArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/replicationControllerList.go
+++ b/sdk/go/kubernetes/core/v1/replicationControllerList.go
@@ -283,6 +283,10 @@ func (o ReplicationControllerListMapOutput) MapIndex(k pulumi.StringInput) Repli
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerListInput)(nil)).Elem(), &ReplicationControllerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerListPtrInput)(nil)).Elem(), &ReplicationControllerList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerListArrayInput)(nil)).Elem(), ReplicationControllerListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicationControllerListMapInput)(nil)).Elem(), ReplicationControllerListMap{})
 	pulumi.RegisterOutputType(ReplicationControllerListOutput{})
 	pulumi.RegisterOutputType(ReplicationControllerListPtrOutput{})
 	pulumi.RegisterOutputType(ReplicationControllerListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/resourceQuota.go
+++ b/sdk/go/kubernetes/core/v1/resourceQuota.go
@@ -281,6 +281,10 @@ func (o ResourceQuotaMapOutput) MapIndex(k pulumi.StringInput) ResourceQuotaOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaInput)(nil)).Elem(), &ResourceQuota{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaPtrInput)(nil)).Elem(), &ResourceQuota{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaArrayInput)(nil)).Elem(), ResourceQuotaArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaMapInput)(nil)).Elem(), ResourceQuotaMap{})
 	pulumi.RegisterOutputType(ResourceQuotaOutput{})
 	pulumi.RegisterOutputType(ResourceQuotaPtrOutput{})
 	pulumi.RegisterOutputType(ResourceQuotaArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/resourceQuotaList.go
+++ b/sdk/go/kubernetes/core/v1/resourceQuotaList.go
@@ -283,6 +283,10 @@ func (o ResourceQuotaListMapOutput) MapIndex(k pulumi.StringInput) ResourceQuota
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaListInput)(nil)).Elem(), &ResourceQuotaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaListPtrInput)(nil)).Elem(), &ResourceQuotaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaListArrayInput)(nil)).Elem(), ResourceQuotaListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ResourceQuotaListMapInput)(nil)).Elem(), ResourceQuotaListMap{})
 	pulumi.RegisterOutputType(ResourceQuotaListOutput{})
 	pulumi.RegisterOutputType(ResourceQuotaListPtrOutput{})
 	pulumi.RegisterOutputType(ResourceQuotaListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/secret.go
+++ b/sdk/go/kubernetes/core/v1/secret.go
@@ -318,6 +318,10 @@ func (o SecretMapOutput) MapIndex(k pulumi.StringInput) SecretOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretInput)(nil)).Elem(), &Secret{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretPtrInput)(nil)).Elem(), &Secret{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretArrayInput)(nil)).Elem(), SecretArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretMapInput)(nil)).Elem(), SecretMap{})
 	pulumi.RegisterOutputType(SecretOutput{})
 	pulumi.RegisterOutputType(SecretPtrOutput{})
 	pulumi.RegisterOutputType(SecretArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/secretList.go
+++ b/sdk/go/kubernetes/core/v1/secretList.go
@@ -283,6 +283,10 @@ func (o SecretListMapOutput) MapIndex(k pulumi.StringInput) SecretListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretListInput)(nil)).Elem(), &SecretList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretListPtrInput)(nil)).Elem(), &SecretList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretListArrayInput)(nil)).Elem(), SecretListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecretListMapInput)(nil)).Elem(), SecretListMap{})
 	pulumi.RegisterOutputType(SecretListOutput{})
 	pulumi.RegisterOutputType(SecretListPtrOutput{})
 	pulumi.RegisterOutputType(SecretListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/service.go
+++ b/sdk/go/kubernetes/core/v1/service.go
@@ -306,6 +306,10 @@ func (o ServiceMapOutput) MapIndex(k pulumi.StringInput) ServiceOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceInput)(nil)).Elem(), &Service{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServicePtrInput)(nil)).Elem(), &Service{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceArrayInput)(nil)).Elem(), ServiceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceMapInput)(nil)).Elem(), ServiceMap{})
 	pulumi.RegisterOutputType(ServiceOutput{})
 	pulumi.RegisterOutputType(ServicePtrOutput{})
 	pulumi.RegisterOutputType(ServiceArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/serviceAccount.go
+++ b/sdk/go/kubernetes/core/v1/serviceAccount.go
@@ -291,6 +291,10 @@ func (o ServiceAccountMapOutput) MapIndex(k pulumi.StringInput) ServiceAccountOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountInput)(nil)).Elem(), &ServiceAccount{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountPtrInput)(nil)).Elem(), &ServiceAccount{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountArrayInput)(nil)).Elem(), ServiceAccountArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountMapInput)(nil)).Elem(), ServiceAccountMap{})
 	pulumi.RegisterOutputType(ServiceAccountOutput{})
 	pulumi.RegisterOutputType(ServiceAccountPtrOutput{})
 	pulumi.RegisterOutputType(ServiceAccountArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/serviceAccountList.go
+++ b/sdk/go/kubernetes/core/v1/serviceAccountList.go
@@ -283,6 +283,10 @@ func (o ServiceAccountListMapOutput) MapIndex(k pulumi.StringInput) ServiceAccou
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountListInput)(nil)).Elem(), &ServiceAccountList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountListPtrInput)(nil)).Elem(), &ServiceAccountList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountListArrayInput)(nil)).Elem(), ServiceAccountListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceAccountListMapInput)(nil)).Elem(), ServiceAccountListMap{})
 	pulumi.RegisterOutputType(ServiceAccountListOutput{})
 	pulumi.RegisterOutputType(ServiceAccountListPtrOutput{})
 	pulumi.RegisterOutputType(ServiceAccountListArrayOutput{})

--- a/sdk/go/kubernetes/core/v1/serviceList.go
+++ b/sdk/go/kubernetes/core/v1/serviceList.go
@@ -283,6 +283,10 @@ func (o ServiceListMapOutput) MapIndex(k pulumi.StringInput) ServiceListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceListInput)(nil)).Elem(), &ServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceListPtrInput)(nil)).Elem(), &ServiceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceListArrayInput)(nil)).Elem(), ServiceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceListMapInput)(nil)).Elem(), ServiceListMap{})
 	pulumi.RegisterOutputType(ServiceListOutput{})
 	pulumi.RegisterOutputType(ServiceListPtrOutput{})
 	pulumi.RegisterOutputType(ServiceListArrayOutput{})

--- a/sdk/go/kubernetes/discovery/v1/endpointSlice.go
+++ b/sdk/go/kubernetes/discovery/v1/endpointSlice.go
@@ -304,6 +304,10 @@ func (o EndpointSliceMapOutput) MapIndex(k pulumi.StringInput) EndpointSliceOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceInput)(nil)).Elem(), &EndpointSlice{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSlicePtrInput)(nil)).Elem(), &EndpointSlice{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceArrayInput)(nil)).Elem(), EndpointSliceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceMapInput)(nil)).Elem(), EndpointSliceMap{})
 	pulumi.RegisterOutputType(EndpointSliceOutput{})
 	pulumi.RegisterOutputType(EndpointSlicePtrOutput{})
 	pulumi.RegisterOutputType(EndpointSliceArrayOutput{})

--- a/sdk/go/kubernetes/discovery/v1/endpointSliceList.go
+++ b/sdk/go/kubernetes/discovery/v1/endpointSliceList.go
@@ -283,6 +283,10 @@ func (o EndpointSliceListMapOutput) MapIndex(k pulumi.StringInput) EndpointSlice
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListInput)(nil)).Elem(), &EndpointSliceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListPtrInput)(nil)).Elem(), &EndpointSliceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListArrayInput)(nil)).Elem(), EndpointSliceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListMapInput)(nil)).Elem(), EndpointSliceListMap{})
 	pulumi.RegisterOutputType(EndpointSliceListOutput{})
 	pulumi.RegisterOutputType(EndpointSliceListPtrOutput{})
 	pulumi.RegisterOutputType(EndpointSliceListArrayOutput{})

--- a/sdk/go/kubernetes/discovery/v1beta1/endpointSlice.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/endpointSlice.go
@@ -304,6 +304,10 @@ func (o EndpointSliceMapOutput) MapIndex(k pulumi.StringInput) EndpointSliceOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceInput)(nil)).Elem(), &EndpointSlice{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSlicePtrInput)(nil)).Elem(), &EndpointSlice{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceArrayInput)(nil)).Elem(), EndpointSliceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceMapInput)(nil)).Elem(), EndpointSliceMap{})
 	pulumi.RegisterOutputType(EndpointSliceOutput{})
 	pulumi.RegisterOutputType(EndpointSlicePtrOutput{})
 	pulumi.RegisterOutputType(EndpointSliceArrayOutput{})

--- a/sdk/go/kubernetes/discovery/v1beta1/endpointSliceList.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/endpointSliceList.go
@@ -283,6 +283,10 @@ func (o EndpointSliceListMapOutput) MapIndex(k pulumi.StringInput) EndpointSlice
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListInput)(nil)).Elem(), &EndpointSliceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListPtrInput)(nil)).Elem(), &EndpointSliceList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListArrayInput)(nil)).Elem(), EndpointSliceListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EndpointSliceListMapInput)(nil)).Elem(), EndpointSliceListMap{})
 	pulumi.RegisterOutputType(EndpointSliceListOutput{})
 	pulumi.RegisterOutputType(EndpointSliceListPtrOutput{})
 	pulumi.RegisterOutputType(EndpointSliceListArrayOutput{})

--- a/sdk/go/kubernetes/events/v1/event.go
+++ b/sdk/go/kubernetes/events/v1/event.go
@@ -371,6 +371,10 @@ func (o EventMapOutput) MapIndex(k pulumi.StringInput) EventOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventPtrInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventArrayInput)(nil)).Elem(), EventArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventMapInput)(nil)).Elem(), EventMap{})
 	pulumi.RegisterOutputType(EventOutput{})
 	pulumi.RegisterOutputType(EventPtrOutput{})
 	pulumi.RegisterOutputType(EventArrayOutput{})

--- a/sdk/go/kubernetes/events/v1/eventList.go
+++ b/sdk/go/kubernetes/events/v1/eventList.go
@@ -283,6 +283,10 @@ func (o EventListMapOutput) MapIndex(k pulumi.StringInput) EventListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListPtrInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListArrayInput)(nil)).Elem(), EventListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListMapInput)(nil)).Elem(), EventListMap{})
 	pulumi.RegisterOutputType(EventListOutput{})
 	pulumi.RegisterOutputType(EventListPtrOutput{})
 	pulumi.RegisterOutputType(EventListArrayOutput{})

--- a/sdk/go/kubernetes/events/v1beta1/event.go
+++ b/sdk/go/kubernetes/events/v1beta1/event.go
@@ -371,6 +371,10 @@ func (o EventMapOutput) MapIndex(k pulumi.StringInput) EventOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventPtrInput)(nil)).Elem(), &Event{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventArrayInput)(nil)).Elem(), EventArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventMapInput)(nil)).Elem(), EventMap{})
 	pulumi.RegisterOutputType(EventOutput{})
 	pulumi.RegisterOutputType(EventPtrOutput{})
 	pulumi.RegisterOutputType(EventArrayOutput{})

--- a/sdk/go/kubernetes/events/v1beta1/eventList.go
+++ b/sdk/go/kubernetes/events/v1beta1/eventList.go
@@ -283,6 +283,10 @@ func (o EventListMapOutput) MapIndex(k pulumi.StringInput) EventListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListPtrInput)(nil)).Elem(), &EventList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListArrayInput)(nil)).Elem(), EventListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EventListMapInput)(nil)).Elem(), EventListMap{})
 	pulumi.RegisterOutputType(EventListOutput{})
 	pulumi.RegisterOutputType(EventListPtrOutput{})
 	pulumi.RegisterOutputType(EventListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/daemonSet.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/daemonSet.go
@@ -292,6 +292,10 @@ func (o DaemonSetMapOutput) MapIndex(k pulumi.StringInput) DaemonSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetPtrInput)(nil)).Elem(), &DaemonSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetArrayInput)(nil)).Elem(), DaemonSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetMapInput)(nil)).Elem(), DaemonSetMap{})
 	pulumi.RegisterOutputType(DaemonSetOutput{})
 	pulumi.RegisterOutputType(DaemonSetPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/daemonSetList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/daemonSetList.go
@@ -283,6 +283,10 @@ func (o DaemonSetListMapOutput) MapIndex(k pulumi.StringInput) DaemonSetListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListPtrInput)(nil)).Elem(), &DaemonSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListArrayInput)(nil)).Elem(), DaemonSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DaemonSetListMapInput)(nil)).Elem(), DaemonSetListMap{})
 	pulumi.RegisterOutputType(DaemonSetListOutput{})
 	pulumi.RegisterOutputType(DaemonSetListPtrOutput{})
 	pulumi.RegisterOutputType(DaemonSetListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/deployment.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/deployment.go
@@ -317,6 +317,10 @@ func (o DeploymentMapOutput) MapIndex(k pulumi.StringInput) DeploymentOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentPtrInput)(nil)).Elem(), &Deployment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentArrayInput)(nil)).Elem(), DeploymentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentMapInput)(nil)).Elem(), DeploymentMap{})
 	pulumi.RegisterOutputType(DeploymentOutput{})
 	pulumi.RegisterOutputType(DeploymentPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/deploymentList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/deploymentList.go
@@ -283,6 +283,10 @@ func (o DeploymentListMapOutput) MapIndex(k pulumi.StringInput) DeploymentListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListPtrInput)(nil)).Elem(), &DeploymentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListArrayInput)(nil)).Elem(), DeploymentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DeploymentListMapInput)(nil)).Elem(), DeploymentListMap{})
 	pulumi.RegisterOutputType(DeploymentListOutput{})
 	pulumi.RegisterOutputType(DeploymentListPtrOutput{})
 	pulumi.RegisterOutputType(DeploymentListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/ingress.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/ingress.go
@@ -306,6 +306,10 @@ func (o IngressMapOutput) MapIndex(k pulumi.StringInput) IngressOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressPtrInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressArrayInput)(nil)).Elem(), IngressArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressMapInput)(nil)).Elem(), IngressMap{})
 	pulumi.RegisterOutputType(IngressOutput{})
 	pulumi.RegisterOutputType(IngressPtrOutput{})
 	pulumi.RegisterOutputType(IngressArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/ingressList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/ingressList.go
@@ -283,6 +283,10 @@ func (o IngressListMapOutput) MapIndex(k pulumi.StringInput) IngressListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListPtrInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListArrayInput)(nil)).Elem(), IngressListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListMapInput)(nil)).Elem(), IngressListMap{})
 	pulumi.RegisterOutputType(IngressListOutput{})
 	pulumi.RegisterOutputType(IngressListPtrOutput{})
 	pulumi.RegisterOutputType(IngressListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/networkPolicy.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/networkPolicy.go
@@ -285,6 +285,10 @@ func (o NetworkPolicyMapOutput) MapIndex(k pulumi.StringInput) NetworkPolicyOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyInput)(nil)).Elem(), &NetworkPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyPtrInput)(nil)).Elem(), &NetworkPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyArrayInput)(nil)).Elem(), NetworkPolicyArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyMapInput)(nil)).Elem(), NetworkPolicyMap{})
 	pulumi.RegisterOutputType(NetworkPolicyOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyPtrOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/networkPolicyList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/networkPolicyList.go
@@ -283,6 +283,10 @@ func (o NetworkPolicyListMapOutput) MapIndex(k pulumi.StringInput) NetworkPolicy
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListInput)(nil)).Elem(), &NetworkPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListPtrInput)(nil)).Elem(), &NetworkPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListArrayInput)(nil)).Elem(), NetworkPolicyListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListMapInput)(nil)).Elem(), NetworkPolicyListMap{})
 	pulumi.RegisterOutputType(NetworkPolicyListOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyListPtrOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicy.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicy.go
@@ -285,6 +285,10 @@ func (o PodSecurityPolicyMapOutput) MapIndex(k pulumi.StringInput) PodSecurityPo
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyInput)(nil)).Elem(), &PodSecurityPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyPtrInput)(nil)).Elem(), &PodSecurityPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyArrayInput)(nil)).Elem(), PodSecurityPolicyArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyMapInput)(nil)).Elem(), PodSecurityPolicyMap{})
 	pulumi.RegisterOutputType(PodSecurityPolicyOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyPtrOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyList.go
@@ -283,6 +283,10 @@ func (o PodSecurityPolicyListMapOutput) MapIndex(k pulumi.StringInput) PodSecuri
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListInput)(nil)).Elem(), &PodSecurityPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListPtrInput)(nil)).Elem(), &PodSecurityPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListArrayInput)(nil)).Elem(), PodSecurityPolicyListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListMapInput)(nil)).Elem(), PodSecurityPolicyListMap{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListPtrOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/replicaSet.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/replicaSet.go
@@ -292,6 +292,10 @@ func (o ReplicaSetMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetPtrInput)(nil)).Elem(), &ReplicaSet{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetArrayInput)(nil)).Elem(), ReplicaSetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetMapInput)(nil)).Elem(), ReplicaSetMap{})
 	pulumi.RegisterOutputType(ReplicaSetOutput{})
 	pulumi.RegisterOutputType(ReplicaSetPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetArrayOutput{})

--- a/sdk/go/kubernetes/extensions/v1beta1/replicaSetList.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/replicaSetList.go
@@ -283,6 +283,10 @@ func (o ReplicaSetListMapOutput) MapIndex(k pulumi.StringInput) ReplicaSetListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListPtrInput)(nil)).Elem(), &ReplicaSetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListArrayInput)(nil)).Elem(), ReplicaSetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReplicaSetListMapInput)(nil)).Elem(), ReplicaSetListMap{})
 	pulumi.RegisterOutputType(ReplicaSetListOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListPtrOutput{})
 	pulumi.RegisterOutputType(ReplicaSetListArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchema.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchema.go
@@ -287,6 +287,10 @@ func (o FlowSchemaMapOutput) MapIndex(k pulumi.StringInput) FlowSchemaOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaInput)(nil)).Elem(), &FlowSchema{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaPtrInput)(nil)).Elem(), &FlowSchema{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaArrayInput)(nil)).Elem(), FlowSchemaArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaMapInput)(nil)).Elem(), FlowSchemaMap{})
 	pulumi.RegisterOutputType(FlowSchemaOutput{})
 	pulumi.RegisterOutputType(FlowSchemaPtrOutput{})
 	pulumi.RegisterOutputType(FlowSchemaArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaList.go
@@ -283,6 +283,10 @@ func (o FlowSchemaListMapOutput) MapIndex(k pulumi.StringInput) FlowSchemaListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListInput)(nil)).Elem(), &FlowSchemaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListPtrInput)(nil)).Elem(), &FlowSchemaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListArrayInput)(nil)).Elem(), FlowSchemaListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListMapInput)(nil)).Elem(), FlowSchemaListMap{})
 	pulumi.RegisterOutputType(FlowSchemaListOutput{})
 	pulumi.RegisterOutputType(FlowSchemaListPtrOutput{})
 	pulumi.RegisterOutputType(FlowSchemaListArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfiguration.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfiguration.go
@@ -287,6 +287,10 @@ func (o PriorityLevelConfigurationMapOutput) MapIndex(k pulumi.StringInput) Prio
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationInput)(nil)).Elem(), &PriorityLevelConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationPtrInput)(nil)).Elem(), &PriorityLevelConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationArrayInput)(nil)).Elem(), PriorityLevelConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationMapInput)(nil)).Elem(), PriorityLevelConfigurationMap{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationList.go
@@ -283,6 +283,10 @@ func (o PriorityLevelConfigurationListMapOutput) MapIndex(k pulumi.StringInput) 
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListInput)(nil)).Elem(), &PriorityLevelConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListPtrInput)(nil)).Elem(), &PriorityLevelConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListArrayInput)(nil)).Elem(), PriorityLevelConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListMapInput)(nil)).Elem(), PriorityLevelConfigurationListMap{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchema.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchema.go
@@ -287,6 +287,10 @@ func (o FlowSchemaMapOutput) MapIndex(k pulumi.StringInput) FlowSchemaOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaInput)(nil)).Elem(), &FlowSchema{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaPtrInput)(nil)).Elem(), &FlowSchema{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaArrayInput)(nil)).Elem(), FlowSchemaArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaMapInput)(nil)).Elem(), FlowSchemaMap{})
 	pulumi.RegisterOutputType(FlowSchemaOutput{})
 	pulumi.RegisterOutputType(FlowSchemaPtrOutput{})
 	pulumi.RegisterOutputType(FlowSchemaArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchemaList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchemaList.go
@@ -283,6 +283,10 @@ func (o FlowSchemaListMapOutput) MapIndex(k pulumi.StringInput) FlowSchemaListOu
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListInput)(nil)).Elem(), &FlowSchemaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListPtrInput)(nil)).Elem(), &FlowSchemaList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListArrayInput)(nil)).Elem(), FlowSchemaListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FlowSchemaListMapInput)(nil)).Elem(), FlowSchemaListMap{})
 	pulumi.RegisterOutputType(FlowSchemaListOutput{})
 	pulumi.RegisterOutputType(FlowSchemaListPtrOutput{})
 	pulumi.RegisterOutputType(FlowSchemaListArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfiguration.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfiguration.go
@@ -287,6 +287,10 @@ func (o PriorityLevelConfigurationMapOutput) MapIndex(k pulumi.StringInput) Prio
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationInput)(nil)).Elem(), &PriorityLevelConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationPtrInput)(nil)).Elem(), &PriorityLevelConfiguration{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationArrayInput)(nil)).Elem(), PriorityLevelConfigurationArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationMapInput)(nil)).Elem(), PriorityLevelConfigurationMap{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationPtrOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationArrayOutput{})

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfigurationList.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfigurationList.go
@@ -283,6 +283,10 @@ func (o PriorityLevelConfigurationListMapOutput) MapIndex(k pulumi.StringInput) 
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListInput)(nil)).Elem(), &PriorityLevelConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListPtrInput)(nil)).Elem(), &PriorityLevelConfigurationList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListArrayInput)(nil)).Elem(), PriorityLevelConfigurationListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityLevelConfigurationListMapInput)(nil)).Elem(), PriorityLevelConfigurationListMap{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListPtrOutput{})
 	pulumi.RegisterOutputType(PriorityLevelConfigurationListArrayOutput{})

--- a/sdk/go/kubernetes/helm/v3/release.go
+++ b/sdk/go/kubernetes/helm/v3/release.go
@@ -464,6 +464,10 @@ func (o ReleaseMapOutput) MapIndex(k pulumi.StringInput) ReleaseOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ReleaseInput)(nil)).Elem(), &Release{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReleasePtrInput)(nil)).Elem(), &Release{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReleaseArrayInput)(nil)).Elem(), ReleaseArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ReleaseMapInput)(nil)).Elem(), ReleaseMap{})
 	pulumi.RegisterOutputType(ReleaseOutput{})
 	pulumi.RegisterOutputType(ReleasePtrOutput{})
 	pulumi.RegisterOutputType(ReleaseArrayOutput{})

--- a/sdk/go/kubernetes/meta/v1/status.go
+++ b/sdk/go/kubernetes/meta/v1/status.go
@@ -298,6 +298,10 @@ func (o StatusMapOutput) MapIndex(k pulumi.StringInput) StatusOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StatusInput)(nil)).Elem(), &Status{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatusPtrInput)(nil)).Elem(), &Status{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatusArrayInput)(nil)).Elem(), StatusArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StatusMapInput)(nil)).Elem(), StatusMap{})
 	pulumi.RegisterOutputType(StatusOutput{})
 	pulumi.RegisterOutputType(StatusPtrOutput{})
 	pulumi.RegisterOutputType(StatusArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/ingress.go
+++ b/sdk/go/kubernetes/networking/v1/ingress.go
@@ -304,6 +304,10 @@ func (o IngressMapOutput) MapIndex(k pulumi.StringInput) IngressOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressPtrInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressArrayInput)(nil)).Elem(), IngressArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressMapInput)(nil)).Elem(), IngressMap{})
 	pulumi.RegisterOutputType(IngressOutput{})
 	pulumi.RegisterOutputType(IngressPtrOutput{})
 	pulumi.RegisterOutputType(IngressArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/ingressClass.go
+++ b/sdk/go/kubernetes/networking/v1/ingressClass.go
@@ -285,6 +285,10 @@ func (o IngressClassMapOutput) MapIndex(k pulumi.StringInput) IngressClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassInput)(nil)).Elem(), &IngressClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassPtrInput)(nil)).Elem(), &IngressClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassArrayInput)(nil)).Elem(), IngressClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassMapInput)(nil)).Elem(), IngressClassMap{})
 	pulumi.RegisterOutputType(IngressClassOutput{})
 	pulumi.RegisterOutputType(IngressClassPtrOutput{})
 	pulumi.RegisterOutputType(IngressClassArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/ingressClassList.go
+++ b/sdk/go/kubernetes/networking/v1/ingressClassList.go
@@ -283,6 +283,10 @@ func (o IngressClassListMapOutput) MapIndex(k pulumi.StringInput) IngressClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListInput)(nil)).Elem(), &IngressClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListPtrInput)(nil)).Elem(), &IngressClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListArrayInput)(nil)).Elem(), IngressClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListMapInput)(nil)).Elem(), IngressClassListMap{})
 	pulumi.RegisterOutputType(IngressClassListOutput{})
 	pulumi.RegisterOutputType(IngressClassListPtrOutput{})
 	pulumi.RegisterOutputType(IngressClassListArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/ingressList.go
+++ b/sdk/go/kubernetes/networking/v1/ingressList.go
@@ -283,6 +283,10 @@ func (o IngressListMapOutput) MapIndex(k pulumi.StringInput) IngressListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListPtrInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListArrayInput)(nil)).Elem(), IngressListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListMapInput)(nil)).Elem(), IngressListMap{})
 	pulumi.RegisterOutputType(IngressListOutput{})
 	pulumi.RegisterOutputType(IngressListPtrOutput{})
 	pulumi.RegisterOutputType(IngressListArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/networkPolicy.go
+++ b/sdk/go/kubernetes/networking/v1/networkPolicy.go
@@ -285,6 +285,10 @@ func (o NetworkPolicyMapOutput) MapIndex(k pulumi.StringInput) NetworkPolicyOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyInput)(nil)).Elem(), &NetworkPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyPtrInput)(nil)).Elem(), &NetworkPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyArrayInput)(nil)).Elem(), NetworkPolicyArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyMapInput)(nil)).Elem(), NetworkPolicyMap{})
 	pulumi.RegisterOutputType(NetworkPolicyOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyPtrOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1/networkPolicyList.go
+++ b/sdk/go/kubernetes/networking/v1/networkPolicyList.go
@@ -283,6 +283,10 @@ func (o NetworkPolicyListMapOutput) MapIndex(k pulumi.StringInput) NetworkPolicy
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListInput)(nil)).Elem(), &NetworkPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListPtrInput)(nil)).Elem(), &NetworkPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListArrayInput)(nil)).Elem(), NetworkPolicyListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NetworkPolicyListMapInput)(nil)).Elem(), NetworkPolicyListMap{})
 	pulumi.RegisterOutputType(NetworkPolicyListOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyListPtrOutput{})
 	pulumi.RegisterOutputType(NetworkPolicyListArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1beta1/ingress.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingress.go
@@ -304,6 +304,10 @@ func (o IngressMapOutput) MapIndex(k pulumi.StringInput) IngressOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressPtrInput)(nil)).Elem(), &Ingress{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressArrayInput)(nil)).Elem(), IngressArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressMapInput)(nil)).Elem(), IngressMap{})
 	pulumi.RegisterOutputType(IngressOutput{})
 	pulumi.RegisterOutputType(IngressPtrOutput{})
 	pulumi.RegisterOutputType(IngressArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1beta1/ingressClass.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressClass.go
@@ -285,6 +285,10 @@ func (o IngressClassMapOutput) MapIndex(k pulumi.StringInput) IngressClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassInput)(nil)).Elem(), &IngressClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassPtrInput)(nil)).Elem(), &IngressClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassArrayInput)(nil)).Elem(), IngressClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassMapInput)(nil)).Elem(), IngressClassMap{})
 	pulumi.RegisterOutputType(IngressClassOutput{})
 	pulumi.RegisterOutputType(IngressClassPtrOutput{})
 	pulumi.RegisterOutputType(IngressClassArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1beta1/ingressClassList.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressClassList.go
@@ -283,6 +283,10 @@ func (o IngressClassListMapOutput) MapIndex(k pulumi.StringInput) IngressClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListInput)(nil)).Elem(), &IngressClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListPtrInput)(nil)).Elem(), &IngressClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListArrayInput)(nil)).Elem(), IngressClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressClassListMapInput)(nil)).Elem(), IngressClassListMap{})
 	pulumi.RegisterOutputType(IngressClassListOutput{})
 	pulumi.RegisterOutputType(IngressClassListPtrOutput{})
 	pulumi.RegisterOutputType(IngressClassListArrayOutput{})

--- a/sdk/go/kubernetes/networking/v1beta1/ingressList.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressList.go
@@ -283,6 +283,10 @@ func (o IngressListMapOutput) MapIndex(k pulumi.StringInput) IngressListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListPtrInput)(nil)).Elem(), &IngressList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListArrayInput)(nil)).Elem(), IngressListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*IngressListMapInput)(nil)).Elem(), IngressListMap{})
 	pulumi.RegisterOutputType(IngressListOutput{})
 	pulumi.RegisterOutputType(IngressListPtrOutput{})
 	pulumi.RegisterOutputType(IngressListArrayOutput{})

--- a/sdk/go/kubernetes/node/v1/runtimeClass.go
+++ b/sdk/go/kubernetes/node/v1/runtimeClass.go
@@ -310,6 +310,10 @@ func (o RuntimeClassMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassPtrInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassArrayInput)(nil)).Elem(), RuntimeClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassMapInput)(nil)).Elem(), RuntimeClassMap{})
 	pulumi.RegisterOutputType(RuntimeClassOutput{})
 	pulumi.RegisterOutputType(RuntimeClassPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassArrayOutput{})

--- a/sdk/go/kubernetes/node/v1/runtimeClassList.go
+++ b/sdk/go/kubernetes/node/v1/runtimeClassList.go
@@ -283,6 +283,10 @@ func (o RuntimeClassListMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListPtrInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListArrayInput)(nil)).Elem(), RuntimeClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListMapInput)(nil)).Elem(), RuntimeClassListMap{})
 	pulumi.RegisterOutputType(RuntimeClassListOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListArrayOutput{})

--- a/sdk/go/kubernetes/node/v1alpha1/runtimeClass.go
+++ b/sdk/go/kubernetes/node/v1alpha1/runtimeClass.go
@@ -292,6 +292,10 @@ func (o RuntimeClassMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassPtrInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassArrayInput)(nil)).Elem(), RuntimeClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassMapInput)(nil)).Elem(), RuntimeClassMap{})
 	pulumi.RegisterOutputType(RuntimeClassOutput{})
 	pulumi.RegisterOutputType(RuntimeClassPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassArrayOutput{})

--- a/sdk/go/kubernetes/node/v1alpha1/runtimeClassList.go
+++ b/sdk/go/kubernetes/node/v1alpha1/runtimeClassList.go
@@ -283,6 +283,10 @@ func (o RuntimeClassListMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListPtrInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListArrayInput)(nil)).Elem(), RuntimeClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListMapInput)(nil)).Elem(), RuntimeClassListMap{})
 	pulumi.RegisterOutputType(RuntimeClassListOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListArrayOutput{})

--- a/sdk/go/kubernetes/node/v1beta1/runtimeClass.go
+++ b/sdk/go/kubernetes/node/v1beta1/runtimeClass.go
@@ -304,6 +304,10 @@ func (o RuntimeClassMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassPtrInput)(nil)).Elem(), &RuntimeClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassArrayInput)(nil)).Elem(), RuntimeClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassMapInput)(nil)).Elem(), RuntimeClassMap{})
 	pulumi.RegisterOutputType(RuntimeClassOutput{})
 	pulumi.RegisterOutputType(RuntimeClassPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassArrayOutput{})

--- a/sdk/go/kubernetes/node/v1beta1/runtimeClassList.go
+++ b/sdk/go/kubernetes/node/v1beta1/runtimeClassList.go
@@ -283,6 +283,10 @@ func (o RuntimeClassListMapOutput) MapIndex(k pulumi.StringInput) RuntimeClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListPtrInput)(nil)).Elem(), &RuntimeClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListArrayInput)(nil)).Elem(), RuntimeClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RuntimeClassListMapInput)(nil)).Elem(), RuntimeClassListMap{})
 	pulumi.RegisterOutputType(RuntimeClassListOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListPtrOutput{})
 	pulumi.RegisterOutputType(RuntimeClassListArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1/podDisruptionBudget.go
+++ b/sdk/go/kubernetes/policy/v1/podDisruptionBudget.go
@@ -287,6 +287,10 @@ func (o PodDisruptionBudgetMapOutput) MapIndex(k pulumi.StringInput) PodDisrupti
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetInput)(nil)).Elem(), &PodDisruptionBudget{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetPtrInput)(nil)).Elem(), &PodDisruptionBudget{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetArrayInput)(nil)).Elem(), PodDisruptionBudgetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetMapInput)(nil)).Elem(), PodDisruptionBudgetMap{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetPtrOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1/podDisruptionBudgetList.go
+++ b/sdk/go/kubernetes/policy/v1/podDisruptionBudgetList.go
@@ -283,6 +283,10 @@ func (o PodDisruptionBudgetListMapOutput) MapIndex(k pulumi.StringInput) PodDisr
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListInput)(nil)).Elem(), &PodDisruptionBudgetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListPtrInput)(nil)).Elem(), &PodDisruptionBudgetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListArrayInput)(nil)).Elem(), PodDisruptionBudgetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListMapInput)(nil)).Elem(), PodDisruptionBudgetListMap{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListPtrOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudget.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudget.go
@@ -287,6 +287,10 @@ func (o PodDisruptionBudgetMapOutput) MapIndex(k pulumi.StringInput) PodDisrupti
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetInput)(nil)).Elem(), &PodDisruptionBudget{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetPtrInput)(nil)).Elem(), &PodDisruptionBudget{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetArrayInput)(nil)).Elem(), PodDisruptionBudgetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetMapInput)(nil)).Elem(), PodDisruptionBudgetMap{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetPtrOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetList.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetList.go
@@ -283,6 +283,10 @@ func (o PodDisruptionBudgetListMapOutput) MapIndex(k pulumi.StringInput) PodDisr
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListInput)(nil)).Elem(), &PodDisruptionBudgetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListPtrInput)(nil)).Elem(), &PodDisruptionBudgetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListArrayInput)(nil)).Elem(), PodDisruptionBudgetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodDisruptionBudgetListMapInput)(nil)).Elem(), PodDisruptionBudgetListMap{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListPtrOutput{})
 	pulumi.RegisterOutputType(PodDisruptionBudgetListArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicy.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicy.go
@@ -285,6 +285,10 @@ func (o PodSecurityPolicyMapOutput) MapIndex(k pulumi.StringInput) PodSecurityPo
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyInput)(nil)).Elem(), &PodSecurityPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyPtrInput)(nil)).Elem(), &PodSecurityPolicy{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyArrayInput)(nil)).Elem(), PodSecurityPolicyArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyMapInput)(nil)).Elem(), PodSecurityPolicyMap{})
 	pulumi.RegisterOutputType(PodSecurityPolicyOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyPtrOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyArrayOutput{})

--- a/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyList.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyList.go
@@ -283,6 +283,10 @@ func (o PodSecurityPolicyListMapOutput) MapIndex(k pulumi.StringInput) PodSecuri
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListInput)(nil)).Elem(), &PodSecurityPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListPtrInput)(nil)).Elem(), &PodSecurityPolicyList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListArrayInput)(nil)).Elem(), PodSecurityPolicyListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodSecurityPolicyListMapInput)(nil)).Elem(), PodSecurityPolicyListMap{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListPtrOutput{})
 	pulumi.RegisterOutputType(PodSecurityPolicyListArrayOutput{})

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -216,6 +216,8 @@ func (o ProviderPtrOutput) Elem() ProviderOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
 	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/sdk/go/kubernetes/providers/provider.go
+++ b/sdk/go/kubernetes/providers/provider.go
@@ -244,6 +244,8 @@ func (o ProviderPtrOutput) Elem() ProviderOutput {
 
 // Deprecated: Use `github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes` instead
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
 	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/sdk/go/kubernetes/rbac/v1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRole.go
@@ -294,6 +294,10 @@ func (o ClusterRoleMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRolePtrInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleArrayInput)(nil)).Elem(), ClusterRoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleMapInput)(nil)).Elem(), ClusterRoleMap{})
 	pulumi.RegisterOutputType(ClusterRoleOutput{})
 	pulumi.RegisterOutputType(ClusterRolePtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleBinding.go
@@ -298,6 +298,10 @@ func (o ClusterRoleBindingMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleB
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingPtrInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingArrayInput)(nil)).Elem(), ClusterRoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingMapInput)(nil)).Elem(), ClusterRoleBindingMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleBindingList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleBindingListMapOutput) MapIndex(k pulumi.StringInput) ClusterR
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListPtrInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListArrayInput)(nil)).Elem(), ClusterRoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListMapInput)(nil)).Elem(), ClusterRoleBindingListMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleListMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListPtrInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListArrayInput)(nil)).Elem(), ClusterRoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListMapInput)(nil)).Elem(), ClusterRoleListMap{})
 	pulumi.RegisterOutputType(ClusterRoleListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/role.go
+++ b/sdk/go/kubernetes/rbac/v1/role.go
@@ -288,6 +288,10 @@ func (o RoleMapOutput) MapIndex(k pulumi.StringInput) RoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RolePtrInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleArrayInput)(nil)).Elem(), RoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleMapInput)(nil)).Elem(), RoleMap{})
 	pulumi.RegisterOutputType(RoleOutput{})
 	pulumi.RegisterOutputType(RolePtrOutput{})
 	pulumi.RegisterOutputType(RoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1/roleBinding.go
@@ -298,6 +298,10 @@ func (o RoleBindingMapOutput) MapIndex(k pulumi.StringInput) RoleBindingOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingPtrInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingArrayInput)(nil)).Elem(), RoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingMapInput)(nil)).Elem(), RoleBindingMap{})
 	pulumi.RegisterOutputType(RoleBindingOutput{})
 	pulumi.RegisterOutputType(RoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1/roleBindingList.go
@@ -283,6 +283,10 @@ func (o RoleBindingListMapOutput) MapIndex(k pulumi.StringInput) RoleBindingList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListPtrInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListArrayInput)(nil)).Elem(), RoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListMapInput)(nil)).Elem(), RoleBindingListMap{})
 	pulumi.RegisterOutputType(RoleBindingListOutput{})
 	pulumi.RegisterOutputType(RoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1/roleList.go
@@ -283,6 +283,10 @@ func (o RoleListMapOutput) MapIndex(k pulumi.StringInput) RoleListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListPtrInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListArrayInput)(nil)).Elem(), RoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListMapInput)(nil)).Elem(), RoleListMap{})
 	pulumi.RegisterOutputType(RoleListOutput{})
 	pulumi.RegisterOutputType(RoleListPtrOutput{})
 	pulumi.RegisterOutputType(RoleListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRole.go
@@ -294,6 +294,10 @@ func (o ClusterRoleMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRolePtrInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleArrayInput)(nil)).Elem(), ClusterRoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleMapInput)(nil)).Elem(), ClusterRoleMap{})
 	pulumi.RegisterOutputType(ClusterRoleOutput{})
 	pulumi.RegisterOutputType(ClusterRolePtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBinding.go
@@ -298,6 +298,10 @@ func (o ClusterRoleBindingMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleB
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingPtrInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingArrayInput)(nil)).Elem(), ClusterRoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingMapInput)(nil)).Elem(), ClusterRoleBindingMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleBindingListMapOutput) MapIndex(k pulumi.StringInput) ClusterR
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListPtrInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListArrayInput)(nil)).Elem(), ClusterRoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListMapInput)(nil)).Elem(), ClusterRoleBindingListMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleListMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListPtrInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListArrayInput)(nil)).Elem(), ClusterRoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListMapInput)(nil)).Elem(), ClusterRoleListMap{})
 	pulumi.RegisterOutputType(ClusterRoleListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/role.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/role.go
@@ -288,6 +288,10 @@ func (o RoleMapOutput) MapIndex(k pulumi.StringInput) RoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RolePtrInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleArrayInput)(nil)).Elem(), RoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleMapInput)(nil)).Elem(), RoleMap{})
 	pulumi.RegisterOutputType(RoleOutput{})
 	pulumi.RegisterOutputType(RolePtrOutput{})
 	pulumi.RegisterOutputType(RoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleBinding.go
@@ -298,6 +298,10 @@ func (o RoleBindingMapOutput) MapIndex(k pulumi.StringInput) RoleBindingOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingPtrInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingArrayInput)(nil)).Elem(), RoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingMapInput)(nil)).Elem(), RoleBindingMap{})
 	pulumi.RegisterOutputType(RoleBindingOutput{})
 	pulumi.RegisterOutputType(RoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleBindingList.go
@@ -283,6 +283,10 @@ func (o RoleBindingListMapOutput) MapIndex(k pulumi.StringInput) RoleBindingList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListPtrInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListArrayInput)(nil)).Elem(), RoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListMapInput)(nil)).Elem(), RoleBindingListMap{})
 	pulumi.RegisterOutputType(RoleBindingListOutput{})
 	pulumi.RegisterOutputType(RoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleList.go
@@ -283,6 +283,10 @@ func (o RoleListMapOutput) MapIndex(k pulumi.StringInput) RoleListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListPtrInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListArrayInput)(nil)).Elem(), RoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListMapInput)(nil)).Elem(), RoleListMap{})
 	pulumi.RegisterOutputType(RoleListOutput{})
 	pulumi.RegisterOutputType(RoleListPtrOutput{})
 	pulumi.RegisterOutputType(RoleListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRole.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRole.go
@@ -294,6 +294,10 @@ func (o ClusterRoleMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRolePtrInput)(nil)).Elem(), &ClusterRole{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleArrayInput)(nil)).Elem(), ClusterRoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleMapInput)(nil)).Elem(), ClusterRoleMap{})
 	pulumi.RegisterOutputType(ClusterRoleOutput{})
 	pulumi.RegisterOutputType(ClusterRolePtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBinding.go
@@ -298,6 +298,10 @@ func (o ClusterRoleBindingMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleB
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingPtrInput)(nil)).Elem(), &ClusterRoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingArrayInput)(nil)).Elem(), ClusterRoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingMapInput)(nil)).Elem(), ClusterRoleBindingMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleBindingListMapOutput) MapIndex(k pulumi.StringInput) ClusterR
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListPtrInput)(nil)).Elem(), &ClusterRoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListArrayInput)(nil)).Elem(), ClusterRoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleBindingListMapInput)(nil)).Elem(), ClusterRoleBindingListMap{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleList.go
@@ -283,6 +283,10 @@ func (o ClusterRoleListMapOutput) MapIndex(k pulumi.StringInput) ClusterRoleList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListPtrInput)(nil)).Elem(), &ClusterRoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListArrayInput)(nil)).Elem(), ClusterRoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ClusterRoleListMapInput)(nil)).Elem(), ClusterRoleListMap{})
 	pulumi.RegisterOutputType(ClusterRoleListOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListPtrOutput{})
 	pulumi.RegisterOutputType(ClusterRoleListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/role.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/role.go
@@ -288,6 +288,10 @@ func (o RoleMapOutput) MapIndex(k pulumi.StringInput) RoleOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RolePtrInput)(nil)).Elem(), &Role{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleArrayInput)(nil)).Elem(), RoleArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleMapInput)(nil)).Elem(), RoleMap{})
 	pulumi.RegisterOutputType(RoleOutput{})
 	pulumi.RegisterOutputType(RolePtrOutput{})
 	pulumi.RegisterOutputType(RoleArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/roleBinding.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleBinding.go
@@ -298,6 +298,10 @@ func (o RoleBindingMapOutput) MapIndex(k pulumi.StringInput) RoleBindingOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingPtrInput)(nil)).Elem(), &RoleBinding{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingArrayInput)(nil)).Elem(), RoleBindingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingMapInput)(nil)).Elem(), RoleBindingMap{})
 	pulumi.RegisterOutputType(RoleBindingOutput{})
 	pulumi.RegisterOutputType(RoleBindingPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/roleBindingList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleBindingList.go
@@ -283,6 +283,10 @@ func (o RoleBindingListMapOutput) MapIndex(k pulumi.StringInput) RoleBindingList
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListPtrInput)(nil)).Elem(), &RoleBindingList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListArrayInput)(nil)).Elem(), RoleBindingListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleBindingListMapInput)(nil)).Elem(), RoleBindingListMap{})
 	pulumi.RegisterOutputType(RoleBindingListOutput{})
 	pulumi.RegisterOutputType(RoleBindingListPtrOutput{})
 	pulumi.RegisterOutputType(RoleBindingListArrayOutput{})

--- a/sdk/go/kubernetes/rbac/v1beta1/roleList.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleList.go
@@ -283,6 +283,10 @@ func (o RoleListMapOutput) MapIndex(k pulumi.StringInput) RoleListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListPtrInput)(nil)).Elem(), &RoleList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListArrayInput)(nil)).Elem(), RoleListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleListMapInput)(nil)).Elem(), RoleListMap{})
 	pulumi.RegisterOutputType(RoleListOutput{})
 	pulumi.RegisterOutputType(RoleListPtrOutput{})
 	pulumi.RegisterOutputType(RoleListArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1/priorityClass.go
@@ -310,6 +310,10 @@ func (o PriorityClassMapOutput) MapIndex(k pulumi.StringInput) PriorityClassOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassPtrInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassArrayInput)(nil)).Elem(), PriorityClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassMapInput)(nil)).Elem(), PriorityClassMap{})
 	pulumi.RegisterOutputType(PriorityClassOutput{})
 	pulumi.RegisterOutputType(PriorityClassPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1/priorityClassList.go
@@ -283,6 +283,10 @@ func (o PriorityClassListMapOutput) MapIndex(k pulumi.StringInput) PriorityClass
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListPtrInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListArrayInput)(nil)).Elem(), PriorityClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListMapInput)(nil)).Elem(), PriorityClassListMap{})
 	pulumi.RegisterOutputType(PriorityClassListOutput{})
 	pulumi.RegisterOutputType(PriorityClassListPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassListArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1alpha1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/priorityClass.go
@@ -310,6 +310,10 @@ func (o PriorityClassMapOutput) MapIndex(k pulumi.StringInput) PriorityClassOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassPtrInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassArrayInput)(nil)).Elem(), PriorityClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassMapInput)(nil)).Elem(), PriorityClassMap{})
 	pulumi.RegisterOutputType(PriorityClassOutput{})
 	pulumi.RegisterOutputType(PriorityClassPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassList.go
@@ -283,6 +283,10 @@ func (o PriorityClassListMapOutput) MapIndex(k pulumi.StringInput) PriorityClass
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListPtrInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListArrayInput)(nil)).Elem(), PriorityClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListMapInput)(nil)).Elem(), PriorityClassListMap{})
 	pulumi.RegisterOutputType(PriorityClassListOutput{})
 	pulumi.RegisterOutputType(PriorityClassListPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassListArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1beta1/priorityClass.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/priorityClass.go
@@ -310,6 +310,10 @@ func (o PriorityClassMapOutput) MapIndex(k pulumi.StringInput) PriorityClassOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassPtrInput)(nil)).Elem(), &PriorityClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassArrayInput)(nil)).Elem(), PriorityClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassMapInput)(nil)).Elem(), PriorityClassMap{})
 	pulumi.RegisterOutputType(PriorityClassOutput{})
 	pulumi.RegisterOutputType(PriorityClassPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassArrayOutput{})

--- a/sdk/go/kubernetes/scheduling/v1beta1/priorityClassList.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/priorityClassList.go
@@ -283,6 +283,10 @@ func (o PriorityClassListMapOutput) MapIndex(k pulumi.StringInput) PriorityClass
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListPtrInput)(nil)).Elem(), &PriorityClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListArrayInput)(nil)).Elem(), PriorityClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PriorityClassListMapInput)(nil)).Elem(), PriorityClassListMap{})
 	pulumi.RegisterOutputType(PriorityClassListOutput{})
 	pulumi.RegisterOutputType(PriorityClassListPtrOutput{})
 	pulumi.RegisterOutputType(PriorityClassListArrayOutput{})

--- a/sdk/go/kubernetes/settings/v1alpha1/podPreset.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/podPreset.go
@@ -273,6 +273,10 @@ func (o PodPresetMapOutput) MapIndex(k pulumi.StringInput) PodPresetOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetInput)(nil)).Elem(), &PodPreset{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetPtrInput)(nil)).Elem(), &PodPreset{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetArrayInput)(nil)).Elem(), PodPresetArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetMapInput)(nil)).Elem(), PodPresetMap{})
 	pulumi.RegisterOutputType(PodPresetOutput{})
 	pulumi.RegisterOutputType(PodPresetPtrOutput{})
 	pulumi.RegisterOutputType(PodPresetArrayOutput{})

--- a/sdk/go/kubernetes/settings/v1alpha1/podPresetList.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/podPresetList.go
@@ -283,6 +283,10 @@ func (o PodPresetListMapOutput) MapIndex(k pulumi.StringInput) PodPresetListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetListInput)(nil)).Elem(), &PodPresetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetListPtrInput)(nil)).Elem(), &PodPresetList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetListArrayInput)(nil)).Elem(), PodPresetListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PodPresetListMapInput)(nil)).Elem(), PodPresetListMap{})
 	pulumi.RegisterOutputType(PodPresetListOutput{})
 	pulumi.RegisterOutputType(PodPresetListPtrOutput{})
 	pulumi.RegisterOutputType(PodPresetListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/csidriver.go
+++ b/sdk/go/kubernetes/storage/v1/csidriver.go
@@ -289,6 +289,10 @@ func (o CSIDriverMapOutput) MapIndex(k pulumi.StringInput) CSIDriverOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverInput)(nil)).Elem(), &CSIDriver{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverPtrInput)(nil)).Elem(), &CSIDriver{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverArrayInput)(nil)).Elem(), CSIDriverArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverMapInput)(nil)).Elem(), CSIDriverMap{})
 	pulumi.RegisterOutputType(CSIDriverOutput{})
 	pulumi.RegisterOutputType(CSIDriverPtrOutput{})
 	pulumi.RegisterOutputType(CSIDriverArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/csidriverList.go
+++ b/sdk/go/kubernetes/storage/v1/csidriverList.go
@@ -283,6 +283,10 @@ func (o CSIDriverListMapOutput) MapIndex(k pulumi.StringInput) CSIDriverListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListInput)(nil)).Elem(), &CSIDriverList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListPtrInput)(nil)).Elem(), &CSIDriverList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListArrayInput)(nil)).Elem(), CSIDriverListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListMapInput)(nil)).Elem(), CSIDriverListMap{})
 	pulumi.RegisterOutputType(CSIDriverListOutput{})
 	pulumi.RegisterOutputType(CSIDriverListPtrOutput{})
 	pulumi.RegisterOutputType(CSIDriverListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/csinode.go
+++ b/sdk/go/kubernetes/storage/v1/csinode.go
@@ -289,6 +289,10 @@ func (o CSINodeMapOutput) MapIndex(k pulumi.StringInput) CSINodeOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeInput)(nil)).Elem(), &CSINode{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodePtrInput)(nil)).Elem(), &CSINode{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeArrayInput)(nil)).Elem(), CSINodeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeMapInput)(nil)).Elem(), CSINodeMap{})
 	pulumi.RegisterOutputType(CSINodeOutput{})
 	pulumi.RegisterOutputType(CSINodePtrOutput{})
 	pulumi.RegisterOutputType(CSINodeArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/csinodeList.go
+++ b/sdk/go/kubernetes/storage/v1/csinodeList.go
@@ -283,6 +283,10 @@ func (o CSINodeListMapOutput) MapIndex(k pulumi.StringInput) CSINodeListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListInput)(nil)).Elem(), &CSINodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListPtrInput)(nil)).Elem(), &CSINodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListArrayInput)(nil)).Elem(), CSINodeListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListMapInput)(nil)).Elem(), CSINodeListMap{})
 	pulumi.RegisterOutputType(CSINodeListOutput{})
 	pulumi.RegisterOutputType(CSINodeListPtrOutput{})
 	pulumi.RegisterOutputType(CSINodeListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/storageClass.go
+++ b/sdk/go/kubernetes/storage/v1/storageClass.go
@@ -328,6 +328,10 @@ func (o StorageClassMapOutput) MapIndex(k pulumi.StringInput) StorageClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassInput)(nil)).Elem(), &StorageClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassPtrInput)(nil)).Elem(), &StorageClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassArrayInput)(nil)).Elem(), StorageClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassMapInput)(nil)).Elem(), StorageClassMap{})
 	pulumi.RegisterOutputType(StorageClassOutput{})
 	pulumi.RegisterOutputType(StorageClassPtrOutput{})
 	pulumi.RegisterOutputType(StorageClassArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/storageClassList.go
+++ b/sdk/go/kubernetes/storage/v1/storageClassList.go
@@ -283,6 +283,10 @@ func (o StorageClassListMapOutput) MapIndex(k pulumi.StringInput) StorageClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListInput)(nil)).Elem(), &StorageClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListPtrInput)(nil)).Elem(), &StorageClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListArrayInput)(nil)).Elem(), StorageClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListMapInput)(nil)).Elem(), StorageClassListMap{})
 	pulumi.RegisterOutputType(StorageClassListOutput{})
 	pulumi.RegisterOutputType(StorageClassListPtrOutput{})
 	pulumi.RegisterOutputType(StorageClassListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1/volumeAttachment.go
@@ -296,6 +296,10 @@ func (o VolumeAttachmentMapOutput) MapIndex(k pulumi.StringInput) VolumeAttachme
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentPtrInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentArrayInput)(nil)).Elem(), VolumeAttachmentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentMapInput)(nil)).Elem(), VolumeAttachmentMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1/volumeAttachmentList.go
@@ -283,6 +283,10 @@ func (o VolumeAttachmentListMapOutput) MapIndex(k pulumi.StringInput) VolumeAtta
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListPtrInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListArrayInput)(nil)).Elem(), VolumeAttachmentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListMapInput)(nil)).Elem(), VolumeAttachmentListMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentListOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1alpha1/csistorageCapacity.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/csistorageCapacity.go
@@ -339,6 +339,10 @@ func (o CSIStorageCapacityMapOutput) MapIndex(k pulumi.StringInput) CSIStorageCa
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityInput)(nil)).Elem(), &CSIStorageCapacity{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityPtrInput)(nil)).Elem(), &CSIStorageCapacity{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityArrayInput)(nil)).Elem(), CSIStorageCapacityArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityMapInput)(nil)).Elem(), CSIStorageCapacityMap{})
 	pulumi.RegisterOutputType(CSIStorageCapacityOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityPtrOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1alpha1/csistorageCapacityList.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/csistorageCapacityList.go
@@ -283,6 +283,10 @@ func (o CSIStorageCapacityListMapOutput) MapIndex(k pulumi.StringInput) CSIStora
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListInput)(nil)).Elem(), &CSIStorageCapacityList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListPtrInput)(nil)).Elem(), &CSIStorageCapacityList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListArrayInput)(nil)).Elem(), CSIStorageCapacityListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListMapInput)(nil)).Elem(), CSIStorageCapacityListMap{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListPtrOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1alpha1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/volumeAttachment.go
@@ -296,6 +296,10 @@ func (o VolumeAttachmentMapOutput) MapIndex(k pulumi.StringInput) VolumeAttachme
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentPtrInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentArrayInput)(nil)).Elem(), VolumeAttachmentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentMapInput)(nil)).Elem(), VolumeAttachmentMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentList.go
@@ -283,6 +283,10 @@ func (o VolumeAttachmentListMapOutput) MapIndex(k pulumi.StringInput) VolumeAtta
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListPtrInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListArrayInput)(nil)).Elem(), VolumeAttachmentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListMapInput)(nil)).Elem(), VolumeAttachmentListMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentListOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csidriver.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csidriver.go
@@ -289,6 +289,10 @@ func (o CSIDriverMapOutput) MapIndex(k pulumi.StringInput) CSIDriverOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverInput)(nil)).Elem(), &CSIDriver{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverPtrInput)(nil)).Elem(), &CSIDriver{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverArrayInput)(nil)).Elem(), CSIDriverArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverMapInput)(nil)).Elem(), CSIDriverMap{})
 	pulumi.RegisterOutputType(CSIDriverOutput{})
 	pulumi.RegisterOutputType(CSIDriverPtrOutput{})
 	pulumi.RegisterOutputType(CSIDriverArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csidriverList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csidriverList.go
@@ -283,6 +283,10 @@ func (o CSIDriverListMapOutput) MapIndex(k pulumi.StringInput) CSIDriverListOutp
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListInput)(nil)).Elem(), &CSIDriverList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListPtrInput)(nil)).Elem(), &CSIDriverList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListArrayInput)(nil)).Elem(), CSIDriverListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIDriverListMapInput)(nil)).Elem(), CSIDriverListMap{})
 	pulumi.RegisterOutputType(CSIDriverListOutput{})
 	pulumi.RegisterOutputType(CSIDriverListPtrOutput{})
 	pulumi.RegisterOutputType(CSIDriverListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csinode.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csinode.go
@@ -291,6 +291,10 @@ func (o CSINodeMapOutput) MapIndex(k pulumi.StringInput) CSINodeOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeInput)(nil)).Elem(), &CSINode{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodePtrInput)(nil)).Elem(), &CSINode{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeArrayInput)(nil)).Elem(), CSINodeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeMapInput)(nil)).Elem(), CSINodeMap{})
 	pulumi.RegisterOutputType(CSINodeOutput{})
 	pulumi.RegisterOutputType(CSINodePtrOutput{})
 	pulumi.RegisterOutputType(CSINodeArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csinodeList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csinodeList.go
@@ -283,6 +283,10 @@ func (o CSINodeListMapOutput) MapIndex(k pulumi.StringInput) CSINodeListOutput {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListInput)(nil)).Elem(), &CSINodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListPtrInput)(nil)).Elem(), &CSINodeList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListArrayInput)(nil)).Elem(), CSINodeListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSINodeListMapInput)(nil)).Elem(), CSINodeListMap{})
 	pulumi.RegisterOutputType(CSINodeListOutput{})
 	pulumi.RegisterOutputType(CSINodeListPtrOutput{})
 	pulumi.RegisterOutputType(CSINodeListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csistorageCapacity.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csistorageCapacity.go
@@ -339,6 +339,10 @@ func (o CSIStorageCapacityMapOutput) MapIndex(k pulumi.StringInput) CSIStorageCa
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityInput)(nil)).Elem(), &CSIStorageCapacity{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityPtrInput)(nil)).Elem(), &CSIStorageCapacity{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityArrayInput)(nil)).Elem(), CSIStorageCapacityArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityMapInput)(nil)).Elem(), CSIStorageCapacityMap{})
 	pulumi.RegisterOutputType(CSIStorageCapacityOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityPtrOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/csistorageCapacityList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csistorageCapacityList.go
@@ -283,6 +283,10 @@ func (o CSIStorageCapacityListMapOutput) MapIndex(k pulumi.StringInput) CSIStora
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListInput)(nil)).Elem(), &CSIStorageCapacityList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListPtrInput)(nil)).Elem(), &CSIStorageCapacityList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListArrayInput)(nil)).Elem(), CSIStorageCapacityListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CSIStorageCapacityListMapInput)(nil)).Elem(), CSIStorageCapacityListMap{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListPtrOutput{})
 	pulumi.RegisterOutputType(CSIStorageCapacityListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/storageClass.go
+++ b/sdk/go/kubernetes/storage/v1beta1/storageClass.go
@@ -328,6 +328,10 @@ func (o StorageClassMapOutput) MapIndex(k pulumi.StringInput) StorageClassOutput
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassInput)(nil)).Elem(), &StorageClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassPtrInput)(nil)).Elem(), &StorageClass{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassArrayInput)(nil)).Elem(), StorageClassArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassMapInput)(nil)).Elem(), StorageClassMap{})
 	pulumi.RegisterOutputType(StorageClassOutput{})
 	pulumi.RegisterOutputType(StorageClassPtrOutput{})
 	pulumi.RegisterOutputType(StorageClassArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/storageClassList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/storageClassList.go
@@ -283,6 +283,10 @@ func (o StorageClassListMapOutput) MapIndex(k pulumi.StringInput) StorageClassLi
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListInput)(nil)).Elem(), &StorageClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListPtrInput)(nil)).Elem(), &StorageClassList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListArrayInput)(nil)).Elem(), StorageClassListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*StorageClassListMapInput)(nil)).Elem(), StorageClassListMap{})
 	pulumi.RegisterOutputType(StorageClassListOutput{})
 	pulumi.RegisterOutputType(StorageClassListPtrOutput{})
 	pulumi.RegisterOutputType(StorageClassListArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/volumeAttachment.go
+++ b/sdk/go/kubernetes/storage/v1beta1/volumeAttachment.go
@@ -296,6 +296,10 @@ func (o VolumeAttachmentMapOutput) MapIndex(k pulumi.StringInput) VolumeAttachme
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentPtrInput)(nil)).Elem(), &VolumeAttachment{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentArrayInput)(nil)).Elem(), VolumeAttachmentArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentMapInput)(nil)).Elem(), VolumeAttachmentMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentArrayOutput{})

--- a/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentList.go
+++ b/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentList.go
@@ -283,6 +283,10 @@ func (o VolumeAttachmentListMapOutput) MapIndex(k pulumi.StringInput) VolumeAtta
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListPtrInput)(nil)).Elem(), &VolumeAttachmentList{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListArrayInput)(nil)).Elem(), VolumeAttachmentListArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*VolumeAttachmentListMapInput)(nil)).Elem(), VolumeAttachmentListMap{})
 	pulumi.RegisterOutputType(VolumeAttachmentListOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListPtrOutput{})
 	pulumi.RegisterOutputType(VolumeAttachmentListArrayOutput{})

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -3,7 +3,9 @@
     "version": "${VERSION}",
     "keywords": [
         "pulumi",
-        "kubernetes"
+        "kubernetes",
+        "category/cloud",
+        "kind/native"
     ],
     "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-kubernetes",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -45,7 +45,7 @@ setup(name='pulumi_kubernetes',
       cmdclass={
           'install': InstallPluginCommand,
       },
-      keywords='pulumi kubernetes',
+      keywords='pulumi kubernetes category/cloud kind/native',
       url='https://pulumi.com',
       project_urls={
           'Repository': 'https://github.com/pulumi/pulumi-kubernetes'

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	github.com/pulumi/pulumi-kubernetes/provider/v3 v3.0.0-rc.1
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.0.0-rc.1
-	github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b
-	github.com/pulumi/pulumi/sdk/v3 v3.14.0
+	github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424
+	github.com/pulumi/pulumi/sdk/v3 v3.16.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -967,11 +967,11 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b h1:3ZM4P/K+2lsvNLq/cHxpVdjcC4iTn0xgY5vUITdy2nY=
-github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b/go.mod h1:0w8C+JDP+OuihIgj/TNljRJdNHyW1vNiH1zzbeB4xeM=
+github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424 h1:MB7LHWmVlMx5XRqOg2Vm9TXfY99VFqhg9I6lZpe+TMw=
+github.com/pulumi/pulumi/pkg/v3 v3.16.1-0.20211027195309-9a78ca1ca424/go.mod h1:jiNNl7RjXQSqkfVA2EJrfwoDVWhuDPVFjOqJ8q+CquA=
 github.com/pulumi/pulumi/sdk/v3 v3.13.2/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
-github.com/pulumi/pulumi/sdk/v3 v3.14.0 h1:UXLRHGQCsO1tLWdv4IO3IQOXrUoZUHhDtDXFoGMmAtA=
-github.com/pulumi/pulumi/sdk/v3 v3.14.0/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
+github.com/pulumi/pulumi/sdk/v3 v3.16.0 h1:yqGysCf1LqlkengBnYqcbl5JI6JGySPN67+g60dMieU=
+github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
### Proposed changes

As the title states, I'd like to set the display name, publisher and some tags for this package that will be reflected in the Pulumi Registry. To do this, I pulled in the `pulumi/pulumi/pkg` dep at commit hash [`9a78ca1ca424e50083d136200ca831ff3433554d`](https://github.com/pulumi/pulumi/commit/9a78ca1ca424e50083d136200ca831ff3433554d). Let me know if you want to avoid the update to `pulumi/pulumi/pkg` due to any codegen changes you are aware of that this package is not ready to take in? 

### Related issues (optional)

N/A
