### PR TITLE
[internal]Update weekly-pulumi-update.yml

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -82,14 +82,6 @@ jobs:
 
         go mod tidy
 
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
         cd ..
 
         git update-index -q --refresh


### PR DESCRIPTION
Don't update the sdk/go.mod as part of weekly update until we can do a major release and move off of go 1.16 there.
