### PR TITLE
Fix replacement behavior for immutable fields in SSA mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add allowNullValues boolean option to pass Null values through helm configs without having them scrubbed (https://github.com/pulumi/pulumi-kubernetes/issues/2089)
+- Fix replacement behavior for immutable fields in SSA mode (https://github.com/pulumi/pulumi-kubernetes/issues/2232)
 
 ## 3.22.1 (October 26, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add allowNullValues boolean option to pass Null values through helm configs without having them
   scrubbed (https://github.com/pulumi/pulumi-kubernetes/issues/2089)
+- Fix replacement behavior for immutable fields in SSA mode
+  (https://github.com/pulumi/pulumi-kubernetes/issues/2235)
 - For SSA conflicts, add a note to the error message about how to resolve
   (https://github.com/pulumi/pulumi-kubernetes/issues/2235)
 - Make room for the `resource` API in Kubernetes 1.26.0 by qualifying the type of the same name in

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2756,7 +2756,7 @@ func (k *kubeProvider) tryServerSidePatch(
 		return nil, nil, false, err
 	}
 	if se, isStatusError := err.(*errors.StatusError); isStatusError {
-		if se.Status().Code == http.StatusUnprocessableEntity ||
+		if se.Status().Code == http.StatusUnprocessableEntity &&
 			strings.Contains(se.ErrStatus.Message, "field is immutable") {
 			// This error occurs if the resource field is immutable.
 			// Ignore this error since this case is handled by the replacement logic.

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2726,6 +2726,11 @@ func (k *kubeProvider) isDryRunDisabledError(err error) bool {
 }
 
 // tryServerSidePatch attempts to compute a server-side patch. Returns true iff the operation succeeded.
+// The following are expected ways in which the server-side apply can not work;
+// we return no error, but a `false` value indicating that there's no result either.
+// The caller will fall back to using the client-side diff. In the particular case of an
+// update to an immutable field, it is already known from the schema when
+// replacement will be necessary.
 func (k *kubeProvider) tryServerSidePatch(
 	oldInputs, newInputs *unstructured.Unstructured,
 	gvk schema.GroupVersionKind,

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2756,10 +2756,11 @@ func (k *kubeProvider) tryServerSidePatch(
 		return nil, nil, false, err
 	}
 	if se, isStatusError := err.(*errors.StatusError); isStatusError {
-		// If the resource field is immutable.
 		if se.Status().Code == http.StatusUnprocessableEntity ||
 			strings.Contains(se.ErrStatus.Message, "field is immutable") {
-			return nil, nil, false, err
+			// This error occurs if the resource field is immutable.
+			// Ignore this error since this case is handled by the replacement logic.
+			return nil, nil, false, nil
 		}
 	}
 	if err.Error() == "name is required" {


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
With Server-side Apply previews, updating an immutable field in a resource will result in a 422 error code from the API server. In these cases, Pulumi will replace the resource, so we need to ignore the error rather than failing the preview.

Note: this change was originally included in https://github.com/pulumi/pulumi-kubernetes/issues/2206 but was reverted in https://github.com/pulumi/pulumi-kubernetes/pull/2216. Re-adding this fix, which was unrelated to the default flag change.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
