### PR TITLE
Fix field names in CRD schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix erroneous resourceVersion diff for CRDs managed with SSA (https://github.com/pulumi/pulumi-kubernetes/pull/2121)
 - Update C# YAML GetResource implementation to compile with .NET v6 (https://github.com/pulumi/pulumi-kubernetes/pull/2122)
 - Change .metadata.name to optional for all Patch resources (https://github.com/pulumi/pulumi-kubernetes/pull/2126)
+- Fix field names in CRD schemas (https://github.com/pulumi/pulumi-kubernetes/pull/2128)
 
 ## 3.20.2 (July 25, 2022)
 

--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -562,7 +562,23 @@ func createGroups(definitionsJSON map[string]interface{}) []GroupConfig {
 					schemaType := makeSchemaType(prop, canonicalGroups)
 
 					// `-` is invalid in variable names, so replace with `_`
-					propName = strings.ReplaceAll(propName, "-", "_")
+					switch propName {
+					case "x-kubernetes-embedded-resource":
+						propName = "x_kubernetes_embedded_resource"
+					case "x-kubernetes-int-or-string":
+						propName = "x_kubernetes_int_or_string"
+					case "x-kubernetes-list-map-keys":
+						propName = "x_kubernetes_list_map_keys"
+					case "x-kubernetes-list-type":
+						propName = "x_kubernetes_list_type"
+					case "x-kubernetes-map-type":
+						propName = "x_kubernetes_map_type"
+					case "x-kubernetes-preserve-unknown-fields":
+						propName = "x_kubernetes_preserve_unknown_fields"
+					case "x-kubernetes-validations":
+						propName = "x_kubernetes_validations"
+					}
+					contract.Assertf(!strings.Contains(propName, "-"), "property names may not contain `-`")
 
 					// Create a const value for the field.
 					var constValue string

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2801,8 +2801,31 @@ func mapReplStripSecrets(v resource.PropertyValue) (interface{}, bool) {
 	return nil, false
 }
 
+// mapReplUnderscoreToDash is needed to work around cases where SDKs don't allow dashes in variable names, and so the
+// parameter is renamed with an underscore during schema generation. This function normalizes those keys to the format
+// expected by the cluster.
+func mapReplUnderscoreToDash(v string) (string, bool) {
+	switch v {
+	case "x_kubernetes_embedded_resource":
+		return "x-kubernetes-embedded-resource", true
+	case "x_kubernetes_int_or_string":
+		return "x-kubernetes-int-or-string", true
+	case "x_kubernetes_list_map_keys":
+		return "x-kubernetes-list-map-keys", true
+	case "x_kubernetes_list_type":
+		return "x-kubernetes-list-type", true
+	case "x_kubernetes_map_type":
+		return "x-kubernetes-map-type", true
+	case "x_kubernetes_preserve_unknown_fields":
+		return "x-kubernetes-preserve-unknown-fields", true
+	case "x_kubernetes_validations":
+		return "x-kubernetes-validations", true
+	}
+	return "", false
+}
+
 func propMapToUnstructured(pm resource.PropertyMap) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: pm.MapRepl(nil, mapReplStripSecrets)}
+	return &unstructured.Unstructured{Object: pm.MapRepl(mapReplUnderscoreToDash, mapReplStripSecrets)}
 }
 
 func getAnnotations(config *unstructured.Unstructured) map[string]string {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Several fields in the CRD schema include dashes in the key name, which cause problems with SDK code generation. As a workaround, these keys were renamed in the SDKs to use underscores rather than dashes. However, the provider was incorrectly using the underscore conversion in the API call to the k8s cluster. This incorrect behavior was uncovered using the Server-Side Apply mode, but was present in both modes. The provider now correctly converts these keys back to the correct form before calling the k8s API.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2125
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
