### PR TITLE
Add await support for networking.k8s.io/v1 variant of ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD (Unreleased)
+- Add await support for networking.k8s.io/v1 variant of ingress (https://github.com/pulumi/pulumi-kubernetes/pull/1795)
 
 - Schematize overlay types (https://github.com/pulumi/pulumi-kubernetes/pull/1793)
 

--- a/provider/pkg/await/awaiters.go
+++ b/provider/pkg/await/awaiters.go
@@ -231,11 +231,11 @@ var awaiters = map[string]awaitSpec{
 	coreV1ServiceAccount: {
 		awaitCreation: untilCoreV1ServiceAccountInitialized,
 	},
-	extensionsV1Beta1Deployment:                 deploymentAwaiter,
+	extensionsV1Beta1Deployment: deploymentAwaiter,
 
-	extensionsV1Beta1Ingress:                    ingressAwaiter,
-	networkingV1Beta1Ingress:                    ingressAwaiter,
-	networkingV1Ingress:                         ingressAwaiter,
+	extensionsV1Beta1Ingress: ingressAwaiter,
+	networkingV1Beta1Ingress: ingressAwaiter,
+	networkingV1Ingress:      ingressAwaiter,
 
 	rbacAuthorizationV1ClusterRole:              { /* NONE */ },
 	rbacAuthorizationV1ClusterRoleBinding:       { /* NONE */ },

--- a/provider/pkg/await/awaiters.go
+++ b/provider/pkg/await/awaiters.go
@@ -115,6 +115,7 @@ const (
 	coreV1ServiceAccount                        = "v1/ServiceAccount"
 	extensionsV1Beta1Deployment                 = "extensions/v1beta1/Deployment"
 	extensionsV1Beta1Ingress                    = "extensions/v1beta1/Ingress"
+	networkingV1Ingress                         = "networking.k8s.io/v1/Ingress"
 	rbacAuthorizationV1ClusterRole              = "rbac.authorization.k8s.io/v1/ClusterRole"
 	rbacAuthorizationV1ClusterRoleBinding       = "rbac.authorization.k8s.io/v1/ClusterRoleBinding"
 	rbacAuthorizationV1Role                     = "rbac.authorization.k8s.io/v1/Role"
@@ -225,6 +226,11 @@ var awaiters = map[string]awaitSpec{
 	},
 	extensionsV1Beta1Deployment: deploymentAwaiter,
 	extensionsV1Beta1Ingress: {
+		awaitCreation: awaitIngressInit,
+		awaitRead:     awaitIngressRead,
+		awaitUpdate:   awaitIngressUpdate,
+	},
+	networkingV1Ingress: {
 		awaitCreation: awaitIngressInit,
 		awaitRead:     awaitIngressRead,
 		awaitUpdate:   awaitIngressUpdate,

--- a/provider/pkg/await/awaiters.go
+++ b/provider/pkg/await/awaiters.go
@@ -116,6 +116,7 @@ const (
 	extensionsV1Beta1Deployment                 = "extensions/v1beta1/Deployment"
 	extensionsV1Beta1Ingress                    = "extensions/v1beta1/Ingress"
 	networkingV1Ingress                         = "networking.k8s.io/v1/Ingress"
+	networkingV1Beta1Ingress                    = "networking.k8s.io/v1beta1/Ingress"
 	rbacAuthorizationV1ClusterRole              = "rbac.authorization.k8s.io/v1/ClusterRole"
 	rbacAuthorizationV1ClusterRoleBinding       = "rbac.authorization.k8s.io/v1/ClusterRoleBinding"
 	rbacAuthorizationV1Role                     = "rbac.authorization.k8s.io/v1/Role"
@@ -149,6 +150,12 @@ var deploymentAwaiter = awaitSpec{
 		return makeDeploymentInitAwaiter(updateAwaitConfig{createAwaitConfig: c}).Read()
 	},
 	awaitDeletion: untilAppsDeploymentDeleted,
+}
+
+var ingressAwaiter = awaitSpec{
+	awaitCreation: awaitIngressInit,
+	awaitRead:     awaitIngressRead,
+	awaitUpdate:   awaitIngressUpdate,
 }
 
 var jobAwaiter = awaitSpec{
@@ -224,17 +231,12 @@ var awaiters = map[string]awaitSpec{
 	coreV1ServiceAccount: {
 		awaitCreation: untilCoreV1ServiceAccountInitialized,
 	},
-	extensionsV1Beta1Deployment: deploymentAwaiter,
-	extensionsV1Beta1Ingress: {
-		awaitCreation: awaitIngressInit,
-		awaitRead:     awaitIngressRead,
-		awaitUpdate:   awaitIngressUpdate,
-	},
-	networkingV1Ingress: {
-		awaitCreation: awaitIngressInit,
-		awaitRead:     awaitIngressRead,
-		awaitUpdate:   awaitIngressUpdate,
-	},
+	extensionsV1Beta1Deployment:                 deploymentAwaiter,
+
+	extensionsV1Beta1Ingress:                    ingressAwaiter,
+	networkingV1Beta1Ingress:                    ingressAwaiter,
+	networkingV1Ingress:                         ingressAwaiter,
+
 	rbacAuthorizationV1ClusterRole:              { /* NONE */ },
 	rbacAuthorizationV1ClusterRoleBinding:       { /* NONE */ },
 	rbacAuthorizationV1Role:                     { /* NONE */ },

--- a/provider/pkg/await/ingress.go
+++ b/provider/pkg/await/ingress.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,7 +218,7 @@ func (iia *ingressInitAwaiter) await(
 		select {
 		case <-iia.config.ctx.Done():
 			// On cancel, check one last time if the ingress is ready.
-			if iia.ingressReady && iia.checkIfEndpointsReady() {
+			if _, ready := iia.checkIfEndpointsReady(); ready && iia.ingressReady {
 				return nil
 			}
 			return &cancellationError{
@@ -226,7 +227,7 @@ func (iia *ingressInitAwaiter) await(
 			}
 		case <-timeout:
 			// On timeout, check one last time if the ingress is ready.
-			if iia.ingressReady && iia.checkIfEndpointsReady() {
+			if _, ready := iia.checkIfEndpointsReady(); ready && iia.ingressReady {
 				return nil
 			}
 			return &timeoutError{
@@ -290,63 +291,103 @@ func (iia *ingressInitAwaiter) processIngressEvent(event watch.Event) {
 	}
 
 	iia.ingress = ingress
-	obj, err := decodeIngress(ingress)
-	if err != nil {
+
+	// To the best of my knowledge, this works across all known ingress api version variations.
+	ingressesRaw, ok := openapi.Pluck(ingress.Object, "status", "loadBalancer", "ingress")
+	if !ok {
 		logger.V(3).Infof("Unable to decode Ingress object from unstructured: %#v", ingress)
 		return
 	}
 
-	logger.V(3).Infof("Received status for ingress %q: %#v", inputIngressName, obj.Status)
+	ingresses, ok := ingressesRaw.([]interface{})
+	if !ok {
+		logger.V(3).Infof("Unexpected ingress object structure from unstructured: %#v", ingress)
+		return
+	}
 
 	// Update status of ingress object so that we can check success.
-	iia.ingressReady = len(obj.Status.LoadBalancer.Ingress) > 0
+	iia.ingressReady = len(ingresses) > 0
 
 	logger.V(3).Infof("Waiting for ingress %q to update .status.loadBalancer with hostname/IP",
 		inputIngressName)
 }
 
-func decodeIngress(u *unstructured.Unstructured) (*networkingv1.Ingress, error) {
+func decodeIngress(u *unstructured.Unstructured, to interface{}) error {
 	b, err := u.MarshalJSON()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	var obj networkingv1.Ingress
-	err = json.Unmarshal(b, &obj)
+	err = json.Unmarshal(b, to)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return &obj, nil
+	return nil
 }
 
-func (iia *ingressInitAwaiter) checkIfEndpointsReady() bool {
-	obj, err := decodeIngress(iia.ingress)
-	if err != nil {
-		logger.V(3).Infof("Unable to decode Ingress object from unstructured: %#v", iia.ingress)
-		return false
+func (iia *ingressInitAwaiter) checkIfEndpointsReady() (string, bool) {
+	apiVersion := iia.ingress.GetAPIVersion()
+	switch apiVersion {
+	case "extensions/v1beta1", "networking.k8s.io/v1beta1":
+		var obj networkingv1beta1.Ingress
+
+		if err := decodeIngress(iia.ingress, &obj); err != nil {
+			logger.V(3).Infof("Unable to decode Ingress object from unstructured: %#v", iia.ingress)
+			return apiVersion, false
+		}
+
+		for _, rule := range obj.Spec.Rules {
+			if rule.HTTP == nil {
+				iia.config.logStatus(diag.Error, fmt.Sprintf("expected value %q is unset for ingress: %s",
+					".spec.rules[*].http", obj.Name))
+				return apiVersion, false
+			}
+			for _, path := range rule.HTTP.Paths {
+				// Ignore ExternalName services
+				if path.Backend.ServiceName != "" && iia.knownExternalNameServices.Has(path.Backend.ServiceName) {
+					continue
+				}
+
+				if path.Backend.ServiceName != "" && !iia.knownEndpointObjects.Has(path.Backend.ServiceName) {
+					iia.config.logStatus(diag.Info, fmt.Sprintf("No matching service found for ingress rule: %s",
+						expectedIngressPath(rule.Host, path.Path, path.Backend.ServiceName)))
+					return apiVersion, false
+				}
+			}
+		}
+	case "networking.k8s.io/v1":
+		var obj networkingv1.Ingress
+		if err := decodeIngress(iia.ingress, &obj); err != nil {
+			logger.V(3).Infof("Unable to decode Ingress object from unstructured: %#v", iia.ingress)
+			return apiVersion, false
+		}
+
+		for _, rule := range obj.Spec.Rules {
+			if rule.HTTP == nil {
+				iia.config.logStatus(diag.Error, fmt.Sprintf("expected value %q is unset for ingress: %s",
+					".spec.rules[*].http", obj.Name))
+				return apiVersion, false
+			}
+			for _, path := range rule.HTTP.Paths {
+				// TODO: Should we worry about "resource" backends?
+				if path.Backend.Service == nil {
+					continue
+				}
+
+				// Ignore ExternalName services
+				if path.Backend.Service.Name != "" && iia.knownExternalNameServices.Has(path.Backend.Service.Name) {
+					continue
+				}
+
+				if path.Backend.Service.Name != "" && !iia.knownEndpointObjects.Has(path.Backend.Service.Name) {
+					iia.config.logStatus(diag.Info, fmt.Sprintf("No matching service found for ingress rule: %s",
+						expectedIngressPath(rule.Host, path.Path, path.Backend.Service.Name)))
+					return apiVersion, false
+				}
+			}
+		}
 	}
 
-	for _, rule := range obj.Spec.Rules {
-		if rule.HTTP == nil {
-			iia.config.logStatus(diag.Error, fmt.Sprintf("expected value %q is unset for ingress: %s",
-				".spec.rules[*].http", obj.Name))
-			return false
-		}
-		for _, path := range rule.HTTP.Paths {
-			// Ignore ExternalName services
-			if path.Backend.Service != nil && iia.knownExternalNameServices.Has(path.Backend.Service.Name) {
-				continue
-			}
-
-			if path.Backend.Service != nil && !iia.knownEndpointObjects.Has(path.Backend.Service.Name) {
-				iia.config.logStatus(diag.Info, fmt.Sprintf("No matching service found for ingress rule: %s",
-					expectedIngressPath(rule.Host, path.Path, path.Backend.Service.Name)))
-				return false
-			}
-		}
-	}
-
-	return true
+	return apiVersion, true
 }
 
 // expectedIngressPath is a helper to print a useful error message.
@@ -402,10 +443,15 @@ func (iia *ingressInitAwaiter) processEndpointEvent(event watch.Event, settledCh
 func (iia *ingressInitAwaiter) errorMessages() []string {
 	messages := make([]string, 0)
 
-	if !iia.checkIfEndpointsReady() {
-		messages = append(messages,
+	if apiVersion, ready := iia.checkIfEndpointsReady(); !ready {
+		field := ".spec.rules[].http.paths[].backend.serviceName"
+		switch apiVersion {
+		case "networking.k8s.io/v1":
+			field = ".spec.rules[].http.paths[].backend.service.name"
+		}
+		messages = append(messages, fmt.Sprintf(
 			"Ingress has at least one rule that does not target any Service. "+
-				"Field '.spec.rules[].http.paths[].backend.serviceName' may not match any active Service")
+				"Field '%v' may not match any active Service", field))
 	}
 
 	if !iia.ingressReady {
@@ -418,11 +464,12 @@ func (iia *ingressInitAwaiter) errorMessages() []string {
 }
 
 func (iia *ingressInitAwaiter) checkAndLogStatus() bool {
-	success := iia.ingressReady && iia.checkIfEndpointsReady()
+	_, ready := iia.checkIfEndpointsReady()
+	success := iia.ingressReady && ready
 	if success {
 		iia.config.logStatus(diag.Info,
 			fmt.Sprintf("%sIngress initialization complete", cmdutil.EmojiOr("✅ ", "")))
-	} else if iia.checkIfEndpointsReady() {
+	} else if ready {
 		iia.config.logStatus(diag.Info, "[2/3] Waiting for update of .status.loadBalancer with hostname/IP")
 	}
 

--- a/provider/pkg/await/ingress_test.go
+++ b/provider/pkg/await/ingress_test.go
@@ -336,8 +336,8 @@ func initializedIngressV1(namespace, name, targetService string) *unstructured.U
                                     "name": "%s",
                                     "port": {
                                         "number": 80
-									}
-								}
+                                    }
+                                }
                             },
                             "path": "/nginx"
                         }

--- a/provider/pkg/await/ingress_test.go
+++ b/provider/pkg/await/ingress_test.go
@@ -362,7 +362,6 @@ func initializedIngressV1(namespace, name, targetService string) *unstructured.U
 	return obj
 }
 
-
 func initializedIngressUnspecifiedPath(namespace, name, targetService string) *unstructured.Unstructured {
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
     "apiVersion": "extensions/v1beta1",

--- a/provider/pkg/await/ingress_test.go
+++ b/provider/pkg/await/ingress_test.go
@@ -32,6 +32,18 @@ func Test_Extensions_Ingress(t *testing.T) {
 			},
 		},
 		{
+			description:  "Should succeed when Ingress (networking/v1) is allocated an IP address and all paths match an existing Endpoint",
+			ingressInput: initializedIngressV1,
+			do: func(ingresses, services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
+				// API server passes initialized ingress and endpoint objects back.
+				ingresses <- watchAddedEvent(initializedIngress("default", "foo", "foo-4setj4y6"))
+				endpoints <- watchAddedEvent(initializedEndpoint("default", "foo-4setj4y6"))
+
+				// Mark endpoint objects as having settled. Success.
+				settled <- struct{}{}
+			},
+		},
+		{
 			description:  "Should succeed when Ingress is allocated an IP address and path references an ExternalName Service",
 			ingressInput: initializedIngress,
 			do: func(ingresses, services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
@@ -159,6 +171,15 @@ func Test_Extensions_Ingress_Read(t *testing.T) {
 			},
 		},
 		{
+			description:  "Read should fail if not all Ingress (networking/v1) paths match existing Endpoints",
+			ingressInput: ingressInput,
+			ingress:      initializedIngressV1,
+			expectedSubErrors: []string{
+				"Ingress has at least one rule that does not target any Service. " +
+					"Field '.spec.rules[].http.paths[].backend.service.name' may not match any active Service",
+			},
+		},
+		{
 			description:  "Read should succeed when Ingress is allocated an IP address and Service is type ExternalName",
 			ingressInput: ingressInput,
 			ingress:      initializedIngress,
@@ -257,7 +278,7 @@ func ingressInput(namespace, name, targetService string) *unstructured.Unstructu
 
 func initializedIngress(namespace, name, targetService string) *unstructured.Unstructured {
 	obj, err := decodeUnstructured(fmt.Sprintf(`{
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "networking.k8s.io/v1beta1",
     "kind": "Ingress",
     "metadata": {
         "name": "%s",
@@ -295,6 +316,52 @@ func initializedIngress(namespace, name, targetService string) *unstructured.Uns
 	}
 	return obj
 }
+
+func initializedIngressV1(namespace, name, targetService string) *unstructured.Unstructured {
+	obj, err := decodeUnstructured(fmt.Sprintf(`{
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "Ingress",
+    "metadata": {
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "spec": {
+        "rules": [
+            {
+                "http": {
+                    "paths": [
+                        {
+                            "backend": {
+                                "service": {
+                                    "name": "%s",
+                                    "port": {
+                                        "number": 80
+									}
+								}
+                            },
+                            "path": "/nginx"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "status": {
+        "loadBalancer": {
+            "ingress": [
+                {
+                    "hostname": "localhost"
+                }
+            ]
+        }
+    }
+}`, name, namespace, targetService))
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
 
 func initializedIngressUnspecifiedPath(namespace, name, targetService string) *unstructured.Unstructured {
 	obj, err := decodeUnstructured(fmt.Sprintf(`{

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -21,7 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1b1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +35,7 @@ func FromUnstructured(obj *unstructured.Unstructured) (metav1.Object, error) {
 	case kinds.Job:
 		output = new(batchv1.Job)
 	case kinds.Ingress:
-		output = new(networkingv1b1.Ingress)
+		output = new(networkingv1.Ingress)
 	case kinds.PersistentVolume:
 		output = new(corev1.PersistentVolume)
 	case kinds.PersistentVolumeClaim:

--- a/tests/sdk/go/helm-local/step1/main.go
+++ b/tests/sdk/go/helm-local/step1/main.go
@@ -33,7 +33,6 @@ func main() {
 			return err
 		}
 
-
 		return nil
 	})
 }

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -134,10 +134,11 @@ func TestAccIngress(t *testing.T) {
 	skipIfShort(t)
 	testNetworkingV1 := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:         filepath.Join(getCwd(t), "ingress"),
-			Quick:       true,
+			Dir:           filepath.Join(getCwd(t), "ingress"),
+			Quick:         true,
+			NoParallel:    true, // We want to run this and the next test serially so nginx ingress isn't clobbered.
 			DebugLogLevel: 3,
-			SkipRefresh: true, // ingress may have changes during refresh.
+			SkipRefresh:   true, // ingress may have changes during refresh.
 			ExtraRuntimeValidation: func(
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
@@ -147,13 +148,13 @@ func TestAccIngress(t *testing.T) {
 				integration.AssertHTTPResultWithRetry(t,
 					fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]),
 					nil, 5*time.Minute, func(body string) bool {
-					return assert.NotEmpty(t, body, "Body should not be empty")
-				})
+						return assert.NotEmpty(t, body, "Body should not be empty")
+					})
 
 				integration.AssertHTTPResultWithRetry(t, fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
 					map[string]string{"Host": "ingresshello.io"}, 5*time.Minute, func(body string) bool {
-					return assert.NotEmpty(t, body, "Body should not be empty")
-				})
+						return assert.NotEmpty(t, body, "Body should not be empty")
+					})
 			},
 		})
 	integration.ProgramTest(t, &testNetworkingV1)
@@ -162,7 +163,8 @@ func TestAccIngress(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:         filepath.Join(getCwd(t), "ingress"),
 			Quick:       true,
-			Config: map[string]string{"use-v1beta1-ingress": "true"},
+			NoParallel:  true,
+			Config:      map[string]string{"use-v1beta1-ingress": "true"},
 			SkipRefresh: true, // ingress may have changes during refresh.
 			ExtraRuntimeValidation: func(
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
@@ -189,14 +191,14 @@ func TestAccIngress(t *testing.T) {
 				integration.AssertHTTPResultWithRetry(t,
 					fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]),
 					nil, 5*time.Minute, func(body string) bool {
-					return assert.NotEmpty(t, body, "Body should not be empty")
-				})
+						return assert.NotEmpty(t, body, "Body should not be empty")
+					})
 
 				integration.AssertHTTPResultWithRetry(t,
 					fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
 					map[string]string{"Host": "ingresshello.io"}, 5*time.Minute, func(body string) bool {
-					return assert.NotEmpty(t, body, "Body should not be empty")
-				})
+						return assert.NotEmpty(t, body, "Body should not be empty")
+					})
 			},
 		})
 	integration.ProgramTest(t, &testWithNetworkingBeta1)

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -221,6 +221,50 @@ func TestAccIngress(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccIngressV1Beta1(t *testing.T) {
+	skipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         filepath.Join(getCwd(t), "ingress"),
+			Quick:       true,
+			Config: map[string]string{"use-v1beta1-ingress": "true"},
+			SkipRefresh: true, // ingress may have changes during refresh.
+			ExtraRuntimeValidation: func(
+				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
+			) {
+				assert.NotNil(t, stackInfo.Deployment)
+				assert.Equal(t, 15, len(stackInfo.Deployment.Resources))
+
+				ingressCount := 0
+				for _, resource := range stackInfo.Deployment.Resources {
+					kind, ok := openapi.Pluck(resource.Outputs, "kind")
+					if !ok {
+						continue
+					}
+					switch kind.(string) {
+					case "Ingress":
+						apiVersion, _ := openapi.Pluck(resource.Outputs, "apiVersion")
+						assert.Equal(t, "networking.k8s.io/v1beta1", apiVersion)
+						ingressCount++
+					}
+				}
+
+				assert.Equal(t, 2, ingressCount)
+
+				integration.AssertHTTPResultWithRetry(t, fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]), nil, 5*time.Minute, func(body string) bool {
+					return assert.NotEmpty(t, body, "Body should not be empty")
+				})
+
+				integration.AssertHTTPResultWithRetry(t, fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]), map[string]string{"Host": "ingresshello.io"}, 5*time.Minute, func(body string) bool {
+					return assert.NotEmpty(t, body, "Body should not be empty")
+				})
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+
 func TestAccHelm(t *testing.T) {
 	skipIfShort(t)
 	test := getBaseOptions(t).

--- a/tests/sdk/nodejs/examples/ingress/Pulumi.yaml
+++ b/tests/sdk/nodejs/examples/ingress/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: guestbook
+name: ingress
 runtime: nodejs
-description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/
+description: Create ingress resources using Kubernetes provider for Pulumi.

--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -19,20 +19,23 @@ import { output as outputs } from "@pulumi/kubernetes/types";
 const ns = new k8s.core.v1.Namespace("test");
 const namespace = ns.metadata.name;
 
+const config = new pulumi.Config();
+const useV1Beta1Ingress = config.get("use-v1beta1-ingress") != undefined;
+
 // Install nginx ingress controller first
-const ingressNs = new k8s.core.v1.Namespace("ingress-nginx-ns", {metadata: {name: "ingress-nginx"}})
+const ingressNs = new k8s.core.v1.Namespace("ingress-nginx");
 const ingressController = new k8s.helm.v3.Release(
     "nginx-ingress", {
-        name: "nginx-ingress",
-        namespace: ingressNs.metadata.name,
-        chart: "ingress-nginx",
-        repositoryOpts: {
-            repo: "https://kubernetes.github.io/ingress-nginx",
-        },
-    });
+    name: "nginx-ingress",
+    namespace: ingressNs.metadata.name,
+    chart: "ingress-nginx",
+    repositoryOpts: {
+        repo: "https://kubernetes.github.io/ingress-nginx",
+    },
+});
 
 // nginx hello app
-let helloLabels = {app: "hello", tier: "frontend"};
+let helloLabels = { app: "hello", tier: "frontend" };
 const helloService = new k8s.core.v1.Service("hello-svc", {
     metadata: {
         namespace: namespace,
@@ -42,7 +45,7 @@ const helloService = new k8s.core.v1.Service("hello-svc", {
     spec: {
         // GKE ingress will only work with service type of NodePort or LoadBalancer.
         // We only want one endpoint through the ingress so choosing NodePort.
-        ports: [{port: 8080, targetPort: 8080}],
+        ports: [{ port: 8080, targetPort: 8080 }],
         selector: helloLabels,
     },
 });
@@ -80,35 +83,63 @@ let helloDeployment = new k8s.apps.v1.Deployment("hello-app", {
     },
 });
 
-// Note - this uses the nginx ingress controller which should work across k8s providers.
-let feIngressNginx = new k8s.networking.v1.Ingress("feIngressNginx", {
-    metadata: {
-        namespace: namespace,
-        name: "feingress-nginx",
-        annotations: {
-            "kubernetes.io/ingress.class": "nginx",
-            "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-        },
-    },
-    spec: {
-        rules: [{
-            host: "ingresshello.io",
-            http: {
-                paths: [{
-                    path: "/hello",
-                    pathType: "Prefix",
-                    backend: {service: {name: helloService.metadata.name, port: {number: 8080}}}
-                }]
-            }
-        }],
-    }
-}, {dependsOn: [ingressController]});
+let feIngressNginx = undefined;
 
+if (!useV1Beta1Ingress) {
+    // Note - this uses the nginx ingress controller which should work across k8s providers.
+    feIngressNginx = new k8s.networking.v1.Ingress("feIngressNginx", {
+        metadata: {
+            namespace: namespace,
+            name: "feingress-nginx",
+            annotations: {
+                "kubernetes.io/ingress.class": "nginx",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+            },
+        },
+        spec: {
+            rules: [{
+                host: "ingresshello.io",
+                http: {
+                    paths: [{
+                        path: "/hello",
+                        pathType: "Prefix",
+                        backend: { service: { name: helloService.metadata.name, port: { number: 8080 } } }
+                    }]
+                }
+            }],
+        }
+    }, { dependsOn: [ingressController] });
+
+} else {
+    // Note - this uses the nginx ingress controller which should work across k8s providers.
+    feIngressNginx = new k8s.networking.v1beta1.Ingress("feIngressNginx", {
+        metadata: {
+            namespace: namespace,
+            name: "feingress-nginx",
+            annotations: {
+                "kubernetes.io/ingress.class": "nginx",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+            },
+        },
+        spec: {
+            rules: [{
+                host: "ingresshello.io",
+                http: {
+                    paths: [{
+                        path: "/hello",
+                        pathType: "Prefix",
+                        backend: { serviceName: helloService.metadata.name, servicePort: 8080 }
+                    }]
+                }
+            }],
+        }
+    }, { dependsOn: [ingressController] });
+}
 export const ingressNginxIp = feIngressNginx.status.loadBalancer.ingress[0].ip;
 
 // REDIS MASTER
 
-let redisMasterLabels = {app: "redis", tier: "backend", role: "master"};
+let redisMasterLabels = { app: "redis", tier: "backend", role: "master" };
 let redisMasterService = new k8s.core.v1.Service("redis-master", {
     metadata: {
         namespace: namespace,
@@ -116,7 +147,7 @@ let redisMasterService = new k8s.core.v1.Service("redis-master", {
         labels: redisMasterLabels,
     },
     spec: {
-        ports: [{port: 6379, targetPort: 6379}],
+        ports: [{ port: 6379, targetPort: 6379 }],
         selector: redisMasterLabels,
     },
 });
@@ -155,7 +186,7 @@ let redisMasterDeployment = new k8s.apps.v1.Deployment("redis-master", {
 });
 
 // REDIS SLAVE
-let redisSlaveLabels = {app: "redis", tier: "backend", role: "slave"};
+let redisSlaveLabels = { app: "redis", tier: "backend", role: "slave" };
 let redisSlaveService = new k8s.core.v1.Service("redis-slave", {
     metadata: {
         namespace: namespace,
@@ -163,7 +194,7 @@ let redisSlaveService = new k8s.core.v1.Service("redis-slave", {
         labels: redisSlaveLabels,
     },
     spec: {
-        ports: [{port: 6379, targetPort: 6379}],
+        ports: [{ port: 6379, targetPort: 6379 }],
         selector: redisSlaveLabels,
     },
 });
@@ -210,7 +241,7 @@ let redisSlaveDeployment = new k8s.apps.v1.Deployment("redis-slave", {
 });
 
 // FRONTEND
-let frontendLabels = {app: "guestbook", tier: "frontend"};
+let frontendLabels = { app: "guestbook", tier: "frontend" };
 const frontendService = new k8s.core.v1.Service("frontend", {
     metadata: {
         namespace: namespace,
@@ -221,7 +252,7 @@ const frontendService = new k8s.core.v1.Service("frontend", {
         // GKE ingress will only work with service type of NodePort or LoadBalancer.
         // We only want one endpoint through the ingress so choosing NodePort.
         type: "NodePort",
-        ports: [{port: 80}],
+        ports: [{ port: 80 }],
         selector: frontendLabels,
     },
 });
@@ -269,26 +300,51 @@ let frontendDeployment = new k8s.apps.v1.Deployment("frontend", {
     },
 });
 
-// Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
-let feIngress = new k8s.networking.v1.Ingress("feIngress", {
-    metadata: {
-        namespace: namespace,
-        name: "feingress",
-        annotations: {
-                "kubernetes.io/ingress.class": "gce"
-        },
-    },
-    spec: {
-        rules: [{
-            http: {
-                paths: [{
-                    path: "/*",
-                    pathType: "ImplementationSpecific",
-                    backend: {service: {name: frontendService.metadata.name, port: {number: 80}}}
-                }]
-            }
-        }],
-    }
-});
+let feIngress = undefined;
 
+if (!useV1Beta1Ingress) {
+    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
+    feIngress = new k8s.networking.v1.Ingress("feIngress", {
+        metadata: {
+            namespace: namespace,
+            name: "feingress",
+            annotations: {
+                "kubernetes.io/ingress.class": "gce"
+            },
+        },
+        spec: {
+            rules: [{
+                http: {
+                    paths: [{
+                        path: "/*",
+                        pathType: "ImplementationSpecific",
+                        backend: { service: { name: frontendService.metadata.name, port: { number: 80 } } }
+                    }]
+                }
+            }],
+        }
+    });
+} else {
+    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
+    feIngress = new k8s.networking.v1beta1.Ingress("feIngress", {
+        metadata: {
+            namespace: namespace,
+            name: "feingress",
+            annotations: {
+                "kubernetes.io/ingress.class": "gce"
+            },
+        },
+        spec: {
+            rules: [{
+                http: {
+                    paths: [{
+                        path: "/*",
+                        pathType: "ImplementationSpecific",
+                        backend: { serviceName: frontendService.metadata.name, servicePort: 80 }
+                    }]
+                }
+            }],
+        }
+    });
+}
 export const ingressIp = feIngress.status.loadBalancer.ingress[0].ip;

--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -323,7 +323,8 @@ if (!useV1Beta1Ingress) {
                 }
             }],
         }
-    });
+        // Don't want to race with the ingress controller admission webhook being fully available.
+    }, { dependsOn: [ingressController] });
 } else {
     // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
     feIngress = new k8s.networking.v1beta1.Ingress("feIngress", {
@@ -345,6 +346,7 @@ if (!useV1Beta1Ingress) {
                 }
             }],
         }
-    });
+        // Don't want to race with the ingress controller admission controller being fully available.
+    }, { dependsOn: [ingressController] });
 }
 export const ingressIp = feIngress.status.loadBalancer.ingress[0].ip;

--- a/tests/sdk/nodejs/examples/ingress/package.json
+++ b/tests/sdk/nodejs/examples/ingress/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "guestbook",
+  "name": "ingress",
   "version": "0.1.0",
   "dependencies": {
     "@pulumi/pulumi": "latest"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
It appears the core issue with the lack of correct await on ingress objects was because of missing support for networking.k8s.io/v1 variants of the ingress object. I considered trying to canonicalize against the preferred version of the api server, but things get complicated quickly when taking upgrades into account. The approach here allows us to support all of the known versions for ingress by adjusting the await logic to each variant's API shape.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
#1649 #1498
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
