### PR TITLE
Helm Release: fix username fetch option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Helm Release: fix username fetch option (https://github.com/pulumi/pulumi-kubernetes/pull/1824)
+
 ## 3.12.0 (December 7, 2021)
 
 - Add support for k8s v1.23.0. (https://github.com/pulumi/pulumi-kubernetes/pull/1681)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -985,7 +985,7 @@ func computeResourceNames(r *Release) (map[string][]string, error) {
 			Keyring:  r.Keyring,
 			Password: r.RepositoryOpts.Password,
 			Repo:     r.RepositoryOpts.Repo,
-			Username: r.RepositoryOpts.Password,
+			Username: r.RepositoryOpts.Username,
 			Version:  r.Version,
 		}
 	} else {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The username was incorrectly being set to the password value,
which caused authentication to fail for private Helm repos.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1757
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
