### PR TITLE
Fix await status for Job and Pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Upgrade to latest helm and k8s client dependencies (https://github.com/pulumi/pulumi-kubernetes/pulls/2292)
+- Fix await status for Job and Pod (https://github.com/pulumi/pulumi-kubernetes/pulls/2299)
 
 ## 3.23.1 (December 19, 2022)
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335
+	github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd
 	github.com/pulumi/pulumi/pkg/v3 v3.53.1
 	github.com/pulumi/pulumi/sdk/v3 v3.53.1
 	github.com/stretchr/testify v1.8.1

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1572,8 +1572,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335 h1:Lujy/rTbyRE1ZM8bkwm26Q1THtUELJ/Zy36BMlPzk+A=
-github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335/go.mod h1:C6HmNtth9oPAWKyRJveZSU4rK/tvzhSGuoOV5y+S17g=
+github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd h1:shFTLvh3MZbBzVDr3xwYjUr5H1y3N5n4pczWtVaUZxo=
+github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd/go.mod h1:C6HmNtth9oPAWKyRJveZSU4rK/tvzhSGuoOV5y+S17g=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1 h1:NSgzjci0ykEoKC2BHmp/brP7/V8ARafl8ovr76B9Jak=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1/go.mod h1:XqciW5mPO8RxBEbN2/My9XjO829UQ2cHuhVLfoKM/yE=
 github.com/pulumi/pulumi/sdk/v3 v3.53.1 h1:fTYqe0fQiGshlOuHwpjOqQOb2SW3CSqXteeGcAuO+Bk=

--- a/provider/pkg/await/job.go
+++ b/provider/pkg/await/job.go
@@ -222,8 +222,8 @@ func (jia *jobInitAwaiter) processJobEvent(event watch.Event) error {
 	for _, message := range messages.MessagesWithSeverity(diag.Warning, diag.Error) {
 		jia.errors.Add(message)
 	}
-	for _, message := range messages {
-		jia.config.logMessage(message)
+	for _, result := range results {
+		jia.config.logStatus(diag.Info, result.Description)
 	}
 
 	if len(messages.Errors()) > 0 {

--- a/provider/pkg/await/pod.go
+++ b/provider/pkg/await/pod.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/clients"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/kinds"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/metadata"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -232,7 +233,7 @@ func (pia *podInitAwaiter) processPodEvent(event watch.Event) {
 	var results checker.Results
 	pia.ready, results = pia.checker.ReadyDetails(pod)
 	pia.messages = results.Messages()
-	for _, message := range pia.messages {
-		pia.config.logMessage(message)
+	for _, result := range results {
+		pia.config.logStatus(diag.Info, result.Description)
 	}
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335 // indirect
+	github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rubenv/sql-migrate v1.2.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1568,8 +1568,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335 h1:Lujy/rTbyRE1ZM8bkwm26Q1THtUELJ/Zy36BMlPzk+A=
-github.com/pulumi/cloud-ready-checks v1.0.1-0.20220105213132-0fbbc00d3335/go.mod h1:C6HmNtth9oPAWKyRJveZSU4rK/tvzhSGuoOV5y+S17g=
+github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd h1:shFTLvh3MZbBzVDr3xwYjUr5H1y3N5n4pczWtVaUZxo=
+github.com/pulumi/cloud-ready-checks v1.0.1-0.20230201174945-00fe9c1b68fd/go.mod h1:C6HmNtth9oPAWKyRJveZSU4rK/tvzhSGuoOV5y+S17g=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1 h1:NSgzjci0ykEoKC2BHmp/brP7/V8ARafl8ovr76B9Jak=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1/go.mod h1:XqciW5mPO8RxBEbN2/My9XjO829UQ2cHuhVLfoKM/yE=
 github.com/pulumi/pulumi/sdk/v3 v3.53.1 h1:fTYqe0fQiGshlOuHwpjOqQOb2SW3CSqXteeGcAuO+Bk=


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Fix a regression where the intermediate status of Job and Pod resources was no longer printed during an update.

The cloud-ready-checks package changed the way that messages are populated in the state checker. Previously, each condition was returned as a StatusMessage when the Update method was called. During the refactor, the Update method was replaced by the ReadyDetails method, which changed the return type. The updated return type includes a Description and an optional message that was only set when a problem was detected. The regression was caused by failing to print the description if the message was empty. Thus, intermediate status was still printed in case of errors, but was erroneously skipped on the happy path.

This change updates the two usages of this library to iterate the result objects and log each result as a status message. This approximates the previous behavior, and fixes the regression. The cloud-ready-checks package was intended to make this process easier, but the current interface still needs some work, since it shouldn't be necessary for clients to understand this nuance between the Description and Message field.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2298
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
