### PR TITLE
Update CustomResource python implementation to pickup snake-case updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [sdk/python] Add ready attribute to await Helm charts (https://github.com/pulumi/pulumi-kubernetes/pull/1782)
 - [sdk/go] Add ready attribute to await Helm charts (https://github.com/pulumi/pulumi-kubernetes/pull/1784)
 - [sdk/dotnet] Add ready attribute to await Helm charts (https://github.com/pulumi/pulumi-kubernetes/pull/1785)
+- [sdk/python] Update CustomResource python implementation to pickup snake-case updates (https://github.com/pulumi/pulumi-kubernetes/pull/1786)
 
 ## 3.8.3 (October 29, 2021)
 

--- a/provider/pkg/gen/python-templates/apiextensions/CustomResource.py
+++ b/provider/pkg/gen/python-templates/apiextensions/CustomResource.py
@@ -18,7 +18,6 @@ class CustomResourceArgs:
     def __init__(__self__, *,
                  api_version: pulumi.Input[str],
                  kind: pulumi.Input[str],
-                 compat: Optional[pulumi.Input[str]] = None,
                  metadata: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']] = None,
                  spec: Optional[Any] = None):
         """
@@ -30,8 +29,6 @@ class CustomResourceArgs:
         """
         pulumi.set(__self__, "api_version", api_version)
         pulumi.set(__self__, "kind", kind)
-        if compat is not None:
-            pulumi.set(__self__, "compat", 'true')
         if metadata is not None:
             pulumi.set(__self__, "metadata", metadata)
         if spec is not None:
@@ -60,15 +57,6 @@ class CustomResourceArgs:
     @kind.setter
     def kind(self, value: pulumi.Input[str]):
         pulumi.set(self, "kind", value)
-
-    @property
-    @pulumi.getter
-    def compat(self) -> Optional[pulumi.Input[str]]:
-        return pulumi.get(self, "compat")
-
-    @compat.setter
-    def compat(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "compat", value)
 
     @property
     @pulumi.getter
@@ -132,7 +120,6 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing resource name argument (for URN creation)')
         if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-#         resource_args, opts = _utilities.get_resource_args_opts(CustomResourceArgs, pulumi.ResourceOptions, *args, **kwargs)
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(version=_utilities.get_version()))
         self._internal_init(resource_name, api_version=api_version, kind=kind, opts=opts, metadata=metadata, spec=spec)
 

--- a/provider/pkg/gen/python-templates/apiextensions/CustomResource.py
+++ b/provider/pkg/gen/python-templates/apiextensions/CustomResource.py
@@ -9,8 +9,90 @@ import pulumi.runtime
 from pulumi import ResourceOptions
 
 from .. import meta as _meta
-from .. import _utilities, _tables
+from .. import _utilities
 
+__all__ = ['CustomResourceArgs', 'CustomResource']
+
+@pulumi.input_type
+class CustomResourceArgs:
+    def __init__(__self__, *,
+                 api_version: pulumi.Input[str],
+                 kind: pulumi.Input[str],
+                 compat: Optional[pulumi.Input[str]] = None,
+                 metadata: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']] = None,
+                 spec: Optional[Any] = None):
+        """
+        The set of arguments for constructing a CustomResource resource.
+        :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input['_meta.v1.ObjectMetaArgs'] metadata: Standard object metadata.
+        :param Any spec: Specification of the CustomResource.
+        """
+        pulumi.set(__self__, "api_version", api_version)
+        pulumi.set(__self__, "kind", kind)
+        if compat is not None:
+            pulumi.set(__self__, "compat", 'true')
+        if metadata is not None:
+            pulumi.set(__self__, "metadata", metadata)
+        if spec is not None:
+            pulumi.set(__self__, "spec", spec)
+
+    @property
+    @pulumi.getter(name="apiVersion")
+    def api_version(self) -> pulumi.Input[str]:
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        return pulumi.get(self, "api_version")
+
+    @api_version.setter
+    def api_version(self, value: pulumi.Input[str]):
+        pulumi.set(self, "api_version", value)
+
+    @property
+    @pulumi.getter
+    def kind(self) -> pulumi.Input[str]:
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        return pulumi.get(self, "kind")
+
+    @kind.setter
+    def kind(self, value: pulumi.Input[str]):
+        pulumi.set(self, "kind", value)
+
+    @property
+    @pulumi.getter
+    def compat(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "compat")
+
+    @compat.setter
+    def compat(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "compat", value)
+
+    @property
+    @pulumi.getter
+    def metadata(self) -> Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]:
+        """
+        Standard object metadata.
+        """
+        return pulumi.get(self, "metadata")
+
+    @metadata.setter
+    def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
+        pulumi.set(self, "metadata", value)
+
+    @property
+    @pulumi.getter
+    def spec(self) -> Optional[Any]:
+        """
+        Specification of the CustomResource.
+        """
+        return pulumi.get(self, "spec")
+
+    @spec.setter
+    def spec(self, value: Optional[Any]):
+        pulumi.set(self, "spec", value)
 
 class CustomResource(pulumi.CustomResource):
     def __init__(self,
@@ -50,19 +132,38 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing resource name argument (for URN creation)')
         if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if opts and not isinstance(opts, pulumi.ResourceOptions):
-            raise TypeError('Expected resource options to be a ResourceOptions instance')
-
-        __props__ = dict()
-
-        __props__['apiVersion'] = api_version
-        __props__['kind'] = kind
-        __props__['spec'] = spec
-        __props__['metadata'] = metadata
-
+#         resource_args, opts = _utilities.get_resource_args_opts(CustomResourceArgs, pulumi.ResourceOptions, *args, **kwargs)
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(version=_utilities.get_version()))
+        self._internal_init(resource_name, api_version=api_version, kind=kind, opts=opts, metadata=metadata, spec=spec)
 
-        super(CustomResource, self).__init__(
+    def _internal_init(__self__,
+                 resource_name: str,
+                 api_version: str,
+                 kind: str,
+                 opts: Optional[pulumi.ResourceOptions] = None,
+                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 spec: Optional[Any] = None,
+                 __props__=None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+        if not isinstance(opts, pulumi.ResourceOptions):
+            raise TypeError('Expected resource options to be a ResourceOptions instance')
+        if opts.version is None:
+            opts.version = _utilities.get_version()
+        if opts.id is None:
+            if __props__ is not None:
+                raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
+            __props__ = CustomResourceArgs.__new__(CustomResourceArgs)
+
+            if api_version is None and not opts.urn:
+                raise TypeError("Missing required property 'api_version'")
+            __props__.__dict__["api_version"] = api_version
+            if kind is None and not opts.urn:
+                raise TypeError("Missing required property 'kind'")
+            __props__.__dict__["kind"] = kind
+            __props__.__dict__["metadata"] = metadata
+            __props__.__dict__["spec"] = spec
+        super(CustomResource, __self__).__init__(
             f"kubernetes:{api_version}:{kind}",
             resource_name,
             __props__,
@@ -95,9 +196,3 @@ class CustomResource(pulumi.CustomResource):
 
         opts = ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
         return CustomResource(resource_name=resource_name, api_version=api_version, kind=kind, opts=opts)
-
-    def translate_output_property(self, prop: str) -> str:
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop: str) -> str:
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop

--- a/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
@@ -18,7 +18,6 @@ class CustomResourceArgs:
     def __init__(__self__, *,
                  api_version: pulumi.Input[str],
                  kind: pulumi.Input[str],
-                 compat: Optional[pulumi.Input[str]] = None,
                  metadata: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']] = None,
                  spec: Optional[Any] = None):
         """
@@ -30,8 +29,6 @@ class CustomResourceArgs:
         """
         pulumi.set(__self__, "api_version", api_version)
         pulumi.set(__self__, "kind", kind)
-        if compat is not None:
-            pulumi.set(__self__, "compat", 'true')
         if metadata is not None:
             pulumi.set(__self__, "metadata", metadata)
         if spec is not None:
@@ -60,15 +57,6 @@ class CustomResourceArgs:
     @kind.setter
     def kind(self, value: pulumi.Input[str]):
         pulumi.set(self, "kind", value)
-
-    @property
-    @pulumi.getter
-    def compat(self) -> Optional[pulumi.Input[str]]:
-        return pulumi.get(self, "compat")
-
-    @compat.setter
-    def compat(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "compat", value)
 
     @property
     @pulumi.getter
@@ -132,7 +120,6 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing resource name argument (for URN creation)')
         if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-#         resource_args, opts = _utilities.get_resource_args_opts(CustomResourceArgs, pulumi.ResourceOptions, *args, **kwargs)
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(version=_utilities.get_version()))
         self._internal_init(resource_name, api_version=api_version, kind=kind, opts=opts, metadata=metadata, spec=spec)
 

--- a/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/CustomResource.py
@@ -9,8 +9,90 @@ import pulumi.runtime
 from pulumi import ResourceOptions
 
 from .. import meta as _meta
-from .. import _utilities, _tables
+from .. import _utilities
 
+__all__ = ['CustomResourceArgs', 'CustomResource']
+
+@pulumi.input_type
+class CustomResourceArgs:
+    def __init__(__self__, *,
+                 api_version: pulumi.Input[str],
+                 kind: pulumi.Input[str],
+                 compat: Optional[pulumi.Input[str]] = None,
+                 metadata: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']] = None,
+                 spec: Optional[Any] = None):
+        """
+        The set of arguments for constructing a CustomResource resource.
+        :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input['_meta.v1.ObjectMetaArgs'] metadata: Standard object metadata.
+        :param Any spec: Specification of the CustomResource.
+        """
+        pulumi.set(__self__, "api_version", api_version)
+        pulumi.set(__self__, "kind", kind)
+        if compat is not None:
+            pulumi.set(__self__, "compat", 'true')
+        if metadata is not None:
+            pulumi.set(__self__, "metadata", metadata)
+        if spec is not None:
+            pulumi.set(__self__, "spec", spec)
+
+    @property
+    @pulumi.getter(name="apiVersion")
+    def api_version(self) -> pulumi.Input[str]:
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        return pulumi.get(self, "api_version")
+
+    @api_version.setter
+    def api_version(self, value: pulumi.Input[str]):
+        pulumi.set(self, "api_version", value)
+
+    @property
+    @pulumi.getter
+    def kind(self) -> pulumi.Input[str]:
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        return pulumi.get(self, "kind")
+
+    @kind.setter
+    def kind(self, value: pulumi.Input[str]):
+        pulumi.set(self, "kind", value)
+
+    @property
+    @pulumi.getter
+    def compat(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "compat")
+
+    @compat.setter
+    def compat(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "compat", value)
+
+    @property
+    @pulumi.getter
+    def metadata(self) -> Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]:
+        """
+        Standard object metadata.
+        """
+        return pulumi.get(self, "metadata")
+
+    @metadata.setter
+    def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
+        pulumi.set(self, "metadata", value)
+
+    @property
+    @pulumi.getter
+    def spec(self) -> Optional[Any]:
+        """
+        Specification of the CustomResource.
+        """
+        return pulumi.get(self, "spec")
+
+    @spec.setter
+    def spec(self, value: Optional[Any]):
+        pulumi.set(self, "spec", value)
 
 class CustomResource(pulumi.CustomResource):
     def __init__(self,
@@ -50,19 +132,38 @@ class CustomResource(pulumi.CustomResource):
             raise TypeError('Missing resource name argument (for URN creation)')
         if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if opts and not isinstance(opts, pulumi.ResourceOptions):
-            raise TypeError('Expected resource options to be a ResourceOptions instance')
-
-        __props__ = dict()
-
-        __props__['apiVersion'] = api_version
-        __props__['kind'] = kind
-        __props__['spec'] = spec
-        __props__['metadata'] = metadata
-
+#         resource_args, opts = _utilities.get_resource_args_opts(CustomResourceArgs, pulumi.ResourceOptions, *args, **kwargs)
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(version=_utilities.get_version()))
+        self._internal_init(resource_name, api_version=api_version, kind=kind, opts=opts, metadata=metadata, spec=spec)
 
-        super(CustomResource, self).__init__(
+    def _internal_init(__self__,
+                 resource_name: str,
+                 api_version: str,
+                 kind: str,
+                 opts: Optional[pulumi.ResourceOptions] = None,
+                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 spec: Optional[Any] = None,
+                 __props__=None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+        if not isinstance(opts, pulumi.ResourceOptions):
+            raise TypeError('Expected resource options to be a ResourceOptions instance')
+        if opts.version is None:
+            opts.version = _utilities.get_version()
+        if opts.id is None:
+            if __props__ is not None:
+                raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
+            __props__ = CustomResourceArgs.__new__(CustomResourceArgs)
+
+            if api_version is None and not opts.urn:
+                raise TypeError("Missing required property 'api_version'")
+            __props__.__dict__["api_version"] = api_version
+            if kind is None and not opts.urn:
+                raise TypeError("Missing required property 'kind'")
+            __props__.__dict__["kind"] = kind
+            __props__.__dict__["metadata"] = metadata
+            __props__.__dict__["spec"] = spec
+        super(CustomResource, __self__).__init__(
             f"kubernetes:{api_version}:{kind}",
             resource_name,
             __props__,
@@ -95,9 +196,3 @@ class CustomResource(pulumi.CustomResource):
 
         opts = ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
         return CustomResource(resource_name=resource_name, api_version=api_version, kind=kind, opts=opts)
-
-    def translate_output_property(self, prop: str) -> str:
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop: str) -> str:
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,6 +10,7 @@ replace (
 )
 
 require (
+	github.com/cheggaaa/pb v1.0.18 // indirect
 	github.com/pulumi/pulumi-kubernetes/provider/v3 v3.0.0-rc.1
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.0.0-rc.1
 	github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -797,6 +797,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.11/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -973,6 +975,8 @@ github.com/pulumi/pulumi/pkg/v3 v3.14.1-0.20211007232357-25a4c9d4398b/go.mod h1:
 github.com/pulumi/pulumi/sdk/v3 v3.14.0/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0 h1:yqGysCf1LqlkengBnYqcbl5JI6JGySPN67+g60dMieU=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/tests/sdk/python/get-one-step/__main__.py
+++ b/tests/sdk/python/get-one-step/__main__.py
@@ -46,7 +46,12 @@ crd = CustomResourceDefinition(
             schema=CustomResourceValidationArgs(
                 open_apiv3_schema=JSONSchemaPropsArgs(
                     type="object",
-                    properties={"foo": JSONSchemaPropsArgs(type="string")},
+                    properties={
+                        "spec": JSONSchemaPropsArgs(type="object", properties={
+                            "foo": JSONSchemaPropsArgs(type="string"),
+                            "node_selector": JSONSchemaPropsArgs(type="string"),
+                        })
+                    },
                 ),
             ),
         )],
@@ -59,7 +64,7 @@ cr = CustomResource(
     api_version="python.test/v1",
     kind="GetTest",
     metadata={"namespace": ns.metadata["name"]},
-    spec={"foo": "bar"},
+    spec={"foo": "bar", "node_selector": 'kubernetes.io/hostname: "docker-desktop"\n'},
     opts=pulumi.ResourceOptions(depends_on=[crd]))
 
 cr_get = CustomResource.get(resource_name="bar", api_version="python.test/v1", kind="GetTest", id=cr.id)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Refresh the python implementation of python implementation of CustomResource to pick up fixes in snake-casing.
CustomResource.py is hand-crafted wrapper so doesn't lie on the codegen path. While I was able to schematize the core CustomResource type, the custom handling around constructing dynamic tokens at resource registration or retrieval is quite painful to substitute in an automated way. That would have to follow in https://github.com/pulumi/pulumi-kubernetes/issues/1778.

The change here uses an input type which signals the pulumi python SDK to handle the snake casing appropriately. I am not yet exposing the input type in the constructor with the interest of not breaking compatibility.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1740

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
