### PR TITLE
Add label if no breaking changes found for internal PRs

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -147,6 +147,15 @@ jobs:
         name: Write details of schema change to the action log
         run: |
           echo $SCHEMA_CHANGES
+      - name: Add label if no breaking changes
+        if: |
+          github.event_name != 'repository_dispatch' &&
+          contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.')
+        uses: actions-ecosystem/action-add-labels@v1.1.0
+        with:
+          labels: impact/no-changelog-required
+          number: ${{ github.event.issue.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tar provider binaries
         run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-gen-${{ env.PROVIDER

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -71,7 +71,6 @@ jobs:
           source_branch: "update-pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
           pr_title: "Automated pulumi/pulumi upgrade"
-          pr_label: "impact/no-changelog-required"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Set Automerge
         if: steps.create-pr.outputs.has_changed_files


### PR DESCRIPTION
Add a step to the `run-acceptance-tests.yml` that will add the `impact/no-changelog-required` label for internal PRs (not triggered by repository dispatch) that have no breaking changes detected by the schema tools.  I also removed the automatic addition of that label from the pulumi/pulumi update action.

part of https://github.com/pulumi/platform-providers-team/issues/44