### PR TITLE
Fix for __inputs secrets #2300

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/obj/
 **/node_modules/
 **/.vs
+**/.vscode
 **/.idea
 **/.ionide
 .pulumi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 3.24.0 (February 6, 2023)
+
+- Fix unencrypted secrets in the state `outputs` after `Secret.get` #2300
 - Upgrade to latest helm and k8s client dependencies (https://github.com/pulumi/pulumi-kubernetes/pulls/2292)
 
 ## 3.23.1 (December 19, 2022)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2955,6 +2955,11 @@ func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resour
 		}
 	}
 
+	inputsCopy := resource.NewObjectProperty(inputsPM)
+	if inputs.GetKind() == "Secret" && !inputsPM.ContainsSecrets() {
+		inputsCopy = resource.MakeSecret(inputsCopy)
+	}
+
 	// Ensure that the annotation we add for lastAppliedConfig is treated as a secret if any of the inputs were secret
 	// (the value of this annotation is a string-ified JSON so marking the entire thing as a secret is really the best
 	// that we can do).
@@ -2970,7 +2975,7 @@ func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resour
 		}
 	}
 
-	object["__inputs"] = resource.NewObjectProperty(inputsPM)
+	object["__inputs"] = inputsCopy
 	object[initialAPIVersionKey] = resource.NewStringProperty(initialAPIVersion)
 	object[fieldManagerKey] = resource.NewStringProperty(fieldManager)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2931,6 +2931,8 @@ func initialAPIVersion(state resource.PropertyMap, oldConfig *unstructured.Unstr
 
 func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resource.PropertyMap,
 	initialAPIVersion, fieldManager string) resource.PropertyMap {
+	const SecretKind = "Secret"
+
 	object := resource.NewPropertyMapFromMap(live.Object)
 	inputsPM := resource.NewPropertyMapFromMap(inputs.Object)
 
@@ -2940,7 +2942,7 @@ func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resour
 	// For secrets, if `stringData` is present in the inputs, the API server will have filled in `data` based on it. By
 	// base64 encoding the secrets. We should mark any of the values which were secrets in the `stringData` object
 	// as secrets in the `data` field as well.
-	if live.GetAPIVersion() == "v1" && live.GetKind() == "Secret" {
+	if live.GetAPIVersion() == "v1" && live.GetKind() == SecretKind {
 		stringData, hasStringData := fromInputs["stringData"]
 		data, hasData := object["data"]
 
@@ -2956,7 +2958,7 @@ func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resour
 	}
 
 	inputsCopy := resource.NewObjectProperty(inputsPM)
-	if inputs.GetKind() == "Secret" && !inputsPM.ContainsSecrets() {
+	if inputs.GetKind() == SecretKind && !inputsPM.ContainsSecrets() {
 		inputsCopy = resource.MakeSecret(inputsCopy)
 	}
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -3352,6 +3352,9 @@ func annotateSecrets(outs, ins resource.PropertyMap) {
 		if data, hasData := outs["data"]; hasData {
 			outs["data"] = resource.MakeSecret(data)
 		}
+		if stringData, hasStringData := outs["stringData"]; hasStringData {
+			outs["stringData"] = resource.MakeSecret(stringData)
+		}
 		return
 	}
 


### PR DESCRIPTION
checkpointObject checks for secrets in the input, but in this case the input is of Kind "Secret" but `ContainsSecret()` is false. `annotateSecrets(inputsPM, fromInputs)` wouldn't do anything in any case because in this `Read()` call, `fromInputs` is empty.

I'm not quite sure yet that this is the best fix but it works in my local repro (described in the linked issue).

Fixes #2300