### PR TITLE
Drop support for legacy pulumi.com/initialApiVersion annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 - Remove deprecated enableReplaceCRD provider flag (https://github.com/pulumi/pulumi-kubernetes/pull/2402)
 - Drop support for Kubernetes clusters older than v1.13 (https://github.com/pulumi/pulumi-kubernetes/pull/2414)
 - Make all resource output properties required (https://github.com/pulumi/pulumi-kubernetes/pull/2422)
+- Drop support for legacy pulumi.com/initialApiVersion annotation (https://github.com/pulumi/pulumi-kubernetes/pull/2443)
 
 Other changes:
 

--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -27,11 +27,10 @@ const (
 
 	AnnotationPrefix = "pulumi.com/"
 
-	AnnotationAutonamed         = AnnotationPrefix + "autonamed"
-	AnnotationSkipAwait         = AnnotationPrefix + "skipAwait"
-	AnnotationTimeoutSeconds    = AnnotationPrefix + "timeoutSeconds"
-	AnnotationInitialAPIVersion = AnnotationPrefix + "initialApiVersion"
-	AnnotationReplaceUnready    = AnnotationPrefix + "replaceUnready"
+	AnnotationAutonamed      = AnnotationPrefix + "autonamed"
+	AnnotationSkipAwait      = AnnotationPrefix + "skipAwait"
+	AnnotationTimeoutSeconds = AnnotationPrefix + "timeoutSeconds"
+	AnnotationReplaceUnready = AnnotationPrefix + "replaceUnready"
 
 	AnnotationPatchForce        = AnnotationPrefix + "patchForce"
 	AnnotationPatchFieldManager = AnnotationPrefix + "patchFieldManager"

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1988,10 +1988,7 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 		}
 	}
 
-	initialAPIVersion, err := initialAPIVersion(oldState, oldInputs)
-	if err != nil {
-		return nil, err
-	}
+	initialAPIVersion := initialAPIVersion(oldState, oldInputs)
 	fieldManager := k.fieldManagerName(nil, oldState, oldInputs)
 
 	if k.yamlRenderMode {
@@ -2253,11 +2250,7 @@ func (k *kubeProvider) Update(
 			newInputs.GetNamespace(), newInputs.GetName(), lastAppliedConfigKey)
 	}
 
-	initialAPIVersion, err := initialAPIVersion(oldState, oldInputs)
-	if err != nil {
-		return nil, err
-	}
-
+	initialAPIVersion := initialAPIVersion(oldState, oldInputs)
 	fieldManagerOld := k.fieldManagerName(nil, oldState, oldInputs)
 	fieldManager := k.fieldManagerName(nil, oldState, newInputs)
 
@@ -2432,10 +2425,7 @@ func (k *kubeProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest)
 			k.clusterUnreachableReason)
 	}
 
-	initialAPIVersion, err := initialAPIVersion(oldState, &unstructured.Unstructured{})
-	if err != nil {
-		return nil, err
-	}
+	initialAPIVersion := initialAPIVersion(oldState, &unstructured.Unstructured{})
 	fieldManager := k.fieldManagerName(nil, oldState, oldInputs)
 	resources, err := k.getResources()
 	if err != nil {
@@ -2946,12 +2936,12 @@ func getAnnotations(config *unstructured.Unstructured) map[string]string {
 
 // initialAPIVersion retrieves the initialAPIVersion property from the checkpoint file and falls back to using
 // the version from the resource metadata if that property is not present.
-func initialAPIVersion(state resource.PropertyMap, oldConfig *unstructured.Unstructured) (string, error) {
+func initialAPIVersion(state resource.PropertyMap, oldInputs *unstructured.Unstructured) string {
 	if v, ok := state[initialAPIVersionKey]; ok {
-		return v.StringValue(), nil
+		return v.StringValue()
 	}
 
-	return oldConfig.GetAPIVersion(), nil
+	return oldInputs.GetAPIVersion()
 }
 
 func checkpointObject(inputs, live *unstructured.Unstructured, fromInputs resource.PropertyMap,


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The pulumi.com/initialApiVersion annotation was briefly used to store information about the apiVersion used to create each resource in early versions of the provider (v1.x). The logic was updated to store this information in the Pulumi state rather than directly on the resource. Subsequent versions of the provider continued to support this annotation as a fallback option in case the state did not contain this information.

Drop support for the annotation to simplify the provider logic.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2442
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
