### PR TITLE
Bump ingress test timeout

### DIFF
--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -148,7 +148,7 @@ func TestAccIngress(t *testing.T) {
 
 				integration.AssertHTTPResultWithRetry(t,
 					fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]),
-					nil, 5*time.Minute, func(body string) bool {
+					nil, 10*time.Minute, func(body string) bool {
 						return assert.NotEmpty(t, body, "Body should not be empty")
 					})
 


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This test previously gave up after 5 minutes of waiting for the Cloud Load Balancer to be ready, but this seemed to cause regular test flakes. Doubling the timeout to 10 minutes to see if that stabilizes the test.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Related https://github.com/pulumi/pulumi-kubernetes/issues/1838

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
