### PR TITLE
Add a "strict mode" configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add a "strict mode" configuration option (https://github.com/pulumi/pulumi-kubernetes/pull/2425)
+
 ## 3.28.0 (May 19, 2023)
 
 - Handle resource change from static name to autoname under SSA (https://github.com/pulumi/pulumi-kubernetes/pull/2392)

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -102,6 +102,10 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					Description: "If present and set to true, suppress unsupported Helm hook warnings from the CLI.\n\nThis config can be specified in the following ways, using this precedence:\n1. This `suppressHelmHookWarnings` parameter.\n2. The `PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
+				"strictMode": {
+					Description: "If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 			},
 		},
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/openapi"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/ssa"
 	pulumischema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -254,6 +255,44 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 			}
 		}
 		return false
+	}
+
+	strictMode := false
+	if pConfig, ok := k.loadPulumiConfig(); ok {
+		if v, ok := pConfig["strictMode"]; ok {
+			if v, ok := v.(string); ok {
+				strictMode = v == "true"
+			}
+		}
+	}
+	if v := news["strictMode"]; v.HasValue() && v.IsString() {
+		strictMode = v.StringValue() == "true"
+	}
+
+	if strictMode && providers.IsProviderType(urn.Type()) {
+		var failures []*pulumirpc.CheckFailure
+
+		if providers.IsDefaultProvider(urn) {
+			failures = append(failures, &pulumirpc.CheckFailure{
+				Reason: fmt.Sprintf("strict mode prohibits default provider"),
+			})
+		}
+		if v := news["kubeconfig"]; !v.HasValue() || v.StringValue() == "" {
+			failures = append(failures, &pulumirpc.CheckFailure{
+				Property: "kubeconfig",
+				Reason:   fmt.Sprintf(`strict mode requires Provider "kubeconfig" argument`),
+			})
+		}
+		if v := news["context"]; !v.HasValue() || v.StringValue() == "" {
+			failures = append(failures, &pulumirpc.CheckFailure{
+				Property: "context",
+				Reason:   fmt.Sprintf(`strict mode requires Provider "context" argument`),
+			})
+		}
+
+		if len(failures) > 0 {
+			return &pulumirpc.CheckResponse{Inputs: req.GetNews(), Failures: failures}, nil
+		}
 	}
 
 	renderYamlEnabled := truthyValue("renderYamlToDirectory", news)
@@ -2865,6 +2904,28 @@ func (k *kubeProvider) gvkExists(obj *unstructured.Unstructured) bool {
 		return false
 	}
 	return true
+}
+
+// loadPulumiConfig loads the PULUMI_CONFIG environment variable set by the engine, unmarshals the JSON string into
+// a map, and returns the map and a bool indicating if the operation succeeded.
+func (k *kubeProvider) loadPulumiConfig() (map[string]interface{}, bool) {
+	configStr, ok := os.LookupEnv("PULUMI_CONFIG")
+	// PULUMI_CONFIG is not set on older versions of the engine, so check if the lookup succeeds.
+	if !ok || configStr == "" {
+		return nil, false
+	}
+
+	// PULUMI_CONFIG should be a JSON string that looks something like this:
+	// {"enableServerSideApply":"true","kubeClientSettings":"{\"burst\":120,\"qps\":50}","strictMode":"true"}
+	// The keys correspond to any project/stack config with a "kubernetes" prefix.
+	var pConfig map[string]interface{}
+	err := json.Unmarshal([]byte(configStr), &pConfig)
+	if err != nil {
+		logger.V(3).Infof("failed to load provider config from PULUMI_CONFIG")
+		return nil, false
+	}
+
+	return pConfig, true
 }
 
 func mapReplStripSecrets(v resource.PropertyValue) (interface{}, bool) {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2921,7 +2921,7 @@ func (k *kubeProvider) loadPulumiConfig() (map[string]interface{}, bool) {
 	var pConfig map[string]interface{}
 	err := json.Unmarshal([]byte(configStr), &pConfig)
 	if err != nil {
-		logger.V(3).Infof("failed to load provider config from PULUMI_CONFIG")
+		logger.V(3).Infof("failed to load provider config from PULUMI_CONFIG: %v", err)
 		return nil, false
 	}
 

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -151,6 +151,16 @@ namespace Pulumi.Kubernetes
             set => _renderYamlToDirectory.Set(value);
         }
 
+        private static readonly __Value<bool?> _strictMode = new __Value<bool?>(() => __config.GetBoolean("strictMode"));
+        /// <summary>
+        /// If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.
+        /// </summary>
+        public static bool? StrictMode
+        {
+            get => _strictMode.Get();
+            set => _strictMode.Set(value);
+        }
+
         private static readonly __Value<bool?> _suppressDeprecationWarnings = new __Value<bool?>(() => __config.GetBoolean("suppressDeprecationWarnings"));
         /// <summary>
         /// If present and set to true, suppress apiVersion deprecation warnings from the CLI.

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -81,6 +81,11 @@ func GetRenderYamlToDirectory(ctx *pulumi.Context) string {
 	return config.Get(ctx, "kubernetes:renderYamlToDirectory")
 }
 
+// If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.
+func GetStrictMode(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:strictMode")
+}
+
 // If present and set to true, suppress apiVersion deprecation warnings from the CLI.
 //
 // This config can be specified in the following ways, using this precedence:

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
@@ -101,6 +101,13 @@ public final class Config {
         return Codegen.stringProp("renderYamlToDirectory").config(config).get();
     }
 /**
+ * If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.
+ * 
+ */
+    public Optional<Boolean> strictMode() {
+        return Codegen.booleanProp("strictMode").config(config).get();
+    }
+/**
  * If present and set to true, suppress apiVersion deprecation warnings from the CLI.
  * 
  * This config can be specified in the following ways, using this precedence:

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -1379,6 +1379,8 @@ func TestStrictMode(t *testing.T) {
 						}
 					}
 					assert.Truef(t, foundMessage, "did not find expected failure message: %q", msg)
+					_, ok := stackInfo.Outputs["cm"]
+					assert.Falsef(t, ok, "ConfigMap should not be present since Provider is invalid")
 				},
 			},
 			{
@@ -1396,6 +1398,8 @@ func TestStrictMode(t *testing.T) {
 						}
 					}
 					assert.Truef(t, foundMessage, "did not find expected failure message: %q", msg)
+					_, ok := stackInfo.Outputs["cm"]
+					assert.Falsef(t, ok, "ConfigMap should not be present since Provider is invalid")
 				},
 			},
 		},

--- a/tests/sdk/nodejs/strict-mode/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/strict-mode/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: strict-mode
+description: Tests strict mode provider configuration.
+runtime: nodejs

--- a/tests/sdk/nodejs/strict-mode/step1/index.ts
+++ b/tests/sdk/nodejs/strict-mode/step1/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test validates the following restrictions enforced by "strict mode":
+// 1. Default providers are not allowed.
+// 2. Each Provider requires a "kubeconfig" argument.
+// 3. Each Provider requires a "context" argument.
+
+// Create a ConfigMap using the default provider.
+new k8s.core.v1.ConfigMap("default", {
+    data: {foo: "bar"},
+});

--- a/tests/sdk/nodejs/strict-mode/step1/package.json
+++ b/tests/sdk/nodejs/strict-mode/step1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "strict-mode",
+  "version": "0.1.0",
+  "dependencies": {
+    "@pulumi/pulumi": "latest"
+  },
+  "devDependencies": {
+  },
+  "peerDependencies": {
+    "@pulumi/kubernetes": "latest"
+  }
+}

--- a/tests/sdk/nodejs/strict-mode/step1/tsconfig.json
+++ b/tests/sdk/nodejs/strict-mode/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/strict-mode/step2/index.ts
+++ b/tests/sdk/nodejs/strict-mode/step2/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test validates the following restrictions enforced by "strict mode":
+// 1. Default providers are not allowed.
+// 2. Each Provider requires a "context" argument.
+// 3. Each Provider requires a "kubeconfig" argument.
+
+// Create a new provider with no context specified.
+new k8s.Provider("missingContext", {
+    kubeconfig: "~/.kube/config",
+});

--- a/tests/sdk/nodejs/strict-mode/step2/index.ts
+++ b/tests/sdk/nodejs/strict-mode/step2/index.ts
@@ -20,6 +20,11 @@ import * as k8s from "@pulumi/kubernetes";
 // 3. Each Provider requires a "kubeconfig" argument.
 
 // Create a new provider with no context specified.
-new k8s.Provider("missingContext", {
+const provider = new k8s.Provider("missingContext", {
     kubeconfig: "~/.kube/config",
 });
+
+// The ConfigMap should not be created since the Provider is invalid under "strict mode".
+const cm = new k8s.core.v1.ConfigMap("default", {
+    data: {foo: "bar"},
+}, {provider});

--- a/tests/sdk/nodejs/strict-mode/step3/index.ts
+++ b/tests/sdk/nodejs/strict-mode/step3/index.ts
@@ -20,6 +20,11 @@ import * as k8s from "@pulumi/kubernetes";
 // 3. Each Provider requires a "kubeconfig" argument.
 
 // Create a new provider with no kubeconfig specified.
-new k8s.Provider("missingKubeconfig", {
+const provider = new k8s.Provider("missingKubeconfig", {
     context: "test",
 });
+
+// The ConfigMap should not be created since the Provider is invalid under "strict mode".
+const cm = new k8s.core.v1.ConfigMap("default", {
+    data: {foo: "bar"},
+}, {provider});

--- a/tests/sdk/nodejs/strict-mode/step3/index.ts
+++ b/tests/sdk/nodejs/strict-mode/step3/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// This test validates the following restrictions enforced by "strict mode":
+// 1. Default providers are not allowed.
+// 2. Each Provider requires a "context" argument.
+// 3. Each Provider requires a "kubeconfig" argument.
+
+// Create a new provider with no kubeconfig specified.
+new k8s.Provider("missingKubeconfig", {
+    context: "test",
+});


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The Kubernetes provider selects a target cluster based on information in a `kubeconfig` file, which contains one or more context settings. If these options are not explicitly specified in a Pulumi stack, the provider will attempt to load ambient configuration similarly to most Kubernetes CLI tooling. While this behavior makes it easier to get started quickly, it is not always desirable in production stacks.

In "strict mode", the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.

These options are already available individually, but "strict mode" makes it more convenient to enforce across a project or stack.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2423
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
