### PR TITLE
Use go embed rather than generating a .go file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 Pulumi.*.yaml
 /provider/pkg/gen/openapi-specs
 /provider/cmd/pulumi-resource-kubernetes/schema.go
+/provider/cmd/pulumi-resource-kubernetes/schema-embed.json
 yarn.lock
 ci-scripts
 /nuget/

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ schema:: k8sgen
 
 k8sprovider::
 	$(WORKING_DIR)/bin/${CODEGEN} kinds $(SCHEMA_FILE) $(CURDIR)
+	@[ ! -f "provider/cmd/${PROVIDER}/schema.go" ] || \
+		(echo "\n    Please remove provider/cmd/${PROVIDER}/schema.go, which is no longer used\n" && false)
 	(cd provider && VERSION=${VERSION} go generate cmd/${PROVIDER}/main.go)
 	(cd provider && CGO_ENABLED=0 go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 

--- a/provider/cmd/pulumi-resource-kubernetes/generate.go
+++ b/provider/cmd/pulumi-resource-kubernetes/generate.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -49,9 +49,7 @@ func main() {
 		log.Fatalf("cannot reserialize schema: %v", err)
 	}
 
-	err = ioutil.WriteFile("./schema.go", []byte(fmt.Sprintf(`package main
-var pulumiSchema = %#v
-`, versionedContents)), 0600)
+	err = ioutil.WriteFile("./schema-embed.json", versionedContents, 0600)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/provider/cmd/pulumi-resource-kubernetes/main.go
+++ b/provider/cmd/pulumi-resource-kubernetes/main.go
@@ -17,11 +17,16 @@
 package main
 
 import (
+	_ "embed"
+
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/provider"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/version"
 )
 
 var providerName = "kubernetes"
+
+//go:embed schema-embed.json
+var pulumiSchema []byte
 
 func main() {
 	provider.Serve(providerName, version.Version, pulumiSchema)


### PR DESCRIPTION
The newer go versions (>=1.16) include the ability to directly embed files as variables, so it's no longer necessary to generate a .go file with the contents of another file. It _is_ still necessary to have a generation step to rewrite the schema itself. This is how the boilerplate provider build is structured now:

    https://github.com/pulumi/pulumi-provider-boilerplate/blob/main/provider/cmd/pulumi-resource-xyz/main.go#L26

Since I'm porting that change, I've included a little failsafe in the Makefile for when people start using the changed build. The build would fail anyway, but it's less mysterious this way.
