### PR TITLE
Pass right parameters to host.Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Remove unused helm ReleaseType type (https://github.com/pulumi/pulumi-kubernetes/pull/1805)
+- Fix Helm Release Panic "Helm uninstall returned information" (https://github.com/pulumi/pulumi-kubernetes/pull/1807)
 
 ## 3.10.0 (November 12, 2021)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -976,7 +976,7 @@ func (r *helmReleaseProvider) Delete(ctx context.Context, req *pulumirpc.DeleteR
 	}
 
 	if res.Info != "" {
-		_ = r.host.Log(context.Background(), diag.Warning, "Helm uninstall returned information: %q", res.Info)
+		_ = r.host.Log(context.Background(), diag.Warning, urn, fmt.Sprintf("Helm uninstall returned information: %q", res.Info))
 	}
 	return &pbempty.Empty{}, nil
 }


### PR DESCRIPTION
Fix #1798

I checked other usages of `host.Log()` and they look correct.