### PR TITLE
[TS] Pass provider to yaml resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-(None)
+- Pass provider options to yaml invokes in TS
 
 ## 3.19.2 (May 25, 2022)
 
@@ -96,7 +96,7 @@ Note: The `kubernetes:storage.k8s.io/v1alpha1:CSIStorageCapacity` API was remove
 
 - Helm Release: Helm Release imports support (https://github.com/pulumi/pulumi-kubernetes/pull/1818)
 - Helm Release: fix username fetch option (https://github.com/pulumi/pulumi-kubernetes/pull/1824)
-- Helm Release: Use URN name as base for autonaming, Drop warning, fix default value for 
+- Helm Release: Use URN name as base for autonaming, Drop warning, fix default value for
   keyring (https://github.com/pulumi/pulumi-kubernetes/pull/1826)
 - Helm Release: Add support for loading values from yaml files (https://github.com/pulumi/pulumi-kubernetes/pull/1828)
 

--- a/sdk/nodejs/helm/v2/helm.ts
+++ b/sdk/nodejs/helm/v2/helm.ts
@@ -246,7 +246,7 @@ export class Chart extends yaml.CollectionComponentResource {
                     },
                 ).toString();
                 return this.parseTemplate(
-                    yamlStream, cfg.transformations, cfg.resourcePrefix, configDeps, cfg.namespace);
+                    yamlStream, cfg.transformations, cfg.resourcePrefix, configDeps, cfg.namespace, opts);
             } catch (e: any) {
                 // Shed stack trace, only emit the error.
                 throw new pulumi.RunError(e.toString());
@@ -269,10 +269,11 @@ export class Chart extends yaml.CollectionComponentResource {
         resourcePrefix: string | undefined,
         dependsOn: pulumi.Resource[],
         defaultNamespace: string | undefined,
+        opts?: pulumi.ComponentResourceOptions
     ): pulumi.Output<{ [key: string]: pulumi.CustomResource }> {
         // Rather than using the default provider for the following invoke call, use the version specified
         // in package.json.
-        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion() };
+        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
 
         const promise = pulumi.runtime.invoke("kubernetes:yaml:decode", {text, defaultNamespace}, invokeOpts);
         return pulumi.output(promise).apply<{[key: string]: pulumi.CustomResource}>(p => yaml.parse(
@@ -281,7 +282,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: transformations || [],
             },
-            { parent: this, dependsOn: dependsOn }
+            { parent: this, dependsOn: dependsOn, provider: opts?.provider }
         ));
     }
 }

--- a/sdk/nodejs/helm/v3/helm.ts
+++ b/sdk/nodejs/helm/v3/helm.ts
@@ -240,7 +240,7 @@ export class Chart extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations,
             },
-            {parent: this}
+            { parent: this, provider: opts?.provider }
         ));
     }
 }

--- a/sdk/nodejs/kustomize/kustomize.ts
+++ b/sdk/nodejs/kustomize/kustomize.ts
@@ -98,7 +98,7 @@ export class Directory extends yaml.CollectionComponentResource {
 
         // Rather than using the default provider for the following invoke call, use the version specified
         // in package.json.
-        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion() };
+        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
 
         const promise = pulumi.runtime.invoke("kubernetes:kustomize:directory", {directory}, invokeOpts);
         this.resources = pulumi.output(promise).apply<{[key: string]: pulumi.CustomResource}>(p => yaml.parse(
@@ -107,7 +107,7 @@ export class Directory extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: config.transformations || [],
             },
-            { parent: this, dependsOn: opts?.dependsOn }
+            { parent: this, dependsOn: opts?.dependsOn, provider: opts?.provider }
         ));
     }
 }

--- a/sdk/nodejs/yaml/yaml.ts
+++ b/sdk/nodejs/yaml/yaml.ts
@@ -2717,7 +2717,7 @@ export class ConfigGroup extends CollectionComponentResource {
      */
     constructor(name: string, config: ConfigGroupOpts, opts?: pulumi.ComponentResourceOptions) {
         super("kubernetes:yaml:ConfigGroup", name, config, opts);
-        this.resources = parse(config, {parent: this});
+        this.resources = parse(config, { parent: this, provider: opts?.provider });
     }
 }
 
@@ -2809,10 +2809,10 @@ export class ConfigFile extends CollectionComponentResource {
         this.resources = pulumi.output(text.then(t => {
             try {
                 return parseYamlDocument({
-                    objs: yamlLoadAll(t),
+                    objs: yamlLoadAll(t, opts),
                     transformations,
                     resourcePrefix: config && config.resourcePrefix || undefined
-                }, {parent: this})
+                }, { parent: this, provider: opts?.provider })
             } catch (e) {
                 throw Error(`Error fetching YAML file '${fileId}': ${e}`);
             }
@@ -2889,10 +2889,10 @@ export interface ConfigOpts {
     resourcePrefix?: string;
 }
 
-/** @ignore */ function yamlLoadAll(text: string): Promise<any[]> {
+/** @ignore */ function yamlLoadAll(text: string, opts?: pulumi.ComponentResourceOptions): Promise<any[]> {
     // Rather than using the default provider for the following invoke call, use the version specified
     // in package.json.
-    let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion() };
+    let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
 
     return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
         .then((p => p.result));
@@ -2958,7 +2958,7 @@ export interface ConfigOpts {
 
         for (const text of yamlTexts) {
             const docResources = parseYamlDocument({
-                    objs: yamlLoadAll(text),
+                    objs: yamlLoadAll(text, opts),
                     transformations,
                     resourcePrefix: config.resourcePrefix
                 },


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This plumbs a provider through a few yaml flows that were implicitly relying on the default provider.

This only covers TS for now -- from the linked issues it seems this might still affect some of the other languages.

I'm not sure how to best test this -- locally it resolved an issue I was seeing with `yaml.ConfigGroup`, but I haven't verified kustomize, helm/v2, etc. I was thinking of setting `disable-default-providers` on a couple of the CI examples, but that feels pretty blunt...

### Related issues (optional)

Refs #1938 #1945
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
