### PR TITLE
Improve check for existing resource GVK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix Helm release creation when the name of the chart conflicts with the name of a folder in the current working directory (https://github.com/pulumi/pulumi-kubernetes/pull/2410)
 - Remove imperative authentication and authorization resources: TokenRequest, TokenReview, LocalSubjectAccessReview, 
     SelfSubjectReview, SelfSubjectAccessReview, SelfSubjectRulesReview, and SubjectAccessReview (https://github.com/pulumi/pulumi-kubernetes/pull/2413)
+- Improve check for existing resource GVK (https://github.com/pulumi/pulumi-kubernetes/pull/2418)
 
 ## 3.27.1 (May 11, 2023)
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Part of the provider's preview and update logic involves checking whether a given GroupVersionKind (GVK) is registered with the Kubernetes cluster. A previous version of this check was implemented as an anonymous function in the provider's `Check` method. This implementation used a set to cache results of the check, but the cache was not saved between invocations, so it was adding unneccesary overhead to the check.

This change reimplements the GVK check as a reusable method, and simplifies the checking logic. We can implement a cache later if needed, but this should already be an improvement over the previous implementation.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
