### PR TITLE
Handle resource change from static name to autoname under SSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Handle resource change from static name to autoname under SSA (https://github.com/pulumi/pulumi-kubernetes/pull/2392)
+
 ## 3.27.1 (May 11, 2023)
 
 - Update Kubernetes client library to v0.27.1 (https://github.com/pulumi/pulumi-kubernetes/pull/2380)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1654,6 +1654,10 @@ func (k *kubeProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*p
 				switch v.Kind {
 				case pulumirpc.PropertyDiff_ADD_REPLACE, pulumirpc.PropertyDiff_DELETE_REPLACE, pulumirpc.PropertyDiff_UPDATE_REPLACE:
 					replaces = append(replaces, k)
+				case pulumirpc.PropertyDiff_DELETE:
+					if k == "metadata" {
+						replaces = append(replaces, k)
+					}
 				}
 			}
 		}

--- a/tests/sdk/nodejs/server-side-apply/step1/index.ts
+++ b/tests/sdk/nodejs/server-side-apply/step1/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import * as k8s from "@pulumi/kubernetes";
 // 4. Patch the Deployment with a partially-specified configuration.
 // 5. Replace a statically-named ConfigMap resource by changing the data on a subsequent update.
 // 6. Ignore changes specified in the ignoreChanges resource option.
+// 7. Statically-named Namespace can be changed to an auto-named Namespace.
 
 // Create provider with SSA enabled.
 const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
@@ -151,4 +152,10 @@ new k8s.core.v1.ConfigMap("test", {
         namespace: ns.metadata.name,
     },
     data: {foo: "bar"}, // <-- Updated value
+}, {provider});
+
+new k8s.core.v1.Namespace("name", {
+    metadata: {
+        name: "test", // Specify a static name.
+    },
 }, {provider});

--- a/tests/sdk/nodejs/server-side-apply/step2/index.ts
+++ b/tests/sdk/nodejs/server-side-apply/step2/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import * as k8s from "@pulumi/kubernetes";
 // 4. Patch the Deployment with a partially-specified configuration.
 // 5. Replace a statically-named ConfigMap resource by changing the data on a subsequent update.
 // 6. Ignore changes specified in the ignoreChanges resource option.
+// 7. Statically-named Namespace can be changed to an auto-named Namespace.
 
 // Create provider with SSA enabled.
 const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
@@ -178,4 +179,8 @@ new k8s.core.v1.ConfigMap("test", {
         namespace: ns.metadata.name,
     },
     data: {foo: "baz"}, // <-- Updated value
+}, {provider});
+
+new k8s.core.v1.Namespace("name", {
+    // Remove the static name to force an auto-name.
 }, {provider});

--- a/tests/sdk/nodejs/server-side-apply/step3/index.ts
+++ b/tests/sdk/nodejs/server-side-apply/step3/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import * as k8s from "@pulumi/kubernetes";
 // 4. Patch the Deployment with a partially-specified configuration.
 // 5. Replace a statically-named ConfigMap resource by changing the data on a subsequent update.
 // 6. Ignore changes specified in the ignoreChanges resource option.
+// 7. Statically-named Namespace can be changed to an auto-named Namespace.
 
 // Create provider with SSA enabled.
 const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
@@ -179,3 +180,7 @@ new k8s.core.v1.ConfigMap("test", {
     },
     data: {foo: "bar"}, // <-- Updated value
 }, {provider, ignoreChanges: ["data.*"]}); // <-- Ignore updated value
+
+new k8s.core.v1.Namespace("name", {
+    // Remove the static name to force an auto-name.
+}, {provider});


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Server-side apply mode had a bug where changing a resource from having a static `.metadata.name` to being autonamed by removing the `.metadata` property would return an error. This change updates the diff logic to account for this case, which will result in the resource being replaced.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2384 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
