### PR TITLE
Fix fetching remote yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-(None)
+- Fix fetching remote yaml files (https://github.com/pulumi/pulumi-kubernetes/pull/1962)
 
 ## 3.18.2 (April 6, 2022)
 - Only add keyring default value when verification is turned on (https://github.com/pulumi/pulumi-kubernetes/pull/1961)

--- a/provider/pkg/gen/_go-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/_go-templates/yaml/yaml.tmpl
@@ -45,7 +45,7 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 		// Read the raw YAML file(s) specified in the input file parameter. It might be a URL or a file path.
 		var yaml []byte
 		u, err := url.Parse(file)
-		if err != nil && u.IsAbs() {
+		if err == nil && u.IsAbs() {
 			// If the string looks like a URL, in that it begins with a scheme, fetch it over the network.
 			resp, err := http.Get(file)
 			if err != nil {

--- a/sdk/go/kubernetes/yaml/yaml.go
+++ b/sdk/go/kubernetes/yaml/yaml.go
@@ -94,7 +94,7 @@ func parseDecodeYamlFiles(ctx *pulumi.Context, args *ConfigGroupArgs, glob bool,
 		// Read the raw YAML file(s) specified in the input file parameter. It might be a URL or a file path.
 		var yaml []byte
 		u, err := url.Parse(file)
-		if err != nil && u.IsAbs() {
+		if err == nil && u.IsAbs() {
 			// If the string looks like a URL, in that it begins with a scheme, fetch it over the network.
 			resp, err := http.Get(file)
 			if err != nil {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Currently it only treats the filepath  as a url if the path fails to parse as url.

### Related issues (optional)

#1851