### PR TITLE
Only add keyring default value when verification is turned on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 - Fix the DaemonSet name on diff which prevented pulumi to replace the resource (https://github.com/pulumi/pulumi-kubernetes/pull/1951)
 (None)
 
+## 3.18.2 (April 6, 2022)
+- Only add keyring default value when verification is turned on (https://github.com/pulumi/pulumi-kubernetes/pull/1961)
+  Regression introduced in 3.18.1
+
 ## 3.18.1 (April 5, 2022)
 - Fix autonaming panic for helm release (https://github.com/pulumi/pulumi-kubernetes/pull/1953)
   This change also adds support for deterministic autonaming through sequence numbers to the kubernetes provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
-- Fix the DaemonSet name on diff which prevented pulumi to replace the resource (https://github.com/pulumi/pulumi-kubernetes/pull/1951)
 (None)
 
 ## 3.18.2 (April 6, 2022)
 - Only add keyring default value when verification is turned on (https://github.com/pulumi/pulumi-kubernetes/pull/1961)
   Regression introduced in 3.18.1
+- Fix the DaemonSet name on diff which prevented pulumi to replace the resource (https://github.com/pulumi/pulumi-kubernetes/pull/1951)
 
 ## 3.18.1 (April 5, 2022)
 - Fix autonaming panic for helm release (https://github.com/pulumi/pulumi-kubernetes/pull/1953)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -395,9 +395,13 @@ func (r *helmReleaseProvider) setDefaults(target resource.PropertyMap) {
 		}
 	}
 
-	keyringVal, ok := target["keyring"]
-	if !ok || (keyringVal.IsString() && keyringVal.StringValue() == "") {
-		target["keyring"] = resource.NewStringProperty(os.ExpandEnv("$HOME/.gnupg/pubring.gpg"))
+	// Discover the keyring if chart verification is requested, and a keyring is not explicitly specified.
+	verify, ok := target["verify"]
+	if ok && verify.IsBool() && verify.BoolValue() {
+		keyringVal, ok := target["keyring"]
+		if !ok || (keyringVal.IsString() && keyringVal.StringValue() == "") {
+			target["keyring"] = resource.NewStringProperty(os.ExpandEnv("$HOME/.gnupg/pubring.gpg"))
+		}
 	}
 }
 

--- a/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
@@ -39,6 +39,7 @@ const release = new k8s.helm.v3.Release("redis", {
     },
     namespace: namespace.metadata.name,
     values: values(redisPassword.result),
+    verify: false, // Turn off verification explicitly.
 });
 
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Regression introduced in #1953 where a default keyring value was being added when not specified unconditionally.
This change only injects the keyring when verification of the chart is requested and a keyring is not explicitly specified.
 
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #1959 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
