### PR TITLE
Add HTTP request timeout option to KubeClientSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update Kubernetes client library to v0.27.1 (https://github.com/pulumi/pulumi-kubernetes/pull/2380)
 - Increase default client burst and QPS to avoid throttling (https://github.com/pulumi/pulumi-kubernetes/pull/2381)
+- Add HTTP request timeout option to KubeClientSettings (https://github.com/pulumi/pulumi-kubernetes/pull/2383)
 
 ## 3.27.0 (May 9, 2023)
 

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -467,6 +467,15 @@ var kubeClientSettings = pschema.ComplexTypeSpec{
 					},
 				},
 			},
+			"timeout": {
+				Description: "Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.",
+				TypeSpec:    pschema.TypeSpec{Type: "integer"},
+				DefaultInfo: &pschema.DefaultSpec{
+					Environment: []string{
+						"PULUMI_K8S_CLIENT_TIMEOUT",
+					},
+				},
+			},
 		},
 		Type: "object",
 	},

--- a/provider/pkg/provider/types.go
+++ b/provider/pkg/provider/types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,4 +37,6 @@ type KubeClientSettings struct {
 	Burst *int `json:"burst"`
 	// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
 	QPS *float64 `json:"qps"`
+	// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+	Timeout *int `json:"timeout"`
 }

--- a/sdk/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/sdk/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -27,10 +27,17 @@ namespace Pulumi.Kubernetes.Types.Inputs.Provider
         [Input("qps")]
         public Input<double>? Qps { get; set; }
 
+        /// <summary>
+        /// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+        /// </summary>
+        [Input("timeout")]
+        public Input<int>? Timeout { get; set; }
+
         public KubeClientSettingsArgs()
         {
             Burst = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_BURST");
             Qps = Utilities.GetEnvDouble("PULUMI_K8S_CLIENT_QPS");
+            Timeout = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_TIMEOUT");
         }
         public static new KubeClientSettingsArgs Empty => new KubeClientSettingsArgs();
     }

--- a/sdk/go/kubernetes/pulumiTypes.go
+++ b/sdk/go/kubernetes/pulumiTypes.go
@@ -284,6 +284,8 @@ type KubeClientSettings struct {
 	Burst *int `pulumi:"burst"`
 	// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
 	Qps *float64 `pulumi:"qps"`
+	// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+	Timeout *int `pulumi:"timeout"`
 }
 
 // Defaults sets the appropriate defaults for KubeClientSettings
@@ -299,6 +301,10 @@ func (val *KubeClientSettings) Defaults() *KubeClientSettings {
 	if tmp.Qps == nil {
 		qps_ := getEnvOrDefault(0.0, parseEnvFloat, "PULUMI_K8S_CLIENT_QPS").(float64)
 		tmp.Qps = &qps_
+	}
+	if tmp.Timeout == nil {
+		timeout_ := getEnvOrDefault(0, parseEnvInt, "PULUMI_K8S_CLIENT_TIMEOUT").(int)
+		tmp.Timeout = &timeout_
 	}
 	return &tmp
 }
@@ -320,6 +326,8 @@ type KubeClientSettingsArgs struct {
 	Burst pulumi.IntPtrInput `pulumi:"burst"`
 	// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
 	Qps pulumi.Float64PtrInput `pulumi:"qps"`
+	// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+	Timeout pulumi.IntPtrInput `pulumi:"timeout"`
 }
 
 // Defaults sets the appropriate defaults for KubeClientSettingsArgs
@@ -333,6 +341,9 @@ func (val *KubeClientSettingsArgs) Defaults() *KubeClientSettingsArgs {
 	}
 	if tmp.Qps == nil {
 		tmp.Qps = pulumi.Float64Ptr(getEnvOrDefault(0.0, parseEnvFloat, "PULUMI_K8S_CLIENT_QPS").(float64))
+	}
+	if tmp.Timeout == nil {
+		tmp.Timeout = pulumi.IntPtr(getEnvOrDefault(0, parseEnvInt, "PULUMI_K8S_CLIENT_TIMEOUT").(int))
 	}
 	return &tmp
 }
@@ -424,6 +435,11 @@ func (o KubeClientSettingsOutput) Qps() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v KubeClientSettings) *float64 { return v.Qps }).(pulumi.Float64PtrOutput)
 }
 
+// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+func (o KubeClientSettingsOutput) Timeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v KubeClientSettings) *int { return v.Timeout }).(pulumi.IntPtrOutput)
+}
+
 type KubeClientSettingsPtrOutput struct{ *pulumi.OutputState }
 
 func (KubeClientSettingsPtrOutput) ElementType() reflect.Type {
@@ -466,6 +482,16 @@ func (o KubeClientSettingsPtrOutput) Qps() pulumi.Float64PtrOutput {
 		}
 		return v.Qps
 	}).(pulumi.Float64PtrOutput)
+}
+
+// Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+func (o KubeClientSettingsPtrOutput) Timeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *KubeClientSettings) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Timeout
+	}).(pulumi.IntPtrOutput)
 }
 
 func init() {

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/inputs/KubeClientSettingsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/inputs/KubeClientSettingsArgs.java
@@ -51,11 +51,27 @@ public final class KubeClientSettingsArgs extends com.pulumi.resources.ResourceA
         return Optional.ofNullable(this.qps);
     }
 
+    /**
+     * Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+     * 
+     */
+    @Import(name="timeout")
+    private @Nullable Output<Integer> timeout;
+
+    /**
+     * @return Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+     * 
+     */
+    public Optional<Output<Integer>> timeout() {
+        return Optional.ofNullable(this.timeout);
+    }
+
     private KubeClientSettingsArgs() {}
 
     private KubeClientSettingsArgs(KubeClientSettingsArgs $) {
         this.burst = $.burst;
         this.qps = $.qps;
+        this.timeout = $.timeout;
     }
 
     public static Builder builder() {
@@ -118,9 +134,31 @@ public final class KubeClientSettingsArgs extends com.pulumi.resources.ResourceA
             return qps(Output.of(qps));
         }
 
+        /**
+         * @param timeout Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder timeout(@Nullable Output<Integer> timeout) {
+            $.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * @param timeout Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder timeout(Integer timeout) {
+            return timeout(Output.of(timeout));
+        }
+
         public KubeClientSettingsArgs build() {
             $.burst = Codegen.integerProp("burst").output().arg($.burst).env("PULUMI_K8S_CLIENT_BURST").getNullable();
             $.qps = Codegen.doubleProp("qps").output().arg($.qps).env("PULUMI_K8S_CLIENT_QPS").getNullable();
+            $.timeout = Codegen.integerProp("timeout").output().arg($.timeout).env("PULUMI_K8S_CLIENT_TIMEOUT").getNullable();
             return $;
         }
     }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -59,6 +59,10 @@ export interface KubeClientSettings {
      * Maximum queries per second (QPS) to the API server from this client. Default value is 5.
      */
     qps?: pulumi.Input<number>;
+    /**
+     * Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+     */
+    timeout?: pulumi.Input<number>;
 }
 /**
  * kubeClientSettingsProvideDefaults sets the appropriate defaults for KubeClientSettings
@@ -68,6 +72,7 @@ export function kubeClientSettingsProvideDefaults(val: KubeClientSettings): Kube
         ...val,
         burst: (val.burst) ?? utilities.getEnvNumber("PULUMI_K8S_CLIENT_BURST"),
         qps: (val.qps) ?? utilities.getEnvNumber("PULUMI_K8S_CLIENT_QPS"),
+        timeout: (val.timeout) ?? utilities.getEnvNumber("PULUMI_K8S_CLIENT_TIMEOUT"),
     };
 }
 export namespace admissionregistration {

--- a/sdk/python/pulumi_kubernetes/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/_inputs.py
@@ -116,11 +116,13 @@ class HelmReleaseSettingsArgs:
 class KubeClientSettingsArgs:
     def __init__(__self__, *,
                  burst: Optional[pulumi.Input[int]] = None,
-                 qps: Optional[pulumi.Input[float]] = None):
+                 qps: Optional[pulumi.Input[float]] = None,
+                 timeout: Optional[pulumi.Input[int]] = None):
         """
         Options for tuning the Kubernetes client used by a Provider.
         :param pulumi.Input[int] burst: Maximum burst for throttle. Default value is 10.
         :param pulumi.Input[float] qps: Maximum queries per second (QPS) to the API server from this client. Default value is 5.
+        :param pulumi.Input[int] timeout: Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
         """
         if burst is None:
             burst = _utilities.get_env_int('PULUMI_K8S_CLIENT_BURST')
@@ -130,6 +132,10 @@ class KubeClientSettingsArgs:
             qps = _utilities.get_env_float('PULUMI_K8S_CLIENT_QPS')
         if qps is not None:
             pulumi.set(__self__, "qps", qps)
+        if timeout is None:
+            timeout = _utilities.get_env_int('PULUMI_K8S_CLIENT_TIMEOUT')
+        if timeout is not None:
+            pulumi.set(__self__, "timeout", timeout)
 
     @property
     @pulumi.getter
@@ -154,5 +160,17 @@ class KubeClientSettingsArgs:
     @qps.setter
     def qps(self, value: Optional[pulumi.Input[float]]):
         pulumi.set(self, "qps", value)
+
+    @property
+    @pulumi.getter
+    def timeout(self) -> Optional[pulumi.Input[int]]:
+        """
+        Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+        """
+        return pulumi.get(self, "timeout")
+
+    @timeout.setter
+    def timeout(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "timeout", value)
 
 


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The HTTP client used to communicate with the Kubernetes server has a default timeout of 32 seconds. In some cases, this timeout is too low, and causes failures during provider initialization. Add an option to override this timeout value. The timeout value can be overridden in the following ways, in order of precedence:

1. The `kubeClientSettings:timeout` parameter for the Provider
2. The PULUMI_K8S_CLIENT_TIMEOUT environment variable

Note that this is distinct from the timeouts resource option, which controls how long Pulumi will wait for a resource operation to complete.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/1839
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
