### PR TITLE
Fix ServiceAccount readiness logic for k8s v1.24+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix ServiceAccount readiness logic for k8s v1.24+ (https://github.com/pulumi/pulumi-kubernetes/issues/2099)
+
 ## 3.20.1 (July 19, 2022)
 
 - Update the provider and tests to use Go 1.18. (https://github.com/pulumi/pulumi-kubernetes/issues/2073)

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -249,6 +249,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 					currentOutputs:    outputs,
 					logger:            c.DedupLogger,
 					timeout:           c.Timeout,
+					clusterVersion:    c.ClusterVersion,
 				}
 				waitErr := awaiter.awaitCreation(conf)
 				if waitErr != nil {
@@ -303,6 +304,7 @@ func Read(c ReadConfig) (*unstructured.Unstructured, error) {
 					currentInputs:     c.Inputs,
 					currentOutputs:    outputs,
 					logger:            c.DedupLogger,
+					clusterVersion:    c.ClusterVersion,
 				}
 				waitErr := awaiter.awaitRead(conf)
 				if waitErr != nil {
@@ -482,6 +484,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 						currentOutputs:    currentOutputs,
 						logger:            c.DedupLogger,
 						timeout:           c.Timeout,
+						clusterVersion:    c.ClusterVersion,
 					},
 					lastInputs:  c.Previous,
 					lastOutputs: liveOldObj,
@@ -581,6 +584,7 @@ func Deletion(c DeleteConfig) error {
 					currentInputs:     c.Inputs,
 					logger:            c.DedupLogger,
 					timeout:           c.Timeout,
+					clusterVersion:    c.ClusterVersion,
 				},
 				clientForResource: client,
 			})


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Starting in Kubernetes v1.24, the default behavior for ServiceAccount resources changed so that a secret is no longer provisioned. This change updates our await logic to only wait for the secret to exist for ServiceAccount resources on older clusters, and immediately returns ready for newer clusters.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2063
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
