### PR TITLE
Remove server generated fields from state

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2101,6 +2101,7 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 
 	// Cleanup some obviously non-input-ty fields.
 	removeNonInputtyFields(liveInputs)
+	removeNonInputtyFields(liveObj)
 
 	// TODO(lblackstone): not sure why this is needed
 	id := fqObjName(liveObj)
@@ -2350,6 +2351,10 @@ func (k *kubeProvider) Update(
 		// If we get here, resource successfully registered with the API server, but failed to
 		// initialize.
 	}
+
+	// Remove non-inputty fields from the object to store in the checkpoint.
+	removeNonInputtyFields(initialized)
+
 	// Return a new "checkpoint object".
 	obj := checkpointObject(newInputs, initialized, newResInputs, initialAPIVersion, fieldManager)
 	inputsAndComputed, err := plugin.MarshalProperties(


### PR DESCRIPTION
### Proposed changes

This PR stops the storage of server generated fields: `.status` and certain nested `.metadata` fields, in our state/checkpoints. This will reduce spurious diffing (eg. when running `pulumi refresh`) as our users do not manage these fields.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
