### PR TITLE
Automatically fall back to client-side preview if server-side preview fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Breaking changes:
 
 ## Unreleased
 
+- Automatically fall back to client-side preview if server-side preview fails (https://github.com/pulumi/pulumi-kubernetes/pull/2419)
+
 ## 3.28.0 (May 19, 2023)
 
 Breaking changes:

--- a/provider/pkg/cluster/version.go
+++ b/provider/pkg/cluster/version.go
@@ -66,8 +66,6 @@ func TryGetServerVersion(cdi discovery.CachedDiscoveryInterface) ServerVersion {
 		if v, err := parseVersion(sv); err == nil {
 			return v
 		}
-
-		return defaultSV
 	}
 
 	return defaultSV

--- a/tests/sdk/nodejs/server-side-apply-preview/manifest.yaml
+++ b/tests/sdk/nodejs/server-side-apply-preview/manifest.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeconfig-sa
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sa-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: kubeconfig-sa
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: view-only
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: kubeconfig-sa
+    namespace: kube-system

--- a/tests/sdk/nodejs/server-side-apply-preview/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/server-side-apply-preview/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: server-side-apply-preview-tests
+description: Tests Server-side Apply preview support with view-only user permissions
+runtime: nodejs

--- a/tests/sdk/nodejs/server-side-apply-preview/step1/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-preview/step1/index.ts
@@ -1,0 +1,40 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test creates a Provider with `enableServerSideApply` enabled. The following scenarios are tested:
+// 1. Create a namespace and ConfigMap with pulumi.
+// 2. Change the provider context to use a ServiceAccount with view-only permission.
+// 3. Change the ConfigMap and run a preview to confirm that the provider falls back to a Client-side preview when
+//    the user does not have permission to perform the "patch" operation used for SSA diff.
+// 4. Change the provider context back to default to allow the update to succeed and clean up.
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    enableConfigMapMutable: true,
+    // context: "kubeconfig-sa",
+});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+export const cm = new k8s.core.v1.ConfigMap("test", {
+    metadata: {
+        name: "foo",
+        namespace: ns.metadata.name,
+    },
+    data: {dataKey: "fake data"},
+}, {provider});

--- a/tests/sdk/nodejs/server-side-apply-preview/step1/package.json
+++ b/tests/sdk/nodejs/server-side-apply-preview/step1/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "server-side-apply-preview",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/server-side-apply-preview/step1/tsconfig.json
+++ b/tests/sdk/nodejs/server-side-apply-preview/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/server-side-apply-preview/step2/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-preview/step2/index.ts
@@ -1,0 +1,40 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test creates a Provider with `enableServerSideApply` enabled. The following scenarios are tested:
+// 1. Create a namespace and ConfigMap with pulumi.
+// 2. Change the provider context to use a ServiceAccount with view-only permission.
+// 3. Change the ConfigMap and run a preview to confirm that the provider falls back to a Client-side preview when
+//    the user does not have permission to perform the "patch" operation used for SSA diff.
+// 4. Change the provider context back to default to allow the update to succeed and clean up.
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    enableConfigMapMutable: true,
+    context: "kubeconfig-sa", // Set the context to the "view"-only ServiceAccount user.
+});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+export const cm = new k8s.core.v1.ConfigMap("test", {
+    metadata: {
+        name: "foo",
+        namespace: ns.metadata.name,
+    },
+    data: {dataKey: "fake data"},
+}, {provider});

--- a/tests/sdk/nodejs/server-side-apply-preview/step3/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-preview/step3/index.ts
@@ -1,0 +1,40 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test creates a Provider with `enableServerSideApply` enabled. The following scenarios are tested:
+// 1. Create a namespace and ConfigMap with pulumi.
+// 2. Change the provider context to use a ServiceAccount with view-only permission.
+// 3. Change the ConfigMap and run a preview to confirm that the provider falls back to a Client-side preview when
+//    the user does not have permission to perform the "patch" operation used for SSA diff.
+// 4. Change the provider context back to default to allow the update to succeed and clean up.
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    enableConfigMapMutable: true,
+    context: "kubeconfig-sa", // Set the context to the "view"-only ServiceAccount user.
+});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+export const cm = new k8s.core.v1.ConfigMap("test", {
+    metadata: {
+        name: "foo",
+        namespace: ns.metadata.name,
+    },
+    data: {dataKey: "updated"}, // Update the data.
+}, {provider});

--- a/tests/sdk/nodejs/server-side-apply-preview/step4/index.ts
+++ b/tests/sdk/nodejs/server-side-apply-preview/step4/index.ts
@@ -1,0 +1,40 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test creates a Provider with `enableServerSideApply` enabled. The following scenarios are tested:
+// 1. Create a namespace and ConfigMap with pulumi.
+// 2. Change the provider context to use a ServiceAccount with view-only permission.
+// 3. Change the ConfigMap and run a preview to confirm that the provider falls back to a Client-side preview when
+//    the user does not have permission to perform the "patch" operation used for SSA diff.
+// 4. Change the provider context back to default to allow the update to succeed and clean up.
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    enableConfigMapMutable: true,
+    // context: "kubeconfig-sa", // Switch back to default context.
+});
+
+// Create a randomly-named Namespace.
+const ns = new k8s.core.v1.Namespace("test", undefined, {provider});
+
+export const cm = new k8s.core.v1.ConfigMap("test", {
+    metadata: {
+        name: "foo",
+        namespace: ns.metadata.name,
+    },
+    data: {dataKey: "fake data"},
+}, {provider});


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Server-side apply previews currently require "patch" permission to run. For cases where the user doesn't have permission to perform a "patch" operation, attempt a graceful fallback to Client-side preview. The Client-side preview may not be 100% accurate, but is preferable to failing with a permission error.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2411
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
