### PR TITLE
Fix detailed diff for server-side apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Fix detailed diff for server-side apply (https://github.com/pulumi/pulumi-kubernetes/pull/1873)
+
 ## 3.14.1 (January 18, 2022)
 
 - Disable last-applied-configuration annotation for replaced CRDs (https://github.com/pulumi/pulumi-kubernetes/pull/1868)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1531,9 +1531,6 @@ func (k *kubeProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*p
 					"converting JSON patch describing resource changes to a diff",
 				newInputs.GetNamespace(), newInputs.GetName())
 		}
-		for _, v := range detailedDiff {
-			v.InputDiff = true
-		}
 
 		for k, v := range detailedDiff {
 			switch v.Kind {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Previously, the provider was erroneously setting all detailed diffs
to the InputDiff mode, which ignored the changes previewed on
the API server. This changes the diff to use the InputDiff value
computed for each property.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
