### PR TITLE
Increase default client burst and QPS to avoid throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Update Kubernetes client library to v0.27.1 (https://github.com/pulumi/pulumi-kubernetes/pull/2380)
+- Increase default client burst and QPS to avoid throttling (https://github.com/pulumi/pulumi-kubernetes/pull/2381)
 
 ## 3.27.0 (May 9, 2023)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -672,6 +672,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 			return nil, fmt.Errorf("invalid value specified for PULUMI_K8S_CLIENT_BURST: %w", err)
 		}
 		kubeClientSettings.Burst = &asInt
+	} else {
+		v := 120 // Increased from default value of 10
+		kubeClientSettings.Burst = &v
 	}
 
 	if qps := os.Getenv("PULUMI_K8S_CLIENT_QPS"); qps != "" && kubeClientSettings.QPS == nil {
@@ -680,6 +683,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 			return nil, fmt.Errorf("invalid value specified for PULUMI_K8S_CLIENT_QPS: %w", err)
 		}
 		kubeClientSettings.QPS = &asFloat
+	} else {
+		v := 50.0 // Increased from default value of 5.0
+		kubeClientSettings.QPS = &v
 	}
 
 	// Attempt to load the configuration from the provided kubeconfig. If this fails, mark the cluster as unreachable.


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The default Kubernetes client rate limits are conservative, and Pulumi frequently exceeds them for typical stacks. Increase the defaults to avoid throttling clients during normal usage.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Related https://github.com/pulumi/pulumi-kubernetes/issues/1228
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
