### PR TITLE
Elide last applied configuration annotation when SSA is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## HEAD (Unreleased)
 
 - Change await log type to cloud-ready-check lib (https://github.com/pulumi/pulumi-kubernetes/pull/1855)
+- Populate inputs from live state for imports (https://github.com/pulumi/pulumi-kubernetes/pull/1846)
+- Elide last-applied-configuration annotation when server-side support is enabled (https://github.com/pulumi/pulumi-kubernetes/pull/1863)
 
 ## 3.12.2 (January 5, 2022)
 
 - Relax ingress await restrictions (https://github.com/pulumi/pulumi-kubernetes/pull/1832)
 - Exclude nil entries from values (https://github.com/pulumi/pulumi-kubernetes/pull/1845)
-- Populate inputs from live state for imports (https://github.com/pulumi/pulumi-kubernetes/pull/1846)
 
 ## 3.12.1 (December 9, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1657,7 +1657,7 @@ func (k *kubeProvider) Create(
 		return &pulumirpc.CreateResponse{Id: "", Properties: req.GetProperties()}, nil
 	}
 
-	annotatedInputs, err := withLastAppliedConfig(newInputs)
+	annotatedInputs, err := k.withLastAppliedConfig(newInputs)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(
 			err, "Failed to create resource %s/%s because of an error generating the %s value in "+
@@ -1971,7 +1971,7 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 		unstructured.RemoveNestedField(liveInputs.Object, "metadata", "managedFields")
 		unstructured.RemoveNestedField(liveInputs.Object, "metadata", "resourceVersion")
 		unstructured.RemoveNestedField(liveInputs.Object, "metadata", "uid")
-		unstructured.RemoveNestedField(liveInputs.Object, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
+		unstructured.RemoveNestedField(liveInputs.Object, "metadata", "annotations", lastAppliedConfigKey)
 	}
 
 	// TODO(lblackstone): not sure why this is needed
@@ -2126,7 +2126,7 @@ func (k *kubeProvider) Update(
 	// Ignore old state; we'll get it from Kubernetes later.
 	oldInputs, _ := parseCheckpointObject(oldState)
 
-	annotatedInputs, err := withLastAppliedConfig(newInputs)
+	annotatedInputs, err := k.withLastAppliedConfig(newInputs)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(
 			err, "Failed to update resource %s/%s because of an error generating the %s value in "+
@@ -2561,6 +2561,27 @@ func (k *kubeProvider) tryServerSidePatch(oldInputs, newInputs *unstructured.Uns
 	return ssPatch, ssPatchBase, true
 }
 
+func (k *kubeProvider) withLastAppliedConfig(config *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if k.supportsDryRun(config.GroupVersionKind()) {
+		// Skip last-applied-config if the resource supports server-side apply.
+		return config, nil
+	}
+	// Serialize the inputs and add the last-applied-configuration annotation.
+	marshaled, err := config.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	// Deep copy the config before returning.
+	config = config.DeepCopy()
+
+	annotations := getAnnotations(config)
+
+	annotations[lastAppliedConfigKey] = string(marshaled)
+	config.SetAnnotations(annotations)
+	return config, nil
+}
+
 func mapReplStripSecrets(v resource.PropertyValue) (interface{}, bool) {
 	if v.IsSecret() {
 		return v.SecretValue().Element.MapRepl(nil, mapReplStripSecrets), true
@@ -2616,23 +2637,6 @@ func initialAPIVersion(state resource.PropertyMap, oldConfig *unstructured.Unstr
 	}
 
 	return oldConfig.GetAPIVersion(), nil
-}
-
-func withLastAppliedConfig(config *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	// Serialize the inputs and add the last-applied-configuration annotation.
-	marshaled, err := config.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	// Deep copy the config before returning.
-	config = config.DeepCopy()
-
-	annotations := getAnnotations(config)
-
-	annotations[lastAppliedConfigKey] = string(marshaled)
-	config.SetAnnotations(annotations)
-	return config, nil
 }
 
 func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resource.PropertyMap, initialAPIVersion string) resource.PropertyMap {

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -475,6 +475,15 @@ func TestDryRun(t *testing.T) {
 				Additive: true,
 			},
 		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			for _, res := range stackInfo.Deployment.Resources {
+				if res.Type == "kubernetes:apps/v1:Deployment" {
+					annotations, _ := openapi.Pluck(res.Outputs, "metadata", "annotations")
+					assert.NotEmpty(t, annotations)
+					assert.NotContains(t, annotations, "kubectl.kubernetes.io/last-applied-configuration")
+				}
+			}
+		},
 	})
 	integration.ProgramTest(t, &test)
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
When server side applies are supported, storing last applied configuration seems redundant. We have longstanding plans of toggling server side apply support to be on by default - see https://github.com/pulumi/pulumi-kubernetes/issues/1556. This change elides last applied config annotation when server-side apply support is enabled. This seems safe since SSA support is not enabled by default anyway thus reducing any potential risk of unexpected behavior change with this.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1048 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
