### PR TITLE
Qualify Pulumi.Resource type to stay out of the way of the `resource` API in K8s v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
-- Add allowNullValues boolean option to pass Null values through helm configs without having them scrubbed (https://github.com/pulumi/pulumi-kubernetes/issues/2089)
-- For SSA conflicts, add a note to the error message about how to resolve (https://github.com/pulumi/pulumi-kubernetes/issues/2235)
+- Add allowNullValues boolean option to pass Null values through helm configs without having them
+  scrubbed (https://github.com/pulumi/pulumi-kubernetes/issues/2089)
+- For SSA conflicts, add a note to the error message about how to resolve
+  (https://github.com/pulumi/pulumi-kubernetes/issues/2235)
+- Make room for the `resource` API in Kubernetes 1.26.0 by qualifying the type of the same name in
+  .NET code templates (https://github.com/pulumi/pulumi-kubernetes/pull/2237)
 
 ## 3.22.1 (October 26, 2022)
 

--- a/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Text.Json;
-using Pulumi;
+using Pu = Pulumi;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
 
@@ -260,8 +260,8 @@ namespace Pulumi.Kubernetes.Helm
         }
 
         private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(string text,
-            List<TransformationAction> transformations, string? resourcePrefix, ImmutableHashSet<Resource> dependsOn,
-            string? defaultNamespace, Pulumi.ProviderResource provider)
+            List<TransformationAction> transformations, string? resourcePrefix, ImmutableHashSet<Pu.Resource> dependsOn,
+            string? defaultNamespace, Pu.ProviderResource provider)
         {
             return Yaml.Invokes
                 .YamlDecode(new YamlDecodeArgs { Text = text, DefaultNamespace = defaultNamespace }, new InvokeOptions { Provider = provider })

--- a/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
@@ -23,6 +23,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
+using Pu = Pulumi;
 
 namespace Pulumi.Kubernetes.Helm.V3
 {
@@ -289,7 +290,7 @@ namespace Pulumi.Kubernetes.Helm.V3
             return string.IsNullOrEmpty(prefix) ? releaseName : $"{prefix}-{releaseName}";
         }
 
-        private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(Union<ChartArgsUnwrap, LocalChartArgsUnwrap> args, string releaseName, ImmutableHashSet<Resource> dependsOn, ComponentResourceOptions? options)
+        private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(Union<ChartArgsUnwrap, LocalChartArgsUnwrap> args, string releaseName, ImmutableHashSet<Pu.Resource> dependsOn, ComponentResourceOptions? options)
         {
             // Build JSON args to Helm provider invoke.
             var serializeOptions = new JsonSerializerOptions

--- a/provider/pkg/gen/dotnet-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/dotnet-templates/yaml/yaml.tmpl
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using GlobExpressions;
+using Pu = Pulumi;
 
 #pragma warning disable CS0618
 
@@ -82,9 +83,9 @@ namespace Pulumi.Kubernetes.Yaml
         /// <summary>
         /// Returns an array of ready resources to be used by DependsOn.
         /// </summary>
-        public Output<ImmutableArray<Resource>> Ready()
+        public Output<ImmutableArray<Pu.Resource>> Ready()
         {
-            return Resources.Apply(resources => resources.Values.Cast<Resource>().ToImmutableArray());
+            return Resources.Apply(resources => resources.Values.Cast<Pu.Resource>().ToImmutableArray());
         }
 
         /// <summary>
@@ -233,7 +234,7 @@ namespace Pulumi.Kubernetes.Yaml
             var opts = new CustomResourceOptions
             {
                 Parent = options?.Parent,
-                DependsOn = options?.DependsOn ?? new InputList<Resource>(),
+                DependsOn = options?.DependsOn ?? new InputList<Pu.Resource>(),
                 IgnoreChanges = options?.IgnoreChanges ?? new List<string>(),
                 Version = options?.Version,
                 Provider = options?.Provider,

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Text.Json;
-using Pulumi;
+using Pu = Pulumi;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
 
@@ -260,8 +260,8 @@ namespace Pulumi.Kubernetes.Helm
         }
 
         private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(string text,
-            List<TransformationAction> transformations, string? resourcePrefix, ImmutableHashSet<Resource> dependsOn,
-            string? defaultNamespace, Pulumi.ProviderResource provider)
+            List<TransformationAction> transformations, string? resourcePrefix, ImmutableHashSet<Pu.Resource> dependsOn,
+            string? defaultNamespace, Pu.ProviderResource provider)
         {
             return Yaml.Invokes
                 .YamlDecode(new YamlDecodeArgs { Text = text, DefaultNamespace = defaultNamespace }, new InvokeOptions { Provider = provider })

--- a/sdk/dotnet/Helm/V3/Chart.cs
+++ b/sdk/dotnet/Helm/V3/Chart.cs
@@ -23,6 +23,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Pulumi.Kubernetes.Yaml;
 using Pulumi.Utilities;
+using Pu = Pulumi;
 
 namespace Pulumi.Kubernetes.Helm.V3
 {
@@ -289,7 +290,7 @@ namespace Pulumi.Kubernetes.Helm.V3
             return string.IsNullOrEmpty(prefix) ? releaseName : $"{prefix}-{releaseName}";
         }
 
-        private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(Union<ChartArgsUnwrap, LocalChartArgsUnwrap> args, string releaseName, ImmutableHashSet<Resource> dependsOn, ComponentResourceOptions? options)
+        private Output<ImmutableDictionary<string, KubernetesResource>> ParseTemplate(Union<ChartArgsUnwrap, LocalChartArgsUnwrap> args, string releaseName, ImmutableHashSet<Pu.Resource> dependsOn, ComponentResourceOptions? options)
         {
             // Build JSON args to Helm provider invoke.
             var serializeOptions = new JsonSerializerOptions

--- a/sdk/dotnet/Yaml/Yaml.cs
+++ b/sdk/dotnet/Yaml/Yaml.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using GlobExpressions;
+using Pu = Pulumi;
 
 #pragma warning disable CS0618
 
@@ -740,9 +741,9 @@ namespace Pulumi.Kubernetes.Yaml
         /// <summary>
         /// Returns an array of ready resources to be used by DependsOn.
         /// </summary>
-        public Output<ImmutableArray<Resource>> Ready()
+        public Output<ImmutableArray<Pu.Resource>> Ready()
         {
-            return Resources.Apply(resources => resources.Values.Cast<Resource>().ToImmutableArray());
+            return Resources.Apply(resources => resources.Values.Cast<Pu.Resource>().ToImmutableArray());
         }
 
         /// <summary>
@@ -891,7 +892,7 @@ namespace Pulumi.Kubernetes.Yaml
             var opts = new CustomResourceOptions
             {
                 Parent = options?.Parent,
-                DependsOn = options?.DependsOn ?? new InputList<Resource>(),
+                DependsOn = options?.DependsOn ?? new InputList<Pu.Resource>(),
                 IgnoreChanges = options?.IgnoreChanges ?? new List<string>(),
                 Version = options?.Version,
                 Provider = options?.Provider,


### PR DESCRIPTION
This PR makes room for the `resource` API in Kubernetes v1.26.0, by qualifying the type `Resource` in templated code for .NET. It would otherwise clash with the namespace `Resource` generated to house the new API types.

Fixes #2233.