### PR TITLE
Fix CRD upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 - Helm Release: fix username fetch option (https://github.com/pulumi/pulumi-kubernetes/pull/1824)
 
+- Fix CRD upgrades (https://github.com/pulumi/pulumi-kubernetes/pull/1819)
+
 ## 3.12.0 (December 7, 2021)
 
 - Add support for k8s v1.23.0. (https://github.com/pulumi/pulumi-kubernetes/pull/1681)

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -26,6 +26,10 @@
                 "type": "boolean",
                 "description": "BETA FEATURE - If present and set to true, enable server-side diff calculations.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `enableDryRun` parameter.\n2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable."
             },
+            "enableReplaceCRD": {
+                "type": "boolean",
+                "description": "BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `enableReplaceCRD` parameter.\n2. The `PULUMI_K8S_ENABLE_REPLACE_CRD` environment variable."
+            },
             "kubeconfig": {
                 "type": "string",
                 "description": "The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.",
@@ -31529,6 +31533,15 @@
                 "defaultInfo": {
                     "environment": [
                         "PULUMI_K8S_ENABLE_DRY_RUN"
+                    ]
+                }
+            },
+            "enableReplaceCRD": {
+                "type": "boolean",
+                "description": "BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.\nThis feature is in developer preview, and is disabled by default.",
+                "defaultInfo": {
+                    "environment": [
+                        "PULUMI_K8S_ENABLE_REPLACE_CRD"
                     ]
                 }
             },

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -58,6 +58,7 @@ type ProviderConfig struct {
 	URN               resource.URN
 	InitialAPIVersion string
 	ClusterVersion    *cluster.ServerVersion
+	EnableReplaceCRD  bool
 
 	ClientSet   *clients.DynamicClientSet
 	DedupLogger *logging.DedupLogger
@@ -367,7 +368,10 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 	}
 
 	var currentOutputs *unstructured.Unstructured
-	if clients.IsCRD(c.Inputs) {
+	if c.EnableReplaceCRD && clients.IsCRD(c.Inputs) {
+		// Note: This feature is currently enabled with a provider feature flag, but is expected to eventually become
+		// the default behavior.
+
 		// CRDs require special handling to update. Rather than computing a patch, replace the CRD with a PUT
 		// operation (equivalent to running `kubectl replace`). This is accomplished by getting the `resourceVersion`
 		// of the existing CRD, setting that as the `resourceVersion` in the request, and then running an update. This

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -72,6 +72,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					Description: "BETA FEATURE - If present and set to true, enable server-side diff calculations.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `enableDryRun` parameter.\n2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
+				"enableReplaceCRD": {
+					Description: "BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `enableReplaceCRD` parameter.\n2. The `PULUMI_K8S_ENABLE_REPLACE_CRD` environment variable.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 				"renderYamlToDirectory": {
 					Description: "BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not\nbe created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes\nto the Pulumi program. This feature is in developer preview, and is disabled by default.\n\nNote that some computed Outputs such as status fields will not be populated\nsince the resources are not created on a Kubernetes cluster. These Output values will remain undefined,\nand may result in an error if they are referenced by other resources. Also note that any secret values\nused in these resources will be rendered in plaintext to the resulting YAML.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
@@ -126,6 +130,15 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 						},
 					},
 					Description: "BETA FEATURE - If present and set to true, enable server-side diff calculations.\nThis feature is in developer preview, and is disabled by default.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
+				"enableReplaceCRD": {
+					DefaultInfo: &pschema.DefaultSpec{
+						Environment: []string{
+							"PULUMI_K8S_ENABLE_REPLACE_CRD",
+						},
+					},
+					Description: "BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.\nThis feature is in developer preview, and is disabled by default.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"renderYamlToDirectory": {

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -67,6 +67,21 @@ namespace Pulumi.Kubernetes
             set => _enableDryRun.Set(value);
         }
 
+        private static readonly __Value<bool?> _enableReplaceCRD = new __Value<bool?>(() => __config.GetBoolean("enableReplaceCRD"));
+        /// <summary>
+        /// BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+        /// This feature is in developer preview, and is disabled by default.
+        /// 
+        /// This config can be specified in the following ways, using this precedence:
+        /// 1. This `enableReplaceCRD` parameter.
+        /// 2. The `PULUMI_K8S_ENABLE_REPLACE_CRD` environment variable.
+        /// </summary>
+        public static bool? EnableReplaceCRD
+        {
+            get => _enableReplaceCRD.Get();
+            set => _enableReplaceCRD.Set(value);
+        }
+
         private static readonly __Value<string?> _kubeconfig = new __Value<string?>(() => __config.Get("kubeconfig"));
         /// <summary>
         /// The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -66,6 +66,13 @@ namespace Pulumi.Kubernetes
         public Input<bool>? EnableDryRun { get; set; }
 
         /// <summary>
+        /// BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+        /// This feature is in developer preview, and is disabled by default.
+        /// </summary>
+        [Input("enableReplaceCRD", json: true)]
+        public Input<bool>? EnableReplaceCRD { get; set; }
+
+        /// <summary>
         /// BETA FEATURE - Options to configure the Helm Release resource.
         /// </summary>
         [Input("helmReleaseSettings", json: true)]
@@ -122,6 +129,7 @@ namespace Pulumi.Kubernetes
         public ProviderArgs()
         {
             EnableDryRun = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN");
+            EnableReplaceCRD = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_REPLACE_CRD");
             KubeConfig = Utilities.GetEnv("KUBECONFIG");
             SuppressDeprecationWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS");
             SuppressHelmHookWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS");

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -28,6 +28,16 @@ func GetEnableDryRun(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:enableDryRun")
 }
 
+// BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+// This feature is in developer preview, and is disabled by default.
+//
+// This config can be specified in the following ways, using this precedence:
+// 1. This `enableReplaceCRD` parameter.
+// 2. The `PULUMI_K8S_ENABLE_REPLACE_CRD` environment variable.
+func GetEnableReplaceCRD(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:enableReplaceCRD")
+}
+
 // The contents of a kubeconfig file or the path to a kubeconfig file. If this is set, this config will be used instead of $KUBECONFIG.
 func GetKubeconfig(ctx *pulumi.Context) string {
 	return config.Get(ctx, "kubernetes:kubeconfig")

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -25,6 +25,9 @@ func NewProvider(ctx *pulumi.Context,
 	if isZero(args.EnableDryRun) {
 		args.EnableDryRun = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "PULUMI_K8S_ENABLE_DRY_RUN").(bool))
 	}
+	if isZero(args.EnableReplaceCRD) {
+		args.EnableReplaceCRD = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "PULUMI_K8S_ENABLE_REPLACE_CRD").(bool))
+	}
 	helmReleaseSettingsApplier := func(v HelmReleaseSettings) *HelmReleaseSettings { return v.Defaults() }
 	if args.HelmReleaseSettings != nil {
 		args.HelmReleaseSettings = args.HelmReleaseSettings.ToHelmReleaseSettingsPtrOutput().Elem().ApplyT(helmReleaseSettingsApplier).(HelmReleaseSettingsPtrOutput)
@@ -58,6 +61,9 @@ type providerArgs struct {
 	// BETA FEATURE - If present and set to true, enable server-side diff calculations.
 	// This feature is in developer preview, and is disabled by default.
 	EnableDryRun *bool `pulumi:"enableDryRun"`
+	// BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+	// This feature is in developer preview, and is disabled by default.
+	EnableReplaceCRD *bool `pulumi:"enableReplaceCRD"`
 	// BETA FEATURE - Options to configure the Helm Release resource.
 	HelmReleaseSettings *HelmReleaseSettings `pulumi:"helmReleaseSettings"`
 	// Options for tuning the Kubernetes client used by a Provider.
@@ -95,6 +101,9 @@ type ProviderArgs struct {
 	// BETA FEATURE - If present and set to true, enable server-side diff calculations.
 	// This feature is in developer preview, and is disabled by default.
 	EnableDryRun pulumi.BoolPtrInput
+	// BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+	// This feature is in developer preview, and is disabled by default.
+	EnableReplaceCRD pulumi.BoolPtrInput
 	// BETA FEATURE - Options to configure the Helm Release resource.
 	HelmReleaseSettings HelmReleaseSettingsPtrInput
 	// Options for tuning the Kubernetes client used by a Provider.

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -38,6 +38,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["cluster"] = args ? args.cluster : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["enableDryRun"] = pulumi.output((args ? args.enableDryRun : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN")).apply(JSON.stringify);
+            resourceInputs["enableReplaceCRD"] = pulumi.output((args ? args.enableReplaceCRD : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_REPLACE_CRD")).apply(JSON.stringify);
             resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
             resourceInputs["kubeClientSettings"] = pulumi.output(args ? (args.kubeClientSettings ? pulumi.output(args.kubeClientSettings).apply(inputs.kubeClientSettingsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
             resourceInputs["kubeconfig"] = (args ? args.kubeconfig : undefined) ?? utilities.getEnv("KUBECONFIG");
@@ -70,6 +71,11 @@ export interface ProviderArgs {
      * This feature is in developer preview, and is disabled by default.
      */
     enableDryRun?: pulumi.Input<boolean>;
+    /**
+     * BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+     * This feature is in developer preview, and is disabled by default.
+     */
+    enableReplaceCRD?: pulumi.Input<boolean>;
     /**
      * BETA FEATURE - Options to configure the Helm Release resource.
      */

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -17,6 +17,7 @@ class ProviderArgs:
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
+                 enable_replace_crd: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
                  kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
                  kubeconfig: Optional[pulumi.Input[str]] = None,
@@ -29,6 +30,8 @@ class ProviderArgs:
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
         :param pulumi.Input[str] context: If present, the name of the kubeconfig context to use.
         :param pulumi.Input[bool] enable_dry_run: BETA FEATURE - If present and set to true, enable server-side diff calculations.
+               This feature is in developer preview, and is disabled by default.
+        :param pulumi.Input[bool] enable_replace_crd: BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
                This feature is in developer preview, and is disabled by default.
         :param pulumi.Input['HelmReleaseSettingsArgs'] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         :param pulumi.Input['KubeClientSettingsArgs'] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
@@ -58,6 +61,10 @@ class ProviderArgs:
             enable_dry_run = _utilities.get_env_bool('PULUMI_K8S_ENABLE_DRY_RUN')
         if enable_dry_run is not None:
             pulumi.set(__self__, "enable_dry_run", enable_dry_run)
+        if enable_replace_crd is None:
+            enable_replace_crd = _utilities.get_env_bool('PULUMI_K8S_ENABLE_REPLACE_CRD')
+        if enable_replace_crd is not None:
+            pulumi.set(__self__, "enable_replace_crd", enable_replace_crd)
         if helm_release_settings is not None:
             pulumi.set(__self__, "helm_release_settings", helm_release_settings)
         if kube_client_settings is not None:
@@ -115,6 +122,19 @@ class ProviderArgs:
     @enable_dry_run.setter
     def enable_dry_run(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "enable_dry_run", value)
+
+    @property
+    @pulumi.getter(name="enableReplaceCRD")
+    def enable_replace_crd(self) -> Optional[pulumi.Input[bool]]:
+        """
+        BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
+        This feature is in developer preview, and is disabled by default.
+        """
+        return pulumi.get(self, "enable_replace_crd")
+
+    @enable_replace_crd.setter
+    def enable_replace_crd(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_replace_crd", value)
 
     @property
     @pulumi.getter(name="helmReleaseSettings")
@@ -221,6 +241,7 @@ class Provider(pulumi.ProviderResource):
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
+                 enable_replace_crd: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
                  kubeconfig: Optional[pulumi.Input[str]] = None,
@@ -237,6 +258,8 @@ class Provider(pulumi.ProviderResource):
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
         :param pulumi.Input[str] context: If present, the name of the kubeconfig context to use.
         :param pulumi.Input[bool] enable_dry_run: BETA FEATURE - If present and set to true, enable server-side diff calculations.
+               This feature is in developer preview, and is disabled by default.
+        :param pulumi.Input[bool] enable_replace_crd: BETA FEATURE - If present and set to true, replace CRDs on update rather than patching.
                This feature is in developer preview, and is disabled by default.
         :param pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
@@ -285,6 +308,7 @@ class Provider(pulumi.ProviderResource):
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
+                 enable_replace_crd: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
                  kubeconfig: Optional[pulumi.Input[str]] = None,
@@ -309,6 +333,9 @@ class Provider(pulumi.ProviderResource):
             if enable_dry_run is None:
                 enable_dry_run = _utilities.get_env_bool('PULUMI_K8S_ENABLE_DRY_RUN')
             __props__.__dict__["enable_dry_run"] = pulumi.Output.from_input(enable_dry_run).apply(pulumi.runtime.to_json) if enable_dry_run is not None else None
+            if enable_replace_crd is None:
+                enable_replace_crd = _utilities.get_env_bool('PULUMI_K8S_ENABLE_REPLACE_CRD')
+            __props__.__dict__["enable_replace_crd"] = pulumi.Output.from_input(enable_replace_crd).apply(pulumi.runtime.to_json) if enable_replace_crd is not None else None
             __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings).apply(pulumi.runtime.to_json) if helm_release_settings is not None else None
             __props__.__dict__["kube_client_settings"] = pulumi.Output.from_input(kube_client_settings).apply(pulumi.runtime.to_json) if kube_client_settings is not None else None
             if kubeconfig is None:

--- a/tests/sdk/nodejs/crd-upgrade/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/crd-upgrade/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: crd-upgrade
+description: A program that tests CRD upgrades.
+runtime: nodejs

--- a/tests/sdk/nodejs/crd-upgrade/step1/index.ts
+++ b/tests/sdk/nodejs/crd-upgrade/step1/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Create a CustomResourceDefinition.
+//
+
+new k8s.yaml.ConfigFile(
+    `operator-manifest`,
+    {
+        file: 'https://download.elastic.co/downloads/eck/1.8.0/crds-legacy.yaml', // Old version of the CRD
+    },
+)

--- a/tests/sdk/nodejs/crd-upgrade/step1/index.ts
+++ b/tests/sdk/nodejs/crd-upgrade/step1/index.ts
@@ -14,6 +14,10 @@
 
 import * as k8s from "@pulumi/kubernetes";
 
+const provider = new k8s.Provider("k8s", {
+    enableReplaceCRD: true,
+});
+
 //
 // Create a CustomResourceDefinition.
 //
@@ -23,4 +27,5 @@ new k8s.yaml.ConfigFile(
     {
         file: 'https://download.elastic.co/downloads/eck/1.8.0/crds-legacy.yaml', // Old version of the CRD
     },
+    {provider},
 )

--- a/tests/sdk/nodejs/crd-upgrade/step1/package.json
+++ b/tests/sdk/nodejs/crd-upgrade/step1/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "crd-upgrade",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/crd-upgrade/step1/tsconfig.json
+++ b/tests/sdk/nodejs/crd-upgrade/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/crd-upgrade/step2/index.ts
+++ b/tests/sdk/nodejs/crd-upgrade/step2/index.ts
@@ -14,6 +14,10 @@
 
 import * as k8s from "@pulumi/kubernetes";
 
+const provider = new k8s.Provider("k8s", {
+    enableReplaceCRD: true,
+});
+
 //
 // Create a CustomResourceDefinition.
 //
@@ -23,4 +27,5 @@ new k8s.yaml.ConfigFile(
     {
         file: 'https://download.elastic.co/downloads/eck/1.8.0/crds.yaml', // New version of the CRD
     },
+    {provider},
 )

--- a/tests/sdk/nodejs/crd-upgrade/step2/index.ts
+++ b/tests/sdk/nodejs/crd-upgrade/step2/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+//
+// Create a CustomResourceDefinition.
+//
+
+new k8s.yaml.ConfigFile(
+    `operator-manifest`,
+    {
+        file: 'https://download.elastic.co/downloads/eck/1.8.0/crds.yaml', // New version of the CRD
+    },
+)

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -271,6 +271,21 @@ func TestCRDs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestCRDUpgrade(t *testing.T) {
+	test := baseOptions.With(integration.ProgramTestOptions{
+		Dir:                  filepath.Join("crd-upgrade", "step1"),
+		Quick:                false,
+		ExpectRefreshChanges: true,
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      filepath.Join("crd-upgrade", "step2"),
+				Additive: true,
+			},
+		},
+	})
+	integration.ProgramTest(t, &test)
+}
+
 func TestPod(t *testing.T) {
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:   filepath.Join("delete-before-replace", "step1"),


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the provider attempted to update CRDs with the
normal PATCH workflow (equivalent to `kubectl apply`). This
process did not work for some CRDs.

Rather than patching the existing CRD, the provider will now
replace the old definition using a PUT operation (equivalent to
`kubectl replace`). This fixes the cases where the PATCH
operation failed, while still providing accurate previews and
replacement semantics.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/1293
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
