### PR TITLE
Add option to transfer required SSA fields on delete

### DIFF
--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -547,7 +547,15 @@ func Deletion(c DeleteConfig) error {
 
 	patchResource := strings.HasSuffix(c.URN.Type().String(), "Patch")
 	if c.ServerSideApply && patchResource {
+		// Optionally switch field manager
+		err = ssa.UpdateFieldManager(c.Context, client, c.Inputs, "override")
+		if err != nil {
+			return err
+		}
 		err = ssa.Relinquish(c.Context, client, c.Inputs, c.FieldManager)
+		if errors.IsInvalid(err) {
+			// TODO: something?
+		}
 		return err
 	}
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -563,7 +563,12 @@ func Deletion(c DeleteConfig) error {
 					requiredFields = append(requiredFields, cause.Field)
 				}
 
+				// TODO: the conflicts in the error message don't seem to be comprehensive. may need to populate this from the values set by pulumi
 				err = ssa.UpdateFieldManager(c.Context, client, c.Inputs, requiredFields, "override")
+				if err != nil {
+					return err
+				}
+				err = ssa.Relinquish(c.Context, client, c.Inputs, c.FieldManager)
 				if err != nil {
 					return err
 				}

--- a/provider/pkg/ssa/actions_test.go
+++ b/provider/pkg/ssa/actions_test.go
@@ -88,6 +88,25 @@ func Test_setRequiredFields(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "sliced value",
+			args: args{
+				live: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": []string{"c", "d"}, // should return the second element of this slice
+						"e": "f", // should be ignored
+					},
+				},
+				obj:   map[string]interface{}{},
+				field: "a.b[1]",
+			},
+			expected: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": []string{"d"},
+					},
+				},
+			want: true,
+		},
+		{
 			name: "invalid path",
 			args: args{
 				live:  map[string]interface{}{},

--- a/provider/pkg/ssa/actions_test.go
+++ b/provider/pkg/ssa/actions_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssa
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_setRequiredFields(t *testing.T) {
+	type args struct {
+		live  map[string]interface{}
+		obj   map[string]interface{}
+		field string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected map[string]interface{}
+		want     bool
+	}{
+		{
+			name: "nested value",
+			args: args{
+				live: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": "c", // should return this value
+						"d": "e", // should be ignored
+					},
+				},
+				obj:   map[string]interface{}{},
+				field: "a.b",
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": "c",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nested map",
+			args: args{
+				live: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": map[string]interface{}{ // should return this map
+							"c": "d",
+						},
+						"e": "f", // should be ignored
+					},
+				},
+				obj:   map[string]interface{}{},
+				field: "a.b",
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "d",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "top level field",
+			args: args{
+				live: map[string]interface{}{
+					"a": "b",
+				},
+				obj:   map[string]interface{}{},
+				field: "a",
+			},
+			expected: map[string]interface{}{
+				"a": "b",
+			},
+			want: true,
+		},
+		{
+			name: "invalid path",
+			args: args{
+				live:  map[string]interface{}{},
+				obj:   map[string]interface{}{},
+				field: "a",
+			},
+			expected: map[string]interface{}{},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := setRequiredField(tt.args.live, tt.args.obj, tt.args.field)
+			if !reflect.DeepEqual(tt.args.obj, tt.expected) {
+				t.Errorf("setRequiredField() got = %v, want %v", tt.args.obj, tt.expected)
+			}
+			if got != tt.want {
+				t.Errorf("setRequiredField() got1 = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/pkg/ssa/actions_test.go
+++ b/provider/pkg/ssa/actions_test.go
@@ -28,8 +28,8 @@ func Test_setRequiredFields(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		expected map[string]interface{}
-		want     bool
+		wantMap  map[string]interface{}
+		wantBool bool
 	}{
 		{
 			name: "nested value",
@@ -43,12 +43,12 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a.b",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": map[string]interface{}{
 					"b": "c",
 				},
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "nested map",
@@ -64,14 +64,14 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a.b",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": map[string]interface{}{
 					"b": map[string]interface{}{
 						"c": "d",
 					},
 				},
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "top level field",
@@ -82,10 +82,10 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": "b",
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "sliced string value",
@@ -99,12 +99,12 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a.b[1]",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": map[string]interface{}{
 					"b": []interface{}{nil, "d"},
 				},
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "sliced int value",
@@ -118,12 +118,12 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a.b[1]",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": map[string]interface{}{
 					"b": []interface{}{nil, 2},
 				},
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "sliced map value",
@@ -141,7 +141,7 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a.b[0]",
 			},
-			expected: map[string]interface{}{
+			wantMap: map[string]interface{}{
 				"a": map[string]interface{}{
 					"b": []interface{}{
 						map[string]interface{}{
@@ -150,7 +150,7 @@ func Test_setRequiredFields(t *testing.T) {
 					},
 				},
 			},
-			want: true,
+			wantBool: true,
 		},
 		{
 			name: "invalid path",
@@ -159,18 +159,30 @@ func Test_setRequiredFields(t *testing.T) {
 				obj:   map[string]interface{}{},
 				field: "a",
 			},
-			expected: map[string]interface{}{},
-			want:     false,
+			wantMap:  nil,
+			wantBool: false,
+		},
+		{
+			name: "invalid index",
+			args: args{
+				live: map[string]interface{}{
+					"a": []interface{}{},
+				},
+				obj:   map[string]interface{}{},
+				field: "a[1]",
+			},
+			wantMap:  nil,
+			wantBool: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := setRequiredField(tt.args.live, tt.args.obj, tt.args.field)
-			if !reflect.DeepEqual(tt.args.obj, tt.expected) {
-				t.Errorf("setRequiredField() got = %v, want %v", tt.args.obj, tt.expected)
+			gotMap, gotBool := setRequiredField(tt.args.live, tt.args.obj, tt.args.field)
+			if !reflect.DeepEqual(gotMap, tt.wantMap) {
+				t.Errorf("setRequiredField() gotMap = %v, want %v", gotMap, tt.wantMap)
 			}
-			if got != tt.want {
-				t.Errorf("setRequiredField() got1 = %v, want %v", got, tt.want)
+			if gotBool != tt.wantBool {
+				t.Errorf("setRequiredField() gotBool = %v, want %v", gotBool, tt.wantBool)
 			}
 		})
 	}

--- a/provider/pkg/ssa/actions_test.go
+++ b/provider/pkg/ssa/actions_test.go
@@ -88,22 +88,68 @@ func Test_setRequiredFields(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "sliced value",
+			name: "sliced string value",
 			args: args{
 				live: map[string]interface{}{
 					"a": map[string]interface{}{
 						"b": []interface{}{"c", "d"}, // should return the second element of this slice
-						"e": "f", // should be ignored
+						"e": "f",                     // should be ignored
 					},
 				},
 				obj:   map[string]interface{}{},
 				field: "a.b[1]",
 			},
 			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": []interface{}{nil, "d"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "sliced int value",
+			args: args{
+				live: map[string]interface{}{
 					"a": map[string]interface{}{
-						"b": []interface{}{"d"},
+						"b": []interface{}{1, 2}, // should return the second element of this slice
+						"e": "f",                 // should be ignored
 					},
 				},
+				obj:   map[string]interface{}{},
+				field: "a.b[1]",
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": []interface{}{nil, 2},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "sliced map value",
+			args: args{
+				live: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": []interface{}{ // should return the first element of this slice
+							map[string]interface{}{
+								"c": "d",
+							},
+						},
+						"e": "f", // should be ignored
+					},
+				},
+				obj:   map[string]interface{}{},
+				field: "a.b[0]",
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": []interface{}{
+						map[string]interface{}{
+							"c": "d",
+						},
+					},
+				},
+			},
 			want: true,
 		},
 		{

--- a/provider/pkg/ssa/actions_test.go
+++ b/provider/pkg/ssa/actions_test.go
@@ -92,7 +92,7 @@ func Test_setRequiredFields(t *testing.T) {
 			args: args{
 				live: map[string]interface{}{
 					"a": map[string]interface{}{
-						"b": []string{"c", "d"}, // should return the second element of this slice
+						"b": []interface{}{"c", "d"}, // should return the second element of this slice
 						"e": "f", // should be ignored
 					},
 				},
@@ -101,7 +101,7 @@ func Test_setRequiredFields(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 					"a": map[string]interface{}{
-						"b": []string{"d"},
+						"b": []interface{}{"d"},
 					},
 				},
 			want: true,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This is a WIP -- I'm attempting to add a way to conditionally transfer ownership of required fields on resource deletion. I initially planned to base this on errors returned from the k8s apiserver, but found that these aren't a reliable source of information for this operation. I'll need to rework this a bit.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2149
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
