### PR TITLE
Add a descriptive message for an invalid Patch delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add a descriptive message for an invalid Patch delete (https://github.com/pulumi/pulumi-kubernetes/pull/2111)
+
 ## 3.20.2 (July 25, 2022)
 
 - Add Java SDK (https://github.com/pulumi/pulumi-kubernetes/pull/2096)

--- a/provider/pkg/await/error.go
+++ b/provider/pkg/await/error.go
@@ -4,6 +4,7 @@ package await
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -128,4 +129,10 @@ func IsResourceExistsErr(err error) bool {
 	}
 
 	return errors.IsAlreadyExists(err)
+}
+
+// IsDeleteRequiredFieldErr is true if the user attempted to delete a Patch resource that was the sole manager of a
+// required field.
+func IsDeleteRequiredFieldErr(err error) bool {
+	return errors.IsInvalid(err) && strings.Contains(err.Error(), "Required value")
 }

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2426,6 +2426,14 @@ func (k *kubeProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest)
 			// to consider the CR to be deleted as well in this case.
 			return &pbempty.Empty{}, nil
 		}
+		if strings.HasSuffix(urn.Type().String(), "Patch") && await.IsDeleteRequiredFieldErr(awaitErr) {
+			if cause, ok := errors.StatusCause(awaitErr, metav1.CauseTypeFieldValueRequired); ok {
+				awaitErr = fmt.Errorf(
+					"this Patch resource is currently managing a required field, so it can't be deleted "+
+						"directly. Either set the `retainOnDelete` resource option, or transfer ownership of the "+
+						"field before deleting: %s", cause.Field)
+			}
+		}
 		partialErr, isPartialErr := awaitErr.(await.PartialError)
 		if !isPartialErr {
 			// There was an error executing the delete operation. The resource is still present and tracked.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

With this change, the error message looks like this:
```
  kubernetes:apps/v1:DeploymentPatch (example):
    error: this Patch resource is currently managing a required field, so it can't be deleted directly. Either set the `retainOnDelete` resource option, or transfer ownership of the field before deleting: spec.template.spec.containers[0].image
```

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2107
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
