### PR TITLE
Automatically fill in .Capabilities in Helm Charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Update Helm and Kubernetes module dependencies (https://github.com/pulumi/pulumi-kubernetes/pull/2152)
+- Automatically fill in .Capabilities in Helm Charts (https://github.com/pulumi/pulumi-kubernetes/pull/2155)
 
 ## 3.21.0 (August 23, 2022)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -726,6 +726,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		apiConfig,
 		overrides,
 		k.config,
+		k.clientSet,
 		k.helmDriver,
 		k.defaultNamespace,
 		k.enableSecrets,
@@ -802,7 +803,7 @@ func (k *kubeProvider) Invoke(ctx context.Context,
 			return nil, pkgerrors.Wrap(err, "failed to unmarshal 'jsonOpts'")
 		}
 
-		text, err := helmTemplate(opts)
+		text, err := helmTemplate(opts, k.clientSet)
 		if err != nil {
 			return nil, pkgerrors.Wrap(err, "failed to generate YAML for specified Helm chart")
 		}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR tries to add automatic filling of Helm capabilities (Kubernetes version and API versions) in Chart resource. I’ve successfully built and tested this PR with a simple chart, but I’m not familiar with development on this repository (on Pulumi providers in general), so I may need some help to bring this PR to proper releasable state.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Fix #196
Fix #2141
Fix #753
