### PR TITLE
Revert use of NewUniqueHexV2

### DIFF
--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -27,8 +27,7 @@ var dns1123Alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
 // AssignNameIfAutonamable generates a name for an object. Uses DNS-1123-compliant characters.
 // All auto-named resources get the annotation `pulumi.com/autonamed` for tooling purposes.
-func AssignNameIfAutonamable(obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN,
-	sequenceNumber int) {
+func AssignNameIfAutonamable(obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
 	contract.Assert(urn.Name().String() != "")
 	// Check if the .metadata.name is set and is a computed value. If so, do not auto-name.
 	if md, ok := propMap["metadata"].V.(resource.PropertyMap); ok {
@@ -39,7 +38,7 @@ func AssignNameIfAutonamable(obj *unstructured.Unstructured, propMap resource.Pr
 
 	if obj.GetName() == "" {
 		prefix := urn.Name().String() + "-"
-		autoname, err := resource.NewUniqueHexV2(urn, sequenceNumber, prefix, 0, 0)
+		autoname, err := resource.NewUniqueHex(prefix, 0, 0)
 		contract.AssertNoError(err)
 		obj.SetName(autoname)
 		SetAnnotationTrue(obj, AnnotationAutonamed)

--- a/provider/pkg/metadata/naming_test.go
+++ b/provider/pkg/metadata/naming_test.go
@@ -31,22 +31,10 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 	o1 := &unstructured.Unstructured{}
 	pm1 := resource.NewPropertyMap(struct{}{})
 	AssignNameIfAutonamable(o1, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
-		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"), 1)
+		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
 	assert.True(t, IsAutonamed(o1))
 	assert.True(t, strings.HasPrefix(o1.GetName(), "foo-"))
 	assert.Len(t, o1.GetName(), 12)
-	existing := o1.GetName()
-	// Call again with the same sequence number should result in the same name
-	o1Same := &unstructured.Unstructured{}
-	AssignNameIfAutonamable(o1Same, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
-		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"), 1)
-	assert.Equal(t, existing, o1Same.GetName())
-
-	// Call with different sequence number returns a different name
-	o1Diff := &unstructured.Unstructured{}
-	AssignNameIfAutonamable(o1Diff, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
-		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"), 2)
-	assert.NotEqual(t, existing, o1Diff.GetName())
 
 	// o2 has a name, so autonaming fails.
 	o2 := &unstructured.Unstructured{
@@ -58,7 +46,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	AssignNameIfAutonamable(o2, pm2, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
-		tokens.Type(""), tokens.Type("bang:boom/fizzle:AnotherResource"), "bar"), 2)
+		tokens.Type(""), tokens.Type("bang:boom/fizzle:AnotherResource"), "bar"))
 	assert.False(t, IsAutonamed(o2))
 	assert.Equal(t, "bar", o2.GetName())
 
@@ -72,7 +60,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	AssignNameIfAutonamable(o3, pm3, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
-		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"), 3)
+		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
 	assert.False(t, IsAutonamed(o3))
 	assert.Equal(t, "[Computed]", o3.GetName())
 }

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -336,7 +336,7 @@ func (r *helmReleaseProvider) Check(ctx context.Context, req *pulumirpc.CheckReq
 	if len(olds.Mappable()) > 0 {
 		adoptOldNameIfUnnamed(news, olds)
 	}
-	assignNameIfAutonameable(news, urn, int(req.GetSequenceNumber()))
+	assignNameIfAutonameable(news, urn)
 	r.setDefaults(news)
 
 	if !news.ContainsUnknowns() {
@@ -621,11 +621,11 @@ func adoptOldNameIfUnnamed(new, old resource.PropertyMap) {
 	new["name"] = old["name"]
 }
 
-func assignNameIfAutonameable(pm resource.PropertyMap, urn resource.URN, sequenceNumber int) {
+func assignNameIfAutonameable(pm resource.PropertyMap, urn resource.URN) {
 	name, ok := pm["name"]
 	if !ok || (name.IsString() && name.StringValue() == "") {
 		prefix := urn.Name().String() + "-"
-		autoname, err := resource.NewUniqueHexV2(urn, sequenceNumber, prefix, 0, 0)
+		autoname, err := resource.NewUniqueHex(prefix, 0, 0)
 		contract.AssertNoError(err)
 		pm["name"] = resource.NewStringProperty(autoname)
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1260,7 +1260,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 			}
 		}
 	} else {
-		metadata.AssignNameIfAutonamable(newInputs, news, urn, int(req.GetSequenceNumber()))
+		metadata.AssignNameIfAutonamable(newInputs, news, urn)
 
 		// Set a "managed-by: pulumi" label on all created k8s resources.
 		_, err = metadata.TrySetManagedByLabel(newInputs)


### PR DESCRIPTION
Platform are going to be taking a different approach to autonames.
Sequence numbers were not sufficient.