### PR TITLE
Ignore local directories when helm.NewRelease is provided a repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Handle resource change from static name to autoname under SSA (https://github.com/pulumi/pulumi-kubernetes/pull/2392)
-- Fix Helm release creation when the name of the chart conflicts with the name of a folder in the current working directory (https://github.com/pulumi/pulumi-kubernetes/pull/2410)
+- Fix Helm release creation when the name of the chart conflicts with the name of a folder in the current working directory (https://github.com/pulumi/pulumi-kubernetes/pull/2410, https://github.com/pulumi/pulumi-kubernetes/pull/2420)
 - Remove imperative authentication and authorization resources: TokenRequest, TokenReview, LocalSubjectAccessReview, 
     SelfSubjectReview, SelfSubjectAccessReview, SelfSubjectRulesReview, and SubjectAccessReview (https://github.com/pulumi/pulumi-kubernetes/pull/2413)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1403,7 +1403,7 @@ func locateChart(cpo *action.ChartPathOptions, registryClient *registry.Client, 
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(cpo.Version)
 
-	if _, err := os.Stat(filepath.Join(name, "Chart.yaml")); err == nil {
+	if _, err := os.Stat(filepath.Join(name, "Chart.yaml")); err == nil && cpo.RepoURL == "" {
 		abs, err := filepath.Abs(name)
 		if err != nil {
 			return abs, err


### PR DESCRIPTION
### Proposed changes

This is a follow-up of #2410 aiming at addressing [this comment](https://github.com/pulumi/pulumi-kubernetes/issues/2409#issuecomment-1550253245).

When `helm.NewRelease(…)` is explicitly invoked with a non-empty `RepositoryOpts.Repo` parameter, it indicates a clear intent of fetching the chart from a remote repository. In such a case, we should most probably completely skip the logic looking for a local chart inside the current working directory.

### Related issues (optional)

* Fixes #2409