### PR TITLE
Add link to installation-configuration guide to config error message

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -677,8 +677,8 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		config, err := kubeconfig.ClientConfig()
 		if err != nil {
 			k.clusterUnreachable = true
-			k.clusterUnreachableReason = fmt.Sprintf("unable to locate kubeconfig. Make sure you have: \n\n" +
-			" \t • Setup the provider as per https://pulumi.io/install/kubernetes.html \n\n")
+			k.clusterUnreachableReason = fmt.Sprintf("unable to load Kubernetes client configuration from kubeconfig file. Make sure you have: \n\n"+
+				" \t • set up the provider as per https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/ \n\n %v", err)
 		} else {
 			if kubeClientSettings.Burst != nil {
 				config.Burst = *kubeClientSettings.Burst

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -677,8 +677,8 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		config, err := kubeconfig.ClientConfig()
 		if err != nil {
 			k.clusterUnreachable = true
-			k.clusterUnreachableReason = fmt.Sprintf(
-				"unable to load Kubernetes client configuration from kubeconfig file: %v", err)
+			k.clusterUnreachableReason = fmt.Sprintf("unable to locate kubeconfig. Make sure you have: \n\n" +
+			" \t • Setup the provider as per https://pulumi.io/install/kubernetes.html \n\n")
 		} else {
 			if kubeClientSettings.Burst != nil {
 				config.Burst = *kubeClientSettings.Burst


### PR DESCRIPTION
### Proposed changes

Provide a link to Kubernetes setup guide if client config is returning an error, but still pass along original error message.

Before:
<img width="985" alt="image" src="https://user-images.githubusercontent.com/41454626/185455602-42d0f4e8-bba2-4892-b6f9-bc0862d19711.png">


After:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/41454626/186025565-c748c4f9-7bdd-4707-a8b5-42b381a052ff.png">


### Related issues (optional)

Resolves #https://github.com/pulumi/home/issues/2253
Resolves #https://github.com/pulumi/home/issues/2254
