### PR TITLE
Add link to resolution guide for SSA conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add `PULUMI_K8S_ENABLE_PATCH_FORCE` env var support (https://github.com/pulumi/pulumi-kubernetes/pulls/2260)
+- Add link to resolution guide for SSA conflicts (https://github.com/pulumi/pulumi-kubernetes/pulls/2265)
 
 ## 3.23.0 (December 8, 2022)
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -139,6 +139,8 @@ func skipRetry(gvk schema.GroupVersionKind, k8sVersion *cluster.ServerVersion, e
 	return false, nil
 }
 
+const ssaConflictDocLink = "https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/#handle-field-conflicts-on-existing-resources"
+
 // Creation (as the usage, `await.Creation`, implies) will block until one of the following is true:
 // (1) the Kubernetes resource is reported to be initialized; (2) the initialization timeout has
 // occurred; or (3) an error has occurred while the resource was being initialized.
@@ -199,7 +201,8 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 					c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 
 				if errors.IsConflict(err) {
-					err = fmt.Errorf(`use the "pulumi.com/patchForce" annotation if you want to overwrite the existing values: %w`, err)
+					err = fmt.Errorf("conflict detected. see %s for troubleshooting help: %w",
+						ssaConflictDocLink, err)
 				}
 			} else {
 				var options metav1.CreateOptions
@@ -436,7 +439,8 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 			currentOutputs, err = client.Patch(c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 			if err != nil {
 				if errors.IsConflict(err) {
-					err = fmt.Errorf("use `pulumi.com/patchForce` to override the conflict: %w", err)
+					err = fmt.Errorf("conflict detected. see %s for troubleshooting help: %w",
+						ssaConflictDocLink, err)
 				}
 				return nil, err
 			}

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -201,7 +201,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 					c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 
 				if errors.IsConflict(err) {
-					err = fmt.Errorf("conflict detected. see %s for troubleshooting help: %w",
+					err = fmt.Errorf("SSA field conflict detected. see %s for troubleshooting help\n: %w",
 						ssaConflictDocLink, err)
 				}
 			} else {
@@ -439,7 +439,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 			currentOutputs, err = client.Patch(c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 			if err != nil {
 				if errors.IsConflict(err) {
-					err = fmt.Errorf("conflict detected. see %s for troubleshooting help: %w",
+					err = fmt.Errorf("SSA field conflict detected. see %s for troubleshooting help\n: %w",
 						ssaConflictDocLink, err)
 				}
 				return nil, err

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -201,7 +201,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 					c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 
 				if errors.IsConflict(err) {
-					err = fmt.Errorf("SSA field conflict detected. see %s for troubleshooting help\n: %w",
+					err = fmt.Errorf("Server-Side Apply field conflict detected. see %s for troubleshooting help\n: %w",
 						ssaConflictDocLink, err)
 				}
 			} else {
@@ -439,7 +439,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 			currentOutputs, err = client.Patch(c.Context, c.Inputs.GetName(), types.ApplyPatchType, objYAML, options)
 			if err != nil {
 				if errors.IsConflict(err) {
-					err = fmt.Errorf("SSA field conflict detected. see %s for troubleshooting help\n: %w",
+					err = fmt.Errorf("Server-Side Apply field conflict detected. see %s for troubleshooting help\n: %w",
 						ssaConflictDocLink, err)
 				}
 				return nil, err

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -421,7 +421,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than 
 one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource. 
 Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-[Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+[Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.`
 					patchResourceSpec.Description = fmt.Sprintf(
 						"%s\n%s", patchDescription, patchResourceSpec.Description)

--- a/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/MutatingWebhookConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
     /// </summary>

--- a/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1/ValidatingWebhookConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
     /// </summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Alpha1/ValidatingAdmissionPolicyBindingPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Alpha1/ValidatingAdmissionPolicyBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
     /// </summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Alpha1/ValidatingAdmissionPolicyPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Alpha1/ValidatingAdmissionPolicyPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
     /// </summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/MutatingWebhookConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
     /// </summary>

--- a/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationPatch.cs
+++ b/sdk/dotnet/AdmissionRegistration/V1Beta1/ValidatingWebhookConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AdmissionRegistration.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
     /// </summary>

--- a/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionPatch.cs
+++ b/sdk/dotnet/ApiExtensions/V1/CustomResourceDefinitionPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;.
     /// </summary>

--- a/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionPatch.cs
+++ b/sdk/dotnet/ApiExtensions/V1Beta1/CustomResourceDefinitionPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.ApiExtensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
     /// </summary>

--- a/sdk/dotnet/ApiRegistration/V1/APIServicePatch.cs
+++ b/sdk/dotnet/ApiRegistration/V1/APIServicePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// APIService represents a server for a particular GroupVersion. Name must be "version.group".
     /// </summary>

--- a/sdk/dotnet/ApiRegistration/V1Beta1/APIServicePatch.cs
+++ b/sdk/dotnet/ApiRegistration/V1Beta1/APIServicePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.ApiRegistration.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// APIService represents a server for a particular GroupVersion. Name must be "version.group".
     /// </summary>

--- a/sdk/dotnet/Apps/V1/ControllerRevisionPatch.cs
+++ b/sdk/dotnet/Apps/V1/ControllerRevisionPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
     /// </summary>

--- a/sdk/dotnet/Apps/V1/DaemonSetPatch.cs
+++ b/sdk/dotnet/Apps/V1/DaemonSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>

--- a/sdk/dotnet/Apps/V1/DeploymentPatch.cs
+++ b/sdk/dotnet/Apps/V1/DeploymentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Apps/V1/ReplicaSetPatch.cs
+++ b/sdk/dotnet/Apps/V1/ReplicaSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>

--- a/sdk/dotnet/Apps/V1/StatefulSetPatch.cs
+++ b/sdk/dotnet/Apps/V1/StatefulSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///   - Network: A single stable DNS and hostname.

--- a/sdk/dotnet/Apps/V1Beta1/ControllerRevisionPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta1/ControllerRevisionPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta1/DeploymentPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta1/DeploymentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Apps/V1Beta1/StatefulSetPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta1/StatefulSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.

--- a/sdk/dotnet/Apps/V1Beta2/ControllerRevisionPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ControllerRevisionPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta2/DaemonSetPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DaemonSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta2/DeploymentPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta2/DeploymentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Apps/V1Beta2/ReplicaSetPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta2/ReplicaSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>

--- a/sdk/dotnet/Apps/V1Beta2/StatefulSetPatch.cs
+++ b/sdk/dotnet/Apps/V1Beta2/StatefulSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Apps.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// StatefulSet represents a set of pods with consistent identities. Identities are defined as:
     ///  - Network: A single stable DNS and hostname.

--- a/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkPatch.cs
+++ b/sdk/dotnet/AuditRegistraion/V1Alpha1/AuditSinkPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.AuditRegistraion.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// AuditSink represents a cluster level audit sink
     /// </summary>

--- a/sdk/dotnet/Authentication/V1/TokenRequestPatch.cs
+++ b/sdk/dotnet/Authentication/V1/TokenRequestPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authentication.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// TokenRequest requests a token for a given service account.
     /// </summary>

--- a/sdk/dotnet/Authentication/V1/TokenReviewPatch.cs
+++ b/sdk/dotnet/Authentication/V1/TokenReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authentication.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
     /// </summary>

--- a/sdk/dotnet/Authentication/V1Alpha1/SelfSubjectReviewPatch.cs
+++ b/sdk/dotnet/Authentication/V1Alpha1/SelfSubjectReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authentication.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
     /// </summary>

--- a/sdk/dotnet/Authentication/V1Beta1/TokenReviewPatch.cs
+++ b/sdk/dotnet/Authentication/V1Beta1/TokenReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authentication.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1/LocalSubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1/LocalSubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1/SelfSubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1/SelfSubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
     /// </summary>

--- a/sdk/dotnet/Authorization/V1/SelfSubjectRulesReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1/SelfSubjectRulesReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1/SubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1/SubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SubjectAccessReview checks whether or not a user or group can perform an action.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1Beta1/LocalSubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/LocalSubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1Beta1/SelfSubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SelfSubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
     /// </summary>

--- a/sdk/dotnet/Authorization/V1Beta1/SelfSubjectRulesReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SelfSubjectRulesReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
     /// </summary>

--- a/sdk/dotnet/Authorization/V1Beta1/SubjectAccessReviewPatch.cs
+++ b/sdk/dotnet/Authorization/V1Beta1/SubjectAccessReviewPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Authorization.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// SubjectAccessReview checks whether or not a user or group can perform an action.
     /// </summary>

--- a/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerPatch.cs
+++ b/sdk/dotnet/Autoscaling/V1/HorizontalPodAutoscalerPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// configuration of a horizontal pod autoscaler.
     /// </summary>

--- a/sdk/dotnet/Autoscaling/V2/HorizontalPodAutoscalerPatch.cs
+++ b/sdk/dotnet/Autoscaling/V2/HorizontalPodAutoscalerPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
     /// </summary>

--- a/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerPatch.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta1/HorizontalPodAutoscalerPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
     /// </summary>

--- a/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerPatch.cs
+++ b/sdk/dotnet/Autoscaling/V2Beta2/HorizontalPodAutoscalerPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Autoscaling.V2Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
     /// </summary>

--- a/sdk/dotnet/Batch/V1/CronJobPatch.cs
+++ b/sdk/dotnet/Batch/V1/CronJobPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Batch.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CronJob represents the configuration of a single cron job.
     /// </summary>

--- a/sdk/dotnet/Batch/V1/JobPatch.cs
+++ b/sdk/dotnet/Batch/V1/JobPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Batch.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Job represents the configuration of a single job.
     /// 

--- a/sdk/dotnet/Batch/V1Beta1/CronJobPatch.cs
+++ b/sdk/dotnet/Batch/V1Beta1/CronJobPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Batch.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CronJob represents the configuration of a single cron job.
     /// </summary>

--- a/sdk/dotnet/Batch/V2Alpha1/CronJobPatch.cs
+++ b/sdk/dotnet/Batch/V2Alpha1/CronJobPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Batch.V2Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CronJob represents the configuration of a single cron job.
     /// </summary>

--- a/sdk/dotnet/Certificates/V1/CertificateSigningRequestPatch.cs
+++ b/sdk/dotnet/Certificates/V1/CertificateSigningRequestPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Certificates.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
     /// 

--- a/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestPatch.cs
+++ b/sdk/dotnet/Certificates/V1Beta1/CertificateSigningRequestPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Certificates.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Describes a certificate signing request
     /// </summary>

--- a/sdk/dotnet/Coordination/V1/LeasePatch.cs
+++ b/sdk/dotnet/Coordination/V1/LeasePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Coordination.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Lease defines a lease concept.
     /// </summary>

--- a/sdk/dotnet/Coordination/V1Beta1/LeasePatch.cs
+++ b/sdk/dotnet/Coordination/V1Beta1/LeasePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Coordination.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Lease defines a lease concept.
     /// </summary>

--- a/sdk/dotnet/Core/V1/BindingPatch.cs
+++ b/sdk/dotnet/Core/V1/BindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
     /// </summary>

--- a/sdk/dotnet/Core/V1/ConfigMapPatch.cs
+++ b/sdk/dotnet/Core/V1/ConfigMapPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ConfigMap holds configuration data for pods to consume.
     /// </summary>

--- a/sdk/dotnet/Core/V1/EndpointsPatch.cs
+++ b/sdk/dotnet/Core/V1/EndpointsPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Endpoints is a collection of endpoints that implement the actual service. Example:
     /// 

--- a/sdk/dotnet/Core/V1/EventPatch.cs
+++ b/sdk/dotnet/Core/V1/EventPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
     /// </summary>

--- a/sdk/dotnet/Core/V1/LimitRangePatch.cs
+++ b/sdk/dotnet/Core/V1/LimitRangePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// LimitRange sets resource usage limits for each kind of resource in a Namespace.
     /// </summary>

--- a/sdk/dotnet/Core/V1/NamespacePatch.cs
+++ b/sdk/dotnet/Core/V1/NamespacePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Namespace provides a scope for Names. Use of multiple namespaces is optional.
     /// </summary>

--- a/sdk/dotnet/Core/V1/NodePatch.cs
+++ b/sdk/dotnet/Core/V1/NodePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
     /// </summary>

--- a/sdk/dotnet/Core/V1/PersistentVolumeClaimPatch.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumeClaimPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PersistentVolumeClaim is a user's request for and claim to a persistent volume
     /// </summary>

--- a/sdk/dotnet/Core/V1/PersistentVolumePatch.cs
+++ b/sdk/dotnet/Core/V1/PersistentVolumePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
     /// </summary>

--- a/sdk/dotnet/Core/V1/PodPatch.cs
+++ b/sdk/dotnet/Core/V1/PodPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
     /// 

--- a/sdk/dotnet/Core/V1/PodTemplatePatch.cs
+++ b/sdk/dotnet/Core/V1/PodTemplatePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodTemplate describes a template for creating copies of a predefined pod.
     /// </summary>

--- a/sdk/dotnet/Core/V1/ReplicationControllerPatch.cs
+++ b/sdk/dotnet/Core/V1/ReplicationControllerPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ReplicationController represents the configuration of a replication controller.
     /// </summary>

--- a/sdk/dotnet/Core/V1/ResourceQuotaPatch.cs
+++ b/sdk/dotnet/Core/V1/ResourceQuotaPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ResourceQuota sets aggregate quota restrictions enforced per namespace
     /// </summary>

--- a/sdk/dotnet/Core/V1/SecretPatch.cs
+++ b/sdk/dotnet/Core/V1/SecretPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
     /// 

--- a/sdk/dotnet/Core/V1/ServiceAccountPatch.cs
+++ b/sdk/dotnet/Core/V1/ServiceAccountPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
     /// </summary>

--- a/sdk/dotnet/Core/V1/ServicePatch.cs
+++ b/sdk/dotnet/Core/V1/ServicePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Core.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
     /// 

--- a/sdk/dotnet/Discovery/V1/EndpointSlicePatch.cs
+++ b/sdk/dotnet/Discovery/V1/EndpointSlicePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Discovery.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
     /// </summary>

--- a/sdk/dotnet/Discovery/V1Beta1/EndpointSlicePatch.cs
+++ b/sdk/dotnet/Discovery/V1Beta1/EndpointSlicePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Discovery.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
     /// </summary>

--- a/sdk/dotnet/Events/V1/EventPatch.cs
+++ b/sdk/dotnet/Events/V1/EventPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Events.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
     /// </summary>

--- a/sdk/dotnet/Events/V1Beta1/EventPatch.cs
+++ b/sdk/dotnet/Events/V1Beta1/EventPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Events.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
     /// </summary>

--- a/sdk/dotnet/Extensions/V1Beta1/DaemonSetPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DaemonSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DaemonSet represents the configuration of a daemon set.
     /// </summary>

--- a/sdk/dotnet/Extensions/V1Beta1/DeploymentPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/DeploymentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Deployment enables declarative updates for Pods and ReplicaSets.
     /// 

--- a/sdk/dotnet/Extensions/V1Beta1/IngressPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/IngressPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
     /// 

--- a/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/NetworkPolicyPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
     /// </summary>

--- a/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/PodSecurityPolicyPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
     /// </summary>

--- a/sdk/dotnet/Extensions/V1Beta1/ReplicaSetPatch.cs
+++ b/sdk/dotnet/Extensions/V1Beta1/ReplicaSetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Extensions.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/FlowSchemaPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Alpha1/PriorityLevelConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PriorityLevelConfiguration represents the configuration of a priority level.
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta1/FlowSchemaPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta1/FlowSchemaPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta1/PriorityLevelConfigurationPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta1/PriorityLevelConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PriorityLevelConfiguration represents the configuration of a priority level.
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta2/FlowSchemaPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta2/FlowSchemaPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta2/PriorityLevelConfigurationPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta2/PriorityLevelConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta2
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PriorityLevelConfiguration represents the configuration of a priority level.
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta3/FlowSchemaPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta3/FlowSchemaPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta3
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
     /// </summary>

--- a/sdk/dotnet/FlowControl/V1Beta3/PriorityLevelConfigurationPatch.cs
+++ b/sdk/dotnet/FlowControl/V1Beta3/PriorityLevelConfigurationPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.FlowControl.V1Beta3
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PriorityLevelConfiguration represents the configuration of a priority level.
     /// </summary>

--- a/sdk/dotnet/Meta/V1/StatusPatch.cs
+++ b/sdk/dotnet/Meta/V1/StatusPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Meta.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Status is a return value for calls that don't return other objects.
     /// </summary>

--- a/sdk/dotnet/Networking/V1/IngressClassPatch.cs
+++ b/sdk/dotnet/Networking/V1/IngressClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
     /// </summary>

--- a/sdk/dotnet/Networking/V1/IngressPatch.cs
+++ b/sdk/dotnet/Networking/V1/IngressPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
     /// 

--- a/sdk/dotnet/Networking/V1/NetworkPolicyPatch.cs
+++ b/sdk/dotnet/Networking/V1/NetworkPolicyPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// NetworkPolicy describes what network traffic is allowed for a set of Pods
     /// </summary>

--- a/sdk/dotnet/Networking/V1Alpha1/ClusterCIDRPatch.cs
+++ b/sdk/dotnet/Networking/V1Alpha1/ClusterCIDRPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
     /// </summary>

--- a/sdk/dotnet/Networking/V1Beta1/IngressClassPatch.cs
+++ b/sdk/dotnet/Networking/V1Beta1/IngressClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
     /// </summary>

--- a/sdk/dotnet/Networking/V1Beta1/IngressPatch.cs
+++ b/sdk/dotnet/Networking/V1Beta1/IngressPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Networking.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
     /// 

--- a/sdk/dotnet/Node/V1/RuntimeClassPatch.cs
+++ b/sdk/dotnet/Node/V1/RuntimeClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Node.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
     /// </summary>

--- a/sdk/dotnet/Node/V1Alpha1/RuntimeClassPatch.cs
+++ b/sdk/dotnet/Node/V1Alpha1/RuntimeClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Node.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
     /// </summary>

--- a/sdk/dotnet/Node/V1Beta1/RuntimeClassPatch.cs
+++ b/sdk/dotnet/Node/V1Beta1/RuntimeClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Node.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
     /// </summary>

--- a/sdk/dotnet/Policy/V1/PodDisruptionBudgetPatch.cs
+++ b/sdk/dotnet/Policy/V1/PodDisruptionBudgetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Policy.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
     /// </summary>

--- a/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetPatch.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodDisruptionBudgetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
     /// </summary>

--- a/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyPatch.cs
+++ b/sdk/dotnet/Policy/V1Beta1/PodSecurityPolicyPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Policy.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1/ClusterRoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1/ClusterRolePatch.cs
+++ b/sdk/dotnet/Rbac/V1/ClusterRolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1/RoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1/RoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1/RolePatch.cs
+++ b/sdk/dotnet/Rbac/V1/RolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/ClusterRolePatch.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/ClusterRolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/RoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Alpha1/RolePatch.cs
+++ b/sdk/dotnet/Rbac/V1Alpha1/RolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Beta1/ClusterRolePatch.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/ClusterRolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Beta1/RoleBindingPatch.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RoleBindingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Rbac/V1Beta1/RolePatch.cs
+++ b/sdk/dotnet/Rbac/V1Beta1/RolePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Rbac.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
     /// </summary>

--- a/sdk/dotnet/Resource/V1Alpha1/PodSchedulingPatch.cs
+++ b/sdk/dotnet/Resource/V1Alpha1/PodSchedulingPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Resource.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
     /// 

--- a/sdk/dotnet/Resource/V1Alpha1/ResourceClaimPatch.cs
+++ b/sdk/dotnet/Resource/V1Alpha1/ResourceClaimPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Resource.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
     /// 

--- a/sdk/dotnet/Resource/V1Alpha1/ResourceClaimTemplatePatch.cs
+++ b/sdk/dotnet/Resource/V1Alpha1/ResourceClaimTemplatePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Resource.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ResourceClaimTemplate is used to produce ResourceClaim objects.
     /// </summary>

--- a/sdk/dotnet/Resource/V1Alpha1/ResourceClassPatch.cs
+++ b/sdk/dotnet/Resource/V1Alpha1/ResourceClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Resource.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// ResourceClass is used by administrators to influence how resources are allocated.
     /// 

--- a/sdk/dotnet/Scheduling/V1/PriorityClassPatch.cs
+++ b/sdk/dotnet/Scheduling/V1/PriorityClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
     /// </summary>

--- a/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassPatch.cs
+++ b/sdk/dotnet/Scheduling/V1Alpha1/PriorityClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
     /// </summary>

--- a/sdk/dotnet/Scheduling/V1Beta1/PriorityClassPatch.cs
+++ b/sdk/dotnet/Scheduling/V1Beta1/PriorityClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Scheduling.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
     /// </summary>

--- a/sdk/dotnet/Settings/V1Alpha1/PodPresetPatch.cs
+++ b/sdk/dotnet/Settings/V1Alpha1/PodPresetPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Settings.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// PodPreset is a policy resource that defines additional runtime requirements for a Pod.
     /// </summary>

--- a/sdk/dotnet/Storage/V1/CSIDriverPatch.cs
+++ b/sdk/dotnet/Storage/V1/CSIDriverPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
     /// </summary>

--- a/sdk/dotnet/Storage/V1/CSINodePatch.cs
+++ b/sdk/dotnet/Storage/V1/CSINodePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
     /// </summary>

--- a/sdk/dotnet/Storage/V1/CSIStorageCapacityPatch.cs
+++ b/sdk/dotnet/Storage/V1/CSIStorageCapacityPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
     /// 

--- a/sdk/dotnet/Storage/V1/StorageClassPatch.cs
+++ b/sdk/dotnet/Storage/V1/StorageClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
     /// 

--- a/sdk/dotnet/Storage/V1/VolumeAttachmentPatch.cs
+++ b/sdk/dotnet/Storage/V1/VolumeAttachmentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
     /// 

--- a/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentPatch.cs
+++ b/sdk/dotnet/Storage/V1Alpha1/VolumeAttachmentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Alpha1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
     /// 

--- a/sdk/dotnet/Storage/V1Beta1/CSIDriverPatch.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSIDriverPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
     /// </summary>

--- a/sdk/dotnet/Storage/V1Beta1/CSINodePatch.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSINodePatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
     /// </summary>

--- a/sdk/dotnet/Storage/V1Beta1/CSIStorageCapacityPatch.cs
+++ b/sdk/dotnet/Storage/V1Beta1/CSIStorageCapacityPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
     /// 

--- a/sdk/dotnet/Storage/V1Beta1/StorageClassPatch.cs
+++ b/sdk/dotnet/Storage/V1Beta1/StorageClassPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
     /// 

--- a/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentPatch.cs
+++ b/sdk/dotnet/Storage/V1Beta1/VolumeAttachmentPatch.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Kubernetes.Storage.V1Beta1
     /// Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
     /// one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
     /// Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+    /// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
     /// additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
     /// VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
     /// 

--- a/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/mutatingWebhookConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 type MutatingWebhookConfigurationPatch struct {

--- a/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1/validatingWebhookConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 type ValidatingWebhookConfigurationPatch struct {

--- a/sdk/go/kubernetes/admissionregistration/v1alpha1/validatingAdmissionPolicyBindingPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1alpha1/validatingAdmissionPolicyBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
 type ValidatingAdmissionPolicyBindingPatch struct {

--- a/sdk/go/kubernetes/admissionregistration/v1alpha1/validatingAdmissionPolicyPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1alpha1/validatingAdmissionPolicyPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
 type ValidatingAdmissionPolicyPatch struct {

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/mutatingWebhookConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
 type MutatingWebhookConfigurationPatch struct {

--- a/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationPatch.go
+++ b/sdk/go/kubernetes/admissionregistration/v1beta1/validatingWebhookConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
 type ValidatingWebhookConfigurationPatch struct {

--- a/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionPatch.go
+++ b/sdk/go/kubernetes/apiextensions/v1/customResourceDefinitionPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
 type CustomResourceDefinitionPatch struct {

--- a/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionPatch.go
+++ b/sdk/go/kubernetes/apiextensions/v1beta1/customResourceDefinitionPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
 type CustomResourceDefinitionPatch struct {

--- a/sdk/go/kubernetes/apiregistration/v1/apiservicePatch.go
+++ b/sdk/go/kubernetes/apiregistration/v1/apiservicePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServicePatch struct {

--- a/sdk/go/kubernetes/apiregistration/v1beta1/apiservicePatch.go
+++ b/sdk/go/kubernetes/apiregistration/v1beta1/apiservicePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // APIService represents a server for a particular GroupVersion. Name must be "version.group".
 type APIServicePatch struct {

--- a/sdk/go/kubernetes/apps/v1/controllerRevisionPatch.go
+++ b/sdk/go/kubernetes/apps/v1/controllerRevisionPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 type ControllerRevisionPatch struct {

--- a/sdk/go/kubernetes/apps/v1/daemonSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1/daemonSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSetPatch struct {

--- a/sdk/go/kubernetes/apps/v1/deploymentPatch.go
+++ b/sdk/go/kubernetes/apps/v1/deploymentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 //

--- a/sdk/go/kubernetes/apps/v1/replicaSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1/replicaSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSetPatch struct {

--- a/sdk/go/kubernetes/apps/v1/statefulSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1/statefulSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // StatefulSet represents a set of pods with consistent identities. Identities are defined as:
 //   - Network: A single stable DNS and hostname.

--- a/sdk/go/kubernetes/apps/v1beta1/controllerRevisionPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta1/controllerRevisionPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 //

--- a/sdk/go/kubernetes/apps/v1beta1/deploymentPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta1/deploymentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 //

--- a/sdk/go/kubernetes/apps/v1beta1/statefulSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta1/statefulSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // StatefulSet represents a set of pods with consistent identities. Identities are defined as:
 //   - Network: A single stable DNS and hostname.

--- a/sdk/go/kubernetes/apps/v1beta2/controllerRevisionPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta2/controllerRevisionPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 //

--- a/sdk/go/kubernetes/apps/v1beta2/daemonSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta2/daemonSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DaemonSet represents the configuration of a daemon set.
 //

--- a/sdk/go/kubernetes/apps/v1beta2/deploymentPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta2/deploymentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 //

--- a/sdk/go/kubernetes/apps/v1beta2/replicaSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta2/replicaSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 //

--- a/sdk/go/kubernetes/apps/v1beta2/statefulSetPatch.go
+++ b/sdk/go/kubernetes/apps/v1beta2/statefulSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // StatefulSet represents a set of pods with consistent identities. Identities are defined as:
 //   - Network: A single stable DNS and hostname.

--- a/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkPatch.go
+++ b/sdk/go/kubernetes/auditregistration/v1alpha1/auditSinkPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // AuditSink represents a cluster level audit sink
 type AuditSinkPatch struct {

--- a/sdk/go/kubernetes/authentication/v1/tokenRequestPatch.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenRequestPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // TokenRequest requests a token for a given service account.
 type TokenRequestPatch struct {

--- a/sdk/go/kubernetes/authentication/v1/tokenReviewPatch.go
+++ b/sdk/go/kubernetes/authentication/v1/tokenReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewPatch struct {

--- a/sdk/go/kubernetes/authentication/v1alpha1/selfSubjectReviewPatch.go
+++ b/sdk/go/kubernetes/authentication/v1alpha1/selfSubjectReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
 type SelfSubjectReviewPatch struct {

--- a/sdk/go/kubernetes/authentication/v1beta1/tokenReviewPatch.go
+++ b/sdk/go/kubernetes/authentication/v1beta1/tokenReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 type TokenReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1/localSubjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1/localSubjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1/selfSubjectRulesReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1/subjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1/subjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/localSubjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 type LocalSubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 type SelfSubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/selfSubjectRulesReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 type SelfSubjectRulesReviewPatch struct {

--- a/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReviewPatch.go
+++ b/sdk/go/kubernetes/authorization/v1beta1/subjectAccessReviewPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // SubjectAccessReview checks whether or not a user or group can perform an action.
 type SubjectAccessReviewPatch struct {

--- a/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerPatch.go
+++ b/sdk/go/kubernetes/autoscaling/v1/horizontalPodAutoscalerPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerPatch struct {

--- a/sdk/go/kubernetes/autoscaling/v2/horizontalPodAutoscalerPatch.go
+++ b/sdk/go/kubernetes/autoscaling/v2/horizontalPodAutoscalerPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerPatch struct {

--- a/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerPatch.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta1/horizontalPodAutoscalerPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerPatch struct {

--- a/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerPatch.go
+++ b/sdk/go/kubernetes/autoscaling/v2beta2/horizontalPodAutoscalerPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 type HorizontalPodAutoscalerPatch struct {

--- a/sdk/go/kubernetes/batch/v1/cronJobPatch.go
+++ b/sdk/go/kubernetes/batch/v1/cronJobPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CronJob represents the configuration of a single cron job.
 type CronJobPatch struct {

--- a/sdk/go/kubernetes/batch/v1/jobPatch.go
+++ b/sdk/go/kubernetes/batch/v1/jobPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Job represents the configuration of a single job.
 //

--- a/sdk/go/kubernetes/batch/v1beta1/cronJobPatch.go
+++ b/sdk/go/kubernetes/batch/v1beta1/cronJobPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CronJob represents the configuration of a single cron job.
 type CronJobPatch struct {

--- a/sdk/go/kubernetes/batch/v2alpha1/cronJobPatch.go
+++ b/sdk/go/kubernetes/batch/v2alpha1/cronJobPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CronJob represents the configuration of a single cron job.
 type CronJobPatch struct {

--- a/sdk/go/kubernetes/certificates/v1/certificateSigningRequestPatch.go
+++ b/sdk/go/kubernetes/certificates/v1/certificateSigningRequestPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
 //

--- a/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestPatch.go
+++ b/sdk/go/kubernetes/certificates/v1beta1/certificateSigningRequestPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Describes a certificate signing request
 type CertificateSigningRequestPatch struct {

--- a/sdk/go/kubernetes/coordination/v1/leasePatch.go
+++ b/sdk/go/kubernetes/coordination/v1/leasePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Lease defines a lease concept.
 type LeasePatch struct {

--- a/sdk/go/kubernetes/coordination/v1beta1/leasePatch.go
+++ b/sdk/go/kubernetes/coordination/v1beta1/leasePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Lease defines a lease concept.
 type LeasePatch struct {

--- a/sdk/go/kubernetes/core/v1/bindingPatch.go
+++ b/sdk/go/kubernetes/core/v1/bindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
 type BindingPatch struct {

--- a/sdk/go/kubernetes/core/v1/configMapPatch.go
+++ b/sdk/go/kubernetes/core/v1/configMapPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ConfigMap holds configuration data for pods to consume.
 type ConfigMapPatch struct {

--- a/sdk/go/kubernetes/core/v1/endpointsPatch.go
+++ b/sdk/go/kubernetes/core/v1/endpointsPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Endpoints is a collection of endpoints that implement the actual service. Example:
 //

--- a/sdk/go/kubernetes/core/v1/eventPatch.go
+++ b/sdk/go/kubernetes/core/v1/eventPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 type EventPatch struct {

--- a/sdk/go/kubernetes/core/v1/limitRangePatch.go
+++ b/sdk/go/kubernetes/core/v1/limitRangePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // LimitRange sets resource usage limits for each kind of resource in a Namespace.
 type LimitRangePatch struct {

--- a/sdk/go/kubernetes/core/v1/namespacePatch.go
+++ b/sdk/go/kubernetes/core/v1/namespacePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Namespace provides a scope for Names. Use of multiple namespaces is optional.
 type NamespacePatch struct {

--- a/sdk/go/kubernetes/core/v1/nodePatch.go
+++ b/sdk/go/kubernetes/core/v1/nodePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
 type NodePatch struct {

--- a/sdk/go/kubernetes/core/v1/persistentVolumeClaimPatch.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumeClaimPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaimPatch struct {

--- a/sdk/go/kubernetes/core/v1/persistentVolumePatch.go
+++ b/sdk/go/kubernetes/core/v1/persistentVolumePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 type PersistentVolumePatch struct {

--- a/sdk/go/kubernetes/core/v1/podPatch.go
+++ b/sdk/go/kubernetes/core/v1/podPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
 //

--- a/sdk/go/kubernetes/core/v1/podTemplatePatch.go
+++ b/sdk/go/kubernetes/core/v1/podTemplatePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplatePatch struct {

--- a/sdk/go/kubernetes/core/v1/replicationControllerPatch.go
+++ b/sdk/go/kubernetes/core/v1/replicationControllerPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationControllerPatch struct {

--- a/sdk/go/kubernetes/core/v1/resourceQuotaPatch.go
+++ b/sdk/go/kubernetes/core/v1/resourceQuotaPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuotaPatch struct {

--- a/sdk/go/kubernetes/core/v1/secretPatch.go
+++ b/sdk/go/kubernetes/core/v1/secretPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
 //

--- a/sdk/go/kubernetes/core/v1/serviceAccountPatch.go
+++ b/sdk/go/kubernetes/core/v1/serviceAccountPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
 type ServiceAccountPatch struct {

--- a/sdk/go/kubernetes/core/v1/servicePatch.go
+++ b/sdk/go/kubernetes/core/v1/servicePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
 //

--- a/sdk/go/kubernetes/discovery/v1/endpointSlicePatch.go
+++ b/sdk/go/kubernetes/discovery/v1/endpointSlicePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 type EndpointSlicePatch struct {

--- a/sdk/go/kubernetes/discovery/v1beta1/endpointSlicePatch.go
+++ b/sdk/go/kubernetes/discovery/v1beta1/endpointSlicePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 type EndpointSlicePatch struct {

--- a/sdk/go/kubernetes/events/v1/eventPatch.go
+++ b/sdk/go/kubernetes/events/v1/eventPatch.go
@@ -16,7 +16,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 type EventPatch struct {

--- a/sdk/go/kubernetes/events/v1beta1/eventPatch.go
+++ b/sdk/go/kubernetes/events/v1beta1/eventPatch.go
@@ -16,7 +16,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
 type EventPatch struct {

--- a/sdk/go/kubernetes/extensions/v1beta1/daemonSetPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/daemonSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DaemonSet represents the configuration of a daemon set.
 //

--- a/sdk/go/kubernetes/extensions/v1beta1/deploymentPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/deploymentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 //

--- a/sdk/go/kubernetes/extensions/v1beta1/ingressPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/ingressPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 //

--- a/sdk/go/kubernetes/extensions/v1beta1/networkPolicyPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/networkPolicyPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyPatch struct {

--- a/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/podSecurityPolicyPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
 type PodSecurityPolicyPatch struct {

--- a/sdk/go/kubernetes/extensions/v1beta1/replicaSetPatch.go
+++ b/sdk/go/kubernetes/extensions/v1beta1/replicaSetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 //

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/flowSchemaPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1alpha1/priorityLevelConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchemaPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/flowSchemaPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfigurationPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta1/priorityLevelConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta2/flowSchemaPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta2/flowSchemaPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta2/priorityLevelConfigurationPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta2/priorityLevelConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta3/flowSchemaPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta3/flowSchemaPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 type FlowSchemaPatch struct {

--- a/sdk/go/kubernetes/flowcontrol/v1beta3/priorityLevelConfigurationPatch.go
+++ b/sdk/go/kubernetes/flowcontrol/v1beta3/priorityLevelConfigurationPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PriorityLevelConfiguration represents the configuration of a priority level.
 type PriorityLevelConfigurationPatch struct {

--- a/sdk/go/kubernetes/meta/v1/statusPatch.go
+++ b/sdk/go/kubernetes/meta/v1/statusPatch.go
@@ -14,7 +14,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Status is a return value for calls that don't return other objects.
 type StatusPatch struct {

--- a/sdk/go/kubernetes/networking/v1/ingressClassPatch.go
+++ b/sdk/go/kubernetes/networking/v1/ingressClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 type IngressClassPatch struct {

--- a/sdk/go/kubernetes/networking/v1/ingressPatch.go
+++ b/sdk/go/kubernetes/networking/v1/ingressPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 //

--- a/sdk/go/kubernetes/networking/v1/networkPolicyPatch.go
+++ b/sdk/go/kubernetes/networking/v1/networkPolicyPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // NetworkPolicy describes what network traffic is allowed for a set of Pods
 type NetworkPolicyPatch struct {

--- a/sdk/go/kubernetes/networking/v1alpha1/clusterCIDRPatch.go
+++ b/sdk/go/kubernetes/networking/v1alpha1/clusterCIDRPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
 type ClusterCIDRPatch struct {

--- a/sdk/go/kubernetes/networking/v1beta1/ingressClassPatch.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 type IngressClassPatch struct {

--- a/sdk/go/kubernetes/networking/v1beta1/ingressPatch.go
+++ b/sdk/go/kubernetes/networking/v1beta1/ingressPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 //

--- a/sdk/go/kubernetes/node/v1/runtimeClassPatch.go
+++ b/sdk/go/kubernetes/node/v1/runtimeClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
 type RuntimeClassPatch struct {

--- a/sdk/go/kubernetes/node/v1alpha1/runtimeClassPatch.go
+++ b/sdk/go/kubernetes/node/v1alpha1/runtimeClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassPatch struct {

--- a/sdk/go/kubernetes/node/v1beta1/runtimeClassPatch.go
+++ b/sdk/go/kubernetes/node/v1beta1/runtimeClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 type RuntimeClassPatch struct {

--- a/sdk/go/kubernetes/policy/v1/podDisruptionBudgetPatch.go
+++ b/sdk/go/kubernetes/policy/v1/podDisruptionBudgetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 type PodDisruptionBudgetPatch struct {

--- a/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetPatch.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podDisruptionBudgetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 type PodDisruptionBudgetPatch struct {

--- a/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyPatch.go
+++ b/sdk/go/kubernetes/policy/v1beta1/podSecurityPolicyPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 type PodSecurityPolicyPatch struct {

--- a/sdk/go/kubernetes/rbac/v1/clusterRoleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRoleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
 type ClusterRoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1/clusterRolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1/clusterRolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 type ClusterRolePatch struct {

--- a/sdk/go/kubernetes/rbac/v1/roleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1/roleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
 type RoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1/rolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1/rolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 type RolePatch struct {

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRoleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1alpha1/clusterRolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/clusterRolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRolePatch struct {

--- a/sdk/go/kubernetes/rbac/v1alpha1/roleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/roleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1alpha1/rolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1alpha1/rolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RolePatch struct {

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRoleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 type ClusterRoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1beta1/clusterRolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/clusterRolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 type ClusterRolePatch struct {

--- a/sdk/go/kubernetes/rbac/v1beta1/roleBindingPatch.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/roleBindingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 type RoleBindingPatch struct {

--- a/sdk/go/kubernetes/rbac/v1beta1/rolePatch.go
+++ b/sdk/go/kubernetes/rbac/v1beta1/rolePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 type RolePatch struct {

--- a/sdk/go/kubernetes/resource/v1alpha1/podSchedulingPatch.go
+++ b/sdk/go/kubernetes/resource/v1alpha1/podSchedulingPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
 //

--- a/sdk/go/kubernetes/resource/v1alpha1/resourceClaimPatch.go
+++ b/sdk/go/kubernetes/resource/v1alpha1/resourceClaimPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
 //

--- a/sdk/go/kubernetes/resource/v1alpha1/resourceClaimTemplatePatch.go
+++ b/sdk/go/kubernetes/resource/v1alpha1/resourceClaimTemplatePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ResourceClaimTemplate is used to produce ResourceClaim objects.
 type ResourceClaimTemplatePatch struct {

--- a/sdk/go/kubernetes/resource/v1alpha1/resourceClassPatch.go
+++ b/sdk/go/kubernetes/resource/v1alpha1/resourceClassPatch.go
@@ -16,7 +16,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // ResourceClass is used by administrators to influence how resources are allocated.
 //

--- a/sdk/go/kubernetes/scheduling/v1/priorityClassPatch.go
+++ b/sdk/go/kubernetes/scheduling/v1/priorityClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassPatch struct {

--- a/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassPatch.go
+++ b/sdk/go/kubernetes/scheduling/v1alpha1/priorityClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassPatch struct {

--- a/sdk/go/kubernetes/scheduling/v1beta1/priorityClassPatch.go
+++ b/sdk/go/kubernetes/scheduling/v1beta1/priorityClassPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 type PriorityClassPatch struct {

--- a/sdk/go/kubernetes/settings/v1alpha1/podPresetPatch.go
+++ b/sdk/go/kubernetes/settings/v1alpha1/podPresetPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 type PodPresetPatch struct {

--- a/sdk/go/kubernetes/storage/v1/csidriverPatch.go
+++ b/sdk/go/kubernetes/storage/v1/csidriverPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverPatch struct {

--- a/sdk/go/kubernetes/storage/v1/csinodePatch.go
+++ b/sdk/go/kubernetes/storage/v1/csinodePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 type CSINodePatch struct {

--- a/sdk/go/kubernetes/storage/v1/csistorageCapacityPatch.go
+++ b/sdk/go/kubernetes/storage/v1/csistorageCapacityPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 //

--- a/sdk/go/kubernetes/storage/v1/storageClassPatch.go
+++ b/sdk/go/kubernetes/storage/v1/storageClassPatch.go
@@ -16,7 +16,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 //

--- a/sdk/go/kubernetes/storage/v1/volumeAttachmentPatch.go
+++ b/sdk/go/kubernetes/storage/v1/volumeAttachmentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 //

--- a/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentPatch.go
+++ b/sdk/go/kubernetes/storage/v1alpha1/volumeAttachmentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 //

--- a/sdk/go/kubernetes/storage/v1beta1/csidriverPatch.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csidriverPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 type CSIDriverPatch struct {

--- a/sdk/go/kubernetes/storage/v1beta1/csinodePatch.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csinodePatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 //

--- a/sdk/go/kubernetes/storage/v1beta1/csistorageCapacityPatch.go
+++ b/sdk/go/kubernetes/storage/v1beta1/csistorageCapacityPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 //

--- a/sdk/go/kubernetes/storage/v1beta1/storageClassPatch.go
+++ b/sdk/go/kubernetes/storage/v1beta1/storageClassPatch.go
@@ -16,7 +16,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 //

--- a/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentPatch.go
+++ b/sdk/go/kubernetes/storage/v1beta1/volumeAttachmentPatch.go
@@ -15,7 +15,7 @@ import (
 // Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
 // one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
 // Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+// [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
 // additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
 // VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 //

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiregistration/v1/APIServicePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiregistration/v1/APIServicePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * APIService represents a server for a particular GroupVersion. Name must be &#34;version.group&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiregistration/v1beta1/APIServicePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiregistration/v1beta1/APIServicePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * APIService represents a server for a particular GroupVersion. Name must be &#34;version.group&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/ControllerRevisionPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/ControllerRevisionPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/DaemonSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/DaemonSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/DeploymentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/DeploymentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/ReplicaSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/ReplicaSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/StatefulSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1/StatefulSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *   - Network: A single stable DNS and hostname.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/ControllerRevisionPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/ControllerRevisionPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/DeploymentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/DeploymentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/StatefulSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta1/StatefulSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *  - Network: A single stable DNS and hostname.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/ControllerRevisionPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/ControllerRevisionPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/DaemonSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/DaemonSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/DeploymentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/DeploymentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/ReplicaSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/ReplicaSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/StatefulSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apps/v1beta2/StatefulSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *  - Network: A single stable DNS and hostname.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/auditregistration/v1alpha1/AuditSinkPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/auditregistration/v1alpha1/AuditSinkPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * AuditSink represents a cluster level audit sink
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1/TokenRequestPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1/TokenRequestPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenRequest requests a token for a given service account.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1/TokenReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1/TokenReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1alpha1/SelfSubjectReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1alpha1/SelfSubjectReviewPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1beta1/TokenReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authentication/v1beta1/TokenReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/LocalSubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/LocalSubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SelfSubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SelfSubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means &#34;in all namespaces&#34;.  Self is a special case, because users should always be able to check whether they can perform an action
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SelfSubjectRulesReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SelfSubjectRulesReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server&#39;s authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1/SubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SubjectAccessReview checks whether or not a user or group can perform an action.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/LocalSubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/LocalSubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SelfSubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SelfSubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means &#34;in all namespaces&#34;.  Self is a special case, because users should always be able to check whether they can perform an action
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SelfSubjectRulesReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SelfSubjectRulesReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server&#39;s authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SubjectAccessReviewPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/authorization/v1beta1/SubjectAccessReviewPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SubjectAccessReview checks whether or not a user or group can perform an action.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * configuration of a horizontal pod autoscaler.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1/CronJobPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1/CronJobPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1/JobPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1/JobPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Job represents the configuration of a single job.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1beta1/CronJobPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v1beta1/CronJobPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v2alpha1/CronJobPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/batch/v2alpha1/CronJobPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/certificates/v1/CertificateSigningRequestPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/certificates/v1/CertificateSigningRequestPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Describes a certificate signing request
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/coordination/v1/LeasePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/coordination/v1/LeasePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Lease defines a lease concept.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/coordination/v1beta1/LeasePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/coordination/v1beta1/LeasePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Lease defines a lease concept.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/BindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/BindingPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ConfigMap holds configuration data for pods to consume.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/EndpointsPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/EndpointsPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Endpoints is a collection of endpoints that implement the actual service. Example:
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/EventPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/EventPatch.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/LimitRangePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/LimitRangePatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LimitRange sets resource usage limits for each kind of resource in a Namespace.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/NamespacePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/NamespacePatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Namespace provides a scope for Names. Use of multiple namespaces is optional.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/NodePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/NodePatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PersistentVolumeClaimPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PersistentVolumeClaimPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PersistentVolumeClaim is a user&#39;s request for and claim to a persistent volume
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PersistentVolumePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PersistentVolumePatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PodPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PodPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PodTemplatePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/PodTemplatePatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodTemplate describes a template for creating copies of a predefined pod.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ReplicationControllerPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ReplicationControllerPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicationController represents the configuration of a replication controller.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ResourceQuotaPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ResourceQuotaPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceQuota sets aggregate quota restrictions enforced per namespace
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/SecretPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/SecretPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ServiceAccountPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ServiceAccountPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ServicePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/core/v1/ServicePatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/discovery/v1/EndpointSlicePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/discovery/v1/EndpointSlicePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/discovery/v1beta1/EndpointSlicePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/discovery/v1beta1/EndpointSlicePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/events/v1/EventPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/events/v1/EventPatch.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/events/v1beta1/EventPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/events/v1beta1/EventPatch.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/DaemonSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/DaemonSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/DeploymentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/DeploymentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/IngressPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/IngressPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/NetworkPolicyPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/NetworkPolicyPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/ReplicaSetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/extensions/v1beta1/ReplicaSetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a &#34;flow distinguisher&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a &#34;flow distinguisher&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a &#34;flow distinguisher&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a &#34;flow distinguisher&#34;.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/meta/v1/StatusPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/meta/v1/StatusPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Status is a return value for calls that don&#39;t return other objects.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/IngressClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/IngressClassPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/IngressPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/IngressPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/NetworkPolicyPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1/NetworkPolicyPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * NetworkPolicy describes what network traffic is allowed for a set of Pods
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1alpha1/ClusterCIDRPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1alpha1/ClusterCIDRPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1beta1/IngressClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1beta1/IngressClassPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1beta1/IngressPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/networking/v1beta1/IngressPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1/RuntimeClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1/RuntimeClassPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1alpha1/RuntimeClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1alpha1/RuntimeClassPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1beta1/RuntimeClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/node/v1beta1/RuntimeClassPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1/PodDisruptionBudgetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1/PodDisruptionBudgetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1beta1/PodSecurityPolicyPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/policy/v1beta1/PodSecurityPolicyPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/ClusterRoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/ClusterRoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/ClusterRolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/ClusterRolePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/RoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/RoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/RolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1/RolePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/ClusterRolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/ClusterRolePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/RoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/RoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/RolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1alpha1/RolePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/ClusterRolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/ClusterRolePatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/RoleBindingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/RoleBindingPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/RolePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/rbac/v1beta1/RolePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/PodSchedulingPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/PodSchedulingPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use &#34;WaitForFirstConsumer&#34; allocation mode.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClaimPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClaimPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClaimTemplate is used to produce ResourceClaim objects.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/resource/v1alpha1/ResourceClassPatch.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClass is used by administrators to influence how resources are allocated.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1/PriorityClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1/PriorityClassPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1alpha1/PriorityClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1alpha1/PriorityClassPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1beta1/PriorityClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/scheduling/v1beta1/PriorityClassPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/settings/v1alpha1/PodPresetPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/settings/v1alpha1/PodPresetPatch.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodPreset is a policy resource that defines additional runtime requirements for a Pod.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSIDriverPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSIDriverPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSINodePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSINodePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn&#39;t create this object. CSINode has an OwnerReference that points to the corresponding node object.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSIStorageCapacityPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/CSIStorageCapacityPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/StorageClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/StorageClassPatch.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/VolumeAttachmentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1/VolumeAttachmentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1alpha1/VolumeAttachmentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1alpha1/VolumeAttachmentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSIDriverPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSIDriverPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSINodePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSINodePatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn&#39;t create this object. CSINode has an OwnerReference that points to the corresponding node object.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSIStorageCapacityPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/CSIStorageCapacityPatch.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/StorageClassPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/StorageClassPatch.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/VolumeAttachmentPatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/storage/v1beta1/VolumeAttachmentPatch.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the &#34;pulumi.com/patchForce&#34; annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  * 

--- a/sdk/nodejs/admissionregistration/v1/mutatingWebhookConfigurationPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1/mutatingWebhookConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
  */

--- a/sdk/nodejs/admissionregistration/v1/validatingWebhookConfigurationPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1/validatingWebhookConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
  */

--- a/sdk/nodejs/admissionregistration/v1alpha1/validatingAdmissionPolicyBindingPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1alpha1/validatingAdmissionPolicyBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
  */

--- a/sdk/nodejs/admissionregistration/v1alpha1/validatingAdmissionPolicyPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1alpha1/validatingAdmissionPolicyPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
  */

--- a/sdk/nodejs/admissionregistration/v1beta1/mutatingWebhookConfigurationPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/mutatingWebhookConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
  */

--- a/sdk/nodejs/admissionregistration/v1beta1/validatingWebhookConfigurationPatch.ts
+++ b/sdk/nodejs/admissionregistration/v1beta1/validatingWebhookConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
  */

--- a/sdk/nodejs/apiextensions/v1/customResourceDefinitionPatch.ts
+++ b/sdk/nodejs/apiextensions/v1/customResourceDefinitionPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
  */

--- a/sdk/nodejs/apiextensions/v1beta1/customResourceDefinitionPatch.ts
+++ b/sdk/nodejs/apiextensions/v1beta1/customResourceDefinitionPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
  */

--- a/sdk/nodejs/apiregistration/v1/apiservicePatch.ts
+++ b/sdk/nodejs/apiregistration/v1/apiservicePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * APIService represents a server for a particular GroupVersion. Name must be "version.group".
  */

--- a/sdk/nodejs/apiregistration/v1beta1/apiservicePatch.ts
+++ b/sdk/nodejs/apiregistration/v1beta1/apiservicePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * APIService represents a server for a particular GroupVersion. Name must be "version.group".
  */

--- a/sdk/nodejs/apps/v1/controllerRevisionPatch.ts
+++ b/sdk/nodejs/apps/v1/controllerRevisionPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  */

--- a/sdk/nodejs/apps/v1/daemonSetPatch.ts
+++ b/sdk/nodejs/apps/v1/daemonSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  */

--- a/sdk/nodejs/apps/v1/deploymentPatch.ts
+++ b/sdk/nodejs/apps/v1/deploymentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  *

--- a/sdk/nodejs/apps/v1/replicaSetPatch.ts
+++ b/sdk/nodejs/apps/v1/replicaSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  */

--- a/sdk/nodejs/apps/v1/statefulSetPatch.ts
+++ b/sdk/nodejs/apps/v1/statefulSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *   - Network: A single stable DNS and hostname.

--- a/sdk/nodejs/apps/v1beta1/controllerRevisionPatch.ts
+++ b/sdk/nodejs/apps/v1beta1/controllerRevisionPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  *

--- a/sdk/nodejs/apps/v1beta1/deploymentPatch.ts
+++ b/sdk/nodejs/apps/v1beta1/deploymentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  *

--- a/sdk/nodejs/apps/v1beta1/statefulSetPatch.ts
+++ b/sdk/nodejs/apps/v1beta1/statefulSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *  - Network: A single stable DNS and hostname.

--- a/sdk/nodejs/apps/v1beta2/controllerRevisionPatch.ts
+++ b/sdk/nodejs/apps/v1beta2/controllerRevisionPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
  *

--- a/sdk/nodejs/apps/v1beta2/daemonSetPatch.ts
+++ b/sdk/nodejs/apps/v1beta2/daemonSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  *

--- a/sdk/nodejs/apps/v1beta2/deploymentPatch.ts
+++ b/sdk/nodejs/apps/v1beta2/deploymentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  *

--- a/sdk/nodejs/apps/v1beta2/replicaSetPatch.ts
+++ b/sdk/nodejs/apps/v1beta2/replicaSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  *

--- a/sdk/nodejs/apps/v1beta2/statefulSetPatch.ts
+++ b/sdk/nodejs/apps/v1beta2/statefulSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StatefulSet represents a set of pods with consistent identities. Identities are defined as:
  *  - Network: A single stable DNS and hostname.

--- a/sdk/nodejs/auditregistration/v1alpha1/auditSinkPatch.ts
+++ b/sdk/nodejs/auditregistration/v1alpha1/auditSinkPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * AuditSink represents a cluster level audit sink
  */

--- a/sdk/nodejs/authentication/v1/tokenRequestPatch.ts
+++ b/sdk/nodejs/authentication/v1/tokenRequestPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenRequest requests a token for a given service account.
  */

--- a/sdk/nodejs/authentication/v1/tokenReviewPatch.ts
+++ b/sdk/nodejs/authentication/v1/tokenReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
  */

--- a/sdk/nodejs/authentication/v1alpha1/selfSubjectReviewPatch.ts
+++ b/sdk/nodejs/authentication/v1alpha1/selfSubjectReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
  */

--- a/sdk/nodejs/authentication/v1beta1/tokenReviewPatch.ts
+++ b/sdk/nodejs/authentication/v1beta1/tokenReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
  */

--- a/sdk/nodejs/authorization/v1/localSubjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1/localSubjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
  */

--- a/sdk/nodejs/authorization/v1/selfSubjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1/selfSubjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
  */

--- a/sdk/nodejs/authorization/v1/selfSubjectRulesReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1/selfSubjectRulesReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
  */

--- a/sdk/nodejs/authorization/v1/subjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1/subjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SubjectAccessReview checks whether or not a user or group can perform an action.
  */

--- a/sdk/nodejs/authorization/v1beta1/localSubjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1beta1/localSubjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
  */

--- a/sdk/nodejs/authorization/v1beta1/selfSubjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1beta1/selfSubjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
  */

--- a/sdk/nodejs/authorization/v1beta1/selfSubjectRulesReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1beta1/selfSubjectRulesReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
  */

--- a/sdk/nodejs/authorization/v1beta1/subjectAccessReviewPatch.ts
+++ b/sdk/nodejs/authorization/v1beta1/subjectAccessReviewPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * SubjectAccessReview checks whether or not a user or group can perform an action.
  */

--- a/sdk/nodejs/autoscaling/v1/horizontalPodAutoscalerPatch.ts
+++ b/sdk/nodejs/autoscaling/v1/horizontalPodAutoscalerPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * configuration of a horizontal pod autoscaler.
  */

--- a/sdk/nodejs/autoscaling/v2/horizontalPodAutoscalerPatch.ts
+++ b/sdk/nodejs/autoscaling/v2/horizontalPodAutoscalerPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  */

--- a/sdk/nodejs/autoscaling/v2beta1/horizontalPodAutoscalerPatch.ts
+++ b/sdk/nodejs/autoscaling/v2beta1/horizontalPodAutoscalerPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  */

--- a/sdk/nodejs/autoscaling/v2beta2/horizontalPodAutoscalerPatch.ts
+++ b/sdk/nodejs/autoscaling/v2beta2/horizontalPodAutoscalerPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  */

--- a/sdk/nodejs/batch/v1/cronJobPatch.ts
+++ b/sdk/nodejs/batch/v1/cronJobPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  */

--- a/sdk/nodejs/batch/v1/jobPatch.ts
+++ b/sdk/nodejs/batch/v1/jobPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Job represents the configuration of a single job.
  *

--- a/sdk/nodejs/batch/v1beta1/cronJobPatch.ts
+++ b/sdk/nodejs/batch/v1beta1/cronJobPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  */

--- a/sdk/nodejs/batch/v2alpha1/cronJobPatch.ts
+++ b/sdk/nodejs/batch/v2alpha1/cronJobPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CronJob represents the configuration of a single cron job.
  */

--- a/sdk/nodejs/certificates/v1/certificateSigningRequestPatch.ts
+++ b/sdk/nodejs/certificates/v1/certificateSigningRequestPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
  *

--- a/sdk/nodejs/certificates/v1beta1/certificateSigningRequestPatch.ts
+++ b/sdk/nodejs/certificates/v1beta1/certificateSigningRequestPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Describes a certificate signing request
  */

--- a/sdk/nodejs/coordination/v1/leasePatch.ts
+++ b/sdk/nodejs/coordination/v1/leasePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Lease defines a lease concept.
  */

--- a/sdk/nodejs/coordination/v1beta1/leasePatch.ts
+++ b/sdk/nodejs/coordination/v1beta1/leasePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Lease defines a lease concept.
  */

--- a/sdk/nodejs/core/v1/bindingPatch.ts
+++ b/sdk/nodejs/core/v1/bindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
  */

--- a/sdk/nodejs/core/v1/configMapPatch.ts
+++ b/sdk/nodejs/core/v1/configMapPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ConfigMap holds configuration data for pods to consume.
  */

--- a/sdk/nodejs/core/v1/endpointsPatch.ts
+++ b/sdk/nodejs/core/v1/endpointsPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Endpoints is a collection of endpoints that implement the actual service. Example:
  *

--- a/sdk/nodejs/core/v1/eventPatch.ts
+++ b/sdk/nodejs/core/v1/eventPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
  */

--- a/sdk/nodejs/core/v1/limitRangePatch.ts
+++ b/sdk/nodejs/core/v1/limitRangePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * LimitRange sets resource usage limits for each kind of resource in a Namespace.
  */

--- a/sdk/nodejs/core/v1/namespacePatch.ts
+++ b/sdk/nodejs/core/v1/namespacePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Namespace provides a scope for Names. Use of multiple namespaces is optional.
  */

--- a/sdk/nodejs/core/v1/nodePatch.ts
+++ b/sdk/nodejs/core/v1/nodePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
  */

--- a/sdk/nodejs/core/v1/persistentVolumeClaimPatch.ts
+++ b/sdk/nodejs/core/v1/persistentVolumeClaimPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PersistentVolumeClaim is a user's request for and claim to a persistent volume
  */

--- a/sdk/nodejs/core/v1/persistentVolumePatch.ts
+++ b/sdk/nodejs/core/v1/persistentVolumePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
  */

--- a/sdk/nodejs/core/v1/podPatch.ts
+++ b/sdk/nodejs/core/v1/podPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
  *

--- a/sdk/nodejs/core/v1/podTemplatePatch.ts
+++ b/sdk/nodejs/core/v1/podTemplatePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodTemplate describes a template for creating copies of a predefined pod.
  */

--- a/sdk/nodejs/core/v1/replicationControllerPatch.ts
+++ b/sdk/nodejs/core/v1/replicationControllerPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicationController represents the configuration of a replication controller.
  */

--- a/sdk/nodejs/core/v1/resourceQuotaPatch.ts
+++ b/sdk/nodejs/core/v1/resourceQuotaPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceQuota sets aggregate quota restrictions enforced per namespace
  */

--- a/sdk/nodejs/core/v1/secretPatch.ts
+++ b/sdk/nodejs/core/v1/secretPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
  *

--- a/sdk/nodejs/core/v1/serviceAccountPatch.ts
+++ b/sdk/nodejs/core/v1/serviceAccountPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
  */

--- a/sdk/nodejs/core/v1/servicePatch.ts
+++ b/sdk/nodejs/core/v1/servicePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
  *

--- a/sdk/nodejs/discovery/v1/endpointSlicePatch.ts
+++ b/sdk/nodejs/discovery/v1/endpointSlicePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
  */

--- a/sdk/nodejs/discovery/v1beta1/endpointSlicePatch.ts
+++ b/sdk/nodejs/discovery/v1beta1/endpointSlicePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
  */

--- a/sdk/nodejs/events/v1/eventPatch.ts
+++ b/sdk/nodejs/events/v1/eventPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
  */

--- a/sdk/nodejs/events/v1beta1/eventPatch.ts
+++ b/sdk/nodejs/events/v1beta1/eventPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
  */

--- a/sdk/nodejs/extensions/v1beta1/daemonSetPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/daemonSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DaemonSet represents the configuration of a daemon set.
  *

--- a/sdk/nodejs/extensions/v1beta1/deploymentPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/deploymentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Deployment enables declarative updates for Pods and ReplicaSets.
  *

--- a/sdk/nodejs/extensions/v1beta1/ingressPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/ingressPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  *

--- a/sdk/nodejs/extensions/v1beta1/networkPolicyPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/networkPolicyPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
  */

--- a/sdk/nodejs/extensions/v1beta1/podSecurityPolicyPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/podSecurityPolicyPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
  */

--- a/sdk/nodejs/extensions/v1beta1/replicaSetPatch.ts
+++ b/sdk/nodejs/extensions/v1beta1/replicaSetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ReplicaSet ensures that a specified number of pod replicas are running at any given time.
  *

--- a/sdk/nodejs/flowcontrol/v1alpha1/flowSchemaPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1alpha1/flowSchemaPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
  */

--- a/sdk/nodejs/flowcontrol/v1alpha1/priorityLevelConfigurationPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1alpha1/priorityLevelConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  */

--- a/sdk/nodejs/flowcontrol/v1beta1/flowSchemaPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta1/flowSchemaPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
  */

--- a/sdk/nodejs/flowcontrol/v1beta1/priorityLevelConfigurationPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta1/priorityLevelConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  */

--- a/sdk/nodejs/flowcontrol/v1beta2/flowSchemaPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta2/flowSchemaPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
  */

--- a/sdk/nodejs/flowcontrol/v1beta2/priorityLevelConfigurationPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta2/priorityLevelConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  */

--- a/sdk/nodejs/flowcontrol/v1beta3/flowSchemaPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta3/flowSchemaPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
  */

--- a/sdk/nodejs/flowcontrol/v1beta3/priorityLevelConfigurationPatch.ts
+++ b/sdk/nodejs/flowcontrol/v1beta3/priorityLevelConfigurationPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityLevelConfiguration represents the configuration of a priority level.
  */

--- a/sdk/nodejs/meta/v1/statusPatch.ts
+++ b/sdk/nodejs/meta/v1/statusPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Status is a return value for calls that don't return other objects.
  */

--- a/sdk/nodejs/networking/v1/ingressClassPatch.ts
+++ b/sdk/nodejs/networking/v1/ingressClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
  */

--- a/sdk/nodejs/networking/v1/ingressPatch.ts
+++ b/sdk/nodejs/networking/v1/ingressPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  *

--- a/sdk/nodejs/networking/v1/networkPolicyPatch.ts
+++ b/sdk/nodejs/networking/v1/networkPolicyPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * NetworkPolicy describes what network traffic is allowed for a set of Pods
  */

--- a/sdk/nodejs/networking/v1alpha1/clusterCIDRPatch.ts
+++ b/sdk/nodejs/networking/v1alpha1/clusterCIDRPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
  */

--- a/sdk/nodejs/networking/v1beta1/ingressClassPatch.ts
+++ b/sdk/nodejs/networking/v1beta1/ingressClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
  */

--- a/sdk/nodejs/networking/v1beta1/ingressPatch.ts
+++ b/sdk/nodejs/networking/v1beta1/ingressPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  *

--- a/sdk/nodejs/node/v1/runtimeClassPatch.ts
+++ b/sdk/nodejs/node/v1/runtimeClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
  */

--- a/sdk/nodejs/node/v1alpha1/runtimeClassPatch.ts
+++ b/sdk/nodejs/node/v1alpha1/runtimeClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
  */

--- a/sdk/nodejs/node/v1beta1/runtimeClassPatch.ts
+++ b/sdk/nodejs/node/v1beta1/runtimeClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
  */

--- a/sdk/nodejs/policy/v1/podDisruptionBudgetPatch.ts
+++ b/sdk/nodejs/policy/v1/podDisruptionBudgetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
  */

--- a/sdk/nodejs/policy/v1beta1/podDisruptionBudgetPatch.ts
+++ b/sdk/nodejs/policy/v1beta1/podDisruptionBudgetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
  */

--- a/sdk/nodejs/policy/v1beta1/podSecurityPolicyPatch.ts
+++ b/sdk/nodejs/policy/v1beta1/podSecurityPolicyPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
  */

--- a/sdk/nodejs/rbac/v1/clusterRoleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1/clusterRoleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
  */

--- a/sdk/nodejs/rbac/v1/clusterRolePatch.ts
+++ b/sdk/nodejs/rbac/v1/clusterRolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
  */

--- a/sdk/nodejs/rbac/v1/roleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1/roleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
  */

--- a/sdk/nodejs/rbac/v1/rolePatch.ts
+++ b/sdk/nodejs/rbac/v1/rolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
  */

--- a/sdk/nodejs/rbac/v1alpha1/clusterRoleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1alpha1/clusterRoleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1alpha1/clusterRolePatch.ts
+++ b/sdk/nodejs/rbac/v1alpha1/clusterRolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1alpha1/roleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1alpha1/roleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1alpha1/rolePatch.ts
+++ b/sdk/nodejs/rbac/v1alpha1/rolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1beta1/clusterRoleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1beta1/clusterRoleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1beta1/clusterRolePatch.ts
+++ b/sdk/nodejs/rbac/v1beta1/clusterRolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1beta1/roleBindingPatch.ts
+++ b/sdk/nodejs/rbac/v1beta1/roleBindingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/rbac/v1beta1/rolePatch.ts
+++ b/sdk/nodejs/rbac/v1beta1/rolePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
  */

--- a/sdk/nodejs/resource/v1alpha1/podSchedulingPatch.ts
+++ b/sdk/nodejs/resource/v1alpha1/podSchedulingPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
  *

--- a/sdk/nodejs/resource/v1alpha1/resourceClaimPatch.ts
+++ b/sdk/nodejs/resource/v1alpha1/resourceClaimPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
  *

--- a/sdk/nodejs/resource/v1alpha1/resourceClaimTemplatePatch.ts
+++ b/sdk/nodejs/resource/v1alpha1/resourceClaimTemplatePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClaimTemplate is used to produce ResourceClaim objects.
  */

--- a/sdk/nodejs/resource/v1alpha1/resourceClassPatch.ts
+++ b/sdk/nodejs/resource/v1alpha1/resourceClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * ResourceClass is used by administrators to influence how resources are allocated.
  *

--- a/sdk/nodejs/scheduling/v1/priorityClassPatch.ts
+++ b/sdk/nodejs/scheduling/v1/priorityClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  */

--- a/sdk/nodejs/scheduling/v1alpha1/priorityClassPatch.ts
+++ b/sdk/nodejs/scheduling/v1alpha1/priorityClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  */

--- a/sdk/nodejs/scheduling/v1beta1/priorityClassPatch.ts
+++ b/sdk/nodejs/scheduling/v1beta1/priorityClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  */

--- a/sdk/nodejs/settings/v1alpha1/podPresetPatch.ts
+++ b/sdk/nodejs/settings/v1alpha1/podPresetPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * PodPreset is a policy resource that defines additional runtime requirements for a Pod.
  */

--- a/sdk/nodejs/storage/v1/csidriverPatch.ts
+++ b/sdk/nodejs/storage/v1/csidriverPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
  */

--- a/sdk/nodejs/storage/v1/csinodePatch.ts
+++ b/sdk/nodejs/storage/v1/csinodePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
  */

--- a/sdk/nodejs/storage/v1/csistorageCapacityPatch.ts
+++ b/sdk/nodejs/storage/v1/csistorageCapacityPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
  *

--- a/sdk/nodejs/storage/v1/storageClassPatch.ts
+++ b/sdk/nodejs/storage/v1/storageClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
  *

--- a/sdk/nodejs/storage/v1/volumeAttachmentPatch.ts
+++ b/sdk/nodejs/storage/v1/volumeAttachmentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  *

--- a/sdk/nodejs/storage/v1alpha1/volumeAttachmentPatch.ts
+++ b/sdk/nodejs/storage/v1alpha1/volumeAttachmentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  *

--- a/sdk/nodejs/storage/v1beta1/csidriverPatch.ts
+++ b/sdk/nodejs/storage/v1beta1/csidriverPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
  */

--- a/sdk/nodejs/storage/v1beta1/csinodePatch.ts
+++ b/sdk/nodejs/storage/v1beta1/csinodePatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
  *

--- a/sdk/nodejs/storage/v1beta1/csistorageCapacityPatch.ts
+++ b/sdk/nodejs/storage/v1beta1/csistorageCapacityPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
  *

--- a/sdk/nodejs/storage/v1beta1/storageClassPatch.ts
+++ b/sdk/nodejs/storage/v1beta1/storageClassPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
  *

--- a/sdk/nodejs/storage/v1beta1/volumeAttachmentPatch.ts
+++ b/sdk/nodejs/storage/v1beta1/volumeAttachmentPatch.ts
@@ -12,7 +12,7 @@ import * as utilities from "../../utilities";
  * Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
  * one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
  * Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
- * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+ * [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
  * additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
  * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
  *

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.py
@@ -101,7 +101,7 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 
@@ -123,7 +123,7 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.py
@@ -101,7 +101,7 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 
@@ -123,7 +123,7 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.py
@@ -101,7 +101,7 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
 
@@ -123,7 +123,7 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
 

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.py
@@ -101,7 +101,7 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
 
@@ -123,7 +123,7 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
 

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.py
@@ -101,7 +101,7 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
 
@@ -123,7 +123,7 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
 

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.py
@@ -101,7 +101,7 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
 
@@ -123,7 +123,7 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
 

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.py
@@ -101,7 +101,7 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
 
@@ -123,7 +123,7 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
 

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.py
@@ -97,7 +97,7 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
 
@@ -118,7 +118,7 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
 

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServicePatch.py
@@ -101,7 +101,7 @@ class APIServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
 
@@ -123,7 +123,7 @@ class APIServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
 

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServicePatch.py
@@ -97,7 +97,7 @@ class APIServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
 
@@ -118,7 +118,7 @@ class APIServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
 

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionPatch.py
@@ -116,7 +116,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 
@@ -139,7 +139,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetPatch.py
@@ -102,7 +102,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 
@@ -124,7 +124,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DeploymentPatch.py
@@ -102,7 +102,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 
@@ -146,7 +146,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetPatch.py
@@ -102,7 +102,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 
@@ -124,7 +124,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetPatch.py
@@ -102,7 +102,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
           - Network: A single stable DNS and hostname.
@@ -141,7 +141,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
           - Network: A single stable DNS and hostname.

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionPatch.py
@@ -116,7 +116,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 
@@ -139,7 +139,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentPatch.py
@@ -102,7 +102,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 
@@ -146,7 +146,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetPatch.py
@@ -98,7 +98,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
          - Network: A single stable DNS and hostname.
@@ -135,7 +135,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
          - Network: A single stable DNS and hostname.

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionPatch.py
@@ -116,7 +116,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 
@@ -139,7 +139,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetPatch.py
@@ -102,7 +102,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 
@@ -124,7 +124,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentPatch.py
@@ -102,7 +102,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 
@@ -146,7 +146,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetPatch.py
@@ -102,7 +102,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 
@@ -124,7 +124,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetPatch.py
@@ -98,7 +98,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
          - Network: A single stable DNS and hostname.
@@ -135,7 +135,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
          - Network: A single stable DNS and hostname.

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkPatch.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkPatch.py
@@ -97,7 +97,7 @@ class AuditSinkPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         AuditSink represents a cluster level audit sink
 
@@ -118,7 +118,7 @@ class AuditSinkPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         AuditSink represents a cluster level audit sink
 

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenRequestPatch.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenRequestPatch.py
@@ -101,7 +101,7 @@ class TokenRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenRequest requests a token for a given service account.
 
@@ -123,7 +123,7 @@ class TokenRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenRequest requests a token for a given service account.
 

--- a/sdk/python/pulumi_kubernetes/authentication/v1/TokenReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1/TokenReviewPatch.py
@@ -101,7 +101,7 @@ class TokenReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 
@@ -123,7 +123,7 @@ class TokenReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 

--- a/sdk/python/pulumi_kubernetes/authentication/v1alpha1/SelfSubjectReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1alpha1/SelfSubjectReviewPatch.py
@@ -84,7 +84,7 @@ class SelfSubjectReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
 
@@ -105,7 +105,7 @@ class SelfSubjectReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.
 

--- a/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authentication/v1beta1/TokenReviewPatch.py
@@ -97,7 +97,7 @@ class TokenReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 
@@ -118,7 +118,7 @@ class TokenReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/LocalSubjectAccessReviewPatch.py
@@ -101,7 +101,7 @@ class LocalSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 
@@ -123,7 +123,7 @@ class LocalSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectAccessReviewPatch.py
@@ -101,7 +101,7 @@ class SelfSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 
@@ -123,7 +123,7 @@ class SelfSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SelfSubjectRulesReviewPatch.py
@@ -101,7 +101,7 @@ class SelfSubjectRulesReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 
@@ -123,7 +123,7 @@ class SelfSubjectRulesReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1/SubjectAccessReviewPatch.py
@@ -101,7 +101,7 @@ class SubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SubjectAccessReview checks whether or not a user or group can perform an action.
 
@@ -123,7 +123,7 @@ class SubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SubjectAccessReview checks whether or not a user or group can perform an action.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/LocalSubjectAccessReviewPatch.py
@@ -97,7 +97,7 @@ class LocalSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 
@@ -118,7 +118,7 @@ class LocalSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectAccessReviewPatch.py
@@ -97,7 +97,7 @@ class SelfSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 
@@ -118,7 +118,7 @@ class SelfSubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SelfSubjectRulesReviewPatch.py
@@ -97,7 +97,7 @@ class SelfSubjectRulesReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 
@@ -118,7 +118,7 @@ class SelfSubjectRulesReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
 

--- a/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReviewPatch.py
+++ b/sdk/python/pulumi_kubernetes/authorization/v1beta1/SubjectAccessReviewPatch.py
@@ -97,7 +97,7 @@ class SubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SubjectAccessReview checks whether or not a user or group can perform an action.
 
@@ -118,7 +118,7 @@ class SubjectAccessReviewPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         SubjectAccessReview checks whether or not a user or group can perform an action.
 

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.py
@@ -101,7 +101,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         configuration of a horizontal pod autoscaler.
 
@@ -123,7 +123,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         configuration of a horizontal pod autoscaler.
 

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.py
@@ -101,7 +101,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 
@@ -123,7 +123,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.py
@@ -101,7 +101,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 
@@ -123,7 +123,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.py
@@ -101,7 +101,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 
@@ -123,7 +123,7 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
 

--- a/sdk/python/pulumi_kubernetes/batch/v1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/CronJobPatch.py
@@ -102,7 +102,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 
@@ -124,7 +124,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 

--- a/sdk/python/pulumi_kubernetes/batch/v1/JobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/JobPatch.py
@@ -102,7 +102,7 @@ class JobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Job represents the configuration of a single job.
 
@@ -144,7 +144,7 @@ class JobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Job represents the configuration of a single job.
 

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobPatch.py
@@ -103,7 +103,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 
@@ -125,7 +125,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobPatch.py
@@ -103,7 +103,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 
@@ -125,7 +125,7 @@ class CronJobPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CronJob represents the configuration of a single cron job.
 

--- a/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestPatch.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestPatch.py
@@ -97,7 +97,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
 
@@ -124,7 +124,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
 

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.py
@@ -97,7 +97,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Describes a certificate signing request
 
@@ -118,7 +118,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Describes a certificate signing request
 

--- a/sdk/python/pulumi_kubernetes/coordination/v1/LeasePatch.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/LeasePatch.py
@@ -101,7 +101,7 @@ class LeasePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Lease defines a lease concept.
 
@@ -123,7 +123,7 @@ class LeasePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Lease defines a lease concept.
 

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeasePatch.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeasePatch.py
@@ -101,7 +101,7 @@ class LeasePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Lease defines a lease concept.
 
@@ -123,7 +123,7 @@ class LeasePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Lease defines a lease concept.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/BindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/BindingPatch.py
@@ -101,7 +101,7 @@ class BindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
 
@@ -123,7 +123,7 @@ class BindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMapPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMapPatch.py
@@ -133,7 +133,7 @@ class ConfigMapPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ConfigMap holds configuration data for pods to consume.
 
@@ -157,7 +157,7 @@ class ConfigMapPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ConfigMap holds configuration data for pods to consume.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/EndpointsPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EndpointsPatch.py
@@ -101,7 +101,7 @@ class EndpointsPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Endpoints is a collection of endpoints that implement the actual service. Example:
 
@@ -135,7 +135,7 @@ class EndpointsPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Endpoints is a collection of endpoints that implement the actual service. Example:
 

--- a/sdk/python/pulumi_kubernetes/core/v1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EventPatch.py
@@ -322,7 +322,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 
@@ -357,7 +357,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRangePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRangePatch.py
@@ -101,7 +101,7 @@ class LimitRangePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LimitRange sets resource usage limits for each kind of resource in a Namespace.
 
@@ -123,7 +123,7 @@ class LimitRangePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         LimitRange sets resource usage limits for each kind of resource in a Namespace.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/NamespacePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NamespacePatch.py
@@ -101,7 +101,7 @@ class NamespacePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Namespace provides a scope for Names. Use of multiple namespaces is optional.
 
@@ -123,7 +123,7 @@ class NamespacePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Namespace provides a scope for Names. Use of multiple namespaces is optional.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/NodePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NodePatch.py
@@ -101,7 +101,7 @@ class NodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
 
@@ -123,7 +123,7 @@ class NodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
 

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimPatch.py
@@ -101,7 +101,7 @@ class PersistentVolumeClaimPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PersistentVolumeClaim is a user's request for and claim to a persistent volume
 
@@ -123,7 +123,7 @@ class PersistentVolumeClaimPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PersistentVolumeClaim is a user's request for and claim to a persistent volume
 

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumePatch.py
@@ -101,7 +101,7 @@ class PersistentVolumePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 
@@ -123,7 +123,7 @@ class PersistentVolumePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 

--- a/sdk/python/pulumi_kubernetes/core/v1/PodPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodPatch.py
@@ -101,7 +101,7 @@ class PodPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
 
@@ -138,7 +138,7 @@ class PodPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplatePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplatePatch.py
@@ -101,7 +101,7 @@ class PodTemplatePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodTemplate describes a template for creating copies of a predefined pod.
 
@@ -123,7 +123,7 @@ class PodTemplatePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodTemplate describes a template for creating copies of a predefined pod.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerPatch.py
@@ -101,7 +101,7 @@ class ReplicationControllerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicationController represents the configuration of a replication controller.
 
@@ -123,7 +123,7 @@ class ReplicationControllerPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicationController represents the configuration of a replication controller.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaPatch.py
@@ -101,7 +101,7 @@ class ResourceQuotaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceQuota sets aggregate quota restrictions enforced per namespace
 
@@ -123,7 +123,7 @@ class ResourceQuotaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceQuota sets aggregate quota restrictions enforced per namespace
 

--- a/sdk/python/pulumi_kubernetes/core/v1/SecretPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/SecretPatch.py
@@ -150,7 +150,7 @@ class SecretPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
 
@@ -185,7 +185,7 @@ class SecretPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
 

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountPatch.py
@@ -135,7 +135,7 @@ class ServiceAccountPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
 
@@ -159,7 +159,7 @@ class ServiceAccountPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
 

--- a/sdk/python/pulumi_kubernetes/core/v1/ServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServicePatch.py
@@ -102,7 +102,7 @@ class ServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
 
@@ -149,7 +149,7 @@ class ServicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
 

--- a/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlicePatch.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlicePatch.py
@@ -136,7 +136,7 @@ class EndpointSlicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 
@@ -160,7 +160,7 @@ class EndpointSlicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlicePatch.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlicePatch.py
@@ -136,7 +136,7 @@ class EndpointSlicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 
@@ -160,7 +160,7 @@ class EndpointSlicePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
 

--- a/sdk/python/pulumi_kubernetes/events/v1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/EventPatch.py
@@ -323,7 +323,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 
@@ -358,7 +358,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
 

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/EventPatch.py
@@ -319,7 +319,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
 
@@ -353,7 +353,7 @@ class EventPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetPatch.py
@@ -102,7 +102,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 
@@ -124,7 +124,7 @@ class DaemonSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DaemonSet represents the configuration of a daemon set.
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentPatch.py
@@ -102,7 +102,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 
@@ -146,7 +146,7 @@ class DeploymentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Deployment enables declarative updates for Pods and ReplicaSets.
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressPatch.py
@@ -102,7 +102,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 
@@ -138,7 +138,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyPatch.py
@@ -101,7 +101,7 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
 
@@ -123,7 +123,7 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.py
@@ -102,7 +102,7 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
 
@@ -124,7 +124,7 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
 

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetPatch.py
@@ -102,7 +102,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 
@@ -124,7 +124,7 @@ class ReplicaSetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.py
@@ -101,7 +101,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 
@@ -123,7 +123,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.py
@@ -101,7 +101,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 
@@ -123,7 +123,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.py
@@ -101,7 +101,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 
@@ -123,7 +123,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.py
@@ -101,7 +101,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 
@@ -123,7 +123,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.py
@@ -101,7 +101,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 
@@ -123,7 +123,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.py
@@ -101,7 +101,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 
@@ -123,7 +123,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.py
@@ -101,7 +101,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 
@@ -123,7 +123,7 @@ class FlowSchemaPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.py
@@ -101,7 +101,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 
@@ -123,7 +123,7 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityLevelConfiguration represents the configuration of a priority level.
 

--- a/sdk/python/pulumi_kubernetes/meta/v1/StatusPatch.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/StatusPatch.py
@@ -151,7 +151,7 @@ class StatusPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Status is a return value for calls that don't return other objects.
 
@@ -176,7 +176,7 @@ class StatusPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Status is a return value for calls that don't return other objects.
 

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressClassPatch.py
@@ -101,7 +101,7 @@ class IngressClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 
@@ -123,7 +123,7 @@ class IngressClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressPatch.py
@@ -102,7 +102,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 
@@ -138,7 +138,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyPatch.py
@@ -101,7 +101,7 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         NetworkPolicy describes what network traffic is allowed for a set of Pods
 
@@ -123,7 +123,7 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         NetworkPolicy describes what network traffic is allowed for a set of Pods
 

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRPatch.py
@@ -102,7 +102,7 @@ class ClusterCIDRPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
 
@@ -124,7 +124,7 @@ class ClusterCIDRPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
 

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassPatch.py
@@ -102,7 +102,7 @@ class IngressClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 
@@ -124,7 +124,7 @@ class IngressClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
 

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressPatch.py
@@ -102,7 +102,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 
@@ -138,7 +138,7 @@ class IngressPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
 

--- a/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassPatch.py
@@ -138,7 +138,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
 
@@ -163,7 +163,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
 

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassPatch.py
@@ -102,7 +102,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 
@@ -124,7 +124,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassPatch.py
@@ -136,7 +136,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 
@@ -160,7 +160,7 @@ class RuntimeClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
 

--- a/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetPatch.py
@@ -101,7 +101,7 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 
@@ -123,7 +123,7 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.py
@@ -97,7 +97,7 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 
@@ -118,7 +118,7 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
 

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyPatch.py
@@ -102,7 +102,7 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 
@@ -124,7 +124,7 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingPatch.py
@@ -118,7 +118,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
 
@@ -141,7 +141,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRolePatch.py
@@ -118,7 +118,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 
@@ -141,7 +141,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingPatch.py
@@ -118,7 +118,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
 
@@ -141,7 +141,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RolePatch.py
@@ -101,7 +101,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 
@@ -123,7 +123,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.py
@@ -118,7 +118,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRolePatch.py
@@ -118,7 +118,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingPatch.py
@@ -118,7 +118,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RolePatch.py
@@ -101,7 +101,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 
@@ -123,7 +123,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.py
@@ -118,7 +118,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRolePatch.py
@@ -118,7 +118,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class ClusterRolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingPatch.py
@@ -118,7 +118,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 
@@ -141,7 +141,7 @@ class RoleBindingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RolePatch.py
@@ -101,7 +101,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 
@@ -123,7 +123,7 @@ class RolePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
 

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingPatch.py
@@ -101,7 +101,7 @@ class PodSchedulingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
 
@@ -125,7 +125,7 @@ class PodSchedulingPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
 

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimPatch.py
@@ -102,7 +102,7 @@ class ResourceClaimPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
 
@@ -126,7 +126,7 @@ class ResourceClaimPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
 

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.py
@@ -105,7 +105,7 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClaimTemplate is used to produce ResourceClaim objects.
 
@@ -129,7 +129,7 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClaimTemplate is used to produce ResourceClaim objects.
 

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassPatch.py
@@ -144,7 +144,7 @@ class ResourceClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClass is used by administrators to influence how resources are allocated.
 
@@ -174,7 +174,7 @@ class ResourceClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         ResourceClass is used by administrators to influence how resources are allocated.
 

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassPatch.py
@@ -150,7 +150,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 
@@ -175,7 +175,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassPatch.py
@@ -150,7 +150,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 
@@ -175,7 +175,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassPatch.py
@@ -150,7 +150,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 
@@ -175,7 +175,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
 

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetPatch.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetPatch.py
@@ -94,7 +94,7 @@ class PodPresetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 
@@ -114,7 +114,7 @@ class PodPresetPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverPatch.py
@@ -101,7 +101,7 @@ class CSIDriverPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 
@@ -123,7 +123,7 @@ class CSIDriverPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINodePatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINodePatch.py
@@ -101,7 +101,7 @@ class CSINodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 
@@ -123,7 +123,7 @@ class CSINodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityPatch.py
@@ -166,7 +166,7 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 
@@ -207,7 +207,7 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClassPatch.py
@@ -202,7 +202,7 @@ class StorageClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 
@@ -232,7 +232,7 @@ class StorageClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentPatch.py
@@ -102,7 +102,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 
@@ -126,7 +126,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentPatch.py
@@ -102,7 +102,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 
@@ -126,7 +126,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverPatch.py
@@ -101,7 +101,7 @@ class CSIDriverPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 
@@ -123,7 +123,7 @@ class CSIDriverPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodePatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodePatch.py
@@ -101,7 +101,7 @@ class CSINodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 
@@ -123,7 +123,7 @@ class CSINodePatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityPatch.py
@@ -166,7 +166,7 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 
@@ -207,7 +207,7 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassPatch.py
@@ -202,7 +202,7 @@ class StorageClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 
@@ -232,7 +232,7 @@ class StorageClassPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentPatch.py
@@ -102,7 +102,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 
@@ -126,7 +126,7 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         Server-Side Apply updates. The name of the resource must be specified, but all other properties are optional. More than
         one patch may be applied to the same resource, and a random FieldManager name will be used for each Patch resource.
         Conflicts will result in an error by default, but can be forced using the "pulumi.com/patchForce" annotation. See the
-        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#server-side-apply) for
+        [Server-Side Apply Docs](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/) for
         additional information about using Server-Side Apply to manage Kubernetes resources with Pulumi.
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2258
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2215

Example output:
```
pulumi up --skip-preview
Updating (dev)

View Live: https://app.pulumi.com/lblackstone/pulumi-k8s-test/dev/updates/380

     Type                                   Name                 Status                  Info
     pulumi:pulumi:Stack                    pulumi-k8s-test-dev  **failed**              1 error
 +   └─ kubernetes:apps/v1:DeploymentPatch  example              **creating failed**     1 error


Diagnostics:
  pulumi:pulumi:Stack (pulumi-k8s-test-dev):
    error: update failed

  kubernetes:apps/v1:DeploymentPatch (example):
    error: resource default/foo was not successfully created by the Kubernetes API server : SSA field conflict detected. see https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/#handle-field-conflicts-on-existing-resources for troubleshooting help
    : Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using apps/v1: .spec.template.spec.containers[name="nginx"].image

Resources:
    2 unchanged

Duration: 1s

```
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
