### PR TITLE
Do not await during .get or import operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Do not await during .get or import operations (https://github.com/pulumi/pulumi-kubernetes/pull/2373)
+
 ## 3.25.0 (April 11, 2023)
 - Update Kubernetes to v1.27.0
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -81,8 +81,9 @@ type CreateConfig struct {
 
 type ReadConfig struct {
 	ProviderConfig
-	Inputs *unstructured.Unstructured
-	Name   string
+	Inputs          *unstructured.Unstructured
+	Name            string
+	ReadFromCluster bool
 }
 
 type UpdateConfig struct {
@@ -299,9 +300,8 @@ func Read(c ReadConfig) (*unstructured.Unstructured, error) {
 	outputs, err := client.Get(c.Context, c.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
-	} else if c.Inputs == nil || len(c.Inputs.Object) == 0 {
-		// No inputs means that we do not manage the resource, i.e., it's a call to
-		// `CustomResource#get`. Simply return the object.
+	} else if c.ReadFromCluster {
+		// If the resource is read from a .get or an import, simply return the resource state from the cluster.
 		return outputs, nil
 	}
 

--- a/tests/sdk/nodejs/get/step1/index.ts
+++ b/tests/sdk/nodejs/get/step1/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,16 +20,40 @@ const namespace = new k8s.core.v1.Namespace("test-namespace");
 // `get`s the Kubernetes API service.
 //
 
-const svc = k8s.core.v1.Service.get("kube-api", "default/kubernetes");
+export const svc = k8s.core.v1.Service.get("kube-api", "default/kubernetes");
 
 // This will fail with a TypeError if the status was not populated (i.e. the .get isn't working)
 export const loadBalancer = svc.status.loadBalancer;
 
 //
+// Create a Service resource with skipAwait that would fail to initialize due to await logic.
+// get should return the resource state without gating on await logic.
+//
+
+export const awaitSvc = new k8s.core.v1.Service("svc", {
+    metadata: {
+        name: "test",
+        namespace: namespace.metadata.name,
+        annotations: {
+            "pulumi.com/skipAwait": "true",
+        },
+    },
+    spec: {
+        type: k8s.types.enums.core.v1.ServiceSpecType.ClusterIP,
+        ports: [{
+            name: "http",
+            port: 8080,
+            targetPort: 80,
+        }],
+        selector: { app: "nginx" }, // selector doesn't match Pods, so await logic would fail
+    }
+});
+
+//
 // Create a CustomResourceDefinition, a CustomResource, and then `.get` it.
 //
 
-const ct = new k8s.apiextensions.v1.CustomResourceDefinition("crontab", {
+export const ct = new k8s.apiextensions.v1.CustomResourceDefinition("crontab", {
     metadata: { name: "crontabs.stable.example.com" },
     spec: {
         group: "stable.example.com",
@@ -71,7 +95,7 @@ const ct = new k8s.apiextensions.v1.CustomResourceDefinition("crontab", {
     }
 });
 
-new k8s.apiextensions.CustomResource(
+export const cr = new k8s.apiextensions.CustomResource(
     "my-new-cron-object",
     {
         apiVersion: "stable.example.com/v1",


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Changes to the provider logic invalidated a check in the await Read method that was supposed to return the cluster state without await checks in the case of a .get or import. As a result, await logic was always executed against resources during a Read operation. This could lead to deadlocks and timeouts in cases where the await logic causes a cyclic dependency.

This change fixes the check so that the provider does not perform await logic on resources during a .get or import operation.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2372 
Related https://github.com/pulumi/pulumi-kubernetes/issues/1656
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
