### PR TITLE
Exclude nil entries from values for helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
 - Relax ingress await restrictions (https://github.com/pulumi/pulumi-kubernetes/pull/1832)
+- Exclude nil entries from values (https://github.com/pulumi/pulumi-kubernetes/pull/1845)
 
 ## 3.12.1 (December 9, 2021)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1237,7 +1237,13 @@ func excludeNulls(in interface{}) interface{} {
 		m := in.(map[string]interface{})
 		for k, v := range m {
 			val := reflect.ValueOf(v)
-			if val.IsValid() && !val.IsNil() {
+			if val.IsValid() {
+				switch val.Kind() {
+				case reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+					if val.IsNil() {
+						continue
+					}
+				}
 				out[k] = excludeNulls(v)
 			}
 		}

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_MergeMaps(t *testing.T) {
 	m := map[string]interface{}{
-		"a": map[string]interface{} {
+		"a": map[string]interface{}{
 			"b": map[string]interface{}{
 				"d": []interface{}{
 					"1", "2",
@@ -17,8 +17,8 @@ func Test_MergeMaps(t *testing.T) {
 		},
 	}
 
-	override :=  map[string]interface{}{
-		"a": map[string]interface{} {
+	override := map[string]interface{}{
+		"a": map[string]interface{}{
 			"b": map[string]interface{}{
 				"d": []interface{}{
 					"3", "4",
@@ -27,32 +27,33 @@ func Test_MergeMaps(t *testing.T) {
 		},
 	}
 
-	for _, test := range []struct{
-		name string
-		dest map[string]interface{}
-		src map[string]interface{}
+	for _, test := range []struct {
+		name     string
+		dest     map[string]interface{}
+		src      map[string]interface{}
 		expected map[string]interface{}
-	} {
+	}{
 		{
-			name: "Precedence",
-			dest: m,
-			src: override,
+			name:     "Precedence",
+			dest:     m,
+			src:      override,
 			expected: override, // Expect the override to take precedence
 		},
 		{
 			name: "Merge maps",
 			dest: m,
 			src: map[string]interface{}{
-				"a": map[string]interface{} {
+				"a": map[string]interface{}{
 					"b": map[string]interface{}{
 						"c": []interface{}{
 							"3", "4",
 						},
+						"f": true,
 					},
 				},
 			},
-			expected:  map[string]interface{}{
-				"a": map[string]interface{} {
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
 					"b": map[string]interface{}{
 						"d": []interface{}{
 							"1", "2",
@@ -60,6 +61,7 @@ func Test_MergeMaps(t *testing.T) {
 						"c": []interface{}{
 							"3", "4",
 						},
+						"f": true,
 					},
 				},
 			},
@@ -68,15 +70,15 @@ func Test_MergeMaps(t *testing.T) {
 			name: "Dest Has Nil Values",
 			dest: m,
 			src: map[string]interface{}{
-				"a": map[string]interface{} {
+				"a": map[string]interface{}{
 					"b": map[string]interface{}{
 						"c": interface{}(nil),
 						"e": (*interface{})(nil),
 					},
 				},
 			},
-			expected:  map[string]interface{}{
-				"a": map[string]interface{} {
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
 					"b": map[string]interface{}{
 						"d": []interface{}{
 							"1", "2",

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_MergeMaps(t *testing.T) {
+	m := map[string]interface{}{
+		"a": map[string]interface{} {
+			"b": map[string]interface{}{
+				"d": []interface{}{
+					"1", "2",
+				},
+			},
+		},
+	}
+
+	override :=  map[string]interface{}{
+		"a": map[string]interface{} {
+			"b": map[string]interface{}{
+				"d": []interface{}{
+					"3", "4",
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct{
+		name string
+		dest map[string]interface{}
+		src map[string]interface{}
+		expected map[string]interface{}
+	} {
+		{
+			name: "Precedence",
+			dest: m,
+			src: override,
+			expected: override, // Expect the override to take precedence
+		},
+		{
+			name: "Merge maps",
+			dest: m,
+			src: map[string]interface{}{
+				"a": map[string]interface{} {
+					"b": map[string]interface{}{
+						"c": []interface{}{
+							"3", "4",
+						},
+					},
+				},
+			},
+			expected:  map[string]interface{}{
+				"a": map[string]interface{} {
+					"b": map[string]interface{}{
+						"d": []interface{}{
+							"1", "2",
+						},
+						"c": []interface{}{
+							"3", "4",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Dest Has Nil Values",
+			dest: m,
+			src: map[string]interface{}{
+				"a": map[string]interface{} {
+					"b": map[string]interface{}{
+						"c": interface{}(nil),
+						"e": (*interface{})(nil),
+					},
+				},
+			},
+			expected:  map[string]interface{}{
+				"a": map[string]interface{} {
+					"b": map[string]interface{}{
+						"d": []interface{}{
+							"1", "2",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			merged, err := mergeMaps(test.dest, test.src)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, merged)
+		})
+	}
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Avoid panics related to invalid/nil values for helm charts/releases which can cause assertion failures when converting to property maps as in #1842.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1842 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
