### PR TITLE
Improve support for helm release operations when cluster is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## HEAD (Unreleased)
 - [Helm/Release] Remove beta warnings (https://github.com/pulumi/pulumi-kubernetes/pull/1885)
-
 - [Helm/Release] Handle partial failure during create/update (https://github.com/pulumi/pulumi-kubernetes/pull/1880)
-
+- [Helm/Release] Improve support for helm release operations when cluster is unreachable (https://github.com/pulumi/pulumi-kubernetes/pull/1886)
 - Fix detailed diff for server-side apply (https://github.com/pulumi/pulumi-kubernetes/pull/1873)
 
 ## 3.14.1 (January 18, 2022)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2247,7 +2247,7 @@ func (k *kubeProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest)
 
 	if isHelmRelease(urn) {
 		if k.clusterUnreachable {
-			return nil, fmt.Errorf("can't delete Helm Release with unreachable cluster")
+			return nil, fmt.Errorf("can't delete Helm Release with unreachable cluster. Reason: %q", k.clusterUnreachableReason)
 		}
 		return k.helmReleaseProvider.Delete(ctx, req)
 	}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This change enables the helm release related previews to happen without requiring an active connection to the cluster. Also includes a few debugging/logging improvements.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1794 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
