### PR TITLE
Fixes to allow import of helm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
--  Fix Helm charts being ignored by policy packs. (https://github.com/pulumi/pulumi-kubernetes/pull/2133)
+- Fix Helm charts being ignored by policy packs. (https://github.com/pulumi/pulumi-kubernetes/pull/2133)
+- Fixes to allow import of helm release (https://github.com/pulumi/pulumi-kubernetes/pull/2136)
 
 ## 3.20.3 (August 9, 2022)
 

--- a/tests/sdk/go/helm-release-import/step1/main.go
+++ b/tests/sdk/go/helm-release-import/step1/main.go
@@ -18,7 +18,8 @@ func main() {
 			Chart:     pulumi.String("nginx"),
 			Version:   pulumi.String("6.0.5"),
 			Values:    pulumi.Map{"service": pulumi.StringMap{"type": pulumi.String("ClusterIP")}},
-			Timeout:   pulumi.Int(300),
+			// Timeouts are not recorded in the release by Helm either.
+			Timeout: pulumi.Int(0),
 		}, pulumi.Import(pulumi.ID(fmt.Sprintf("%s/mynginx", namespace))))
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Since helm release don't record any information about the corresponding helm chart, some of the preview functionality in Helm release runs up against some rough edges. This change declares bankruptcy on generating a link to underlying resources specified in the chart if the helm chart can't be resolved. 

Note: imported helm release resources will by default not contain `repositoryOpts` field since its not recorded in Helm itself. So the CLI will generate code similar to this:
```
ulumi import kubernetes:helm.sh/v3:Release nvidia-device-plugin nvidia-device-plugin/nvdp
Previewing import (dev)

...

Please copy the following code into your Pulumi application. Not doing so
will cause Pulumi to report that an update will happen on the next update command.

Please note that the imported resources are marked as protected. To destroy them
you will need to remove the `protect` option and run `pulumi update` *before*
the destroy will take effect.

import * as pulumi from "@pulumi/pulumi";
import * as kubernetes from "@pulumi/kubernetes";

const nvidia_device_plugin = new kubernetes.helm.v3.Release("nvidia-device-plugin", {
    atomic: false,
    chart: "nvidia-device-plugin",
    cleanupOnFail: false,
    createNamespace: false,
    dependencyUpdate: false,
    description: "",
    devel: false,
    disableCRDHooks: false,
    disableOpenapiValidation: false,
    disableWebhooks: false,
    forceUpdate: false,
    keyring: "",
    lint: false,
    name: "nvdp",
    namespace: "nvidia-device-plugin",
    postrender: "",
    recreatePods: false,
    renderSubchartNotes: false,
    replace: false,
    resetValues: false,
    resourceNames: {
        "DaemonSet.apps/apps/v1": ["nvdp-nvidia-device-plugin"],
    },
    reuseValues: false,
    skipAwait: false,
    skipCrds: false,
    timeout: 0,
    values: {},
    verify: false,
    version: "0.12.2",
    waitForJobs: false,
}, {
    protect: true,
});
```
or for imports from within pulumi code, the code will look something like this:
```
new k8s.helm.v3.Release("nvidia-device-plugin", {
    chart: "nvidia-device-plugin",
    version: "0.12.2",
    name: "nvdp",     
    namespace: "nvidia-device-plugin",
    // Not supported in import
    // repositoryOpts: { repo: "https://nvidia.github.io/k8s-device-plugin" },
    resourceNames: {
                "DaemonSet.apps/apps/v1": ["nvdp-nvidia-device-plugin"],
    },
    timeout: 0,                                                                  
  }, { 
    import: "nvidia-device-plugin/nvdp",
  });
```


<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #2014 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
