### PR TITLE
Change destroy operation to use foreground cascading delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Change destroy operation to use foreground cascading delete (https://github.com/pulumi/pulumi-kubernetes/pull/2379)
+
 ## 3.26.0 (May 1, 2023)
 
 - Do not await during .get or import operations (https://github.com/pulumi/pulumi-kubernetes/pull/2373)

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -686,20 +686,9 @@ func deleteResource(
 		boolFalse := false
 		// nolint
 		deleteOpts.OrphanDependents = &boolFalse
-	} else if version.Compare(cluster.ServerVersion{Major: 1, Minor: 7}) < 0 {
-		// 1.6.x option. Background delete propagation is broken in k8s v1.6.
+	} else {
 		fg := metav1.DeletePropagationForeground
 		deleteOpts.PropagationPolicy = &fg
-	} else {
-		// > 1.7.x. Prior to 1.9.x, the default is to orphan children[1]. Our kubespy experiments
-		// with 1.9.11 show that the controller will actually _still_ mark these resources with the
-		// `orphan` finalizer, although it appears to actually do background delete correctly. We
-		// therefore set it to background manually, just to be safe.
-		//
-		// nolint
-		// [1] https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy
-		bg := metav1.DeletePropagationBackground
-		deleteOpts.PropagationPolicy = &bg
 	}
 
 	// Issue deletion request.


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
By default, Kubernetes uses "background cascading deletion" (BCD) to clean up resources. This works in most cases with the eventual consistency model as resources are garbage collected. However, there are cases where BCD can lead to stuck resources due to race conditions between dependents. A concrete example is an application Deployment that includes a volume mount managed by a Container Storage Interface (CSI) driver. The underlying Pods managed by this Deployment depend on the CSI driver to unmount the volume on teardown, and this process can take some time. Thus, if a Namespace containing both the CSI driver and the application Deployment is deleted, it is possible for the CSI driver to be removed before it has finished tearing down the application Pods, leaving them stuck in a "Terminating" state.

A reliable way to avoid this race condition is by using "foreground cascading deletion" (FCD) instead. FCD blocks deletion of the parent resource until any children have been deleted. In the previous example, the application Deployment resource would not be deleted until all of the underlying Pods had unmounted the CSI volume and finished terminating. Once the application Deployment is gone, then Pulumi can safely clean up the CSI driver as well.

One downside of this approach is that resource deletion can take longer to resolve since Kubernetes is explicitly waiting on the delete operation to complete. However, this increases reliability of the delete operation by making it less prone to race conditions, so the tradeoff seems worth it.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/customer-support/issues/931
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
