### PR TITLE
Update Patch resources rather than replacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Update Patch resources rather than replacing (https://github.com/pulumi/pulumi-kubernetes/pull/2429)
+
 ## 3.28.1 (May 24, 2023)
 
 - Add a "strict mode" configuration option (https://github.com/pulumi/pulumi-kubernetes/pull/2425)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Patch resources are used to manage Server-side patch operations, so their semantics are different from normal resources. In particular, Patch resources can be updated in place rather than requiring a replacement. The previous logic reused the replacement calculation logic from normal resources, which could inadvertently result in the replacement of the Patch resource. In the replacement case, the patch is dropped and then reapplied as a second operation, while the update case makes the change in a single operation. The results are nearly identical, but result in a new field manager being created in the replacement case. This only applied in special cases where a mutable field was treated as requiring replacement by the provider, such as the `.data` field of a ConfigMap resource. Attempting to patch an immutable field results in an error.

This commit updates Patch resources to always use the update behavior, except when the identity (`.metadata.namespace` or `.metadata.name`) changes, since this moves the patch to a different resource and would not make sense as an update.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2424 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
