### PR TITLE
[internal] Add function to prune map keys

### DIFF
--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -196,6 +196,11 @@ func pruneSlice(source, target []interface{}) []interface{} {
 		}
 		value := source[i]
 
+		if value == nil || targetValue == nil {
+			result = append(result, value)
+			continue
+		}
+
 		switch valueT.Kind() {
 		case reflect.Map:
 			nestedResult := pruneMap(value.(map[string]interface{}), targetValue.(map[string]interface{}))

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -135,8 +135,8 @@ func getActiveClusterFromConfig(config *clientapi.Config, overrides resource.Pro
 	return activeCluster
 }
 
-// pruneMap recursively drops keys from the source map that don't have a matching key in the target map and returns
-// the result. This is useful as a preprocessing step for live resource state before comparing it to program inputs.
+// pruneMap builds a pruned map by recursively copying elements from the source map that have a matching key in the
+// target map. This is useful as a preprocessing step for live resource state before comparing it to program inputs.
 func pruneMap(source, target map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
@@ -183,7 +183,8 @@ func pruneMap(source, target map[string]interface{}) map[string]interface{} {
 	return result
 }
 
-// pruneSlice drops elements from the source slice that don't have a matching element in the target slice
+// pruneSlice builds a pruned slice by copying elements from the source slice that have a matching element in the
+// target slice.
 func pruneSlice(source, target []interface{}) []interface{} {
 	result := make([]interface{}, 0)
 

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -142,42 +142,30 @@ func pruneMap(source, target map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	for key, value := range source {
+		valueT := reflect.TypeOf(value)
+
 		if targetValue, ok := target[key]; ok {
-			valueT := reflect.TypeOf(value)
 			targetValueT := reflect.TypeOf(targetValue)
 
-			if valueT == nil || targetValueT == nil {
+			if valueT == nil || targetValueT == nil || valueT != targetValueT {
 				result[key] = value
 				continue
 			}
 
-			if valueT.Kind() == reflect.Map {
-				if targetValueT.Kind() == reflect.Map {
-					nestedResult := pruneMap(value.(map[string]interface{}), targetValue.(map[string]interface{}))
-					if len(nestedResult) > 0 {
-						result[key] = nestedResult
-						continue
-					}
-				} else {
-					result[key] = value
-					continue
+			switch valueT.Kind() {
+			case reflect.Map:
+				nestedResult := pruneMap(value.(map[string]interface{}), targetValue.(map[string]interface{}))
+				if len(nestedResult) > 0 {
+					result[key] = nestedResult
 				}
-			}
-
-			if reflect.TypeOf(value).Kind() == reflect.Slice {
-				if reflect.TypeOf(targetValue).Kind() == reflect.Slice {
-					nestedResult := pruneSlice(value.([]interface{}), targetValue.([]interface{}))
-					if len(nestedResult) > 0 {
-						result[key] = nestedResult
-						continue
-					}
-				} else {
-					result[key] = value
-					continue
+			case reflect.Slice:
+				nestedResult := pruneSlice(value.([]interface{}), targetValue.([]interface{}))
+				if len(nestedResult) > 0 {
+					result[key] = nestedResult
 				}
+			default:
+				result[key] = value
 			}
-
-			result[key] = value
 		}
 	}
 

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -823,6 +823,30 @@ func TestPruneMap(t *testing.T) {
 			},
 		},
 		{
+			name:        "nested map with nil",
+			description: "a map with a nested map with nil where target matches",
+			args: args{
+				source: map[string]interface{}{
+					"a": "a",
+					"b": map[string]interface{}{
+						"c": nil,
+					},
+				},
+				target: map[string]interface{}{
+					"a": "a",
+					"b": map[string]interface{}{
+						"c": nil,
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"a": "a",
+				"b": map[string]interface{}{
+					"c": nil,
+				},
+			},
+		},
+		{
 			name:        "nested value slice",
 			description: "a map with a nested slice of simple values where target matches",
 			args: args{
@@ -1135,6 +1159,33 @@ func TestPruneSlice(t *testing.T) {
 					"a": "a",
 					"b": "b",
 				},
+			},
+		},
+		{
+			name:        "map slice with nil value",
+			description: "a slice of map values that include a nil value",
+			args: args{
+				source: []interface{}{
+					map[string]interface{}{
+						"a": "a",
+						"b": "b",
+					},
+					nil,
+				},
+				target: []interface{}{
+					map[string]interface{}{
+						"a": "a",
+						"b": "b",
+					},
+					nil,
+				},
+			},
+			want: []interface{}{
+				map[string]interface{}{
+					"a": "a",
+					"b": "b",
+				},
+				nil,
 			},
 		},
 	}

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -1031,7 +1031,7 @@ func TestPruneSlice(t *testing.T) {
 						"a": "a",
 						"b": "b", // not present in target, so will be dropped
 					},
-					map[string]interface{}{ // not present in target, so will be dropped
+					map[string]interface{}{ // map not present in target, so will be dropped
 						"c": "c",
 						"d": "d",
 					},

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -322,212 +322,273 @@ v0dohqdVlO32gd6+BQNF8fP29o0dOCAjV/4wBbccuHubvBgu4rqHsHog371ETul/
 
 func TestPruneMap(t *testing.T) {
 	oldLiveJSON := []byte(`{
-	 "__fieldManager": "pulumi-kubernetes-b5647a00",
-	 "__initialApiVersion": "apps/v1",
-	 "apiVersion": "apps/v1",
-	 "kind": "Deployment",
-	 "metadata": {
-	   "annotations": {
-	     "deployment.kubernetes.io/revision": "1"
-	   },
-	   "creationTimestamp": "2023-05-31T15:37:37Z",
-	   "generation": 1,
-	   "managedFields": [
-	     {
-	       "apiVersion": "apps/v1",
-	       "fieldsType": "FieldsV1",
-	       "fieldsV1": {
-	         "f:spec": {
-	           "f:replicas": {},
-	           "f:selector": {},
-	           "f:template": {
-	             "f:metadata": {
-	               "f:labels": {
-	                 "f:app": {}
-	               }
-	             },
-	             "f:spec": {
-	               "f:containers": {
-	                 "k:{\"name\":\"nginx\"}": {
-	                   ".": {},
-	                   "f:image": {},
-	                   "f:name": {},
-	                   "f:ports": {
-	                     "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
-	                       ".": {},
-	                       "f:containerPort": {}
-	                     }
-	                   }
-	                 }
-	               }
-	             }
-	           }
-	         }
-	       },
-	       "manager": "pulumi-kubernetes-b5647a00",
-	       "operation": "Apply",
-	       "time": "2023-05-31T15:37:37Z"
-	     },
-	     {
-	       "apiVersion": "apps/v1",
-	       "fieldsType": "FieldsV1",
-	       "fieldsV1": {
-	         "f:metadata": {
-	           "f:annotations": {
-	             ".": {},
-	             "f:deployment.kubernetes.io/revision": {}
-	           }
-	         },
-	         "f:status": {
-	           "f:availableReplicas": {},
-	           "f:conditions": {
-	             ".": {},
-	             "k:{\"type\":\"Available\"}": {
-	               ".": {},
-	               "f:lastTransitionTime": {},
-	               "f:lastUpdateTime": {},
-	               "f:message": {},
-	               "f:reason": {},
-	               "f:status": {},
-	               "f:type": {}
-	             },
-	             "k:{\"type\":\"Progressing\"}": {
-	               ".": {},
-	               "f:lastTransitionTime": {},
-	               "f:lastUpdateTime": {},
-	               "f:message": {},
-	               "f:reason": {},
-	               "f:status": {},
-	               "f:type": {}
-	             }
-	           },
-	           "f:observedGeneration": {},
-	           "f:readyReplicas": {},
-	           "f:replicas": {},
-	           "f:updatedReplicas": {}
-	         }
-	       },
-	       "manager": "kube-controller-manager",
-	       "operation": "Update",
-	       "subresource": "status",
-	       "time": "2023-05-31T15:37:37Z"
-	     }
-	   ],
-	   "name": "scale-test",
-	   "namespace": "default",
-	   "resourceVersion": "6559979",
-	   "uid": "a02656af-058c-47fd-9754-555c24ace524"
-	 },
-	 "spec": {
-	   "progressDeadlineSeconds": 600,
-	   "replicas": 1,
-	   "revisionHistoryLimit": 10,
-	   "selector": {
-	     "matchLabels": {
-	       "app": "nginx"
-	     }
-	   },
-	   "strategy": {
-	     "rollingUpdate": {
-	       "maxSurge": "25%",
-	       "maxUnavailable": "25%"
-	     },
-	     "type": "RollingUpdate"
-	   },
-	   "template": {
-	     "metadata": {
-	       "labels": {
-	         "app": "nginx"
-	       }
-	     },
-	     "spec": {
-	       "containers": [
-	         {
-	           "image": "nginx:1.13",
-	           "imagePullPolicy": "IfNotPresent",
-	           "name": "nginx",
-	           "ports": [
-	             {
-	               "containerPort": 80,
-	               "protocol": "TCP"
-	             }
-	           ],
-	           "resources": {},
-	           "terminationMessagePath": "/dev/termination-log",
-	           "terminationMessagePolicy": "File"
-	         }
-	       ],
-	       "dnsPolicy": "ClusterFirst",
-	       "restartPolicy": "Always",
-	       "schedulerName": "default-scheduler",
-	       "securityContext": {},
-	       "terminationGracePeriodSeconds": 30
-	     }
-	   }
-	 },
-	 "status": {
-	   "availableReplicas": 1,
-	   "conditions": [
-	     {
-	       "lastTransitionTime": "2023-05-31T15:37:37Z",
-	       "lastUpdateTime": "2023-05-31T15:37:37Z",
-	       "message": "Deployment has minimum availability.",
-	       "reason": "MinimumReplicasAvailable",
-	       "status": "True",
-	       "type": "Available"
-	     },
-	     {
-	       "lastTransitionTime": "2023-05-31T15:37:37Z",
-	       "lastUpdateTime": "2023-05-31T15:37:37Z",
-	       "message": "ReplicaSet \"scale-test-75c9695c65\" has successfully progressed.",
-	       "reason": "NewReplicaSetAvailable",
-	       "status": "True",
-	       "type": "Progressing"
-	     }
-	   ],
-	   "observedGeneration": 1,
-	   "readyReplicas": 1,
-	   "replicas": 1,
-	   "updatedReplicas": 1
-	 }
-	}`)
+  "__fieldManager": "pulumi-kubernetes",
+  "__initialApiVersion": "apps/v1",
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "deployment.kubernetes.io/revision": "1",
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app.kubernetes.io/managed-by\":\"pulumi\"},\"name\":\"scale-test\",\"namespace\":\"default\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.13\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\",\"SYS_TIME\"]}}}]}}}}\n"
+    },
+    "creationTimestamp": "2023-06-02T15:33:42Z",
+    "generation": 1,
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "apps/v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": {
+              ".": {},
+              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+            },
+            "f:labels": {
+              ".": {},
+              "f:app.kubernetes.io/managed-by": {}
+            }
+          },
+          "f:spec": {
+            "f:progressDeadlineSeconds": {},
+            "f:replicas": {},
+            "f:revisionHistoryLimit": {},
+            "f:selector": {},
+            "f:strategy": {
+              "f:rollingUpdate": {
+                ".": {},
+                "f:maxSurge": {},
+                "f:maxUnavailable": {}
+              },
+              "f:type": {}
+            },
+            "f:template": {
+              "f:metadata": {
+                "f:labels": {
+                  ".": {},
+                  "f:app": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"nginx\"}": {
+                    ".": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:ports": {
+                      ".": {},
+                      "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:protocol": {}
+                      }
+                    },
+                    "f:resources": {},
+                    "f:securityContext": {
+                      ".": {},
+                      "f:capabilities": {
+                        ".": {},
+                        "f:add": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {}
+              }
+            }
+          }
+        },
+        "manager": "pulumi-kubernetes",
+        "operation": "Update",
+        "time": "2023-06-02T15:33:42Z"
+      },
+      {
+        "apiVersion": "apps/v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": {
+              "f:deployment.kubernetes.io/revision": {}
+            }
+          },
+          "f:status": {
+            "f:availableReplicas": {},
+            "f:conditions": {
+              ".": {},
+              "k:{\"type\":\"Available\"}": {
+                ".": {},
+                "f:lastTransitionTime": {},
+                "f:lastUpdateTime": {},
+                "f:message": {},
+                "f:reason": {},
+                "f:status": {},
+                "f:type": {}
+              },
+              "k:{\"type\":\"Progressing\"}": {
+                ".": {},
+                "f:lastTransitionTime": {},
+                "f:lastUpdateTime": {},
+                "f:message": {},
+                "f:reason": {},
+                "f:status": {},
+                "f:type": {}
+              }
+            },
+            "f:observedGeneration": {},
+            "f:readyReplicas": {},
+            "f:replicas": {},
+            "f:updatedReplicas": {}
+          }
+        },
+        "manager": "kube-controller-manager",
+        "operation": "Update",
+        "subresource": "status",
+        "time": "2023-06-02T15:33:43Z"
+      }
+    ],
+    "name": "scale-test",
+    "namespace": "default",
+    "resourceVersion": "6639864",
+    "uid": "12990b2a-5476-4f4c-be63-cb5fcafe0cf2"
+  },
+  "spec": {
+    "progressDeadlineSeconds": 600,
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "strategy": {
+      "rollingUpdate": {
+        "maxSurge": "25%",
+        "maxUnavailable": "25%"
+      },
+      "type": "RollingUpdate"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "nginx:1.13",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "nginx",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "securityContext": {
+              "capabilities": {
+                "add": [
+                  "NET_ADMIN",
+                  "SYS_TIME"
+                ]
+              }
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  },
+  "status": {
+    "availableReplicas": 1,
+    "conditions": [
+      {
+        "lastTransitionTime": "2023-06-02T15:33:43Z",
+        "lastUpdateTime": "2023-06-02T15:33:43Z",
+        "message": "Deployment has minimum availability.",
+        "reason": "MinimumReplicasAvailable",
+        "status": "True",
+        "type": "Available"
+      },
+      {
+        "lastTransitionTime": "2023-06-02T15:33:42Z",
+        "lastUpdateTime": "2023-06-02T15:33:43Z",
+        "message": "ReplicaSet \"scale-test-544b74d7f9\" has successfully progressed.",
+        "reason": "NewReplicaSetAvailable",
+        "status": "True",
+        "type": "Progressing"
+      }
+    ],
+    "observedGeneration": 1,
+    "readyReplicas": 1,
+    "replicas": 1,
+    "updatedReplicas": 1
+  }
+}`)
 
 	oldInputsJSON := []byte(`{
-	 "apiVersion": "apps/v1",
-	 "kind": "Deployment",
-	 "metadata": {
-	   "name": "scale-test",
-	   "namespace": "default"
-	 },
-	 "spec": {
-	   "replicas": 1,
-	   "selector": {
-	     "matchLabels": {
-	       "app": "nginx"
-	     }
-	   },
-	   "template": {
-	     "metadata": {
-	       "labels": {
-	         "app": "nginx"
-	       }
-	     },
-	     "spec": {
-	       "containers": [
-	         {
-	           "image": "nginx:1.13",
-	           "name": "nginx",
-	           "ports": [
-	             {
-	               "containerPort": 80
-	             }
-	           ]
-	         }
-	       ]
-	     }
-	   }
-	 }
-	}`)
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "labels": {
+      "app.kubernetes.io/managed-by": "pulumi"
+    },
+    "name": "scale-test",
+    "namespace": "default"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "nginx:1.13",
+            "name": "nginx",
+            "ports": [
+              {
+                "containerPort": 80
+              }
+            ],
+            "securityContext": {
+              "capabilities": {
+                "add": [
+                  "NET_ADMIN",
+                  "SYS_TIME"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`)
 
 	var err error
 	var source, target map[string]interface{}


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Add a "pruneMap" function and supporting "pruneSlice" function to prune map keys that are not present in a target map.

Kubernetes sets a significant amount of additional state on cluster resources after they are created, which complicates diffing with the subset of properties that are set by a user program. The pruneMap function can be used to preprocess live resource state before diffing against program inputs.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
