### PR TITLE
Add option to specify that helm chart should do an upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `PULUMI_K8S_ENABLE_PATCH_FORCE` env var support (https://github.com/pulumi/pulumi-kubernetes/pulls/2260)
 - Add link to resolution guide for SSA conflicts (https://github.com/pulumi/pulumi-kubernetes/pulls/2265)
+- Add isUpgrade flag to helm chart options. (https://github.com/pulumi/pulumi-kubernetes/pull/2276)
 
 ## 3.23.0 (December 8, 2022)
 

--- a/provider/pkg/gen/_go-templates/helm/v3/pulumiTypes.go
+++ b/provider/pkg/gen/_go-templates/helm/v3/pulumiTypes.go
@@ -125,6 +125,8 @@ type ChartArgs struct {
 	SkipAwait pulumi.BoolInput
 	// By default CRDs are also rendered along side templates. Set this to skip CRDs.
 	SkipCRDRendering pulumi.BoolInput
+	// Manually override to tell the provider to run helm template w/ --is-upgrade.
+	IsUpgrade pulumi.BoolInput
 	// The optional namespace to install chart resources into.
 	Namespace pulumi.StringInput
 	// Overrides for chart values.
@@ -168,6 +170,7 @@ type chartArgs struct {
 	Chart                    string                 `json:"chart,omitempty" pulumi:"chart"`
 	Version                  string                 `json:"version,omitempty" pulumi:"version"`
 	FetchArgs                fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
+	IsUpgrade                bool                   `json:"is_upgrade,omitempty" pulumi:"isUpgrade"`
 	Path                     string                 `json:"path,omitempty" pulumi:"path"`
 }
 

--- a/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/ChartBase.cs
@@ -421,6 +421,11 @@ namespace Pulumi.Kubernetes.Helm
         // </summary>
         public Input<bool>? SkipAwait { get; set; }
 
+        // <summary>
+        // Manually override to tell the provider to run helm template w/ --is-upgrade.
+        // </summary>
+        public Input<bool>? IsUpgrade { get; set; }
+
         /// <summary>
         /// The optional namespace to install chart resources into.
         /// </summary>

--- a/provider/pkg/gen/dotnet-templates/helm/Unwraps.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/Unwraps.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Kubernetes.Helm
         public bool? IncludeTestHookResources { get; set; }
         public bool? SkipCRDRendering { get; set; }
         public bool? SkipAwait { get; set; }
+        public bool? IsUpgrade { get; set; }
         public string? Namespace { get; set; }
         public ImmutableDictionary<string, object> Values { get; set; } = null!;
         public List<TransformationAction> Transformations { get; set; } = null!;
@@ -70,7 +71,7 @@ namespace Pulumi.Kubernetes.Helm
         public static Output<Union<ChartArgsUnwrap, LocalChartArgsUnwrap>> Unwrap(this Union<ChartArgs, LocalChartArgs> options)
         {
             return options.Match(
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap(), new InputList<bool?> { v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable() }).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap(), new InputList<bool?> { v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.IsUpgrade.ToNullable() }).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT0(
                         new ChartArgsUnwrap
                         {
@@ -85,9 +86,10 @@ namespace Pulumi.Kubernetes.Helm
                             FetchOptions = vs.Item7,
                             IncludeTestHookResources = vs.Item8[0],
                             SkipCRDRendering = vs.Item8[1],
-                            SkipAwait = vs.Item8[2]
+                            SkipAwait = vs.Item8[2],
+                            IsUpgrade = vs.Item8[3]
                         })),
-                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.Namespace.ToNullable(), v.Values).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.Namespace.ToNullable(), v.Values, v.IsUpgrade.ToNullable()).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT1(
                         new LocalChartArgsUnwrap
                         {
@@ -97,6 +99,7 @@ namespace Pulumi.Kubernetes.Helm
                             SkipAwait = vs.Item4,
                             Namespace = vs.Item5,
                             Values = vs.Item6,
+                            IsUpgrade = vs.Item7,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
                             Path = v.Path

--- a/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
+++ b/provider/pkg/gen/dotnet-templates/helm/v3/Chart.cs
@@ -313,6 +313,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                     ApiVersions = cfgBase.ApiVersions,
                     IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     SkipCRDRendering = cfgBase.SkipCRDRendering,
+                    IsUpgrade = cfgBase.IsUpgrade,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -351,6 +352,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                     ApiVersions = cfgBase.ApiVersions,
                     IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     SkipCRDRendering = cfgBase.SkipCRDRendering,
+                    IsUpgrade = cfgBase.IsUpgrade,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -399,6 +401,8 @@ namespace Pulumi.Kubernetes.Helm.V3
             public string? Version { get; set; }
             [JsonPropertyName("fetch_opts")]
             public JsonOptsFetch? FetchOptions { get; set; }
+            [JsonPropertyName("is_upgrade")]
+            public bool? IsUpgrade { get; set; }
             [JsonPropertyName("path")]
             public string? Path { get; set; }
             [JsonPropertyName("release_name")]

--- a/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
+++ b/provider/pkg/gen/nodejs-templates/helm/v3/helm.ts
@@ -201,6 +201,10 @@ export class Chart extends yaml.CollectionComponentResource {
                                 obj["fetch_opts"] = value;
                                 break;
                             }
+                            case "isUpgrade": {
+                                obj["is_upgrade"] = value;
+                                break;
+                            }
                             case "includeTestHookResources": {
                                 obj["include_test_hook_resources"] = value;
                                 break;
@@ -296,6 +300,10 @@ interface BaseChartOpts {
      * Warning: This option should not be used if you have resources depending on Outputs from the Chart.
      */
     skipAwait?: pulumi.Input<boolean>;
+    /**
+     * Manually override to tell the provider to run helm template w/ --is-upgrade.
+     */
+    isUpgrade?: pulumi.Input<boolean>;
 }
 
 /**

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -173,6 +173,12 @@ var helmV3ChartResource = pschema.ResourceSpec{
 			},
 			Description: "Additional options to customize the fetching of the Helm chart.",
 		},
+		"isUpgrade": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "boolean",
+			},
+			Description: "Manually override to tell the provider to run helm template w/ --is-upgrade.",
+		},
 		"path": {
 			TypeSpec: pschema.TypeSpec{
 				Type: "string",

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -415,6 +415,10 @@ class BaseChartOpts:
     Warning: This option should not be used if you have resources depending on Outputs from the Chart.
     """
 
+    is_upgrade: Optional[pulumi.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
                  values: Optional[pulumi.Inputs] = None,
@@ -423,7 +427,8 @@ class BaseChartOpts:
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
@@ -442,6 +447,8 @@ class BaseChartOpts:
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
         self.namespace = namespace
         self.include_test_hook_resources = include_test_hook_resources
@@ -451,6 +458,7 @@ class BaseChartOpts:
         self.transformations = transformations
         self.resource_prefix = resource_prefix
         self.api_versions = api_versions
+        self.is_upgrade = is_upgrade
 
     def to_json(self):
         return pulumi.Output.from_input(self.__dict__).apply(
@@ -485,6 +493,10 @@ class ChartOpts(BaseChartOpts):
     Additional options to customize the fetching of the Helm chart.
     """
 
+    is_upgrade: Optional[pulumu.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
     def __init__(self,
                  chart: pulumi.Input[str],
                  namespace: Optional[pulumi.Input[str]] = None,
@@ -497,7 +509,8 @@ class ChartOpts(BaseChartOpts):
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] chart: The name of the chart to deploy.  If `repo` is provided, this chart name
                will be prefixed by the repo name.
@@ -526,9 +539,11 @@ class ChartOpts(BaseChartOpts):
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
         super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
-                                        include_test_hook_resources, skip_crd_rendering, skip_await)
+                                        include_test_hook_resources, skip_crd_rendering, skip_await, is_upgrade)
         self.chart = chart
         self.repo = repo
         self.version = version
@@ -545,6 +560,11 @@ class LocalChartOpts(BaseChartOpts):
     The path to the chart directory which contains the `Chart.yaml` file.
     """
 
+    is_upgrade: Optional[pulumu.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
+
     def __init__(self,
                  path: pulumi.Input[str],
                  namespace: Optional[pulumi.Input[str]] = None,
@@ -554,7 +574,8 @@ class LocalChartOpts(BaseChartOpts):
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] path: The path to the chart directory which contains the
                `Chart.yaml` file.
@@ -575,10 +596,12 @@ class LocalChartOpts(BaseChartOpts):
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
 
         super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
-                                             include_test_hook_resources, skip_crd_rendering, skip_await)
+                                             include_test_hook_resources, skip_crd_rendering, skip_await, is_upgrade)
         self.path = path
 
 

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -71,6 +71,7 @@ type HelmChartOpts struct {
 	Version                  string                 `json:"version,omitempty"`
 	HelmChartDebug           bool                   `json:"helm_chart_debug,omitempty"`
 	HelmRegistryConfig       string                 `json:"helm_registry_config,omitempty"`
+	IsUpgrade                bool                   `json:"is_upgrade,omitempty"`
 }
 
 // helmTemplate performs Helm fetch/pull + template operations and returns the resulting YAML manifest based on the
@@ -241,6 +242,9 @@ func (c *chart) template(clientSet *clients.DynamicClientSet) (string, error) {
 	installAction.NameTemplate = c.opts.ReleaseName
 	installAction.ReleaseName = c.opts.ReleaseName
 	installAction.Version = c.opts.Version
+	if c.opts.IsUpgrade {
+		installAction.IsUpgrade = c.opts.IsUpgrade
+	}
 
 	// Preserve backward compatibility
 	if len(c.opts.APIVersions) > 0 {

--- a/sdk/dotnet/Helm/ChartBase.cs
+++ b/sdk/dotnet/Helm/ChartBase.cs
@@ -421,6 +421,11 @@ namespace Pulumi.Kubernetes.Helm
         // </summary>
         public Input<bool>? SkipAwait { get; set; }
 
+        // <summary>
+        // Manually override to tell the provider to run helm template w/ --is-upgrade.
+        // </summary>
+        public Input<bool>? IsUpgrade { get; set; }
+
         /// <summary>
         /// The optional namespace to install chart resources into.
         /// </summary>

--- a/sdk/dotnet/Helm/Unwraps.cs
+++ b/sdk/dotnet/Helm/Unwraps.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Kubernetes.Helm
         public bool? IncludeTestHookResources { get; set; }
         public bool? SkipCRDRendering { get; set; }
         public bool? SkipAwait { get; set; }
+        public bool? IsUpgrade { get; set; }
         public string? Namespace { get; set; }
         public ImmutableDictionary<string, object> Values { get; set; } = null!;
         public List<TransformationAction> Transformations { get; set; } = null!;
@@ -70,7 +71,7 @@ namespace Pulumi.Kubernetes.Helm
         public static Output<Union<ChartArgsUnwrap, LocalChartArgsUnwrap>> Unwrap(this Union<ChartArgs, LocalChartArgs> options)
         {
             return options.Match(
-                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap(), new InputList<bool?> { v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable() }).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.Namespace.ToNullable(), v.Values, v.Repo.ToNullable(), v.Chart, v.Version.ToNullable(), v.FetchOptions.Unwrap(), new InputList<bool?> { v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.IsUpgrade.ToNullable() }).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT0(
                         new ChartArgsUnwrap
                         {
@@ -85,9 +86,10 @@ namespace Pulumi.Kubernetes.Helm
                             FetchOptions = vs.Item7,
                             IncludeTestHookResources = vs.Item8[0],
                             SkipCRDRendering = vs.Item8[1],
-                            SkipAwait = vs.Item8[2]
+                            SkipAwait = vs.Item8[2],
+                            IsUpgrade = vs.Item8[3]
                         })),
-                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.Namespace.ToNullable(), v.Values).Apply(vs =>
+                v => Output.Tuple(v.ApiVersions, v.IncludeTestHookResources.ToNullable(), v.SkipCRDRendering.ToNullable(), v.SkipAwait.ToNullable(), v.Namespace.ToNullable(), v.Values, v.IsUpgrade.ToNullable()).Apply(vs =>
                     Union<ChartArgsUnwrap, LocalChartArgsUnwrap>.FromT1(
                         new LocalChartArgsUnwrap
                         {
@@ -97,6 +99,7 @@ namespace Pulumi.Kubernetes.Helm
                             SkipAwait = vs.Item4,
                             Namespace = vs.Item5,
                             Values = vs.Item6,
+                            IsUpgrade = vs.Item7,
                             Transformations = v.Transformations,
                             ResourcePrefix = v.ResourcePrefix,
                             Path = v.Path

--- a/sdk/dotnet/Helm/V3/Chart.cs
+++ b/sdk/dotnet/Helm/V3/Chart.cs
@@ -313,6 +313,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                     ApiVersions = cfgBase.ApiVersions,
                     IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     SkipCRDRendering = cfgBase.SkipCRDRendering,
+                    IsUpgrade = cfgBase.IsUpgrade,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -351,6 +352,7 @@ namespace Pulumi.Kubernetes.Helm.V3
                     ApiVersions = cfgBase.ApiVersions,
                     IncludeTestHookResources = cfgBase.IncludeTestHookResources,
                     SkipCRDRendering = cfgBase.SkipCRDRendering,
+                    IsUpgrade = cfgBase.IsUpgrade,
                     Namespace = cfgBase.Namespace,
                     Values = cfgBase.Values,
                     ReleaseName = releaseName,
@@ -399,6 +401,8 @@ namespace Pulumi.Kubernetes.Helm.V3
             public string? Version { get; set; }
             [JsonPropertyName("fetch_opts")]
             public JsonOptsFetch? FetchOptions { get; set; }
+            [JsonPropertyName("is_upgrade")]
+            public bool? IsUpgrade { get; set; }
             [JsonPropertyName("path")]
             public string? Path { get; set; }
             [JsonPropertyName("release_name")]

--- a/sdk/go/kubernetes/helm/v3/chartPulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v3/chartPulumiTypes.go
@@ -125,6 +125,8 @@ type ChartArgs struct {
 	SkipAwait pulumi.BoolInput
 	// By default CRDs are also rendered along side templates. Set this to skip CRDs.
 	SkipCRDRendering pulumi.BoolInput
+	// Manually override to tell the provider to run helm template w/ --is-upgrade.
+	IsUpgrade pulumi.BoolInput
 	// The optional namespace to install chart resources into.
 	Namespace pulumi.StringInput
 	// Overrides for chart values.
@@ -168,6 +170,7 @@ type chartArgs struct {
 	Chart                    string                 `json:"chart,omitempty" pulumi:"chart"`
 	Version                  string                 `json:"version,omitempty" pulumi:"version"`
 	FetchArgs                fetchArgs              `json:"fetch_opts,omitempty" pulumi:"fetchArgs"`
+	IsUpgrade                bool                   `json:"is_upgrade,omitempty" pulumi:"isUpgrade"`
 	Path                     string                 `json:"path,omitempty" pulumi:"path"`
 }
 

--- a/sdk/nodejs/helm/v3/helm.ts
+++ b/sdk/nodejs/helm/v3/helm.ts
@@ -201,6 +201,10 @@ export class Chart extends yaml.CollectionComponentResource {
                                 obj["fetch_opts"] = value;
                                 break;
                             }
+                            case "isUpgrade": {
+                                obj["is_upgrade"] = value;
+                                break;
+                            }
                             case "includeTestHookResources": {
                                 obj["include_test_hook_resources"] = value;
                                 break;
@@ -296,6 +300,10 @@ interface BaseChartOpts {
      * Warning: This option should not be used if you have resources depending on Outputs from the Chart.
      */
     skipAwait?: pulumi.Input<boolean>;
+    /**
+     * Manually override to tell the provider to run helm template w/ --is-upgrade.
+     */
+    isUpgrade?: pulumi.Input<boolean>;
 }
 
 /**

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -415,6 +415,10 @@ class BaseChartOpts:
     Warning: This option should not be used if you have resources depending on Outputs from the Chart.
     """
 
+    is_upgrade: Optional[pulumi.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
     def __init__(self,
                  namespace: Optional[pulumi.Input[str]] = None,
                  values: Optional[pulumi.Inputs] = None,
@@ -423,7 +427,8 @@ class BaseChartOpts:
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param Optional[pulumi.Input[str]] namespace: Optional namespace to install chart resources into.
         :param Optional[pulumi.Inputs] values: Optional overrides for chart values.
@@ -442,6 +447,8 @@ class BaseChartOpts:
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
         self.namespace = namespace
         self.include_test_hook_resources = include_test_hook_resources
@@ -451,6 +458,7 @@ class BaseChartOpts:
         self.transformations = transformations
         self.resource_prefix = resource_prefix
         self.api_versions = api_versions
+        self.is_upgrade = is_upgrade
 
     def to_json(self):
         return pulumi.Output.from_input(self.__dict__).apply(
@@ -485,6 +493,10 @@ class ChartOpts(BaseChartOpts):
     Additional options to customize the fetching of the Helm chart.
     """
 
+    is_upgrade: Optional[pulumu.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
     def __init__(self,
                  chart: pulumi.Input[str],
                  namespace: Optional[pulumi.Input[str]] = None,
@@ -497,7 +509,8 @@ class ChartOpts(BaseChartOpts):
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] chart: The name of the chart to deploy.  If `repo` is provided, this chart name
                will be prefixed by the repo name.
@@ -526,9 +539,11 @@ class ChartOpts(BaseChartOpts):
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
         super(ChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
-                                        include_test_hook_resources, skip_crd_rendering, skip_await)
+                                        include_test_hook_resources, skip_crd_rendering, skip_await, is_upgrade)
         self.chart = chart
         self.repo = repo
         self.version = version
@@ -545,6 +560,11 @@ class LocalChartOpts(BaseChartOpts):
     The path to the chart directory which contains the `Chart.yaml` file.
     """
 
+    is_upgrade: Optional[pulumu.Input[bool]]
+    """
+    Manually override to tell the provider to run helm template w/ --is-upgrade.
+    """
+
     def __init__(self,
                  path: pulumi.Input[str],
                  namespace: Optional[pulumi.Input[str]] = None,
@@ -554,7 +574,8 @@ class LocalChartOpts(BaseChartOpts):
                  api_versions: Optional[Sequence[pulumi.Input[str]]] = None,
                  include_test_hook_resources: Optional[pulumi.Input[bool]] = None,
                  skip_crd_rendering: Optional[pulumi.Input[bool]] = None,
-                 skip_await: Optional[pulumi.Input[bool]] = None):
+                 skip_await: Optional[pulumi.Input[bool]] = None,
+                 is_upgrade: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[str] path: The path to the chart directory which contains the
                `Chart.yaml` file.
@@ -575,10 +596,12 @@ class LocalChartOpts(BaseChartOpts):
         :param Optional[pulumi.Input[bool]] skip_await: Skip await logic for all resources in this Chart. Resources
                will be marked ready as soon as they are created. Warning: This option should not be used if you have
                resources depending on Outputs from the Chart.
+        :param Optional[pulumi.Input[bool]] is_upgrade: Manually override to tell the provider
+                to run helm template w/ --is-upgrade.
         """
 
         super(LocalChartOpts, self).__init__(namespace, values, transformations, resource_prefix, api_versions,
-                                             include_test_hook_resources, skip_crd_rendering, skip_await)
+                                             include_test_hook_resources, skip_crd_rendering, skip_await, is_upgrade)
         self.path = path
 
 


### PR DESCRIPTION
### Proposed changes

I'm using an OSS chart that is heavily coupled to whether the chart is doing an install or upgrade. (It relies on the .Release.IsInstall built-in for helm to determine some application logic.)

The [k8s.helm.v3.Chart](https://github.com/pulumi/pulumi-kubernetes/blob/master/provider/pkg/provider/invoke_helm_template.go) uses the helm templating golang library but never with the `isUpgrade` configuration. Particularly, this means the chart I'm installing or upgrading always thinks it is being installed. This leads to some interesting bugs. This chart won't change its behaviour since it is so ingrained in how it handles a few operations.

[k8s.helm.v3.Release ](https://github.com/pulumi/pulumi-kubernetes/blob/master/provider/pkg/provider/helm_release.go) does properly set isUpgrade when it is running an upgrade.

Sadly, there's no way to swap from one to another. And sadly, while I can handle downtime, deleting the k8s.helm.v3.Chart resource and adding the k8s.helm.v3.Release resource doesn't work since it tries to do both simultaneously.

**This draft PR proposes an `isUpgrade` flag in the k8s.helm.v3.Chart to get people out of my rare situation where they need to tell the chart that it is doing an upgrade, not an install.** I would prefer if the code itself could figure out if the pulumi k8s.helm.v3.Chart resource exists and sets the upgrade flag as needed, but I can't find a spot in the code where it knows whether it is doing an update or create.

### Related issues (optional)

I asked over in the slack for some help or insight: https://pulumi-community.slack.com/archives/C84L4E3N1/p1671216316161989

If https://github.com/pulumi/pulumi/issues/2877 was implemented, I could seamlessly swap between the k8s.helm.v3.Chart and k8s.helm.v3.Release.