### PR TITLE
Fixes for Check() on updates for helm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-(None)
+- Fix autonaming panic for helm release (https://github.com/pulumi/pulumi-kubernetes/pull/1953)
+  This change also adds support for deterministic autonaming through sequence numbers to the kubernetes provider.
 
 ## 3.18.0 (March 31, 2022)
 - Pass provider options to helm invokes in Python, Go and TS (https://github.com/pulumi/pulumi-kubernetes/pull/1919)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -32,12 +32,10 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/mapstructure"
 	pkgerrors "github.com/pkg/errors"
-	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -335,34 +333,41 @@ func (r *helmReleaseProvider) Check(ctx context.Context, req *pulumirpc.CheckReq
 		return nil, pkgerrors.Wrapf(err, "check failed because malformed resource inputs: %+v", err)
 	}
 
-	logger.V(9).Infof("Decoding new release.")
-	new, err := decodeRelease(news, fmt.Sprintf("%s.news", label))
-	if err != nil {
-		return nil, err
-	}
-
-	logger.V(9).Infof("Decoding old release.")
-	old, err := decodeRelease(olds, fmt.Sprintf("%s.olds", label))
-	if err != nil {
-		return nil, err
-	}
-
 	if len(olds.Mappable()) > 0 {
-		adoptOldNameIfUnnamed(new, old)
+		adoptOldNameIfUnnamed(news, olds)
 	}
-	assignNameIfAutonameable(new, news, urn.Name())
-	r.setDefaults(new)
+	assignNameIfAutonameable(news, urn, int(req.GetSequenceNumber()))
+	r.setDefaults(news)
 
-	resourceNames, err := r.computeResourceNames(new)
+	if !news.ContainsUnknowns() {
+		logger.V(9).Infof("Decoding new release.")
+		new, err := decodeRelease(news, fmt.Sprintf("%s.news", label))
+		if err != nil {
+			return nil, err
+		}
+
+		resourceNames, err := r.computeResourceNames(new)
+		if err != nil {
+			return nil, err
+		}
+		new.ResourceNames = resourceNames
+		logger.V(9).Infof("New: %+v", new)
+		news = resource.NewPropertyMap(new)
+	}
+
+	newInputs, err := plugin.UnmarshalProperties(newResInputs, plugin.MarshalOptions{
+		Label:        fmt.Sprintf("%s.newInputs", label),
+		KeepUnknowns: true,
+		SkipNulls:    true,
+		KeepSecrets:  true,
+	})
 	if err != nil {
-		return nil, err
+		return nil, pkgerrors.Wrapf(err, "check failed because malformed resource inputs: %+v", err)
 	}
-	new.ResourceNames = resourceNames
+	// ensure we don't leak secrets into state.
+	annotateSecrets(news, newInputs)
 
-	logger.V(9).Infof("New: %+v", new)
-	autonamed := resource.NewPropertyMap(new)
-	annotateSecrets(autonamed, news)
-	autonamedInputs, err := plugin.MarshalProperties(autonamed, plugin.MarshalOptions{
+	autonamedInputs, err := plugin.MarshalProperties(news, plugin.MarshalOptions{
 		Label:        fmt.Sprintf("%s.autonamedInputs", label),
 		KeepUnknowns: true,
 		SkipNulls:    true,
@@ -376,17 +381,23 @@ func (r *helmReleaseProvider) Check(ctx context.Context, req *pulumirpc.CheckReq
 	return &pulumirpc.CheckResponse{Inputs: autonamedInputs}, nil
 }
 
-func (r *helmReleaseProvider) setDefaults(new *Release) {
-	if new.Namespace == "" {
-		new.Namespace = r.defaultNamespace
+func (r *helmReleaseProvider) setDefaults(target resource.PropertyMap) {
+	namespace, ok := target["namespace"]
+	if !ok || (namespace.IsString() && namespace.StringValue() == "") {
+		target["namespace"] = resource.NewStringProperty(r.defaultNamespace)
 	}
 
-	if !new.SkipAwait && new.Timeout == 0 {
-		new.Timeout = defaultTimeoutSeconds
+	skipAwaitVal, ok := target["skipAwait"]
+	if !ok || (skipAwaitVal.IsBool() && skipAwaitVal.BoolValue()) {
+		timeout, has := target["timeout"]
+		if !has || (timeout.IsNumber() && timeout.NumberValue() == 0) {
+			target["timeout"] = resource.NewNumberProperty(defaultTimeoutSeconds)
+		}
 	}
 
-	if new.Keyring == "" && new.Verify {
-		new.Keyring = os.ExpandEnv("$HOME/.gnupg/pubring.gpg")
+	keyringVal, ok := target["keyring"]
+	if !ok || (keyringVal.IsString() && keyringVal.StringValue() == "") {
+		target["keyring"] = resource.NewStringProperty(os.ExpandEnv("$HOME/.gnupg/pubring.gpg"))
 	}
 }
 
@@ -598,20 +609,21 @@ func (r *helmReleaseProvider) helmUpdate(newRelease, oldRelease *Release) error 
 	return err
 }
 
-func adoptOldNameIfUnnamed(new, old *Release) {
-	contract.Assert(old.Name != "")
-	new.Name = old.Name
+func adoptOldNameIfUnnamed(new, old resource.PropertyMap) {
+	if _, ok := new["name"]; ok {
+		return
+	}
+	contract.Assert(old["name"].StringValue() != "")
+	new["name"] = old["name"]
 }
 
-func assignNameIfAutonameable(release *Release, pm resource.PropertyMap, base tokens.QName) {
-	if release.Name != "" {
-		return
-	}
-	if name, ok := pm["name"]; ok && name.IsComputed() {
-		return
-	}
-	if name, ok := pm["name"]; !ok || name.StringValue() == "" {
-		release.Name = fmt.Sprintf("%s-%s", base, metadata.RandString(8))
+func assignNameIfAutonameable(pm resource.PropertyMap, urn resource.URN, sequenceNumber int) {
+	name, ok := pm["name"]
+	if !ok || (name.IsString() && name.StringValue() == "") {
+		prefix := urn.Name().String() + "-"
+		autoname, err := resource.NewUniqueHexV2(urn, sequenceNumber, prefix, 0, 0)
+		contract.AssertNoError(err)
+		pm["name"] = resource.NewStringProperty(autoname)
 	}
 }
 
@@ -898,11 +910,9 @@ func (r *helmReleaseProvider) Read(ctx context.Context, req *pulumirpc.ReadReque
 	oldInputs, _ := parseCheckpointRelease(oldState)
 	if oldInputs == nil {
 		// No old inputs suggests this is an import. Hydrate the imports from the current live object
-		r.setDefaults(existingRelease)
 		logger.V(9).Infof("existingRelease: %#v", existingRelease)
-		logger.V(9).Infof("existingRelease.Status: %#v", existingRelease.Status)
-		logger.V(9).Infof("existingRelease.Status.Revision: %#v", *existingRelease.Status.Revision)
 		oldInputs = r.serializeImportInputs(existingRelease)
+		r.setDefaults(oldInputs)
 	}
 
 	// Return a new "checkpoint object".

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -388,7 +388,7 @@ func (r *helmReleaseProvider) setDefaults(target resource.PropertyMap) {
 	}
 
 	skipAwaitVal, ok := target["skipAwait"]
-	if !ok || (skipAwaitVal.IsBool() && skipAwaitVal.BoolValue()) {
+	if !ok || (skipAwaitVal.IsBool() && !skipAwaitVal.BoolValue()) {
 		timeout, has := target["timeout"]
 		if !has || (timeout.IsNumber() && timeout.NumberValue() == 0) {
 			target["timeout"] = resource.NewNumberProperty(defaultTimeoutSeconds)

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -505,10 +505,16 @@ func TestHelmReleaseRedis(t *testing.T) {
 	skipIfShort(t)
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:         filepath.Join(getCwd(t), "helm-release-redis"),
+			Dir:         filepath.Join(getCwd(t), "helm-release-redis", "step1"),
 			SkipRefresh: false,
 			Verbose:     true,
 			Quick:       true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      filepath.Join(getCwd(t), "helm-release-redis", "step2"),
+					Additive: true,
+				},
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -500,6 +500,20 @@ func TestHelmReleaseNamespace(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestHelmReleaseRedis(t *testing.T) {
+	// Validate fix for https://github.com/pulumi/pulumi-kubernetes/issues/1933
+	skipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         filepath.Join(getCwd(t), "helm-release-redis"),
+			SkipRefresh: false,
+			Verbose:     true,
+			Quick:       true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestRancher(t *testing.T) {
 	// Validate fix for https://github.com/pulumi/pulumi-kubernetes/issues/1848
 	skipIfShort(t)

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: helm-release-redis
+runtime: nodejs
+description: A minimal Kubernetes TypeScript Pulumi program

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/kubernetes": "latest",
-    "@pulumi/kubernetesx": "^0.1.5"
+    "@pulumi/kubernetesx": "^0.1.5",
+    "@pulumi/random": "^4.4.2"
   }
 }

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "helm-release-redis",
+  "devDependencies": {
+    "@types/node": "^10.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/kubernetes": "latest",
+    "@pulumi/kubernetesx": "^0.1.5"
+  }
+}

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/tsconfig.json
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
@@ -1,0 +1,47 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+import * as random from "@pulumi/random";
+
+const redisPassword = new random.RandomPassword("password", {length: 16}); // Change password
+
+const nsName = new random.RandomPet("test");
+const namespace = new k8s.core.v1.Namespace("release-ns", {
+    metadata: {
+        name: nsName.id
+    }
+});
+
+// Validates fix for https://github.com/pulumi/pulumi-kubernetes/issues/1933
+function values(password: pulumi.Output<string>): pulumi.Input<{ [key: string]: any }> {
+    return pulumi.output({
+        cluster: {
+            enabled: true,
+            slaveCount: 1,
+        },
+        global: {
+            redis: {
+                password: password,
+            }
+        },
+        rbac: {
+            create: true,
+        },
+        service: {
+            type: "ClusterIP"
+        }
+    });
+};
+
+const release = new k8s.helm.v3.Release("redis", {
+    chart: "redis",
+    repositoryOpts: {
+        repo: "https://charts.bitnami.com/bitnami",
+    },
+    namespace: namespace.metadata.name,
+    values: values(redisPassword.result),
+});
+
+
+const srv = k8s.core.v1.Service.get("redis-master-svc", pulumi.interpolate`${release.status.namespace}/${release.status.name}-master`);
+export const redisMasterClusterIP = srv.spec.clusterIP;
+export const status = release.status.status;


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This change fixes a bug in helm release support where `Check()` wasn't kicking-in for release resources and the default k8s autonaming was being used. The autonames in previews previously bore no similarity to what was used during the apply (when unknowns are resolved).

This change also extends support to deterministic autonames using sequence numbers to all kubernetes and helm release resources while we are at it.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1933 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
