### PR TITLE
Load default kubeconfig if not specified in provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix Helm Chart preview with unconfigured provider (C#) (https://github.com/pulumi/pulumi-kubernetes/issues/2162)
+- Load default kubeconfig if not specified in provider (https://github.com/pulumi/pulumi-kubernetes/issues/2180)
 - Skip computing a preview for Patch resources (https://github.com/pulumi/pulumi-kubernetes/issues/2182)
 - [sdk/python] Handle CRDs with status field input (https://github.com/pulumi/pulumi-kubernetes/issues/2183)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -597,7 +597,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		usr, _ := user.Current()
 		return usr.HomeDir
 	}
-	if pathOrContents, ok := vars["kubernetes:config:kubeconfig"]; ok {
+	if pathOrContents, ok := vars["kubernetes:config:kubeconfig"]; ok && pathOrContents != "" {
 		var contents string
 
 		// Handle the '~' character if it is set in the config string. Normally, this would be expanded by the shell

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -597,6 +597,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		usr, _ := user.Current()
 		return usr.HomeDir
 	}
+	// Note: the Python SDK was setting the kubeconfig value to "" by default, so explicitly check for empty string.
 	if pathOrContents, ok := vars["kubernetes:config:kubeconfig"]; ok && pathOrContents != "" {
 		var contents string
 

--- a/tests/sdk/go/kustomize/main.go
+++ b/tests/sdk/go/kustomize/main.go
@@ -23,9 +23,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		provider, err := k8s.NewProvider(ctx, "k8s", &k8s.ProviderArgs{
-			Kubeconfig: pulumi.String("~/.kube/config"),
-		})
+		provider, err := k8s.NewProvider(ctx, "k8s", &k8s.ProviderArgs{})
 		if err != nil {
 			return err
 		}
@@ -34,8 +32,7 @@ func main() {
 			return err
 		}
 		nsProvider, err := k8s.NewProvider(ctx, "k8s-ns", &k8s.ProviderArgs{
-			Kubeconfig: pulumi.String("~/.kube/config"),
-			Namespace:  ns.Metadata.Name(),
+			Namespace: ns.Metadata.Name(),
 		})
 		if err != nil {
 			return err

--- a/tests/sdk/go/server-side-apply/main.go
+++ b/tests/sdk/go/server-side-apply/main.go
@@ -13,7 +13,6 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		provider, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
 			EnableServerSideApply: pulumi.BoolPtr(true),
-			Kubeconfig:            pulumi.String("~/.kube/config"),
 		})
 		if err != nil {
 			return err

--- a/tests/sdk/go/server-side-apply/step2/main.go
+++ b/tests/sdk/go/server-side-apply/step2/main.go
@@ -15,7 +15,6 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		provider, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
 			EnableServerSideApply: pulumi.BoolPtr(true),
-			Kubeconfig:            pulumi.String("~/.kube/config"),
 		})
 		if err != nil {
 			return err

--- a/tests/sdk/go/yaml/main.go
+++ b/tests/sdk/go/yaml/main.go
@@ -26,9 +26,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		provider, err := k8s.NewProvider(ctx, "k8s", &k8s.ProviderArgs{
-			Kubeconfig: pulumi.String("~/.kube/config"),
-		})
+		provider, err := k8s.NewProvider(ctx, "k8s", &k8s.ProviderArgs{})
 		if err != nil {
 			return err
 		}

--- a/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
+++ b/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
@@ -14,9 +14,7 @@
 
 import * as k8s from '@pulumi/kubernetes'
 
-const k8sProvider = new k8s.Provider(`k8s-provider`, {
-    kubeconfig: '~/.kube/config',
-})
+const k8sProvider = new k8s.Provider(`k8s-provider`, {})
 
 const namespace = new k8s.core.v1.Namespace("release-ns");
 

--- a/tests/sdk/python/provider-old/__main__.py
+++ b/tests/sdk/python/provider-old/__main__.py
@@ -1,27 +1,22 @@
-# Copyright 2016-2019, Pulumi Corporation.
+#  Copyright 2016-2022, Pulumi Corporation.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from os import path
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from pulumi import ResourceOptions
 from pulumi_kubernetes import Provider
 from pulumi_kubernetes.core.v1 import Pod, Namespace
 
-kubeconfig_file = path.join(path.expanduser("~"), ".kube", "config")
-with open(kubeconfig_file) as f:
-    kubeconfig = f.read()
-
-my_k8s = Provider("myk8s", kubeconfig=kubeconfig)
+my_k8s = Provider("myk8s")
 
 namespace = Namespace("test")
 

--- a/tests/sdk/python/provider/__main__.py
+++ b/tests/sdk/python/provider/__main__.py
@@ -1,28 +1,23 @@
-# Copyright 2016-2020, Pulumi Corporation.
+#  Copyright 2016-2022, Pulumi Corporation.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from os import path
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from pulumi import ResourceOptions
 from pulumi_kubernetes import Provider
 from pulumi_kubernetes.core.v1 import Pod, Namespace, PodSpecArgs, ContainerArgs, ContainerPortArgs
 from pulumi_kubernetes.meta.v1 import ObjectMetaArgs
 
-kubeconfig_file = path.join(path.expanduser("~"), ".kube", "config")
-with open(kubeconfig_file) as f:
-    kubeconfig = f.read()
-
-my_k8s = Provider("myk8s", kubeconfig=kubeconfig)
+my_k8s = Provider("myk8s")
 
 namespace = Namespace("test")
 

--- a/tests/sdk/python/server-side-apply/__main__.py
+++ b/tests/sdk/python/server-side-apply/__main__.py
@@ -11,16 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from os import path
 
 import pulumi
 import pulumi_kubernetes as k8s
 
-kubeconfig_file = path.join(path.expanduser("~"), ".kube", "config")
-with open(kubeconfig_file) as f:
-    kubeconfig = f.read()
-
-provider = k8s.Provider("myk8s", kubeconfig=kubeconfig, enable_server_side_apply=True)
+provider = k8s.Provider("myk8s", enable_server_side_apply=True)
 
 ns = k8s.core.v1.Namespace("test", opts=pulumi.ResourceOptions(provider=provider))
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The default kubeconfig behavior was previously inconsistent across SDKs, and required the kubeconfig path to be specified manually in some cases. This change unifies the behavior and will load the ambient kubeconfig if unspecified for a provider.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2072
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
