### PR TITLE
Improve local helm chart validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Handle resource change from static name to autoname under SSA (https://github.com/pulumi/pulumi-kubernetes/pull/2392)
+- Fix Helm release creation when the name of the chart conflicts with the name of a folder in the current working directory (https://github.com/pulumi/pulumi-kubernetes/pull/2410)
 
 ## 3.27.1 (May 11, 2023)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1403,7 +1403,7 @@ func locateChart(cpo *action.ChartPathOptions, registryClient *registry.Client, 
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(cpo.Version)
 
-	if _, err := os.Stat(name); err == nil {
+	if _, err := os.Stat(filepath.Join(name, "Chart.yaml")); err == nil {
 		abs, err := filepath.Abs(name)
 		if err != nil {
 			return abs, err


### PR DESCRIPTION
### Proposed changes

The `helm.NewRelease(…)` function has some logic to look for a local chart before trying to contact a remote registry, even if a `RepositoryOpts.Repo` parameter has been explicitly provided.

This is an issue when the chart we want to create a release from has a name that conflicts with a local folder name.

This change improves the logic and considers a local directory to be a valid chart only if it contains a `Chart.yaml` file.

### Related issues (optional)

* #2409
