### PR TITLE
Support deleting resources on unreachable cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Use fully-qualified resource name for generating manifests, to avoid conflicts (https://github.com/pulumi/pulumi-kubernetes/pull/2007)
 - Upgrade helm and k8s client-go module dependencies (https://github.com/pulumi/pulumi-kubernetes/pull/2008)
+- Allow a user to opt-in to removing resources from Pulumi state when a cluster is unreachable (https://github.com/pulumi/pulumi-kubernetes/pull/2037)
 
 ## 3.19.3 (June 8, 2022)
 

--- a/provider/cmd/pulumi-resource-kubernetes/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes/schema.json
@@ -359,6 +359,10 @@
                 "type": "string",
                 "description": "If present, the name of the kubeconfig context to use."
             },
+            "deleteUnreachable": {
+                "type": "boolean",
+                "description": "If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state"
+            },
             "enableConfigMapMutable": {
                 "type": "boolean",
                 "description": "BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways using this precedence:\n1. This `enableConfigMapMutable` parameter.\n2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable."
@@ -31909,6 +31913,10 @@
             "context": {
                 "type": "string",
                 "description": "If present, the name of the kubeconfig context to use."
+            },
+            "deleteUnreachable": {
+                "type": "boolean",
+                "description": "If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state"
             },
             "enableConfigMapMutable": {
                 "type": "boolean",

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -68,6 +68,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					Description: "If present, the default namespace to use. This flag is ignored for cluster-scoped resources.\n\nA namespace can be specified in multiple places, and the precedence is as follows:\n1. `.metadata.namespace` set on the resource.\n2. This `namespace` parameter.\n3. `namespace` set for the active context in the kubeconfig.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
+				"deleteUnreachable": {
+					Description: "If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 				"enableDryRun": {
 					Description: "BETA FEATURE - If present and set to true, enable server-side diff calculations.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `enableDryRun` parameter.\n2. The `PULUMI_K8S_ENABLE_DRY_RUN` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
@@ -123,6 +127,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 				"cluster": {
 					Description: "If present, the name of the kubeconfig cluster to use.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
+				},
+				"deleteUnreachable": {
+					Description: "If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"namespace": {
 					Description: "If present, the default namespace to use. This flag is ignored for cluster-scoped resources.\n\nA namespace can be specified in multiple places, and the precedence is as follows:\n1. `.metadata.namespace` set on the resource.\n2. This `namespace` parameter.\n3. `namespace` set for the active context in the kubeconfig.",

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -52,6 +52,16 @@ namespace Pulumi.Kubernetes
             set => _context.Set(value);
         }
 
+        private static readonly __Value<bool?> _deleteUnreachable = new __Value<bool?>(() => __config.GetBoolean("deleteUnreachable"));
+        /// <summary>
+        /// If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+        /// </summary>
+        public static bool? DeleteUnreachable
+        {
+            get => _deleteUnreachable.Get();
+            set => _deleteUnreachable.Set(value);
+        }
+
         private static readonly __Value<bool?> _enableConfigMapMutable = new __Value<bool?>(() => __config.GetBoolean("enableConfigMapMutable"));
         /// <summary>
         /// BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -59,6 +59,12 @@ namespace Pulumi.Kubernetes
         public Input<string>? Context { get; set; }
 
         /// <summary>
+        /// If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+        /// </summary>
+        [Input("deleteUnreachable", json: true)]
+        public Input<bool>? DeleteUnreachable { get; set; }
+
+        /// <summary>
         /// BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
         /// This feature is in developer preview, and is disabled by default.
         /// 

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -18,6 +18,11 @@ func GetContext(ctx *pulumi.Context) string {
 	return config.Get(ctx, "kubernetes:context")
 }
 
+// If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+func GetDeleteUnreachable(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:deleteUnreachable")
+}
+
 // BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
 // This feature is in developer preview, and is disabled by default.
 //

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -59,6 +59,8 @@ type providerArgs struct {
 	Cluster *string `pulumi:"cluster"`
 	// If present, the name of the kubeconfig context to use.
 	Context *string `pulumi:"context"`
+	// If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+	DeleteUnreachable *bool `pulumi:"deleteUnreachable"`
 	// BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
 	// This feature is in developer preview, and is disabled by default.
 	//
@@ -107,6 +109,8 @@ type ProviderArgs struct {
 	Cluster pulumi.StringPtrInput
 	// If present, the name of the kubeconfig context to use.
 	Context pulumi.StringPtrInput
+	// If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+	DeleteUnreachable pulumi.BoolPtrInput
 	// BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
 	// This feature is in developer preview, and is disabled by default.
 	//

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -37,6 +37,7 @@ export class Provider extends pulumi.ProviderResource {
         {
             resourceInputs["cluster"] = args ? args.cluster : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
+            resourceInputs["deleteUnreachable"] = pulumi.output(args ? args.deleteUnreachable : undefined).apply(JSON.stringify);
             resourceInputs["enableConfigMapMutable"] = pulumi.output((args ? args.enableConfigMapMutable : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE")).apply(JSON.stringify);
             resourceInputs["enableDryRun"] = pulumi.output((args ? args.enableDryRun : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN")).apply(JSON.stringify);
             resourceInputs["enableReplaceCRD"] = pulumi.output((args ? args.enableReplaceCRD : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_REPLACE_CRD")).apply(JSON.stringify);
@@ -65,6 +66,10 @@ export interface ProviderArgs {
      * If present, the name of the kubeconfig context to use.
      */
     context?: pulumi.Input<string>;
+    /**
+     * If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+     */
+    deleteUnreachable?: pulumi.Input<boolean>;
     /**
      * BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
      * This feature is in developer preview, and is disabled by default.

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -16,6 +16,7 @@ class ProviderArgs:
     def __init__(__self__, *,
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
+                 delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
                  enable_replace_crd: Optional[pulumi.Input[bool]] = None,
@@ -30,6 +31,7 @@ class ProviderArgs:
         The set of arguments for constructing a Provider resource.
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
         :param pulumi.Input[str] context: If present, the name of the kubeconfig context to use.
+        :param pulumi.Input[bool] delete_unreachable: If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
         :param pulumi.Input[bool] enable_config_map_mutable: BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
                This feature is in developer preview, and is disabled by default.
                
@@ -63,6 +65,8 @@ class ProviderArgs:
             pulumi.set(__self__, "cluster", cluster)
         if context is not None:
             pulumi.set(__self__, "context", context)
+        if delete_unreachable is not None:
+            pulumi.set(__self__, "delete_unreachable", delete_unreachable)
         if enable_config_map_mutable is None:
             enable_config_map_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE')
         if enable_config_map_mutable is not None:
@@ -122,6 +126,18 @@ class ProviderArgs:
     @context.setter
     def context(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "context", value)
+
+    @property
+    @pulumi.getter(name="deleteUnreachable")
+    def delete_unreachable(self) -> Optional[pulumi.Input[bool]]:
+        """
+        If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
+        """
+        return pulumi.get(self, "delete_unreachable")
+
+    @delete_unreachable.setter
+    def delete_unreachable(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "delete_unreachable", value)
 
     @property
     @pulumi.getter(name="enableConfigMapMutable")
@@ -269,6 +285,7 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
+                 delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
                  enable_replace_crd: Optional[pulumi.Input[bool]] = None,
@@ -287,6 +304,7 @@ class Provider(pulumi.ProviderResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] cluster: If present, the name of the kubeconfig cluster to use.
         :param pulumi.Input[str] context: If present, the name of the kubeconfig context to use.
+        :param pulumi.Input[bool] delete_unreachable: If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state
         :param pulumi.Input[bool] enable_config_map_mutable: BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.
                This feature is in developer preview, and is disabled by default.
                
@@ -342,6 +360,7 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  cluster: Optional[pulumi.Input[str]] = None,
                  context: Optional[pulumi.Input[str]] = None,
+                 delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_dry_run: Optional[pulumi.Input[bool]] = None,
                  enable_replace_crd: Optional[pulumi.Input[bool]] = None,
@@ -366,6 +385,7 @@ class Provider(pulumi.ProviderResource):
 
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["context"] = context
+            __props__.__dict__["delete_unreachable"] = pulumi.Output.from_input(delete_unreachable).apply(pulumi.runtime.to_json) if delete_unreachable is not None else None
             if enable_config_map_mutable is None:
                 enable_config_map_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE')
             __props__.__dict__["enable_config_map_mutable"] = pulumi.Output.from_input(enable_config_map_mutable).apply(pulumi.runtime.to_json) if enable_config_map_mutable is not None else None


### PR DESCRIPTION
Fixes: #2033

Introduces `kubernetes:deleteUnresponsive` and `PULUMI_K8S_DELETE_UNREACHABLE`
as ways of being able to specify that you want to delete resources
when a cluster is unreachable

[![asciicast](https://asciinema.org/a/0Xwo1OaCs4YWfxL07V4F3xZck.svg)](https://asciinema.org/a/0Xwo1OaCs4YWfxL07V4F3xZck)