### PR TITLE
[sdk/python] Handle CRDs with status field input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
+
 - Fix Helm Chart preview with unconfigured provider (C#) (https://github.com/pulumi/pulumi-kubernetes/issues/2162)
+- [sdk/python] Handle CRDs with status field input (https://github.com/pulumi/pulumi-kubernetes/issues/2183)
 
 ## 3.21.2 (September 1, 2022)
 

--- a/provider/cmd/pulumi-gen-kubernetes/main.go
+++ b/provider/cmd/pulumi-gen-kubernetes/main.go
@@ -245,6 +245,9 @@ func writePythonClient(pkg *schema.Package, outdir string, templateDir string) {
 		if resourcesToFilterFromTemplate.Has(tok) {
 			continue
 		}
+		if resource.Name == "CustomResourceDefinition" { // Use manual overlay in yaml.tmpl
+			continue
+		}
 		if strings.HasSuffix(resource.Name, "Patch") {
 			continue
 		}

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -499,6 +499,20 @@ def _parse_yaml_object(
             lambda x: (f"{{.GVK}}:{x}",
                        {{.Name}}(f"{x}", opts, **obj)))]
 {{- end}}
+    if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinition":
+        # Import locally to avoid name collisions.
+        from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinition
+        del obj["status"] # Delete output-only status field to avoid errors.
+        return [identifier.apply(
+            lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinition:{x}",
+                       CustomResourceDefinition(f"{x}", opts, **obj)))]
+    if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinition":
+        # Import locally to avoid name collisions.
+        from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinition
+        del obj["status"] # Delete output-only status field to avoid errors.
+        return [identifier.apply(
+            lambda x: (f"apiextensions.k8s.io/v1beta1/CustomResourceDefinition:{x}",
+                       CustomResourceDefinition(f"{x}", opts, **obj)))]
     return [identifier.apply(
         lambda x: (f"{gvk}:{x}",
                    CustomResource(f"{x}", api_version, kind, spec, metadata, opts)))]

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -502,14 +502,14 @@ def _parse_yaml_object(
     if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinition":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinition
-        del obj["status"] # Delete output-only status field to avoid errors.
+        obj.pop("status", None) # Delete output-only status field to avoid errors.
         return [identifier.apply(
             lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinition:{x}",
                        CustomResourceDefinition(f"{x}", opts, **obj)))]
     if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinition":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinition
-        del obj["status"] # Delete output-only status field to avoid errors.
+        obj.pop("status", None) # Delete output-only status field to avoid errors.
         return [identifier.apply(
             lambda x: (f"apiextensions.k8s.io/v1beta1/CustomResourceDefinition:{x}",
                        CustomResourceDefinition(f"{x}", opts, **obj)))]

--- a/sdk/python/pulumi_kubernetes/yaml/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml/yaml.py
@@ -1808,14 +1808,14 @@ def _parse_yaml_object(
     if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinition":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinition
-        del obj["status"] # Delete output-only status field to avoid errors.
+        obj.pop("status", None) # Delete output-only status field to avoid errors.
         return [identifier.apply(
             lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinition:{x}",
                        CustomResourceDefinition(f"{x}", opts, **obj)))]
     if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinition":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinition
-        del obj["status"] # Delete output-only status field to avoid errors.
+        obj.pop("status", None) # Delete output-only status field to avoid errors.
         return [identifier.apply(
             lambda x: (f"apiextensions.k8s.io/v1beta1/CustomResourceDefinition:{x}",
                        CustomResourceDefinition(f"{x}", opts, **obj)))]

--- a/sdk/python/pulumi_kubernetes/yaml/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml/yaml.py
@@ -539,24 +539,12 @@ def _parse_yaml_object(
         return [identifier.apply(
             lambda x: (f"admissionregistration.k8s.io/v1beta1/ValidatingWebhookConfigurationList:{x}",
                        ValidatingWebhookConfigurationList(f"{x}", opts, **obj)))]
-    if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinition":
-        # Import locally to avoid name collisions.
-        from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinition
-        return [identifier.apply(
-            lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinition:{x}",
-                       CustomResourceDefinition(f"{x}", opts, **obj)))]
     if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinitionList":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinitionList
         return [identifier.apply(
             lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinitionList:{x}",
                        CustomResourceDefinitionList(f"{x}", opts, **obj)))]
-    if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinition":
-        # Import locally to avoid name collisions.
-        from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinition
-        return [identifier.apply(
-            lambda x: (f"apiextensions.k8s.io/v1beta1/CustomResourceDefinition:{x}",
-                       CustomResourceDefinition(f"{x}", opts, **obj)))]
     if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinitionList":
         # Import locally to avoid name collisions.
         from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinitionList
@@ -1817,6 +1805,20 @@ def _parse_yaml_object(
         return [identifier.apply(
             lambda x: (f"storage.k8s.io/v1beta1/VolumeAttachmentList:{x}",
                        VolumeAttachmentList(f"{x}", opts, **obj)))]
+    if gvk == "apiextensions.k8s.io/v1/CustomResourceDefinition":
+        # Import locally to avoid name collisions.
+        from pulumi_kubernetes.apiextensions.v1 import CustomResourceDefinition
+        del obj["status"] # Delete output-only status field to avoid errors.
+        return [identifier.apply(
+            lambda x: (f"apiextensions.k8s.io/v1/CustomResourceDefinition:{x}",
+                       CustomResourceDefinition(f"{x}", opts, **obj)))]
+    if gvk == "apiextensions.k8s.io/v1beta1/CustomResourceDefinition":
+        # Import locally to avoid name collisions.
+        from pulumi_kubernetes.apiextensions.v1beta1 import CustomResourceDefinition
+        del obj["status"] # Delete output-only status field to avoid errors.
+        return [identifier.apply(
+            lambda x: (f"apiextensions.k8s.io/v1beta1/CustomResourceDefinition:{x}",
+                       CustomResourceDefinition(f"{x}", opts, **obj)))]
     return [identifier.apply(
         lambda x: (f"{gvk}:{x}",
                    CustomResource(f"{x}", api_version, kind, spec, metadata, opts)))]


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Although .status is an output-only field for CRDs, this is a frequent occurrence in real-world manifests. Manually delete the status field in the YAML handler to avoid an error on deserialization.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/800
Fix https://github.com/pulumi/pulumi-kubernetes/issues/1481
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
