### PR TITLE
Another fix for managed-by label in SSA mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Update autonaming to use NewUniqueName for deterministic update plans. (https://github.com/pulumi/pulumi-kubernetes/pull/2137)
+- Another fix for managed-by label in SSA mode. (https://github.com/pulumi/pulumi-kubernetes/pull/2140)
 
 ## 3.20.4 (August 15, 2022)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1293,9 +1293,9 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 		contract.Assert(oldInputs.GetName() != "")
 		metadata.AdoptOldAutonameIfUnnamed(newInputs, oldInputs)
 
-		// If this resource does not have a "managed-by: pulumi" label in its inputs, it is likely we are importing
-		// a resource that was created out-of-band. In this case, we do not add the `managed-by` label here, as doing
-		// so would result in a persistent failure to import due to a diff that the user cannot correct.
+		// If the resource has existing state, we only set the "managed-by: pulumi" label if it is already present. This
+		// avoids causing diffs for cases where the resource is being imported, or was created using SSA. The goal in
+		// both cases is to leave the resource unchanged. The label is added if already present, or omitted if not.
 		if metadata.HasManagedByLabel(oldInputs) {
 			_, err = metadata.TrySetManagedByLabel(newInputs)
 			if err != nil {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
#2138 attempted to fix the case where a resource was created using CSA, and then updated to use SSA. For this case, the resource should retain the "managed-by" label. However, there was a bug in the conditional logic, so that fix was not effective. This change fixes this logic so that the label is only created for CSA resources, but is retained once present on a resource in both cases.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
