### PR TITLE
Fix: Moving yaml_decode, and using it in ConfigGroup as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Unreleased
 
+- moves `invoke_yaml_decode` into ConfigGroup for python (https://github.com/pulumi/pulumi-kubernetes/pull/2317)
 ## 3.24.0 (February 6, 2023)
 
-- Fix unencrypted secrets in the state `outputs` after `Secret.get` #2300
+- Fix unencrypted secrets in the state `outputs` after `Secret.get` (https://github.com/pulumi/pulumi-kubernetes/pull/2300)
 - Upgrade to latest helm and k8s client dependencies (https://github.com/pulumi/pulumi-kubernetes/pull/2292)
 - Fix await status for Job and Pod (https://github.com/pulumi/pulumi-kubernetes/pull/2299)
 

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -193,7 +193,7 @@ class ConfigGroup(pulumi.ComponentResource):
             invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
                                                provider=opts.provider if opts.provider else None)
 
-            __ret__ = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts).value['result']
+            __ret__ = invoke_yaml_decode(text, invoke_opts)
             resources = _parse_yaml_document(__ret__, opts, transformations, resource_prefix)
             # Add any new YAML resources to the ConfigGroup's resources
             self.resources = pulumi.Output.all(resources, self.resources).apply(lambda x: {**x[0], **x[1]})
@@ -344,10 +344,8 @@ class ConfigFile(pulumi.ComponentResource):
         # in package.json.
         invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
                                            provider=opts.provider if opts.provider else None)
-        def invoke_yaml_decode(text):
-            inv = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts)
-            return inv.value['result'] if inv is not None and inv.value is not None else []
-        __ret__ = invoke_yaml_decode(text)
+
+        __ret__ = invoke_yaml_decode(text, invoke_opts)
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the
@@ -516,3 +514,7 @@ def _parse_yaml_object(
     return [identifier.apply(
         lambda x: (f"{gvk}:{x}",
                    CustomResource(f"{x}", api_version, kind, spec, metadata, opts)))]
+
+def invoke_yaml_decode(text, invoke_opts):
+    inv = pulumi.runtime.invoke('kubernetes:yaml:decode', {'text': text}, invoke_opts)
+    return inv.value['result'] if inv is not None and inv.value is not None else []


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This moves the fix from: #2156 into ConfigGroup as well. It moves `invoke_yaml_decode` out of ConfigFile and reuses it in both places. 

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2309
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
