### PR TITLE
Miscelaneous helm release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## HEAD (Unreleased)
 - Helm Release: Helm Release imports support (https://github.com/pulumi/pulumi-kubernetes/pull/1818)
-
 - Helm Release: fix username fetch option (https://github.com/pulumi/pulumi-kubernetes/pull/1824)
+- Helm Release: Use URN name as base for autonaming, Drop warning, fix default value for 
+  keyring (https://github.com/pulumi/pulumi-kubernetes/pull/1826)
 
 ## 3.12.0 (December 7, 2021)
 

--- a/provider/pkg/provider/custom.go
+++ b/provider/pkg/provider/custom.go
@@ -12,7 +12,7 @@ type customResourceProvider interface {
 	// Check validates that the given property bag is valid for a resource of the given type and returns
 	// the inputs that should be passed to successive calls to Diff, Create, or Update for this
 	// resource.
-	Check(ctx context.Context, req *pulumirpc.CheckRequest, displayBetaWarning bool) (*pulumirpc.CheckResponse, error)
+	Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error)
 	// Diff checks what impacts a hypothetical update will have on the resource's properties.
 	Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error)
 	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -123,13 +123,12 @@ type kubeProvider struct {
 	suppressDeprecationWarnings bool
 	suppressHelmHookWarnings    bool
 
-	suppressHelmReleaseBetaWarning bool
-	helmDriver                     string
-	helmPluginsPath                string
-	helmRegistryConfigPath         string
-	helmRepositoryConfigPath       string
-	helmRepositoryCache            string
-	helmReleaseProvider            customResourceProvider
+	helmDriver               string
+	helmPluginsPath          string
+	helmRegistryConfigPath   string
+	helmRepositoryConfigPath string
+	helmRepositoryCache      string
+	helmReleaseProvider      customResourceProvider
 
 	yamlRenderMode bool
 	yamlDirectory  string
@@ -543,19 +542,6 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		return helmpath.CachePath("repository")
 	}
 	k.helmRepositoryCache = helmRepositoryCache()
-
-	suppressHelmReleaseBetaWarning := func() bool {
-		if helmReleaseSettings.SuppressBetaWarning != nil {
-			return *helmReleaseSettings.SuppressBetaWarning
-		}
-
-		// If the provider flag is not set, fall back to the ENV var.
-		if disabled, exists := os.LookupEnv("PULUMI_K8S_SUPPRESS_HELM_RELEASE_BETA_WARNING"); exists {
-			return disabled == trueStr
-		}
-		return false
-	}
-	k.suppressHelmReleaseBetaWarning = suppressHelmReleaseBetaWarning()
 
 	// Rather than erroring out on an invalid k8s config, mark the cluster as unreachable and conditionally bail out on
 	// operations that require a valid cluster. This will allow us to perform invoke operations using the default
@@ -1231,7 +1217,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 
 	if isHelmRelease(urn) && !hasComputedValue(newInputs) {
 		if !k.clusterUnreachable {
-			return k.helmReleaseProvider.Check(ctx, req, !k.suppressHelmReleaseBetaWarning)
+			return k.helmReleaseProvider.Check(ctx, req)
 		}
 		return nil, fmt.Errorf("can't use Helm Release with unreachable cluster. Reason: %q", k.clusterUnreachableReason)
 	}


### PR DESCRIPTION
1. Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1825 - keyring should
   only be autopopulated if verification is requested
2. Autonaming now uses the URN name as base instead of "release"
3. Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1749 - Drop the onerous beta warning for Helm release

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
