### PR TITLE
Fix yaml bug resulting in `TypeError: Cannot read properties of undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update Helm and Kubernetes module dependencies (https://github.com/pulumi/pulumi-kubernetes/pull/2152)
 - Automatically fill in .Capabilities in Helm Charts (https://github.com/pulumi/pulumi-kubernetes/pull/2155)
+- Fix yaml bug resulting in `TypeError: Cannot read properties of undefined` (https://github.com/pulumi/pulumi-kubernetes/pull/2156)
 
 ## 3.21.0 (August 23, 2022)
 

--- a/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
@@ -22,6 +22,7 @@ import fetch from "node-fetch";
 {{- range .Packages}}
 import * as {{.}} from "../{{.}}";
 {{- end}}
+import * as provider from "../provider";
 import * as outputs from "../types/output";
 import { getVersion } from "../utilities";
 
@@ -374,10 +375,13 @@ export interface ConfigOpts {
 }
 
 /** @ignore */ function yamlLoadAll(text: string, opts?: pulumi.ComponentResourceOptions): Promise<any[]> {
-    // Rather than using the default provider for the following invoke call, use the version specified
-    // in package.json.
     let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
 
+    if (provider.Provider.isInstance(invokeOpts.provider)) {
+        const prov: provider.Provider = invokeOpts.provider as provider.Provider;
+        // return prov.kubeconfig.apply(_ => pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
+        //            .then((p => p.result)));
+    }
     return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
         .then((p => p.result));
 }
@@ -473,9 +477,9 @@ export interface ConfigOpts {
     opts?: pulumi.CustomResourceOptions,
 ):  pulumi.Output<{[key: string]: pulumi.CustomResource}> {
     const objs = config.objs.then(configObjs => {
-        return configObjs
+        return Array.isArray(configObjs) ? configObjs
             .map(obj => parseYamlObject(obj, config.transformations, config.resourcePrefix, opts))
-            .reduce((array, objs) => (array.concat(...objs)), []);
+            .reduce((array, objs) => (array.concat(...objs)), []) : [];
     });
     return pulumi.output(objs).apply(objs => objs
             .reduce((map: {[key: string]: pulumi.CustomResource}, val) => (map[val.name] = val.resource, map), {}));

--- a/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
@@ -291,13 +291,22 @@ export class ConfigFile extends CollectionComponentResource {
             transformations.push(skipAwait);
         }
 
-        this.resources = pulumi.output(text.then(t => {
+       this.resources = pulumi.output(text.then(t => {
             try {
-                return parseYamlDocument({
+                const parsed = parseYamlDocument({
                     objs: yamlLoadAll(t, opts),
                     transformations,
                     resourcePrefix: config && config.resourcePrefix || undefined
-                }, {...opts, parent: this})
+                }, {...opts, parent: this});
+                // If the provider is not fully initialized, the engine skips invoking on the provider and returns an
+                // empty result. This may change based on how https://github.com/pulumi/pulumi/issues/10209 is addressed.
+                parsed.apply(p => {
+                    if (opts?.provider !== undefined && (Object.entries(p).length == 0)) {
+                        pulumi.log.info("Can't decode yaml config when provider is not fully initialized. " +
+                         "This can result in empty previews but should resolve correctly during apply.", this);
+                    }
+                });
+                return parsed;
             } catch (e) {
                 throw Error(`Error fetching YAML file '${fileId}': ${e}`);
             }
@@ -377,13 +386,8 @@ export interface ConfigOpts {
 /** @ignore */ function yamlLoadAll(text: string, opts?: pulumi.ComponentResourceOptions): Promise<any[]> {
     let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
 
-    if (provider.Provider.isInstance(invokeOpts.provider)) {
-        const prov: provider.Provider = invokeOpts.provider as provider.Provider;
-        // return prov.kubeconfig.apply(_ => pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
-        //            .then((p => p.result)));
-    }
     return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
-        .then((p => p.result));
+        .then(p => p.result);
 }
 
 /** @ignore */ export function skipAwait(o: any, opts: pulumi.ComponentResourceOptions) {

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -597,6 +597,8 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
     if config.skip_await:
         transformations.append(_skip_await)
 
-    objects = json_opts.apply(lambda x: pulumi.runtime.invoke('kubernetes:helm:template',
-                                                              {'jsonOpts': x}, invoke_opts).value['result'])
+    def invoke_helm_template(opts):
+        inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
+        return inv.value['result'] if inv is not None else []
+    objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -599,6 +599,6 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     def invoke_helm_template(opts):
         inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
-        return inv.value['result'] if inv is not None else []
+        return inv.value['result'] if inv is not None and inv.value is not None else []
     objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -344,8 +344,10 @@ class ConfigFile(pulumi.ComponentResource):
         # in package.json.
         invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
                                            provider=opts.provider if opts.provider else None)
-
-        __ret__ = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts).value['result']
+        def invoke_yaml_decode(text):
+            inv = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts)
+            return inv.value['result'] if inv is not None and inv.value is not None else []
+        __ret__ = invoke_yaml_decode(text)
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -597,6 +597,8 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
     if config.skip_await:
         transformations.append(_skip_await)
 
-    objects = json_opts.apply(lambda x: pulumi.runtime.invoke('kubernetes:helm:template',
-                                                              {'jsonOpts': x}, invoke_opts).value['result'])
+    def invoke_helm_template(opts):
+        inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
+        return inv.value['result'] if inv is not None else []
+    objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -599,6 +599,6 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     def invoke_helm_template(opts):
         inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
-        return inv.value['result'] if inv is not None else []
+        return inv.value['result'] if inv is not None and inv.value is not None else []
     objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))

--- a/sdk/python/pulumi_kubernetes/yaml/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml/yaml.py
@@ -344,8 +344,10 @@ class ConfigFile(pulumi.ComponentResource):
         # in package.json.
         invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
                                            provider=opts.provider if opts.provider else None)
-
-        __ret__ = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts).value['result']
+        def invoke_yaml_decode(text):
+            inv = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts)
+            return inv.value['result'] if inv is not None and inv.value is not None else []
+        __ret__ = invoke_yaml_decode(text)
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Fixes #2038 for typescript.
Fixes #1987 for python.

As discussed on the issue, calling an invoke on an unconfigured provider results in the invoke never reaching the provider. This fixes a halting error here but it will not return the correct preview if things like kubeconfig are missing in the provider.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
#2038 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
