### PR TITLE
Add resolution note to SSA conflict message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add allowNullValues boolean option to pass Null values through helm configs without having them scrubbed (https://github.com/pulumi/pulumi-kubernetes/issues/2089)
+- For SSA conflicts, add a note to the error message about how to resolve (https://github.com/pulumi/pulumi-kubernetes/issues/2235)
 
 ## 3.22.1 (October 26, 2022)
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -196,6 +196,10 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				}
 				outputs, err = client.Patch(
 					c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
+
+				if errors.IsConflict(err) {
+					err = fmt.Errorf(`use the "pulumi.com/patchForce" annotation if you want to overwrite the existing values: %w`, err)
+				}
 			} else {
 				var options metav1.CreateOptions
 				if c.Preview {


### PR DESCRIPTION
For SSA conflicts, add a note about using the "patchForce" annotation to overwrite the existing resource values

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Fix #2157 

Here's an example of the updated error message
```
Diagnostics:
  kubernetes:apps/v1:DeploymentPatch (example):
    error: resource default/foo was not successfully created by the Kubernetes API server : use the "pulumi.com/patchForce" annotation if you want to overwrite the existing values: Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using apps/v1: .spec.template.spec.containers[name="nginx"].image
```
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
