### PR TITLE
fix: infer default namespace unless provided by provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Infer default namespace from kubeconfig when not configured via the provider
+- Infer default namespace from kubeconfig when not configured via the provider (https://github.com/pulumi/pulumi-kubernetes/pull/1896)
 
 ## 3.15.1 (February 2, 2022)
 - [Helm/Release] Add import docs (https://github.com/pulumi/pulumi-kubernetes/pull/1893)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Infer default namespace from kubeconfig when not configured via the provider
+
 ## 3.15.1 (February 2, 2022)
 - [Helm/Release] Add import docs (https://github.com/pulumi/pulumi-kubernetes/pull/1893)
 


### PR DESCRIPTION
### Proposed changes

Use the discovered kubeconfig namespace when one isn't provided by the Provider configuration instead of default.

### Related issues (optional)

Fix #971 