### PR TITLE
Always set a field manager name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `PULUMI_K8S_ENABLE_PATCH_FORCE` env var support (https://github.com/pulumi/pulumi-kubernetes/pulls/2260)
 - Add link to resolution guide for SSA conflicts (https://github.com/pulumi/pulumi-kubernetes/pulls/2265)
+- Always set a field manager name (https://github.com/pulumi/pulumi-kubernetes/pulls/2271)
 
 ## 3.23.0 (December 8, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `PULUMI_K8S_ENABLE_PATCH_FORCE` env var support (https://github.com/pulumi/pulumi-kubernetes/pulls/2260)
 - Add link to resolution guide for SSA conflicts (https://github.com/pulumi/pulumi-kubernetes/pulls/2265)
-- Always set a field manager name (https://github.com/pulumi/pulumi-kubernetes/pulls/2271)
+- Always set a field manager name to avoid conflicts in Client-Side Apply mode (https://github.com/pulumi/pulumi-kubernetes/pulls/2271)
 
 ## 3.23.0 (December 8, 2022)
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -205,7 +205,9 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 						ssaConflictDocLink, err)
 				}
 			} else {
-				var options metav1.CreateOptions
+				options := metav1.CreateOptions{
+					FieldManager: c.FieldManager,
+				}
 				if c.Preview {
 					options.DryRun = []string{metav1.DryRunAll}
 				}
@@ -452,7 +454,9 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 				return nil, err
 			}
 
-			var options metav1.PatchOptions
+			options := metav1.PatchOptions{
+				FieldManager: c.FieldManager,
+			}
 			if c.Preview {
 				options.DryRun = []string{metav1.DryRunAll}
 			}


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Recent versions of Kubernetes have started to create a managedFields entry for every resource, even those that use Client-Side Apply (CSA). The name of the field manager is inferred from the name of the executable performing the update. This can lead to cross-platform conflicts, because the executable name can be different (e.g., myprogram vs. myprogram.exe). This leads to multiple field managers owning the same fields.

To avoid auto-naming conflicts like this, always set a field manager name. In the CSA mode, this name will always be "pulumi-kubernetes". In Server-Side Apply (SSA) mode, the name will be "pulumi-kubernetes-<suffix>", with a randomly-generated suffix.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

Fix https://github.com/pulumi/pulumi-kubernetes/issues/2218
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
