### PR TITLE
Use NewUniqueName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 -  Fix Helm charts being ignored by policy packs. (https://github.com/pulumi/pulumi-kubernetes/pull/2133)
+-  Update autonaming to use NewUniqueName for deterministic update plans. (https://github.com/pulumi/pulumi-kubernetes/pull/2137)
 
 ## 3.20.3 (August 9, 2022)
 
@@ -134,7 +135,7 @@ Note: The `kubernetes:storage.k8s.io/v1alpha1:CSIStorageCapacity` API was remove
 
 - Helm Release: Helm Release imports support (https://github.com/pulumi/pulumi-kubernetes/pull/1818)
 - Helm Release: fix username fetch option (https://github.com/pulumi/pulumi-kubernetes/pull/1824)
-- Helm Release: Use URN name as base for autonaming, Drop warning, fix default value for 
+- Helm Release: Use URN name as base for autonaming, Drop warning, fix default value for
   keyring (https://github.com/pulumi/pulumi-kubernetes/pull/1826)
 - Helm Release: Add support for loading values from yaml files (https://github.com/pulumi/pulumi-kubernetes/pull/1828)
 

--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -27,7 +27,7 @@ var dns1123Alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
 // AssignNameIfAutonamable generates a name for an object. Uses DNS-1123-compliant characters.
 // All auto-named resources get the annotation `pulumi.com/autonamed` for tooling purposes.
-func AssignNameIfAutonamable(obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
+func AssignNameIfAutonamable(randomSeed []byte, obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
 	contract.Assert(urn.Name().String() != "")
 	// Check if the .metadata.name is set and is a computed value. If so, do not auto-name.
 	if md, ok := propMap["metadata"].V.(resource.PropertyMap); ok {
@@ -38,7 +38,7 @@ func AssignNameIfAutonamable(obj *unstructured.Unstructured, propMap resource.Pr
 
 	if obj.GetName() == "" {
 		prefix := urn.Name().String() + "-"
-		autoname, err := resource.NewUniqueHex(prefix, 0, 0)
+		autoname, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
 		contract.AssertNoError(err)
 		obj.SetName(autoname)
 		SetAnnotationTrue(obj, AnnotationAutonamed)

--- a/provider/pkg/metadata/naming_test.go
+++ b/provider/pkg/metadata/naming_test.go
@@ -30,7 +30,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 	// o1 has no name, so autonaming succeeds.
 	o1 := &unstructured.Unstructured{}
 	pm1 := resource.NewPropertyMap(struct{}{})
-	AssignNameIfAutonamable(o1, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	AssignNameIfAutonamable(nil, o1, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
 	assert.True(t, IsAutonamed(o1))
 	assert.True(t, strings.HasPrefix(o1.GetName(), "foo-"))
@@ -45,7 +45,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 			"name": resource.NewStringProperty("bar"),
 		}),
 	}
-	AssignNameIfAutonamable(o2, pm2, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	AssignNameIfAutonamable(nil, o2, pm2, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:AnotherResource"), "bar"))
 	assert.False(t, IsAutonamed(o2))
 	assert.Equal(t, "bar", o2.GetName())
@@ -59,7 +59,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 			"name": resource.MakeComputed(resource.NewStringProperty("bar")),
 		}),
 	}
-	AssignNameIfAutonamable(o3, pm3, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	AssignNameIfAutonamable(nil, o3, pm3, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
 	assert.False(t, IsAutonamed(o3))
 	assert.Equal(t, "[Computed]", o3.GetName())

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1543,7 +1543,6 @@ func (k *kubeProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*p
 			newInputs.GetNamespace(), newInputs.GetName())
 	}
 
-	// TODO: This is wrong, we shouldn't have randomness in diff, we need to resolve this in Check.
 	fieldManager := fieldManagerName(nil, newResInputs, newInputs)
 
 	// Try to compute a server-side patch.
@@ -1737,7 +1736,6 @@ func (k *kubeProvider) Create(
 	}
 
 	initialAPIVersion := newInputs.GetAPIVersion()
-	// TODO: This is wrong, we shouldn't have randomness in create, we need to resolve this in Check.
 	fieldManager := fieldManagerName(nil, newResInputs, newInputs)
 
 	if k.yamlRenderMode {
@@ -1962,7 +1960,6 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	// TODO: This is wrong, we shouldn't have randomness in read, we need to resolve this in Check.
 	fieldManager := fieldManagerName(nil, oldState, oldInputs)
 
 	if k.yamlRenderMode {
@@ -2232,7 +2229,6 @@ func (k *kubeProvider) Update(
 		return nil, err
 	}
 
-	// TODO: This is wrong, we shouldn't have randomness in update, we need to resolve this in Check.
 	fieldManagerOld := fieldManagerName(nil, oldState, oldInputs)
 	fieldManager := fieldManagerName(nil, oldState, newInputs)
 
@@ -2411,7 +2407,6 @@ func (k *kubeProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: This is wrong, we shouldn't have randomness in delete, we need to resolve this in Check.
 	fieldManager := fieldManagerName(nil, oldState, oldInputs)
 	resources, err := k.getResources()
 	if err != nil {
@@ -2892,6 +2887,9 @@ func fieldManagerName(randomSeed []byte, state resource.PropertyMap, inputs *uns
 	}
 
 	prefix := "pulumi-kubernetes-"
+	// This function is called from other provider function apart from Check and so doesn't have a randomSeed
+	// for those calls, but the field manager name should have already been filled in via Check so this case
+	// shouldn't actually get hit.
 	fieldManager, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
 	contract.AssertNoError(err)
 


### PR DESCRIPTION
This updates the k8s provider to use NewUniqueName, the new autonaming system compatible with update plans. There are some questions of how to resolve the fact that the field manager name doesn't get resolved in Check, this will break update plans as is.