### PR TITLE
Increase burst and qps for test clients

### DIFF
--- a/tests/sdk/dotnet/dotnet_test.go
+++ b/tests/sdk/dotnet/dotnet_test.go
@@ -35,6 +35,10 @@ var baseOptions = &integration.ProgramTestOptions{
 	Dependencies: []string{
 		"Pulumi.Kubernetes",
 	},
+	Env: []string{
+		"PULUMI_K8S_CLIENT_BURST=200",
+		"PULUMI_K8S_CLIENT_QPS=100",
+	},
 }
 
 func TestDotnet_Basic(t *testing.T) {

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -34,6 +34,10 @@ var baseOptions = &integration.ProgramTestOptions{
 	Dependencies: []string{
 		"github.com/pulumi/pulumi-kubernetes/sdk/v3",
 	},
+	Env: []string{
+		"PULUMI_K8S_CLIENT_BURST=200",
+		"PULUMI_K8S_CLIENT_QPS=100",
+	},
 }
 
 // TestGo runs Go SDK tests sequentially to avoid OOM errors in CI

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -16,12 +16,6 @@ package examples
 
 import (
 	"fmt"
-	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/openapi"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
-	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +23,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/openapi"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccMinimal(t *testing.T) {
@@ -478,6 +479,10 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	return integration.ProgramTestOptions{
 		Dependencies: []string{
 			"@pulumi/kubernetes",
+		},
+		Env: []string{
+			"PULUMI_K8S_CLIENT_BURST=200",
+			"PULUMI_K8S_CLIENT_QPS=100",
 		},
 	}
 }

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -41,6 +41,10 @@ var baseOptions = &integration.ProgramTestOptions{
 	Dependencies: []string{
 		"@pulumi/kubernetes",
 	},
+	Env: []string{
+		"PULUMI_K8S_CLIENT_BURST=200",
+		"PULUMI_K8S_CLIENT_QPS=100",
+	},
 }
 
 func TestAliases(t *testing.T) {

--- a/tests/sdk/python/python_test.go
+++ b/tests/sdk/python/python_test.go
@@ -37,6 +37,10 @@ var baseOptions = &integration.ProgramTestOptions{
 	Dependencies: []string{
 		filepath.Join("..", "..", "..", "sdk", "python", "bin"),
 	},
+	Env: []string{
+		"PULUMI_K8S_CLIENT_BURST=200",
+		"PULUMI_K8S_CLIENT_QPS=100",
+	},
 }
 
 func TestSmoke(t *testing.T) {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Increase the kube client burst and qps settings to avoid client-side throttling in tests.

Previous to this change, tests would include warnings like this:
```
I1206 21:48:21.676874   15390 request.go:665] Waited for 1.045983679s due to client-side throttling, not priority and fairness, request: GET:https://34.83.73.7/api/v1/namespaces/default/endpoints
```

These warnings are not present with this change.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
