### PR TITLE
Update go package install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For .NET, dependencies will be automatically installed as part of your Pulumi de
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-kubernetes/sdk/v3/go/...
+    $ go install github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes@latest
 
 ## Quick Examples
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pip install pulumi-kubernetes
 
 For .NET, dependencies will be automatically installed as part of your Pulumi deployments using `dotnet build`.
 
-To use from Go, use `go get` to grab the latest version of the library
+To use from Go, use `go install` to grab the latest version of the library
 
     $ go install github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes@latest
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
(https://go.dev/doc/go-get-install-deprecation)
Pulumi requires Go 1.18 or later.
(https://www.pulumi.com/docs/get-started/kubernetes/begin/#choose-your-language)

So I propose updating install command in readme.md

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
