### PR TITLE
[internal] Migrate CHANGELOG to use GitHub Releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,15 @@ builds:
       - -X github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/version.Version={{.Tag}}
     main: ./cmd/pulumi-resource-kubernetes/
 changelog:
-  skip: true
+  filters:
+    exclude:
+      - Merge branch
+      - Merge pull request
+      - \Winternal\W
+      - \Wci\W
+      - \Wchore\W
+  sort: asc
+  use: git
 release:
   disable: false
 snapshot:

--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,3 +1,7 @@
+## Notice (2022-03-11)
+
+*As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-kubernetes/releases) for this repository*
+
 ## Unreleased
 (None)
 


### PR DESCRIPTION
Fixes: #1890
