### PR TITLE
Disable flaky ingress e2e test

### DIFF
--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -195,11 +195,12 @@ func TestAccIngress(t *testing.T) {
 						return assert.NotEmpty(t, body, "Body should not be empty")
 					})
 
-				integration.AssertHTTPResultWithRetry(t,
-					fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
-					map[string]string{"Host": "ingresshello.io"}, 5*time.Minute, func(body string) bool {
-						return assert.NotEmpty(t, body, "Body should not be empty")
-					})
+				// Disabling this to avoid test flakes.
+				// integration.AssertHTTPResultWithRetry(t,
+				// 	 fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
+				//	 map[string]string{"Host": "ingresshello.io"}, 5*time.Minute, func(body string) bool {
+				//		 return assert.NotEmpty(t, body, "Body should not be empty")
+				//	 })
 			},
 		})
 	integration.ProgramTest(t, &testWithNetworkingBeta1)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This disables a flaky timeout during e2e tests: https://github.com/pulumi/pulumi-kubernetes/runs/5129873614?check_suite_focus=true

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
