### PR TITLE
Fix an error handling bug in await logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Infer default namespace from kubeconfig when not configured via the provider (https://github.com/pulumi/pulumi-kubernetes/pull/1896)
+- Fix an error handling bug in await logic (https://github.com/pulumi/pulumi-kubernetes/pull/1899)
 
 ## 3.15.1 (February 2, 2022)
 - [Helm/Release] Add import docs (https://github.com/pulumi/pulumi-kubernetes/pull/1893)

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -379,6 +379,9 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 		// it. The PUT operation is still validated by the api server, so a badly formed request will fail as usual.
 		c.Inputs.SetResourceVersion(liveOldObj.GetResourceVersion())
 		currentOutputs, err = client.Update(context.TODO(), c.Inputs, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// Create merge patch (prefer strategic merge patch, fall back to JSON merge patch).
 		patch, patchType, _, err := openapi.PatchForResourceUpdate(c.Resources, c.Previous, c.Inputs, liveOldObj)
@@ -395,6 +398,9 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 		// NOTE: We can use the same client because if the `kind` changes, this will cause
 		// a replace (i.e., destroy and create).
 		currentOutputs, err = client.Patch(context.TODO(), c.Inputs.GetName(), patchType, patch, options)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This code was missing an err check based on the mistaken assumption that it would be checked following the conditional block. This wasn't working as intended due to block scoping.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
