### PR TITLE
Skip computing a preview for Patch resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Fix Helm Chart preview with unconfigured provider (C#) (https://github.com/pulumi/pulumi-kubernetes/issues/2162)
+- Skip computing a preview for Patch resources (https://github.com/pulumi/pulumi-kubernetes/issues/2182)
 
 ## 3.21.2 (September 1, 2022)
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Since Patch resources do not have to specify a complete resource, attempting to patch a nonexistent resource will return an Invalid error response during preview. To avoid this, skip computing a preview for Patch resources, and return the inputs directly. This is the same behavior used for resources containing unknowns.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2177 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
