### PR TITLE
Correct syntax typo in doc [impact/no-changelog-required ]

### DIFF
--- a/provider/pkg/gen/examples/overlays/helmRelease.md
+++ b/provider/pkg/gen/examples/overlays/helmRelease.md
@@ -500,7 +500,7 @@ nginx_ingress = Release(
         repository_opts=RepositoryOptsArgs(
             repo="https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami",
         ),
-        value_yaml_files=pulumi.FileAsset("./metrics.yml"),
+        value_yaml_files=[pulumi.FileAsset("./metrics.yml")],
         values={
             cluster: {
                 enabled: true,

--- a/sdk/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/Release.py
@@ -727,7 +727,7 @@ class Release(pulumi.CustomResource):
                 repository_opts=RepositoryOptsArgs(
                     repo="https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami",
                 ),
-                value_yaml_files=pulumi.FileAsset("./metrics.yml"),
+                value_yaml_files=[pulumi.FileAsset("./metrics.yml")],
                 values={
                     cluster: {
                         enabled: true,
@@ -933,7 +933,7 @@ class Release(pulumi.CustomResource):
                 repository_opts=RepositoryOptsArgs(
                     repo="https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami",
                 ),
-                value_yaml_files=pulumi.FileAsset("./metrics.yml"),
+                value_yaml_files=[pulumi.FileAsset("./metrics.yml")],
                 values={
                     cluster: {
                         enabled: true,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details, such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Correct syntax mistake in documentation related to kubernetes.helm.sh/v3.Release library. The mistake is in example "Specify Helm Chart Values in File and Code" - when you provide `value_yaml_files=pulumi.FileAsset("./metrics.yml")`, you should know, that `value_yaml_files` variable should be `Optional[Sequence[Union[pulumi.Asset, pulumi.Archive]]]` type, so it means that correct variable defenition `value_yaml_files=[pulumi.FileAsset("./metrics.yml")]`, (pay attention on square brackets).

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Related issues: #2178, #1922