### PR TITLE
Fix panic for deletions from virtual fields in Helm Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change await log type to cloud-ready-check lib (https://github.com/pulumi/pulumi-kubernetes/pull/1855)
 - Populate inputs from live state for imports (https://github.com/pulumi/pulumi-kubernetes/pull/1846)
 - Elide last-applied-configuration annotation when server-side support is enabled (https://github.com/pulumi/pulumi-kubernetes/pull/1863)
+- Fix panic for deletions from virtual fields in Helm Release (https://github.com/pulumi/pulumi-kubernetes/pull/1850)
 
 ## 3.12.2 (January 5, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## HEAD (Unreleased)
-(None)
+- Fix panic for deletions from virtual fields in Helm Release (https://github.com/pulumi/pulumi-kubernetes/pull/1850)
 
 ## 3.13.0 (January 7, 2022)
 - Change await log type to cloud-ready-check lib (https://github.com/pulumi/pulumi-kubernetes/pull/1855)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2881,7 +2881,6 @@ type patchConverter struct {
 func (pc *patchConverter) addPatchValueToDiff(
 	path []interface{}, v, old, newInput, oldInput interface{}, inArray bool,
 ) error {
-
 	contract.Assertf(v != nil || old != nil || oldInput != nil,
 		"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v",
 		path, v, old, oldInput)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2882,7 +2882,9 @@ func (pc *patchConverter) addPatchValueToDiff(
 	path []interface{}, v, old, newInput, oldInput interface{}, inArray bool,
 ) error {
 
-	contract.Assert(v != nil || old != nil)
+	contract.Assertf(v != nil || old != nil || oldInput != nil,
+		"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v",
+		path, v, old, oldInput)
 
 	// If there is no new input, then the only possible diff here is a delete. All other diffs must be diffs between
 	// old and new properties that are populated by the server. If there is also no old input, then there is no diff

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -409,7 +409,7 @@ func TestHelmRelease(t *testing.T) {
 				assert.Contains(t, values, "cluster")
 				valMap := values.(map[string]interface{})
 				assert.Equal(t, valMap["cluster"], map[string]interface{}{
-					"enabled": true,
+					"enabled":    true,
 					"slaveCount": float64(2),
 				})
 				// not asserting contents since the secret is hard to assert equality on.
@@ -423,7 +423,7 @@ func TestHelmRelease(t *testing.T) {
 						},
 					},
 				})
-				assert.Contains(t, values,"rbac")
+				assert.Contains(t, values, "rbac")
 				assert.Equal(t, valMap["rbac"], map[string]interface{}{
 					"create": true,
 				})
@@ -432,14 +432,14 @@ func TestHelmRelease(t *testing.T) {
 	}
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:         filepath.Join(getCwd(t), "helm-release", "step1"),
-			SkipRefresh: false,
-			Verbose:     true,
+			Dir:                    filepath.Join(getCwd(t), "helm-release", "step1"),
+			SkipRefresh:            false,
+			Verbose:                true,
 			ExtraRuntimeValidation: validationFunc,
 			EditDirs: []integration.EditDir{
 				{
-					Dir:      filepath.Join(getCwd(t), "helm-release", "step2"),
-					Additive: true,
+					Dir:                    filepath.Join(getCwd(t), "helm-release", "step2"),
+					Additive:               true,
 					ExtraRuntimeValidation: validationFunc,
 				},
 			},
@@ -482,6 +482,25 @@ func TestHelmReleaseNamespace(t *testing.T) {
 			},
 		})
 
+	integration.ProgramTest(t, &test)
+}
+
+func TestRancher(t *testing.T) {
+	// Validate fix for https://github.com/pulumi/pulumi-kubernetes/issues/1848
+	skipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         filepath.Join(getCwd(t), "rancher", "step1"),
+			SkipRefresh: true,
+			Verbose:     true,
+			NoParallel:  true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      filepath.Join(getCwd(t), "rancher", "step2"),
+					Additive: true,
+				},
+			},
+		})
 	integration.ProgramTest(t, &test)
 }
 

--- a/tests/sdk/nodejs/examples/rancher/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/examples/rancher/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: rancher
+runtime: nodejs
+description: A minimal Kubernetes TypeScript Pulumi program

--- a/tests/sdk/nodejs/examples/rancher/step1/index.ts
+++ b/tests/sdk/nodejs/examples/rancher/step1/index.ts
@@ -1,0 +1,22 @@
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("release-ns");
+
+const release = new k8s.helm.v3.Release("rancher-release", {
+    chart: "rancher",
+    repositoryOpts: {
+        repo: "https://releases.rancher.com/server-charts/latest",
+    },
+    version: "v2.6.2",
+    namespace: namespace.metadata.name,
+    values: {
+        hostname: "rancher.examples.pulumi.com",
+        ingress: {
+            tls: {
+                source: "secret",
+            },
+        },
+    },
+    skipAwait: true,
+});
+

--- a/tests/sdk/nodejs/examples/rancher/step1/package.json
+++ b/tests/sdk/nodejs/examples/rancher/step1/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "rancher",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/examples/rancher/step1/tsconfig.json
+++ b/tests/sdk/nodejs/examples/rancher/step1/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/examples/rancher/step2/index.ts
+++ b/tests/sdk/nodejs/examples/rancher/step2/index.ts
@@ -1,0 +1,22 @@
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("release-ns");
+
+const release = new k8s.helm.v3.Release("rancher-release", {
+    chart: "rancher",
+    repositoryOpts: {
+        repo: "https://releases.rancher.com/server-charts/latest",
+    },
+    version: "v2.6.3", // <--- change.
+    namespace: namespace.metadata.name,
+    values: {
+        hostname: "rancher.examples.pulumi.com",
+        ingress: {
+            tls: {
+                source: "secret",
+            },
+        },
+    },
+    skipAwait: true,
+});
+


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
In the Helm Release resource, we have dynamically generated utility fields like `resourceNames` which are a mapping from k8s GVK to names which are in place to provide some partial visibility into changes in release versions/values. We compute this map from the manifests for the helm release in `Check` and as such is only part of input and not of the release state. During changes we recompute the `resourceNames` map and compute a diff of the release state and inputs. An assertion in the diff calculation code made some strong assumptions on the state for deletions which this relaxes.
The provided test would panic without this change.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1848 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
