### PR TITLE
Fix DaemonSet name on diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix the DaemonSet name on diff which prevented pulumi to replace the resource (https://github.com/pulumi/pulumi-kubernetes/pull/1951)
 (None)
 
 ## 3.18.1 (April 5, 2022)

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -41,14 +41,14 @@ type properties []string
 
 var forceNew = _groups{
 	"apps": _versions{
-		// NOTE: .spec.selector triggers a replacement in Deployment/Daemonset only AFTER v1beta1.
+		// NOTE: .spec.selector triggers a replacement in Deployment/DaemonSet only AFTER v1beta1.
 		"v1beta1": _kinds{"StatefulSet": statefulSet},
 		"v1beta2": _kinds{
-			"Daemonset":   daemonset,
+			"DaemonSet":   daemonset,
 			"Deployment":  deployment,
 			"StatefulSet": statefulSet},
 		"v1": _kinds{
-			"Daemonset":   daemonset,
+			"DaemonSet":   daemonset,
 			"Deployment":  deployment,
 			"StatefulSet": statefulSet},
 	},

--- a/tests/sdk/nodejs/replace-daemonset/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/replace-daemonset/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: replace-daemonset
+description: A program to test if the DaemonSet is replaced when the .spec.selector is updated
+runtime: nodejs

--- a/tests/sdk/nodejs/replace-daemonset/step1/index.ts
+++ b/tests/sdk/nodejs/replace-daemonset/step1/index.ts
@@ -1,0 +1,17 @@
+import * as k8s from "@pulumi/kubernetes";
+
+const appLabels = {
+    app: "nginx",
+};
+
+const daemonset = new k8s.apps.v1.DaemonSet("test-replacement", {
+    spec: {
+        selector: { matchLabels: appLabels },
+        template: {
+            metadata: { labels: appLabels },
+            spec: { containers: [{ name: "nginx", image: "nginx" }] },
+        },
+    },
+});
+
+export const name = daemonset.metadata.name;

--- a/tests/sdk/nodejs/replace-daemonset/step1/package.json
+++ b/tests/sdk/nodejs/replace-daemonset/step1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "daemonset-replacement",
+  "version": "0.1.0",
+  "dependencies": {
+    "@pulumi/pulumi": "latest"
+  },
+  "devDependencies": {
+  },
+  "peerDependencies": {
+    "@pulumi/kubernetes": "latest"
+  }
+}

--- a/tests/sdk/nodejs/replace-daemonset/step1/tsconfig.json
+++ b/tests/sdk/nodejs/replace-daemonset/step1/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/replace-daemonset/step2/index.ts
+++ b/tests/sdk/nodejs/replace-daemonset/step2/index.ts
@@ -1,0 +1,18 @@
+import * as k8s from "@pulumi/kubernetes";
+
+const appLabels = {
+    app: "nginx",
+    test: "new-value",
+};
+
+const daemonset = new k8s.apps.v1.DaemonSet("test-replacement", {
+    spec: {
+        selector: { matchLabels: appLabels },
+        template: {
+            metadata: { labels: appLabels },
+            spec: { containers: [{ name: "nginx", image: "nginx" }] },
+        },
+    },
+});
+
+export const name = daemonset.metadata.name;


### PR DESCRIPTION
### Proposed changes

The DaemonSet name was set with a lower case s (Daemonset), but the kind
in the state is created with upper case (DaemonSet), and this was
preventing changes on the .spec.selector to trigger a replacement.

This issue was also causing the Kubernetes API to fail as this field is
immutable, but pulumi was trying to update it.

### Related issues (optional)

Related to https://github.com/pulumi/pulumi-kubernetes/pull/1008

Ps. I'm still testing it, but this was the only place where the DaemonSet 
    was with lower case in the code. 
    
Update: Tested locally and this fixes the issue.
