### PR TITLE
Make allowNullValues an InputProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Expose the allowNullValues boolean as an InputProperty so that it can be set in SDKs (https://github.com/pulumi/pulumi-kubernetes/pulls/2255)
+
 ## 3.22.2 (November 30, 2022)
 
 - Add allowNullValues boolean option to pass Null values through helm configs without having them

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1024,6 +1024,12 @@ var helmV3ReleaseResource = pschema.ResourceSpec{
 			},
 			Const: "true",
 		},
+		"allowNullValues": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "boolean",
+			},
+			Description: "Whether to allow Null values in helm chart configs.",
+		},
 	},
 	RequiredInputs: []string{
 		"chart",

--- a/sdk/dotnet/Helm/V3/Release.cs
+++ b/sdk/dotnet/Helm/V3/Release.cs
@@ -523,6 +523,12 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
     public class ReleaseArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether to allow Null values in helm chart configs.
+        /// </summary>
+        [Input("allowNullValues")]
+        public Input<bool>? AllowNullValues { get; set; }
+
+        /// <summary>
         /// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         /// </summary>
         [Input("atomic")]

--- a/sdk/go/kubernetes/helm/v3/release.go
+++ b/sdk/go/kubernetes/helm/v3/release.go
@@ -409,6 +409,8 @@ func (ReleaseState) ElementType() reflect.Type {
 }
 
 type releaseArgs struct {
+	// Whether to allow Null values in helm chart configs.
+	AllowNullValues *bool `pulumi:"allowNullValues"`
 	// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 	Atomic *bool `pulumi:"atomic"`
 	// Chart name to be installed. A path may be used.
@@ -480,6 +482,8 @@ type releaseArgs struct {
 
 // The set of arguments for constructing a Release resource.
 type ReleaseArgs struct {
+	// Whether to allow Null values in helm chart configs.
+	AllowNullValues pulumi.BoolPtrInput
 	// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 	Atomic pulumi.BoolPtrInput
 	// Chart name to be installed. A path may be used.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
@@ -24,6 +24,21 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
     public static final ReleaseArgs Empty = new ReleaseArgs();
 
     /**
+     * Whether to allow Null values in helm chart configs.
+     * 
+     */
+    @Import(name="allowNullValues")
+    private @Nullable Output<Boolean> allowNullValues;
+
+    /**
+     * @return Whether to allow Null values in helm chart configs.
+     * 
+     */
+    public Optional<Output<Boolean>> allowNullValues() {
+        return Optional.ofNullable(this.allowNullValues);
+    }
+
+    /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      * 
      */
@@ -528,6 +543,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
     private ReleaseArgs() {}
 
     private ReleaseArgs(ReleaseArgs $) {
+        this.allowNullValues = $.allowNullValues;
         this.atomic = $.atomic;
         this.chart = $.chart;
         this.cleanupOnFail = $.cleanupOnFail;
@@ -580,6 +596,27 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
 
         public Builder(ReleaseArgs defaults) {
             $ = new ReleaseArgs(Objects.requireNonNull(defaults));
+        }
+
+        /**
+         * @param allowNullValues Whether to allow Null values in helm chart configs.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder allowNullValues(@Nullable Output<Boolean> allowNullValues) {
+            $.allowNullValues = allowNullValues;
+            return this;
+        }
+
+        /**
+         * @param allowNullValues Whether to allow Null values in helm chart configs.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder allowNullValues(Boolean allowNullValues) {
+            return allowNullValues(Output.of(allowNullValues));
         }
 
         /**

--- a/sdk/nodejs/helm/v3/release.ts
+++ b/sdk/nodejs/helm/v3/release.ts
@@ -188,7 +188,7 @@ export class Release extends pulumi.CustomResource {
     /**
      * Whether to allow Null values in helm chart configs.
      */
-    public /*out*/ readonly allowNullValues!: pulumi.Output<boolean>;
+    public readonly allowNullValues!: pulumi.Output<boolean>;
     /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      */
@@ -340,6 +340,7 @@ export class Release extends pulumi.CustomResource {
             if ((!args || args.chart === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'chart'");
             }
+            resourceInputs["allowNullValues"] = args ? args.allowNullValues : undefined;
             resourceInputs["atomic"] = args ? args.atomic : undefined;
             resourceInputs["chart"] = args ? args.chart : undefined;
             resourceInputs["cleanupOnFail"] = args ? args.cleanupOnFail : undefined;
@@ -374,7 +375,6 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["verify"] = args ? args.verify : undefined;
             resourceInputs["version"] = args ? args.version : undefined;
             resourceInputs["waitForJobs"] = args ? args.waitForJobs : undefined;
-            resourceInputs["allowNullValues"] = undefined /*out*/;
             resourceInputs["status"] = undefined /*out*/;
         } else {
             resourceInputs["allowNullValues"] = undefined /*out*/;
@@ -422,6 +422,10 @@ export class Release extends pulumi.CustomResource {
  * The set of arguments for constructing a Release resource.
  */
 export interface ReleaseArgs {
+    /**
+     * Whether to allow Null values in helm chart configs.
+     */
+    allowNullValues?: pulumi.Input<boolean>;
     /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      */

--- a/sdk/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/Release.py
@@ -17,6 +17,7 @@ __all__ = ['ReleaseArgs', 'Release']
 class ReleaseArgs:
     def __init__(__self__, *,
                  chart: pulumi.Input[str],
+                 allow_null_values: Optional[pulumi.Input[bool]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
                  compat: Optional[pulumi.Input[str]] = None,
@@ -53,6 +54,7 @@ class ReleaseArgs:
         """
         The set of arguments for constructing a Release resource.
         :param pulumi.Input[str] chart: Chart name to be installed. A path may be used.
+        :param pulumi.Input[bool] allow_null_values: Whether to allow Null values in helm chart configs.
         :param pulumi.Input[bool] atomic: If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         :param pulumi.Input[bool] cleanup_on_fail: Allow deletion of new resources created in this upgrade when upgrade fails.
         :param pulumi.Input[bool] create_namespace: Create the namespace if it does not exist.
@@ -87,6 +89,8 @@ class ReleaseArgs:
         :param pulumi.Input[bool] wait_for_jobs: Will wait until all Jobs have been completed before marking the release as successful. This is ignored if `skipAwait` is enabled.
         """
         pulumi.set(__self__, "chart", chart)
+        if allow_null_values is not None:
+            pulumi.set(__self__, "allow_null_values", allow_null_values)
         if atomic is not None:
             pulumi.set(__self__, "atomic", atomic)
         if cleanup_on_fail is not None:
@@ -165,6 +169,18 @@ class ReleaseArgs:
     @chart.setter
     def chart(self, value: pulumi.Input[str]):
         pulumi.set(self, "chart", value)
+
+    @property
+    @pulumi.getter(name="allowNullValues")
+    def allow_null_values(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to allow Null values in helm chart configs.
+        """
+        return pulumi.get(self, "allow_null_values")
+
+    @allow_null_values.setter
+    def allow_null_values(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "allow_null_values", value)
 
     @property
     @pulumi.getter
@@ -565,6 +581,7 @@ class Release(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 allow_null_values: Optional[pulumi.Input[bool]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  chart: Optional[pulumi.Input[str]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
@@ -765,6 +782,7 @@ class Release(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] allow_null_values: Whether to allow Null values in helm chart configs.
         :param pulumi.Input[bool] atomic: If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         :param pulumi.Input[str] chart: Chart name to be installed. A path may be used.
         :param pulumi.Input[bool] cleanup_on_fail: Allow deletion of new resources created in this upgrade when upgrade fails.
@@ -983,6 +1001,7 @@ class Release(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 allow_null_values: Optional[pulumi.Input[bool]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  chart: Optional[pulumi.Input[str]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
@@ -1026,6 +1045,7 @@ class Release(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ReleaseArgs.__new__(ReleaseArgs)
 
+            __props__.__dict__["allow_null_values"] = allow_null_values
             __props__.__dict__["atomic"] = atomic
             if chart is None and not opts.urn:
                 raise TypeError("Missing required property 'chart'")
@@ -1062,7 +1082,6 @@ class Release(pulumi.CustomResource):
             __props__.__dict__["verify"] = verify
             __props__.__dict__["version"] = version
             __props__.__dict__["wait_for_jobs"] = wait_for_jobs
-            __props__.__dict__["allow_null_values"] = None
             __props__.__dict__["status"] = None
         super(Release, __self__).__init__(
             'kubernetes:helm.sh/v3:Release',


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

- adds `allowNullValues` to the resource schema `InputProperties`
- rebuilds SDKs to expose the argument so that it can be set with the SDKs

### Related issues (optional)

Completes missing piece from #2220 which added this in the Properties but did not allow one to set the value in the SDKs. The objective is to be able to pass empty arrays through to helm deployments when desired.

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
