### PR TITLE
Handle CSA to SSA field manager conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Handle CSA to SSA field manager conflicts (https://github.com/pulumi/pulumi-kubernetes/pull/2354)
+
 ## 3.24.2 (March 16, 2023)
 
 - Update Pulumi Java SDK to v0.8.0 (https://github.com/pulumi/pulumi-kubernetes/pull/2337)

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	managedByLabel = "app.kubernetes.io/managed-by"
+	LabelManagedBy = "app.kubernetes.io/managed-by"
 )
 
 // TrySetLabel attempts to set the specified key/value pair as a label on the provided Unstructured
@@ -96,13 +96,13 @@ func TrySetManagedByLabel(obj *unstructured.Unstructured) (bool, error) {
 	if exists {
 		managedBy = labelVal
 	}
-	return TrySetLabel(obj, managedByLabel, managedBy)
+	return TrySetLabel(obj, LabelManagedBy, managedBy)
 }
 
 // HasManagedByLabel returns true if the object has the `app.kubernetes.io/managed-by` label set to the value
 // of `PULUMI_KUBERNETES_MANAGED_BY_LABEL` EnvVar, `pulumi`, or is a computed value.
 func HasManagedByLabel(obj *unstructured.Unstructured) bool {
-	val := GetLabel(obj, managedByLabel)
+	val := GetLabel(obj, LabelManagedBy)
 	if isComputedValue(val) {
 		return true
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: server-side-apply-upgrade
+description: Tests Server-side Apply CSA to SSA upgrade
+runtime: nodejs

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step1/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step1/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Some versions of k8s have started setting managed fields for all resources, even those managed by
+// Client-side Apply (CSA). This can cause field manager conflicts when a resource is upgraded to
+// Server-side Apply (SSA). This test validates the following scenario does not fail with a field manager conflict:
+// 1. Create a Deployment with Client-side Apply.
+// 2. Update the Provider to use Server-side Apply.
+// 3. Change a field in the Deployment.
+
+// Create provider with SSA disabled.
+export const provider = new k8s.Provider("k8s", {enableServerSideApply: false});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+const appLabels = { app: "nginx" };
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    metadata: {
+        namespace: ns.metadata.name,
+    },
+    spec: {
+        selector: { matchLabels: appLabels },
+        template: {
+            metadata: { labels: appLabels },
+            spec: {
+                containers: [{
+                    name: "nginx",
+                    image: "nginx:1.16",
+                }],
+            }
+        }
+    }
+}, { provider });

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step1/package.json
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step1/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "server-side-apply-upgrade",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step1/tsconfig.json
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step2/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step2/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Some versions of k8s have started setting managed fields for all resources, even those managed by
+// Client-side Apply (CSA). This can cause field manager conflicts when a resource is upgraded to
+// Server-side Apply (SSA). This test validates the following scenario does not fail with a field manager conflict:
+// 1. Create a Deployment with Client-side Apply.
+// 2. Update the Provider to use Server-side Apply.
+// 3. Change a field in the Deployment.
+
+// Create provider with SSA disabled.
+export const provider = new k8s.Provider("k8s", {enableServerSideApply: true}); // Enable SSA
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+const appLabels = { app: "nginx" };
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    metadata: {
+        namespace: ns.metadata.name,
+    },
+    spec: {
+        selector: { matchLabels: appLabels },
+        template: {
+            metadata: { labels: appLabels },
+            spec: {
+                containers: [{
+                    name: "nginx",
+                    image: "nginx:1.16",
+                }],
+            }
+        }
+    }
+}, { provider });

--- a/tests/sdk/nodejs/server-side-apply-upgrade/step3/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-upgrade/step3/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Some versions of k8s have started setting managed fields for all resources, even those managed by
+// Client-side Apply (CSA). This can cause field manager conflicts when a resource is upgraded to
+// Server-side Apply (SSA). This test validates the following scenario does not fail with a field manager conflict:
+// 1. Create a Deployment with Client-side Apply.
+// 2. Update the Provider to use Server-side Apply.
+// 3. Change a field in the Deployment.
+
+// Create provider with SSA disabled.
+export const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+const appLabels = { app: "nginx" };
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    metadata: {
+        namespace: ns.metadata.name,
+    },
+    spec: {
+        selector: { matchLabels: appLabels },
+        template: {
+            metadata: { labels: appLabels },
+            spec: {
+                containers: [{
+                    name: "nginx",
+                    image: "nginx:1.17", // Update a field to ensure that field manager conflicts don't cause an error
+                }],
+            }
+        }
+    }
+}, { provider });


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Some versions of k8s have started setting managed fields for all resources, even those managed by
Client-side Apply (CSA). This can cause field manager conflicts when a resource is upgraded to
Server-side Apply (SSA). This change detects this type of conflict and forces the patch to avoid raising an
error.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2352
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
