### PR TITLE
Docs: dotnet 3.1 and pulumictl is required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@
 1. Python: `python-setuptools`, `pip`
 1. Go: [golangci-lint](https://github.com/golangci/golangci-lint)
 1. JS: `npm`, `yarn`
-1. .NET: [.NET SDK 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+1. .NET: [.NET SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+1. [pulumictl](https://github.com/pulumi/pulumictl)
 
 ### Restore Vendor Dependencies
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for more details.
 ## Prerequisites
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/kubernetes/install-pulumi/).
-1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download/dotnet-core/3.0).
+1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 1. Install a package manager
     * For Node.js, use [NPM](https://www.npmjs.com/get-npm) or [Yarn](https://yarnpkg.com/lang/en/docs/install).
     * For Python, use [pip](https://pip.pypa.io/en/stable/installing/).


### PR DESCRIPTION
### Proposed changes

While I was following the README and contributing guide, particularly around the make commands, I got two errors popping out:

- I get told that .NET 3.1, not 3.0, is needed
- The make blurts out that I need pulumictl

I've updated the README and contributing docs with these two bits.