### PR TITLE
Revert "[internal] Migrate CHANGELOG to use GitHub Releases"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,15 +31,7 @@ builds:
       - -X github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/version.Version={{.Tag}}
     main: ./cmd/pulumi-resource-kubernetes/
 changelog:
-  filters:
-    exclude:
-      - Merge branch
-      - Merge pull request
-      - \Winternal\W
-      - \Wci\W
-      - \Wchore\W
-  sort: asc
-  use: git
+  skip: true
 release:
   disable: false
 snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Notice (2022-03-11)
-
-*As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-kubernetes/releases) for this repository*
-
 ## Unreleased
 (None)
 


### PR DESCRIPTION
Reverts pulumi/pulumi-kubernetes#1927