### PR TITLE
[internal] Replace interface{} usages with any

### DIFF
--- a/provider/cmd/pulumi-gen-kubernetes/main.go
+++ b/provider/cmd/pulumi-gen-kubernetes/main.go
@@ -156,7 +156,7 @@ func generateSchema(swaggerPath string) schema.PackageSpec {
 		swagger = mergeSwaggerSpecs(legacySwagger, swagger)
 	}
 
-	var schemaMap map[string]interface{}
+	var schemaMap map[string]any
 	err = json.Unmarshal(swagger, &schemaMap)
 	if err != nil {
 		panic(err)
@@ -425,7 +425,7 @@ func mustLoadGoFile(path string) []byte {
 	return formattedSource
 }
 
-func mustRenderTemplate(path string, resources interface{}) []byte {
+func mustRenderTemplate(path string, resources any) []byte {
 	b := mustLoadFile(path)
 	t := template.Must(template.New("resources").Parse(string(b)))
 
@@ -437,7 +437,7 @@ func mustRenderTemplate(path string, resources interface{}) []byte {
 	return buf.Bytes()
 }
 
-func mustRenderGoTemplate(path string, resources interface{}) []byte {
+func mustRenderGoTemplate(path string, resources any) []byte {
 	bytes := mustRenderTemplate(path, resources)
 
 	formattedSource, err := format.Source(bytes)
@@ -497,7 +497,7 @@ func mustWriteFile(rootDir, filename string, contents []byte) {
 	}
 }
 
-func makeJSONString(v interface{}) ([]byte, error) {
+func makeJSONString(v any) ([]byte, error) {
 	var out bytes.Buffer
 	encoder := json.NewEncoder(&out)
 	encoder.SetEscapeHTML(false)

--- a/provider/cmd/pulumi-gen-kubernetes/merge.go
+++ b/provider/cmd/pulumi-gen-kubernetes/merge.go
@@ -22,7 +22,7 @@ import (
 
 func mergeSwaggerSpecs(legacyBytes, currentBytes []byte) []byte {
 
-	var legacyObj, newObj map[string]interface{}
+	var legacyObj, newObj map[string]any
 	err := json.Unmarshal(legacyBytes, &legacyObj)
 	if err != nil {
 		panic(err)

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -73,7 +73,7 @@ func (mri *mockResourceInterface) DeleteCollection(
 func (mri *mockResourceInterface) Get(
 	ctx context.Context, name string, options metav1.GetOptions, subresources ...string,
 ) (*unstructured.Unstructured, error) {
-	return &unstructured.Unstructured{Object: map[string]interface{}{}}, nil
+	return &unstructured.Unstructured{Object: map[string]any{}}, nil
 }
 func (mri *mockResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	panic("List not implemented")

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -472,7 +472,7 @@ func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
 	// Check Deployments conditions to see whether new ReplicaSet is available. If it is, we are
 	// successful.
 	rawConditions, hasConditions := openapi.Pluck(deployment.Object, "status", "conditions")
-	conditions, isSlice := rawConditions.([]interface{})
+	conditions, isSlice := rawConditions.([]any)
 	if !hasConditions || !isSlice {
 		// Deployment controller has not made progress yet. Do nothing.
 		return
@@ -481,7 +481,7 @@ func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
 	// Success occurs when the ReplicaSet of the `replicaSetGeneration` is marked as available, and
 	// when the deployment is available.
 	for _, rawCondition := range conditions {
-		condition, isMap := rawCondition.(map[string]interface{})
+		condition, isMap := rawCondition.(map[string]any)
 		if !isMap {
 			continue
 		}
@@ -592,7 +592,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 		specReplicas = 1
 	}
 
-	var rawReadyReplicas interface{}
+	var rawReadyReplicas any
 	var readyReplicas int64
 	var readyReplicasExists bool
 	var unavailableReplicas int64
@@ -775,11 +775,11 @@ func (dia *deploymentInitAwaiter) processPersistentVolumeClaimsEvent(event watch
 	// Check any PersistentVolumeClaims that the Deployments Volumes may have
 	// by name against the PersistentVolumeClaim in the event
 	volumes, _ := openapi.Pluck(dia.deployment.Object, "spec", "template", "spec", "volumes")
-	vols, _ := volumes.([]interface{})
+	vols, _ := volumes.([]any)
 	for _, vol := range vols {
-		v := vol.(map[string]interface{})
+		v := vol.(map[string]any)
 		if deployPVC, exists := v["persistentVolumeClaim"]; exists {
-			p := deployPVC.(map[string]interface{})
+			p := deployPVC.(map[string]any)
 			claimName := p["claimName"].(string)
 
 			if claimName == pvc.GetName() {

--- a/provider/pkg/await/informers/informer.go
+++ b/provider/pkg/await/informers/informer.go
@@ -102,19 +102,19 @@ func New(
 
 	if options.informChan != nil {
 		_, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				options.informChan <- watch.Event{
 					Object: obj.(*unstructured.Unstructured),
 					Type:   watch.Added,
 				}
 			},
-			UpdateFunc: func(_, newObj interface{}) {
+			UpdateFunc: func(_, newObj any) {
 				options.informChan <- watch.Event{
 					Object: newObj.(*unstructured.Unstructured),
 					Type:   watch.Modified,
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 					options.informChan <- watch.Event{
 						Object: unknown.Obj.(*unstructured.Unstructured),

--- a/provider/pkg/await/ingress.go
+++ b/provider/pkg/await/ingress.go
@@ -319,7 +319,7 @@ func (iia *ingressInitAwaiter) processIngressEvent(event watch.Event) {
 		return
 	}
 
-	ingresses, ok := ingressesRaw.([]interface{})
+	ingresses, ok := ingressesRaw.([]any)
 	if !ok {
 		logger.V(3).Infof("Unexpected ingress object structure from unstructured: %#v", ingress)
 		return
@@ -332,7 +332,7 @@ func (iia *ingressInitAwaiter) processIngressEvent(event watch.Event) {
 		inputIngressName)
 }
 
-func decodeIngress(u *unstructured.Unstructured, to interface{}) error {
+func decodeIngress(u *unstructured.Unstructured, to any) error {
 	b, err := u.MarshalJSON()
 	if err != nil {
 		return err

--- a/provider/pkg/await/service.go
+++ b/provider/pkg/await/service.go
@@ -303,7 +303,7 @@ func (sia *serviceInitAwaiter) processServiceEvent(event watch.Event) {
 		status, _ := openapi.Pluck(service.Object, "status")
 
 		logger.V(3).Infof("Received status for service %q: %#v", inputServiceName, status)
-		ing, isSlice := lbIngress.([]interface{})
+		ing, isSlice := lbIngress.([]any)
 
 		// Update status of service object so that we can check success.
 		sia.serviceReady = isSlice && len(ing) > 0
@@ -341,7 +341,7 @@ func (sia *serviceInitAwaiter) processEndpointEvent(event watch.Event, settledCh
 	// Update status of endpoint objects so we can check success.
 	if event.Type == watch.Added || event.Type == watch.Modified {
 		subsets, hasTargets := openapi.Pluck(endpoint.Object, "subsets")
-		targets, targetsIsSlice := subsets.([]interface{})
+		targets, targetsIsSlice := subsets.([]any)
 		endpointTargetsPod := hasTargets && targetsIsSlice && len(targets) > 0
 
 		sia.endpointsReady = endpointTargetsPod
@@ -397,7 +397,7 @@ func (sia *serviceInitAwaiter) isExternalNameService() bool {
 // [1]: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
 func (sia *serviceInitAwaiter) emptyHeadlessOrExternalName() bool {
 	selectorI, _ := openapi.Pluck(sia.service.Object, "spec", "selector")
-	selector, _ := selectorI.(map[string]interface{})
+	selector, _ := selectorI.(map[string]any)
 
 	headlessEmpty := len(selector) == 0 && sia.isHeadlessService()
 	return headlessEmpty || sia.isExternalNameService()
@@ -419,7 +419,7 @@ func (sia *serviceInitAwaiter) hasHeadlessServicePortBug(version cluster.ServerV
 	// k8s versions < 1.12 have the bug.
 	if version.Compare(cluster.ServerVersion{Major: 1, Minor: 12}) < 0 {
 		portsI, _ := openapi.Pluck(sia.service.Object, "spec", "ports")
-		ports, _ := portsI.([]map[string]interface{})
+		ports, _ := portsI.([]map[string]any)
 		hasPorts := len(ports) > 0
 
 		// The bug affects Services with no specified ports.

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -44,14 +44,14 @@ var (
 	}
 
 	validPodUnstructured = &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "foo"},
-			"spec": map[string]interface{}{
-				"containers": []interface{}{
-					map[string]interface{}{
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{
 						"name":  "foo",
 						"image": "nginx"}},
 			},
@@ -81,16 +81,16 @@ var (
 	}
 
 	validDeploymentUnstructured = &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "apps/v1",
 			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "foo"},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
 								"name":  "foo",
 								"image": "nginx"}},
 					},
@@ -101,16 +101,16 @@ var (
 
 	// Unregistered GVK
 	unregisteredGVK = &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "pulumi/test",
 			"kind":       "Foo",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "foo"},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
 								"name":  "foo",
 								"image": "nginx"}},
 					},

--- a/provider/pkg/gen/examples/upstream/generate.go
+++ b/provider/pkg/gen/examples/upstream/generate.go
@@ -91,7 +91,7 @@ func processYaml(path string, mdDir string) error {
 	decoder := yaml.NewDecoder(yamlFile)
 	exampleStrings := []string{}
 	for {
-		example := map[string]interface{}{}
+		example := map[string]any{}
 		err := decoder.Decode(&example)
 		if err == io.EOF {
 			break

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -33,7 +33,7 @@ var typeOverlays = map[string]pschema.ComplexTypeSpec{}
 var resourceOverlays = map[string]pschema.ResourceSpec{}
 
 // PulumiSchema will generate a Pulumi schema for the given k8s schema.
-func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
+func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 	pkg := pschema.PackageSpec{
 		Name:        "kubernetes",
 		Description: "A Pulumi package for creating and managing Kubernetes resources.",
@@ -51,7 +51,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 						" this config will be used instead of $KUBECONFIG.",
 					TypeSpec: pschema.TypeSpec{Type: "string"},
 					Language: map[string]pschema.RawMessage{
-						"csharp": rawMessage(map[string]interface{}{
+						"csharp": rawMessage(map[string]any{
 							"name": "KubeConfig",
 						}),
 					},
@@ -124,7 +124,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 					Description: "The contents of a kubeconfig file or the path to a kubeconfig file.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 					Language: map[string]pschema.RawMessage{
-						"csharp": rawMessage(map[string]interface{}{
+						"csharp": rawMessage(map[string]any{
 							"name": "KubeConfig",
 						}),
 					},
@@ -245,7 +245,7 @@ func PulumiSchema(swagger map[string]interface{}) pschema.PackageSpec {
 		"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/helm/v3": "helmv3",
 	}
 
-	definitions := swagger["definitions"].(map[string]interface{})
+	definitions := swagger["definitions"].(map[string]any)
 	groupsSlice := createGroups(definitions)
 
 	for _, group := range groupsSlice {
@@ -461,7 +461,7 @@ additional information about using Server-Side Apply to manage Kubernetes resour
 	// Compatibility mode for Kubernetes 2.0 SDK
 	const kubernetes20 = "kubernetes20"
 
-	pkg.Language["csharp"] = rawMessage(map[string]interface{}{
+	pkg.Language["csharp"] = rawMessage(map[string]any{
 		"packageReferences": map[string]string{
 			"Glob":   "1.1.5",
 			"Pulumi": "3.*",
@@ -471,18 +471,18 @@ additional information about using Server-Side Apply to manage Kubernetes resour
 		"dictionaryConstructors": true,
 	})
 
-	pkg.Language["java"] = rawMessage(map[string]interface{}{
+	pkg.Language["java"] = rawMessage(map[string]any{
 		"packages": javaPackages,
 	})
 
-	pkg.Language["go"] = rawMessage(map[string]interface{}{
+	pkg.Language["go"] = rawMessage(map[string]any{
 		"importBasePath":                 goImportPath,
 		"moduleToPackage":                modToPkg,
 		"packageImportAliases":           pkgImportAliases,
 		"generateResourceContainerTypes": true,
 		"generateExtraInputTypes":        true,
 	})
-	pkg.Language["nodejs"] = rawMessage(map[string]interface{}{
+	pkg.Language["nodejs"] = rawMessage(map[string]any{
 		"compatibility": kubernetes20,
 		"dependencies": map[string]string{
 			"@pulumi/pulumi":    "^3.25.0",
@@ -516,7 +516,7 @@ If this is your first time using this package, these two resources may be helpfu
 Use the navigation below to see detailed documentation for each of the supported Kubernetes resources.
 `,
 	})
-	pkg.Language["python"] = rawMessage(map[string]interface{}{
+	pkg.Language["python"] = rawMessage(map[string]any{
 		"requires": map[string]string{
 			"pulumi":   ">=3.25.0,<4.0.0",
 			"requests": ">=2.21,<3.0",
@@ -588,7 +588,7 @@ func genPropertySpec(p Property, resourceKind string) pschema.PropertySpec {
 	if languageName == resourceKind {
 		// .NET does not allow properties to be the same as the enclosing class - so special case these
 		propertySpec.Language = map[string]pschema.RawMessage{
-			"csharp": rawMessage(map[string]interface{}{
+			"csharp": rawMessage(map[string]any{
 				"name": languageName + "Value",
 			}),
 		}
@@ -597,7 +597,7 @@ func genPropertySpec(p Property, resourceKind string) pschema.PropertySpec {
 	// the generated names. Replace them with `Ref` and `Schema`.
 	if strings.HasPrefix(p.name, "$") {
 		propertySpec.Language = map[string]pschema.RawMessage{
-			"csharp": rawMessage(map[string]interface{}{
+			"csharp": rawMessage(map[string]any{
 				"name": strings.ToUpper(p.name[1:2]) + p.name[2:],
 			}),
 		}
@@ -611,7 +611,7 @@ func genPropertySpec(p Property, resourceKind string) pschema.PropertySpec {
 	return propertySpec
 }
 
-func rawMessage(v interface{}) pschema.RawMessage {
+func rawMessage(v any) pschema.RawMessage {
 	var out bytes.Buffer
 	encoder := json.NewEncoder(&out)
 	encoder.SetEscapeHTML(false)

--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -68,16 +68,16 @@ func SetAnnotation(obj *unstructured.Unstructured, key, value string) {
 	if isComputedValue(metadataRaw) {
 		return
 	}
-	metadata := metadataRaw.(map[string]interface{})
+	metadata := metadataRaw.(map[string]any)
 	annotationsRaw, ok := metadata["annotations"]
 	if isComputedValue(annotationsRaw) {
 		return
 	}
-	var annotations map[string]interface{}
+	var annotations map[string]any
 	if !ok {
-		annotations = make(map[string]interface{})
+		annotations = make(map[string]any)
 	} else {
-		annotations = annotationsRaw.(map[string]interface{})
+		annotations = annotationsRaw.(map[string]any)
 	}
 	annotations[key] = value
 
@@ -102,7 +102,7 @@ func GetAnnotationValue(obj *unstructured.Unstructured, key string) string {
 	return annotations[key]
 }
 
-func isComputedValue(v interface{}) bool {
+func isComputedValue(v any) bool {
 	_, isComputed := v.(resource.Computed)
 	return isComputed
 }

--- a/provider/pkg/metadata/annotations_test.go
+++ b/provider/pkg/metadata/annotations_test.go
@@ -23,21 +23,21 @@ import (
 )
 
 func TestSetAnnotation(t *testing.T) {
-	noAnnotationObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{},
+	noAnnotationObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{},
 	}}
-	existingAnnotationObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
+	existingAnnotationObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
 				"pulumi": "rocks",
 			},
 		},
 	}}
-	computedMetadataObj := &unstructured.Unstructured{Object: map[string]interface{}{
+	computedMetadataObj := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": resource.Computed{Element: resource.NewObjectProperty(nil)},
 	}}
-	computedAnnotationObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
+	computedAnnotationObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
 			"annotations": resource.Computed{Element: resource.NewObjectProperty(nil)},
 		},
 	}}

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -40,12 +40,12 @@ func TrySetLabel(obj *unstructured.Unstructured, key, value string) (succeeded b
 	}
 
 	var isMap bool
-	var metadata map[string]interface{}
+	var metadata map[string]any
 	if !ok {
-		metadata = map[string]interface{}{}
+		metadata = map[string]any{}
 		obj.Object["metadata"] = metadata
 	} else {
-		metadata, isMap = metadataRaw.(map[string]interface{})
+		metadata, isMap = metadataRaw.(map[string]any)
 		if !isMap {
 			return false, fmt.Errorf("expected .metadata to be a map[string]interface{}, got %q",
 				reflect.TypeOf(metadata))
@@ -56,11 +56,11 @@ func TrySetLabel(obj *unstructured.Unstructured, key, value string) (succeeded b
 	if isComputedValue(labelsRaw) {
 		return false, nil
 	}
-	var labels map[string]interface{}
+	var labels map[string]any
 	if !ok {
-		labels = make(map[string]interface{})
+		labels = make(map[string]any)
 	} else {
-		labels, isMap = labelsRaw.(map[string]interface{})
+		labels, isMap = labelsRaw.(map[string]any)
 		if !isMap {
 			return false, fmt.Errorf("expected .metadata.labels to be a map[string]interface{}, got %q",
 				reflect.TypeOf(labels))
@@ -73,17 +73,17 @@ func TrySetLabel(obj *unstructured.Unstructured, key, value string) (succeeded b
 }
 
 // GetLabel gets the value of the specified label from the given object.
-func GetLabel(obj *unstructured.Unstructured, key string) interface{} {
+func GetLabel(obj *unstructured.Unstructured, key string) any {
 	metadataRaw := obj.Object["metadata"]
 	if isComputedValue(metadataRaw) || metadataRaw == nil {
 		return metadataRaw
 	}
-	metadata := metadataRaw.(map[string]interface{})
+	metadata := metadataRaw.(map[string]any)
 	labelsRaw := metadata["labels"]
 	if isComputedValue(labelsRaw) || labelsRaw == nil {
 		return labelsRaw
 	}
-	return labelsRaw.(map[string]interface{})[key]
+	return labelsRaw.(map[string]any)[key]
 }
 
 // TrySetManagedByLabel attempts to set the `app.kubernetes.io/managed-by` label to the `pulumi` key

--- a/provider/pkg/metadata/labels_test.go
+++ b/provider/pkg/metadata/labels_test.go
@@ -24,27 +24,27 @@ import (
 )
 
 func TestSetLabel(t *testing.T) {
-	noLabelObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{},
+	noLabelObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{},
 	}}
-	existingLabelObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
+	existingLabelObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
 				"pulumi": "rocks",
 			},
 		},
 	}}
-	incorrectMetadataType := &unstructured.Unstructured{Object: map[string]interface{}{
+	incorrectMetadataType := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": "badtyping",
 	}}
-	incorrectLabelsType := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{"labels": "badtyping"},
+	incorrectLabelsType := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"labels": "badtyping"},
 	}}
-	computedMetadataObj := &unstructured.Unstructured{Object: map[string]interface{}{
+	computedMetadataObj := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": resource.Computed{Element: resource.NewObjectProperty(nil)},
 	}}
-	computedLabelObj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
+	computedLabelObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
 			"labels": resource.Computed{Element: resource.NewObjectProperty(nil)},
 		},
 	}}

--- a/provider/pkg/metadata/naming_test.go
+++ b/provider/pkg/metadata/naming_test.go
@@ -38,7 +38,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 
 	// o2 has a name, so autonaming fails.
 	o2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "bar"}},
+		Object: map[string]any{"metadata": map[string]any{"name": "bar"}},
 	}
 	pm2 := resource.PropertyMap{
 		"metadata": resource.NewObjectProperty(resource.PropertyMap{
@@ -52,7 +52,7 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 
 	// o3 has a computed name, so autonaming fails.
 	o3 := &unstructured.Unstructured{
-		Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "[Computed]"}},
+		Object: map[string]any{"metadata": map[string]any{"name": "[Computed]"}},
 	}
 	pm3 := resource.PropertyMap{
 		"metadata": resource.NewObjectProperty(resource.PropertyMap{
@@ -68,17 +68,17 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 func TestAdoptName(t *testing.T) {
 	// new1 is named and therefore DOES NOT adopt old1's name.
 	old1 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"name": "old1",
 				// NOTE: annotations needs to be a `map[string]interface{}` rather than `map[string]string`
 				// or the k8s utility functions fail.
-				"annotations": map[string]interface{}{AnnotationAutonamed: "true"},
+				"annotations": map[string]any{AnnotationAutonamed: "true"},
 			},
 		},
 	}
 	new1 := &unstructured.Unstructured{
-		Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "new1"}},
+		Object: map[string]any{"metadata": map[string]any{"name": "new1"}},
 	}
 	AdoptOldAutonameIfUnnamed(new1, old1)
 	assert.Equal(t, "old1", old1.GetName())
@@ -88,7 +88,7 @@ func TestAdoptName(t *testing.T) {
 
 	// new2 is unnamed and therefore DOES adopt old1's name.
 	new2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{},
+		Object: map[string]any{},
 	}
 	AdoptOldAutonameIfUnnamed(new2, old1)
 	assert.Equal(t, "old1", new2.GetName())
@@ -96,11 +96,11 @@ func TestAdoptName(t *testing.T) {
 
 	// old2 is not autonamed, so new3 DOES NOT adopt old2's name.
 	new3 := &unstructured.Unstructured{
-		Object: map[string]interface{}{},
+		Object: map[string]any{},
 	}
 	old2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"name": "old1",
 			},
 		},

--- a/provider/pkg/openapi/example_openapi_test.go
+++ b/provider/pkg/openapi/example_openapi_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func ExamplePluck_pathFound() {
-	obj := map[string]interface{}{
-		"a": map[string]interface{}{
-			"x": map[string]interface{}{
+	obj := map[string]any{
+		"a": map[string]any{
+			"x": map[string]any{
 				"foo": 1,
 				"bar": 2,
 			},
@@ -26,9 +26,9 @@ func ExamplePluck_pathFound() {
 }
 
 func ExamplePluck_pathNotFound() {
-	obj := map[string]interface{}{
-		"a": map[string]interface{}{
-			"x": map[string]interface{}{
+	obj := map[string]any{
+		"a": map[string]any{
+			"x": map[string]any{
 				"foo": 1,
 				"bar": 2,
 			},

--- a/provider/pkg/openapi/match.go
+++ b/provider/pkg/openapi/match.go
@@ -15,7 +15,7 @@ import (
 // PropertiesChanged compares two versions of an object to see if any path specified in `paths` has
 // been changed. Paths are specified as JSONPaths, e.g., `.spec.accessModes` refers to `{spec:
 // {accessModes: {}}}`.
-func PropertiesChanged(oldObj, newObj map[string]interface{}, paths []string) ([]string, error) {
+func PropertiesChanged(oldObj, newObj map[string]any, paths []string) ([]string, error) {
 	patch, err := mergePatchObj(oldObj, newObj)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func PropertiesChanged(oldObj, newObj map[string]interface{}, paths []string) ([
 // PatchPropertiesChanged scrapes the given patch object to see if any path specified in `paths` has
 // been changed. Paths are specified as JSONPaths, e.g., `.spec.accessModes` refers to `{spec:
 // {accessModes: {}}}`.
-func PatchPropertiesChanged(patch map[string]interface{}, paths []string) ([]string, error) {
+func PatchPropertiesChanged(patch map[string]any, paths []string) ([]string, error) {
 	j := jsonpath.New("")
 	matches := []string{}
 	for _, path := range paths {
@@ -54,7 +54,7 @@ func PatchPropertiesChanged(patch map[string]interface{}, paths []string) ([]str
 // For example, say we have {a: 1, c:3} and {a:1, b:2}. This function would then return {b:2, c:3}.
 //
 // This is useful so that we can (e.g.) use jsonpath to see which fields were altered.
-func mergePatchObj(oldObj, newObj map[string]interface{}) (map[string]interface{}, error) {
+func mergePatchObj(oldObj, newObj map[string]any) (map[string]any, error) {
 	oldJSON, err := json.Marshal(oldObj)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func mergePatchObj(oldObj, newObj map[string]interface{}) (map[string]interface{
 		return nil, err
 	}
 
-	patch := map[string]interface{}{}
+	patch := map[string]any{}
 	err = json.Unmarshal(patchBytes, &patch)
 	if err != nil {
 		return nil, err

--- a/provider/pkg/openapi/openapi.go
+++ b/provider/pkg/openapi/openapi.go
@@ -157,11 +157,11 @@ func SupportsDryRun(dryRunVerifier *resource.QueryParamVerifier, gvk schema.Grou
 
 // Pluck obtains the property identified by the string components in `path`. For example,
 // `Pluck(foo, "bar", "baz")` returns `foo.bar.baz`.
-func Pluck(obj map[string]interface{}, path ...string) (interface{}, bool) {
-	var curr interface{} = obj
+func Pluck(obj map[string]any, path ...string) (any, bool) {
+	var curr any = obj
 	for _, component := range path {
 		// Make sure we can actually dot into the current element.
-		currObj, isMap := curr.(map[string]interface{})
+		currObj, isMap := curr.(map[string]any)
 		if !isMap {
 			return nil, false
 		}

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type object = map[string]interface{}
-type list = []interface{}
+type object = map[string]any
+type list = []any
 type expected = map[string]*pulumirpc.PropertyDiff
 
 func TestPatchToDiff(t *testing.T) {
@@ -204,7 +204,7 @@ func TestPatchToDiff(t *testing.T) {
 			patchBytes, err := jsonpatch.CreateMergePatch(oldJSON, newJSON)
 			assert.NoError(t, err)
 
-			patch := map[string]interface{}{}
+			patch := map[string]any{}
 			err = json.Unmarshal(patchBytes, &patch)
 			assert.NoError(t, err)
 

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -22,20 +22,20 @@ import (
 )
 
 func Test_MergeMaps(t *testing.T) {
-	m := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b": map[string]interface{}{
-				"d": []interface{}{
+	m := map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{
+				"d": []any{
 					"1", "2",
 				},
 			},
 		},
 	}
 
-	override := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b": map[string]interface{}{
-				"d": []interface{}{
+	override := map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{
+				"d": []any{
 					"3", "4",
 				},
 			},
@@ -45,9 +45,9 @@ func Test_MergeMaps(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		allowNil bool
-		dest     map[string]interface{}
-		src      map[string]interface{}
-		expected map[string]interface{}
+		dest     map[string]any
+		src      map[string]any
+		expected map[string]any
 	}{
 		{
 			name:     "Precedence",
@@ -60,23 +60,23 @@ func Test_MergeMaps(t *testing.T) {
 			name:     "Merge maps",
 			allowNil: false,
 			dest:     m,
-			src: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"c": []interface{}{
+			src: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": []any{
 							"3", "4",
 						},
 						"f": true,
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"d": []interface{}{
+			expected: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"d": []any{
 							"1", "2",
 						},
-						"c": []interface{}{
+						"c": []any{
 							"3", "4",
 						},
 						"f": true,
@@ -88,18 +88,18 @@ func Test_MergeMaps(t *testing.T) {
 			name:     "Dest Has Nil Values- disallow nil",
 			allowNil: false,
 			dest:     m,
-			src: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"c": interface{}(nil),
-						"e": (*interface{})(nil),
+			src: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": any(nil),
+						"e": (*any)(nil),
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"d": []interface{}{
+			expected: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"d": []any{
 							"1", "2",
 						},
 					},
@@ -110,20 +110,20 @@ func Test_MergeMaps(t *testing.T) {
 			name:     "Dest Has Nil Values- allow nil",
 			allowNil: true,
 			dest:     m,
-			src: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"c": interface{}(nil),
-						"e": (*interface{})(nil),
+			src: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": any(nil),
+						"e": (*any)(nil),
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"a": map[string]interface{}{
-					"b": map[string]interface{}{
-						"c": interface{}(nil),
-						"e": (*interface{})(nil),
-						"d": []interface{}{
+			expected: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": any(nil),
+						"e": (*any)(nil),
+						"d": []any{
 							"1", "2",
 						},
 					},

--- a/provider/pkg/provider/invoke_decode_yaml.go
+++ b/provider/pkg/provider/invoke_decode_yaml.go
@@ -25,12 +25,12 @@ import (
 
 // decodeYaml parses a YAML string, and then returns a slice of untyped structs that can be marshalled into
 // Pulumi RPC calls. If a default namespace is specified, set that on the relevant decoded objects.
-func decodeYaml(text, defaultNamespace string, clientSet *clients.DynamicClientSet) ([]interface{}, error) {
+func decodeYaml(text, defaultNamespace string, clientSet *clients.DynamicClientSet) ([]any, error) {
 	var resources []unstructured.Unstructured
 
 	dec := yaml.NewYAMLOrJSONDecoder(io.NopCloser(strings.NewReader(text)), 128)
 	for {
-		var value map[string]interface{}
+		var value map[string]any
 		if err := dec.Decode(&value); err != nil {
 			if err == io.EOF {
 				break
@@ -63,7 +63,7 @@ func decodeYaml(text, defaultNamespace string, clientSet *clients.DynamicClientS
 		resources = append(resources, resource)
 	}
 
-	result := make([]interface{}, 0, len(resources))
+	result := make([]any, 0, len(resources))
 	for _, resource := range resources {
 		result = append(result, resource.Object)
 	}

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -59,18 +59,18 @@ type HelmFetchOpts struct {
 type HelmChartOpts struct {
 	HelmFetchOpts `json:"fetch_opts,omitempty"`
 
-	APIVersions              []string               `json:"api_versions,omitempty"`
-	Chart                    string                 `json:"chart,omitempty"`
-	IncludeTestHookResources bool                   `json:"include_test_hook_resources,omitempty"`
-	SkipCRDRendering         bool                   `json:"skip_crd_rendering,omitempty"`
-	Namespace                string                 `json:"namespace,omitempty"`
-	Path                     string                 `json:"path,omitempty"`
-	ReleaseName              string                 `json:"release_name,omitempty"`
-	Repo                     string                 `json:"repo,omitempty"`
-	Values                   map[string]interface{} `json:"values,omitempty"`
-	Version                  string                 `json:"version,omitempty"`
-	HelmChartDebug           bool                   `json:"helm_chart_debug,omitempty"`
-	HelmRegistryConfig       string                 `json:"helm_registry_config,omitempty"`
+	APIVersions              []string       `json:"api_versions,omitempty"`
+	Chart                    string         `json:"chart,omitempty"`
+	IncludeTestHookResources bool           `json:"include_test_hook_resources,omitempty"`
+	SkipCRDRendering         bool           `json:"skip_crd_rendering,omitempty"`
+	Namespace                string         `json:"namespace,omitempty"`
+	Path                     string         `json:"path,omitempty"`
+	ReleaseName              string         `json:"release_name,omitempty"`
+	Repo                     string         `json:"repo,omitempty"`
+	Values                   map[string]any `json:"values,omitempty"`
+	Version                  string         `json:"version,omitempty"`
+	HelmChartDebug           bool           `json:"helm_chart_debug,omitempty"`
+	HelmRegistryConfig       string         `json:"helm_registry_config,omitempty"`
 }
 
 // helmTemplate performs Helm fetch/pull + template operations and returns the resulting YAML manifest based on the

--- a/provider/pkg/provider/invoke_kustomize.go
+++ b/provider/pkg/provider/invoke_kustomize.go
@@ -27,7 +27,7 @@ import (
 
 // kustomizeDirectory takes a path to a kustomization directory, either a local directory or a folder in a git repo,
 // and then returns a slice of untyped structs that can be marshalled into Pulumi RPC calls.
-func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) ([]interface{}, error) {
+func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) ([]any, error) {
 	path := directory
 
 	// If provided directory doesn't exist locally, assume it's a git repo link.

--- a/provider/pkg/provider/manifest_json.go
+++ b/provider/pkg/provider/manifest_json.go
@@ -23,9 +23,9 @@ import (
 // a deserialized map representation of the manifest (with secrets masked), a map
 // grouping resource names in the manifests by group version and any error encountered.
 // Not, currently only kubernetes secret data is masked.
-func convertYAMLManifestToJSON(manifest string) (map[string]interface{}, map[string][]string, error) {
+func convertYAMLManifestToJSON(manifest string) (map[string]any, map[string][]string, error) {
 	releaseResources := map[string]codegen.StringSet{}
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	resources := releaseutil.SplitManifests(manifest)
 	for _, resource := range resources {
@@ -60,7 +60,7 @@ func convertYAMLManifestToJSON(manifest string) (map[string]interface{}, map[str
 			key = fmt.Sprintf("%s/%s", namespace, key)
 		}
 
-		var o interface{} = &obj.Object
+		var o any = &obj.Object
 		if gvk.Kind == "Secret" {
 			var secret corev1.Secret
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &secret)

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -23,26 +23,26 @@ import (
 )
 
 var (
-	objInputs = map[string]interface{}{
+	objInputs = map[string]any{
 		"foo": "bar",
 		"baz": float64(1234),
-		"qux": map[string]interface{}{
+		"qux": map[string]any{
 			"xuq": "oof",
 		},
 	}
-	objLive = map[string]interface{}{
+	objLive = map[string]any{
 		initialAPIVersionKey: "",
 		fieldManagerKey:      "",
 		"oof":                "bar",
 		"zab":                float64(4321),
-		"xuq": map[string]interface{}{
+		"xuq": map[string]any{
 			"qux": "foo",
 		},
 	}
 )
 
 func TestParseOldCheckpointObject(t *testing.T) {
-	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+	old := resource.NewPropertyMapFromMap(map[string]any{
 		"inputs": objInputs,
 		"live":   objLive,
 	})
@@ -77,17 +77,17 @@ func TestCheckpointObject(t *testing.T) {
 
 // #2300 - Read() on top-level k8s objects of kind "secret" led to unencrypted __input
 func TestCheckpointSecretObject(t *testing.T) {
-	objInputSecret := map[string]interface{}{
+	objInputSecret := map[string]any{
 		"kind": "Secret",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"password": "verysecret",
 		},
 	}
-	objSecretLive := map[string]interface{}{
+	objSecretLive := map[string]any{
 		initialAPIVersionKey: "",
 		fieldManagerKey:      "",
 		"kind":               "Secret",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"password": "verysecret",
 		},
 	}
@@ -126,8 +126,8 @@ func TestRoundtripCheckpointObject(t *testing.T) {
 
 func Test_equalNumbers(t *testing.T) {
 	type args struct {
-		a interface{}
-		b interface{}
+		a any
+		b any
 	}
 	tests := []struct {
 		name string

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -45,19 +45,19 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name:             "Object with no computed values does not have a computed value",
-			obj:              &unstructured.Unstructured{Object: map[string]interface{}{}},
+			obj:              &unstructured.Unstructured{Object: map[string]any{}},
 			hasComputedValue: false,
 		},
 		{
 			name: "Object with one concrete value does not have a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
 			}},
 			hasComputedValue: false,
 		},
 		{
 			name: "Object with one computed value does have a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
 				"field2": resource.Computed{},
 			}},
@@ -65,9 +65,9 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with one nested computed value does have a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": map[string]interface{}{
+				"field2": map[string]any{
 					"field3": resource.Computed{},
 				},
 			}},
@@ -75,9 +75,9 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with nested maps and no computed values",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": map[string]interface{}{
+				"field2": map[string]any{
 					"field3": "3",
 				},
 			}},
@@ -85,11 +85,11 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with doubly nested maps and 1 computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": map[string]interface{}{
+				"field2": map[string]any{
 					"field3": "3",
-					"field4": map[string]interface{}{
+					"field4": map[string]any{
 						"field5": resource.Computed{},
 					},
 				},
@@ -98,9 +98,9 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with nested slice of map[string]interface{} has a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": []map[string]interface{}{
+				"field2": []map[string]any{
 					{"field3": resource.Computed{}},
 				},
 			}},
@@ -108,9 +108,9 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with nested slice of interface{} has a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": []interface{}{
+				"field2": []any{
 					resource.Computed{},
 				},
 			}},
@@ -118,10 +118,10 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Object with nested slice of map[string]interface{} with nested slice of interface{} has a computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": []map[string]interface{}{
-					{"field3": []interface{}{
+				"field2": []map[string]any{
+					{"field3": []any{
 						resource.Computed{},
 					}},
 				},
@@ -130,12 +130,12 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Complex nested object with computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": []map[string]interface{}{
-					{"field3": []interface{}{
-						[]map[string]interface{}{
-							{"field4": []interface{}{
+				"field2": []map[string]any{
+					{"field3": []any{
+						[]map[string]any{
+							{"field4": []any{
 								resource.Computed{},
 							}},
 						},
@@ -146,12 +146,12 @@ func TestHasComputedValue(t *testing.T) {
 		},
 		{
 			name: "Complex nested object with no computed value",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"field1": 1,
-				"field2": []map[string]interface{}{
-					{"field3": []interface{}{
-						[]map[string]interface{}{
-							{"field4": []interface{}{
+				"field2": []map[string]any{
+					{"field3": []any{
+						[]map[string]any{
+							{"field4": []any{
 								"field5",
 							}},
 						},
@@ -169,10 +169,10 @@ func TestHasComputedValue(t *testing.T) {
 
 func TestFqName(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "tests/v1alpha1",
 			"kind":       "Test",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "myname",
 			},
 		},
@@ -591,60 +591,60 @@ func TestPruneMap(t *testing.T) {
 }`)
 
 	var err error
-	var source, target map[string]interface{}
+	var source, target map[string]any
 	err = json.Unmarshal(oldInputsJSON, &target)
 	assert.NoErrorf(t, err, "failed to unmarshal oldInputsJSON")
 	err = json.Unmarshal(oldLiveJSON, &source)
 	assert.NoErrorf(t, err, "failed to unmarshal oldLiveJSON")
 
 	type args struct {
-		source map[string]interface{}
-		target map[string]interface{}
+		source map[string]any
+		target map[string]any
 	}
 	tests := []struct {
 		name        string
 		description string
 		args        args
-		want        map[string]interface{}
+		want        map[string]any
 	}{
 		{
 			name:        "empty target",
 			description: "empty target map should result in empty result map",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
-				target: map[string]interface{}{},
+				target: map[string]any{},
 			},
-			want: map[string]interface{}{},
+			want: map[string]any{},
 		},
 		{
 			name:        "empty source",
 			description: "empty source map should result in empty result map",
 			args: args{
-				source: map[string]interface{}{},
-				target: map[string]interface{}{
+				source: map[string]any{},
+				target: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
 			},
-			want: map[string]interface{}{},
+			want: map[string]any{},
 		},
 		{
 			name:        "matching keys with different values",
 			description: "a map where target has matching keys and different values",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 					"b": "B",
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 				"b": "b",
 			},
@@ -653,16 +653,16 @@ func TestPruneMap(t *testing.T) {
 			name:        "matching keys with nil source value",
 			description: "a map where target has matching keys and source has a nil value",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": nil,
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 					"b": "B",
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 				"b": nil,
 			},
@@ -671,16 +671,16 @@ func TestPruneMap(t *testing.T) {
 			name:        "matching keys with nil target value",
 			description: "a map where target has matching keys and target has a nil value",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 					"b": nil,
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 				"b": "b",
 			},
@@ -689,16 +689,16 @@ func TestPruneMap(t *testing.T) {
 			name:        "matching keys but different value types",
 			description: "a map where target has matching keys and different value types",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 					"b": 2,
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 				"b": "b", // key is present in target, so keep it even though the value type doesn't match
 			},
@@ -707,16 +707,16 @@ func TestPruneMap(t *testing.T) {
 			name:        "simple map",
 			description: "a map where target matches",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "a",
 					"b": "b",
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 				"b": "b",
 			},
@@ -725,15 +725,15 @@ func TestPruneMap(t *testing.T) {
 			name:        "simple map subset",
 			description: "a map where target is a subset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 					"b": "b", // not present in target, so will be ignored
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 			},
 		},
@@ -741,15 +741,15 @@ func TestPruneMap(t *testing.T) {
 			name:        "simple map superset",
 			description: "a map where target is a superset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "A",
 					"b": "B", // the extra key will be ignored if not present in source
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
 			},
 		},
@@ -757,22 +757,22 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map",
 			description: "a map with a nested map where target matches",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": "c",
 					},
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "a",
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": "c",
 					},
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
-				"b": map[string]interface{}{
+				"b": map[string]any{
 					"c": "c",
 				},
 			},
@@ -781,20 +781,20 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map subset",
 			description: "a map with a nested map where target is a subset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": "c",
 					},
 				},
-				target: map[string]interface{}{
-					"b": map[string]interface{}{
+				target: map[string]any{
+					"b": map[string]any{
 						"c": "C",
 					},
 				},
 			},
-			want: map[string]interface{}{
-				"b": map[string]interface{}{
+			want: map[string]any{
+				"b": map[string]any{
 					"c": "c",
 				},
 			},
@@ -803,21 +803,21 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map superset",
 			description: "a map with a nested map where target is a superset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": "c",
 					},
 				},
-				target: map[string]interface{}{
-					"b": map[string]interface{}{
+				target: map[string]any{
+					"b": map[string]any{
 						"c": "C",
 					},
 					"d": "D", // the extra key will be ignored if not present in source
 				},
 			},
-			want: map[string]interface{}{
-				"b": map[string]interface{}{
+			want: map[string]any{
+				"b": map[string]any{
 					"c": "c",
 				},
 			},
@@ -826,22 +826,22 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map with nil",
 			description: "a map with a nested map with nil where target matches",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": nil,
 					},
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "a",
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": nil,
 					},
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
-				"b": map[string]interface{}{
+				"b": map[string]any{
 					"c": nil,
 				},
 			},
@@ -850,79 +850,79 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested value slice",
 			description: "a map with a nested slice of simple values where target matches",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
-					"b": []interface{}{"c", "d"},
+					"b": []any{"c", "d"},
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "a",
-					"b": []interface{}{"c", "d"},
+					"b": []any{"c", "d"},
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
-				"b": []interface{}{"c", "d"},
+				"b": []any{"c", "d"},
 			},
 		},
 		{
 			name:        "nested value slice subset",
 			description: "a map with a nested slice of simple values where target is a subset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": []interface{}{"c", "d"},
+					"b": []any{"c", "d"},
 				},
-				target: map[string]interface{}{
-					"b": []interface{}{"c"},
+				target: map[string]any{
+					"b": []any{"c"},
 				},
 			},
-			want: map[string]interface{}{
-				"b": []interface{}{"c"}, // items compared by index, so only the first item in source will be kept
+			want: map[string]any{
+				"b": []any{"c"}, // items compared by index, so only the first item in source will be kept
 			},
 		},
 		{
 			name:        "nested value slice superset",
 			description: "a map with a nested slice of simple values where target is a superset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": []interface{}{"c", "d"},
+					"b": []any{"c", "d"},
 				},
-				target: map[string]interface{}{
-					"b": []interface{}{"c", "d", "e"},
+				target: map[string]any{
+					"b": []any{"c", "d", "e"},
 				},
 			},
-			want: map[string]interface{}{
-				"b": []interface{}{"c", "d"},
+			want: map[string]any{
+				"b": []any{"c", "d"},
 			},
 		},
 		{
 			name:        "nested map slice",
 			description: "a map with a nested slice of map values where target matches",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a",
-					"b": []interface{}{
-						map[string]interface{}{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 							"d": "d",
 						},
 					},
 				},
-				target: map[string]interface{}{
+				target: map[string]any{
 					"a": "a",
-					"b": []interface{}{
-						map[string]interface{}{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 							"d": "d",
 						},
 					},
 				},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"a": "a",
-				"b": []interface{}{
-					map[string]interface{}{
+				"b": []any{
+					map[string]any{
 						"c": "c",
 						"d": "d",
 					},
@@ -933,26 +933,26 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map slice subset",
 			description: "a map with a nested slice of map values where target is a subset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": []interface{}{
-						map[string]interface{}{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 							"d": "d", // not present in target, so will be ignored
 						},
 					},
 				},
-				target: map[string]interface{}{
-					"b": []interface{}{
-						map[string]interface{}{
+				target: map[string]any{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 						},
 					},
 				},
 			},
-			want: map[string]interface{}{
-				"b": []interface{}{
-					map[string]interface{}{
+			want: map[string]any{
+				"b": []any{
+					map[string]any{
 						"c": "c",
 					},
 				},
@@ -962,18 +962,18 @@ func TestPruneMap(t *testing.T) {
 			name:        "nested map slice superset",
 			description: "a map with a nested slice of map values where target is a superset",
 			args: args{
-				source: map[string]interface{}{
+				source: map[string]any{
 					"a": "a", // not present in target, so will be ignored
-					"b": []interface{}{
-						map[string]interface{}{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 							"d": "d",
 						},
 					},
 				},
-				target: map[string]interface{}{
-					"b": []interface{}{
-						map[string]interface{}{
+				target: map[string]any{
+					"b": []any{
+						map[string]any{
 							"c": "c",
 							"d": "d",
 							"e": "e",
@@ -981,9 +981,9 @@ func TestPruneMap(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]interface{}{
-				"b": []interface{}{
-					map[string]interface{}{
+			want: map[string]any{
+				"b": []any{
+					map[string]any{
 						"c": "c",
 						"d": "d",
 					},
@@ -1011,97 +1011,97 @@ func TestPruneMap(t *testing.T) {
 
 func TestPruneSlice(t *testing.T) {
 	type args struct {
-		source []interface{}
-		target []interface{}
+		source []any
+		target []any
 	}
 	tests := []struct {
 		name        string
 		description string
 		args        args
-		want        []interface{}
+		want        []any
 	}{
 		{
 			name:        "empty target",
 			description: "empty target slice should result in empty result slice",
 			args: args{
-				source: []interface{}{"a", "b"},
-				target: []interface{}{},
+				source: []any{"a", "b"},
+				target: []any{},
 			},
-			want: []interface{}{},
+			want: []any{},
 		},
 		{
 			name:        "empty source",
 			description: "empty source slice should result in empty result slice",
 			args: args{
-				source: []interface{}{},
-				target: []interface{}{"a", "b"},
+				source: []any{},
+				target: []any{"a", "b"},
 			},
-			want: []interface{}{},
+			want: []any{},
 		},
 		{
 			name:        "matching number of elements with different values",
 			description: "a slice where target has matching number of elements with different values",
 			args: args{
-				source: []interface{}{"a", "b"},
-				target: []interface{}{"c", "d"},
+				source: []any{"a", "b"},
+				target: []any{"c", "d"},
 			},
-			want: []interface{}{"a", "b"},
+			want: []any{"a", "b"},
 		},
 		{
 			name:        "matching number of elements but different types",
 			description: "a slice where target has matching number of elements with different types",
 			args: args{
-				source: []interface{}{"a", "b"},
-				target: []interface{}{1, 2},
+				source: []any{"a", "b"},
+				target: []any{1, 2},
 			},
-			want: []interface{}{"a", "b"},
+			want: []any{"a", "b"},
 		},
 		{
 			name:        "simple slice",
 			description: "a slice where target matches",
 			args: args{
-				source: []interface{}{"a", "b"},
-				target: []interface{}{"a", "b"},
+				source: []any{"a", "b"},
+				target: []any{"a", "b"},
 			},
-			want: []interface{}{"a", "b"},
+			want: []any{"a", "b"},
 		},
 		{
 			name:        "simple slice subset",
 			description: "a slice where target is a subset",
 			args: args{
-				source: []interface{}{"a", "b"},
-				target: []interface{}{"a"},
+				source: []any{"a", "b"},
+				target: []any{"a"},
 			},
-			want: []interface{}{"a"},
+			want: []any{"a"},
 		},
 		{
 			name:        "simple slice superset",
 			description: "a slice where target is a superset",
 			args: args{
-				source: []interface{}{"a"},
-				target: []interface{}{"a", "b"},
+				source: []any{"a"},
+				target: []any{"a", "b"},
 			},
-			want: []interface{}{"a"},
+			want: []any{"a"},
 		},
 		{
 			name:        "map slice",
 			description: "a slice of map values where target matches",
 			args: args{
-				source: []interface{}{
-					map[string]interface{}{
+				source: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
 				},
-				target: []interface{}{
-					map[string]interface{}{
+				target: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
 				},
 			},
-			want: []interface{}{
-				map[string]interface{}{
+			want: []any{
+				map[string]any{
 					"a": "a",
 					"b": "b",
 				},
@@ -1111,24 +1111,24 @@ func TestPruneSlice(t *testing.T) {
 			name:        "map slice subset",
 			description: "a slice of map values where target is a subset",
 			args: args{
-				source: []interface{}{
-					map[string]interface{}{
+				source: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b", // not present in target, so will be dropped
 					},
-					map[string]interface{}{ // map not present in target, so will be dropped
+					map[string]any{
 						"c": "c",
 						"d": "d",
 					},
 				},
-				target: []interface{}{
-					map[string]interface{}{
+				target: []any{
+					map[string]any{
 						"a": "a",
 					},
 				},
 			},
-			want: []interface{}{
-				map[string]interface{}{
+			want: []any{
+				map[string]any{
 					"a": "a",
 				},
 			},
@@ -1137,25 +1137,25 @@ func TestPruneSlice(t *testing.T) {
 			name:        "map slice superset",
 			description: "a slice of map values where target is a superset",
 			args: args{
-				source: []interface{}{
-					map[string]interface{}{
+				source: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
 				},
-				target: []interface{}{
-					map[string]interface{}{
+				target: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"c": "c",
 						"d": "d",
 					},
 				},
 			},
-			want: []interface{}{
-				map[string]interface{}{
+			want: []any{
+				map[string]any{
 					"a": "a",
 					"b": "b",
 				},
@@ -1165,23 +1165,23 @@ func TestPruneSlice(t *testing.T) {
 			name:        "map slice with nil value",
 			description: "a slice of map values that include a nil value",
 			args: args{
-				source: []interface{}{
-					map[string]interface{}{
+				source: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
 					nil,
 				},
-				target: []interface{}{
-					map[string]interface{}{
+				target: []any{
+					map[string]any{
 						"a": "a",
 						"b": "b",
 					},
 					nil,
 				},
 			},
-			want: []interface{}{
-				map[string]interface{}{
+			want: []any{
+				map[string]any{
 					"a": "a",
 					"b": "b",
 				},

--- a/tests/sdk/dotnet/dotnet_test.go
+++ b/tests/sdk/dotnet/dotnet_test.go
@@ -110,7 +110,7 @@ func TestDotnet_Helm(t *testing.T) {
 				if res.Type == tokens.Type("kubernetes:core/v1:Service") {
 					spec, has := res.Outputs["status"]
 					assert.True(t, has)
-					specMap, is := spec.(map[string]interface{})
+					specMap, is := spec.(map[string]any)
 					assert.True(t, is)
 					sigKey, has := specMap[resource.SigKey]
 					assert.True(t, has)

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -345,7 +345,7 @@ func TestGo(t *testing.T) {
 					Additive: true,
 					ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 						// Validate patched CustomResource
-						crPatchedLabels := stackInfo.Outputs["crPatchedLabels"].(map[string]interface{})
+						crPatchedLabels := stackInfo.Outputs["crPatchedLabels"].(map[string]any)
 						fooV, ok, err := unstructured.NestedString(crPatchedLabels, "foo")
 						assert.True(t, ok)
 						assert.NoError(t, err)

--- a/tests/sdk/go/helm-local/step1/main.go
+++ b/tests/sdk/go/helm-local/step1/main.go
@@ -18,7 +18,7 @@ func main() {
 		}
 
 		svc := chart.GetResource("v1/Service", "prefix-prefix-test-nginx", "").
-			ApplyT(func(r interface{}) (interface{}, error) {
+			ApplyT(func(r any) (any, error) {
 				svc := r.(*corev1.Service)
 				return svc.Spec.ClusterIP(), nil
 			})

--- a/tests/sdk/go/helm-local/step2/main.go
+++ b/tests/sdk/go/helm-local/step2/main.go
@@ -18,7 +18,7 @@ func main() {
 		}
 
 		svc := chart.GetResource("v1/Service", "prefix-prefix-test-nginx", "").
-			ApplyT(func(r interface{}) (interface{}, error) {
+			ApplyT(func(r any) (any, error) {
 				svc := r.(*corev1.Service)
 				return svc.Spec.ClusterIP(), nil
 			})

--- a/tests/sdk/go/helm-partial-error/step1/main.go
+++ b/tests/sdk/go/helm-partial-error/step1/main.go
@@ -38,8 +38,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)

--- a/tests/sdk/go/helm-partial-error/step2/main.go
+++ b/tests/sdk/go/helm-partial-error/step2/main.go
@@ -38,8 +38,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)

--- a/tests/sdk/go/helm-release-import/step1/main.go
+++ b/tests/sdk/go/helm-release-import/step1/main.go
@@ -25,8 +25,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s", *namespace, *name)), nil)

--- a/tests/sdk/go/helm-release-local-tar/step1/main.go
+++ b/tests/sdk/go/helm-release-local-tar/step1/main.go
@@ -25,8 +25,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)

--- a/tests/sdk/go/helm-release-local/step1/main.go
+++ b/tests/sdk/go/helm-release-local/step1/main.go
@@ -25,8 +25,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)

--- a/tests/sdk/go/helm-release/step1/main.go
+++ b/tests/sdk/go/helm-release/step1/main.go
@@ -23,8 +23,8 @@ func main() {
 			return err
 		}
 		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
-			ApplyT(func(r interface{}) (interface{}, error) {
-				arr := r.([]interface{})
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)

--- a/tests/sdk/go/helm/step1/main.go
+++ b/tests/sdk/go/helm/step1/main.go
@@ -21,7 +21,7 @@ func main() {
 		}
 
 		svc := chart.GetResource("v1/Service", "test-nginx", "").
-			ApplyT(func(r interface{}) (interface{}, error) {
+			ApplyT(func(r any) (any, error) {
 				svc := r.(*corev1.Service)
 				return svc.Spec.ClusterIP(), nil
 			})

--- a/tests/sdk/go/helm/step2/main.go
+++ b/tests/sdk/go/helm/step2/main.go
@@ -21,7 +21,7 @@ func main() {
 		}
 
 		svc := chart.GetResource("v1/Service", "test-nginx", "").
-			ApplyT(func(r interface{}) (interface{}, error) {
+			ApplyT(func(r any) (any, error) {
 				svc := r.(*corev1.Service)
 				return svc.Spec.ClusterIP(), nil
 			})

--- a/tests/sdk/go/manual.go
+++ b/tests/sdk/go/manual.go
@@ -69,7 +69,7 @@ func createRelease(releaseName, releaseNamespace, baseDir string, createNamespac
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(kubeconfig, releaseNamespace, os.Getenv("HELM_DRIVER"), func(format string, v ...interface{}) {
+	if err := actionConfig.Init(kubeconfig, releaseNamespace, os.Getenv("HELM_DRIVER"), func(format string, v ...any) {
 		_ = fmt.Sprintf(format, v)
 	}); err != nil {
 		panic(err)
@@ -83,7 +83,7 @@ func createRelease(releaseName, releaseNamespace, baseDir string, createNamespac
 	// we might end up with mysterious test failures (initErrors during updates might trigger an update).
 	install.Wait = true
 	install.Timeout = 5 * time.Minute
-	rel, err := install.Run(chart, map[string]interface{}{"service": map[string]interface{}{"type": "ClusterIP"}})
+	rel, err := install.Run(chart, map[string]any{"service": map[string]any{"type": "ClusterIP"}})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func listReleases(releaseNamespace string) ([]*release.Release, error) {
 		return nil, err
 	}
 	if err := actionConfig.Init(kubeconfig, releaseNamespace, os.Getenv("HELM_DRIVER"), func(format string,
-		v ...interface{}) {
+		v ...any) {
 		_ = fmt.Sprintf(format, v)
 	}); err != nil {
 		panic(err)
@@ -121,7 +121,7 @@ func deleteRelease(releaseName, releaseNamespace string) error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(kubeconfig, releaseNamespace, os.Getenv("HELM_DRIVER"), func(format string, v ...interface{}) {
+	if err := actionConfig.Init(kubeconfig, releaseNamespace, os.Getenv("HELM_DRIVER"), func(format string, v ...any) {
 		_ = fmt.Sprintf(format, v)
 	}); err != nil {
 		panic(err)

--- a/tests/sdk/go/server-side-apply/step2/main.go
+++ b/tests/sdk/go/server-side-apply/step2/main.go
@@ -104,7 +104,7 @@ func main() {
 		}
 
 		crPatchedLabels := pulumi.All(ns.Metadata.Name(), crPatch.Metadata.Name()).
-			ApplyT(func(arr []interface{}) (interface{}, error) {
+			ApplyT(func(arr []any) (any, error) {
 				namespace := arr[0].(*string)
 				name := arr[1].(*string)
 				cr, err := apiextensions.GetCustomResource(ctx, "crPatched",

--- a/tests/sdk/go/yaml/main.go
+++ b/tests/sdk/go/yaml/main.go
@@ -42,9 +42,9 @@ func main() {
 			&yaml.ConfigGroupArgs{
 				Files: []string{filepath.Join("manifests", "*.yaml")},
 				Transformations: []yaml.Transformation{
-					func(state map[string]interface{}, opts ...pulumi.ResourceOption) {
+					func(state map[string]any, opts ...pulumi.ResourceOption) {
 						if state["apiVersion"] == "v1" && state["kind"] == "Pod" {
-							metadata := state["metadata"].(map[string]interface{})
+							metadata := state["metadata"].(map[string]any)
 							_, ok := metadata["labels"]
 							if !ok {
 								metadata["labels"] = map[string]string{"foo": "bar"}
@@ -66,9 +66,9 @@ func main() {
 		ctx.Export("hostIP", hostIP)
 
 		ct := resources.GetResource("stable.example.com/v1/GoYamlCronTab", "my-new-cron-object", "")
-		cronSpec := ct.(*apiextensions.CustomResource).OtherFields.ApplyT(func(otherFields interface{}) string {
-			fields := otherFields.(map[string]interface{})
-			spec := fields["spec"].(map[string]interface{})
+		cronSpec := ct.(*apiextensions.CustomResource).OtherFields.ApplyT(func(otherFields any) string {
+			fields := otherFields.(map[string]any)
+			spec := fields["spec"].(map[string]any)
 			return spec["cronSpec"].(string)
 		})
 		ctx.Export("cronSpec", cronSpec)

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -63,8 +63,8 @@ func TestAccGuestbook(t *testing.T) {
 						fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
 				})
 
-				var name interface{}
-				var status interface{}
+				var name any
+				var status any
 
 				// Verify frontend deployment.
 				frontendDepl := stackInfo.Deployment.Resources[0]
@@ -174,7 +174,7 @@ func TestAccHelm(t *testing.T) {
 					if res.Type == "kubernetes:core/v1:Service" {
 						spec, has := res.Outputs["status"]
 						assert.True(t, has)
-						specMap, is := spec.(map[string]interface{})
+						specMap, is := spec.(map[string]any)
 						assert.True(t, is)
 						sigKey, has := specMap[resource.SigKey]
 						assert.True(t, has)
@@ -370,7 +370,7 @@ func TestHelmRelease(t *testing.T) {
 				assert.True(t, has)
 				stat, has := res.Outputs["status"]
 				assert.True(t, has)
-				specMap, is := stat.(map[string]interface{})
+				specMap, is := stat.(map[string]any)
 				assert.True(t, is)
 				versionOut, has := specMap["version"]
 				assert.True(t, has)
@@ -378,24 +378,24 @@ func TestHelmRelease(t *testing.T) {
 				values, has := res.Outputs["values"]
 				assert.True(t, has)
 				assert.Contains(t, values, "cluster")
-				valMap := values.(map[string]interface{})
-				assert.Equal(t, valMap["cluster"], map[string]interface{}{
+				valMap := values.(map[string]any)
+				assert.Equal(t, valMap["cluster"], map[string]any{
 					"enabled":    true,
 					"slaveCount": float64(2),
 				})
 				// not asserting contents since the secret is hard to assert equality on.
 				assert.Contains(t, values, "global")
 				assert.Contains(t, values, "metrics")
-				assert.Equal(t, valMap["metrics"], map[string]interface{}{
+				assert.Equal(t, valMap["metrics"], map[string]any{
 					"enabled": true,
-					"service": map[string]interface{}{
-						"annotations": map[string]interface{}{
+					"service": map[string]any{
+						"annotations": map[string]any{
 							"prometheus.io/port": "9127",
 						},
 					},
 				})
 				assert.Contains(t, values, "rbac")
-				assert.Equal(t, valMap["rbac"], map[string]interface{}{
+				assert.Equal(t, valMap["rbac"], map[string]any{
 					"create": true,
 				})
 			}

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -64,7 +64,7 @@ func TestAliases(t *testing.T) {
 			assert.Equal(t, "alias-test", string(deployment.URN.Name()))
 			assert.Equal(t, "kubernetes:apps/v1:Deployment", string(deployment.Type))
 			containers, _ := openapi.Pluck(deployment.Outputs, "spec", "template", "spec", "containers")
-			containerStatus := containers.([]interface{})[0].(map[string]interface{})
+			containerStatus := containers.([]any)[0].(map[string]any)
 			image := containerStatus["image"]
 			assert.Equal(t, image.(string), "nginx:1.14")
 		},
@@ -82,7 +82,7 @@ func TestAliases(t *testing.T) {
 					assert.Equal(t, "alias-test", string(deployment.URN.Name()))
 					assert.Equal(t, "kubernetes:apps/v1:Deployment", string(deployment.Type))
 					containers, _ := openapi.Pluck(deployment.Outputs, "spec", "template", "spec", "containers")
-					containerStatus := containers.([]interface{})[0].(map[string]interface{})
+					containerStatus := containers.([]any)[0].(map[string]any)
 					image := containerStatus["image"]
 					assert.Equal(t, image.(string), "nginx:1.15")
 				},
@@ -93,9 +93,9 @@ func TestAliases(t *testing.T) {
 }
 
 func TestAutonaming(t *testing.T) {
-	var step1Name interface{}
-	var step2Name interface{}
-	var step3Name interface{}
+	var step1Name any
+	var step2Name any
+	var step3Name any
 
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:   filepath.Join("autonaming", "step1"),
@@ -307,7 +307,7 @@ func TestPod(t *testing.T) {
 
 			// Status "Ready" is "True".
 			conditions, _ := openapi.Pluck(pod.Outputs, "status", "conditions")
-			ready := conditions.([]interface{})[1].(map[string]interface{})
+			ready := conditions.([]any)[1].(map[string]any)
 			readyType := ready["type"]
 			assert.Equal(t, "Ready", readyType)
 			readyStatus := ready["status"]
@@ -315,7 +315,7 @@ func TestPod(t *testing.T) {
 
 			// Container is called "nginx" and uses image "docker.io/library/nginx:1.13-alpine".
 			containerStatuses, _ := openapi.Pluck(pod.Outputs, "status", "containerStatuses")
-			containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
+			containerStatus := containerStatuses.([]any)[0].(map[string]any)
 			containerName := containerStatus["name"]
 			assert.Equal(t, "nginx", containerName)
 			image := containerStatus["image"]
@@ -360,7 +360,7 @@ func TestPod(t *testing.T) {
 
 					// Status "Ready" is "True".
 					conditions, _ := openapi.Pluck(pod.Outputs, "status", "conditions")
-					ready := conditions.([]interface{})[1].(map[string]interface{})
+					ready := conditions.([]any)[1].(map[string]any)
 					readyType := ready["type"]
 					assert.Equal(t, "Ready", readyType)
 					readyStatus := ready["status"]
@@ -368,7 +368,7 @@ func TestPod(t *testing.T) {
 
 					// Container is called "nginx" and uses image "docker.io/library/nginx:1.15-alpine".
 					containerStatuses, _ := openapi.Pluck(pod.Outputs, "status", "containerStatuses")
-					containerStatus := containerStatuses.([]interface{})[0].(map[string]interface{})
+					containerStatus := containerStatuses.([]any)[0].(map[string]any)
 					containerName := containerStatus["name"]
 					assert.Equal(t, "nginx", containerName)
 					image := containerStatus["image"]
@@ -407,13 +407,13 @@ func TestDeploymentRollout(t *testing.T) {
 			name, _ := openapi.Pluck(appsv1Deploy.Outputs, "metadata", "name")
 			assert.True(t, strings.Contains(name.(string), "nginx"))
 			containers, _ := openapi.Pluck(appsv1Deploy.Outputs, "spec", "template", "spec", "containers")
-			containerStatus := containers.([]interface{})[0].(map[string]interface{})
+			containerStatus := containers.([]any)[0].(map[string]any)
 			image := containerStatus["image"]
 			assert.Equal(t, image.(string), "nginx")
 
 			assert.True(t, strings.Contains(name.(string), "nginx"))
 			containers, _ = openapi.Pluck(appsv1Deploy.Outputs, "spec", "template", "spec", "containers")
-			containerStatus = containers.([]interface{})[0].(map[string]interface{})
+			containerStatus = containers.([]any)[0].(map[string]any)
 			image = containerStatus["image"]
 			assert.Equal(t, image.(string), "nginx")
 		},
@@ -444,7 +444,7 @@ func TestDeploymentRollout(t *testing.T) {
 					name, _ := openapi.Pluck(appsv1Deploy.Outputs, "metadata", "name")
 					assert.True(t, strings.Contains(name.(string), "nginx"))
 					containers, _ := openapi.Pluck(appsv1Deploy.Outputs, "spec", "template", "spec", "containers")
-					containerStatus := containers.([]interface{})[0].(map[string]interface{})
+					containerStatus := containers.([]any)[0].(map[string]any)
 					image := containerStatus["image"]
 					assert.Equal(t, image.(string), "nginx:stable")
 				},
@@ -480,7 +480,7 @@ func TestGet(t *testing.T) {
 			// Assert we can use .get to retrieve the kube-api Service.
 			//
 
-			service := stackInfo.Outputs["svc"].(map[string]interface{})
+			service := stackInfo.Outputs["svc"].(map[string]any)
 			svcURN, _ := openapi.Pluck(service, "urn")
 			assert.Containsf(t, svcURN, "kube-api", "urn missing expected name")
 			svcName, _ := openapi.Pluck(service, "metadata", "name")
@@ -490,7 +490,7 @@ func TestGet(t *testing.T) {
 			// Assert that the uninitialized Service exists
 			//
 
-			awaitSvc := stackInfo.Outputs["awaitSvc"].(map[string]interface{})
+			awaitSvc := stackInfo.Outputs["awaitSvc"].(map[string]any)
 			awaitSvcName, _ := openapi.Pluck(awaitSvc, "metadata", "name")
 			assert.Equalf(t, "test", awaitSvcName, "unexpected service name")
 			awaitSvcAnnotation, ok := openapi.Pluck(awaitSvc, "metadata", "annotations", "pulumi.com/skipAwait")
@@ -501,11 +501,11 @@ func TestGet(t *testing.T) {
 			// Assert that CRD and CR exist
 			//
 
-			crd := stackInfo.Outputs["ct"].(map[string]interface{})
+			crd := stackInfo.Outputs["ct"].(map[string]any)
 			crdURN, _ := openapi.Pluck(crd, "urn")
 			assert.Containsf(t, crdURN, "crontab", "urn missing expected name")
 
-			cr := stackInfo.Outputs["cr"].(map[string]interface{})
+			cr := stackInfo.Outputs["cr"].(map[string]any)
 			crURN, _ := openapi.Pluck(cr, "urn")
 			assert.Containsf(t, crURN, "my-new-cron-object", "urn missing expected name")
 		},
@@ -521,7 +521,7 @@ func TestGet(t *testing.T) {
 					// Assert we can use .get to retrieve the kube-api Service.
 					//
 
-					service := stackInfo.Outputs["svc"].(map[string]interface{})
+					service := stackInfo.Outputs["svc"].(map[string]any)
 					svcURN, _ := openapi.Pluck(service, "urn")
 					assert.Containsf(t, svcURN, "kube-api", "urn missing expected name")
 					svcName, _ := openapi.Pluck(service, "metadata", "name")
@@ -531,7 +531,7 @@ func TestGet(t *testing.T) {
 					// Assert that the uninitialized Service exists
 					//
 
-					awaitSvc := stackInfo.Outputs["awaitSvc"].(map[string]interface{})
+					awaitSvc := stackInfo.Outputs["awaitSvc"].(map[string]any)
 					awaitSvcName, _ := openapi.Pluck(awaitSvc, "metadata", "name")
 					assert.Equalf(t, "test", awaitSvcName, "unexpected service name")
 					awaitSvcAnnotation, ok := openapi.Pluck(awaitSvc, "metadata", "annotations", "pulumi.com/skipAwait")
@@ -542,7 +542,7 @@ func TestGet(t *testing.T) {
 					// Assert we can use .get to retrieve a Service that would fail await logic.
 					//
 
-					awaitSvcGet := stackInfo.Outputs["awaitSvcGet"].(map[string]interface{})
+					awaitSvcGet := stackInfo.Outputs["awaitSvcGet"].(map[string]any)
 					awaitSvcGetURN, _ := openapi.Pluck(awaitSvcGet, "urn")
 					assert.Containsf(t, awaitSvcGetURN, "await", "urn missing expected name")
 
@@ -550,7 +550,7 @@ func TestGet(t *testing.T) {
 					// Assert we can use an output from a Service that would fail await logic.
 					//
 
-					cm := stackInfo.Outputs["cm"].(map[string]interface{})
+					cm := stackInfo.Outputs["cm"].(map[string]any)
 					cmURN, _ := openapi.Pluck(cm, "urn")
 					assert.Containsf(t, cmURN, "svc-test", "urn missing expected name")
 					clusterIP, _ := openapi.Pluck(cm, "data", "key")
@@ -560,11 +560,11 @@ func TestGet(t *testing.T) {
 					// Assert that CRD and CR exist
 					//
 
-					crd := stackInfo.Outputs["ct"].(map[string]interface{})
+					crd := stackInfo.Outputs["ct"].(map[string]any)
 					crdURN, _ := openapi.Pluck(crd, "urn")
 					assert.Containsf(t, crdURN, "crontab", "urn missing expected name")
 
-					cr := stackInfo.Outputs["cr"].(map[string]interface{})
+					cr := stackInfo.Outputs["cr"].(map[string]any)
 					crURN, _ := openapi.Pluck(cr, "urn")
 					assert.Containsf(t, crURN, "my-new-cron-object", "urn missing expected name")
 
@@ -572,7 +572,7 @@ func TestGet(t *testing.T) {
 					// Assert we can use .get to retrieve CRDs.
 					//
 
-					crGet := stackInfo.Outputs["crGet"].(map[string]interface{})
+					crGet := stackInfo.Outputs["crGet"].(map[string]any)
 					crGetURN, _ := openapi.Pluck(crGet, "urn")
 					assert.Containsf(t, crGetURN, "my-new-cron-object-get", "urn missing expected name")
 				},
@@ -688,7 +688,7 @@ func TestNamespace(t *testing.T) {
 					namespace := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, tokens.Type("kubernetes:core/v1:Namespace"), namespace.URN.Type())
 					namespaceLabels, _ := openapi.Pluck(namespace.Outputs, "metadata", "labels")
-					assert.True(t, namespaceLabels.(map[string]interface{})["hello"] == "world")
+					assert.True(t, namespaceLabels.(map[string]any)["hello"] == "world")
 				},
 			},
 			{
@@ -1056,14 +1056,14 @@ func TestServerSideApply(t *testing.T) {
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Validate patched Namespace
-			nsPatched := stackInfo.Outputs["nsPatched"].(map[string]interface{})
+			nsPatched := stackInfo.Outputs["nsPatched"].(map[string]any)
 			fooV, ok, err := unstructured.NestedString(nsPatched, "metadata", "labels", "foo")
 			assert.True(t, ok)
 			assert.NoError(t, err)
 			assert.Equal(t, "foo", fooV)
 
 			// Validate patched CustomResource
-			crPatched := stackInfo.Outputs["crPatched"].(map[string]interface{})
+			crPatched := stackInfo.Outputs["crPatched"].(map[string]any)
 			fooV, ok, err = unstructured.NestedString(crPatched, "metadata", "labels", "foo")
 			assert.True(t, ok)
 			assert.NoError(t, err)
@@ -1098,14 +1098,14 @@ func TestServerSideApply(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Validate patched Deployment
-					deploymentPatched := stackInfo.Outputs["deploymentPatched"].(map[string]interface{})
+					deploymentPatched := stackInfo.Outputs["deploymentPatched"].(map[string]any)
 					containersV, ok, err := unstructured.NestedSlice(
 						deploymentPatched, "spec", "template", "spec", "containers")
 					assert.True(t, ok)
 					assert.NoError(t, err)
 					assert.Len(t, containersV, 1)
 					limitsV, ok, err := unstructured.NestedMap(
-						containersV[0].(map[string]interface{}), "resources", "limits")
+						containersV[0].(map[string]any), "resources", "limits")
 					assert.True(t, ok)
 					assert.NoError(t, err)
 					assert.Contains(t, limitsV, "memory")
@@ -1158,13 +1158,13 @@ func TestServerSideApplyEmptyMaps(t *testing.T) {
 			},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			cm := stackInfo.Outputs["cm"].(map[string]interface{})
+			cm := stackInfo.Outputs["cm"].(map[string]any)
 			// Save the name and namespace for later use with kubectl. We check that the vars are empty,
 			// in case pulumi up creates a new ConfigMap/Namespace instead of updating the existing one on
 			// subsequent runs.
 			if ns == "" && cmName == "" {
-				ns = cm["metadata"].(map[string]interface{})["namespace"].(string)
-				cmName = cm["metadata"].(map[string]interface{})["name"].(string)
+				ns = cm["metadata"].(map[string]any)["namespace"].(string)
+				cmName = cm["metadata"].(map[string]any)["name"].(string)
 			}
 
 			// Validate we applied ConfigMap with wanted labels.
@@ -1219,7 +1219,7 @@ func TestServerSideApplyUpgrade(t *testing.T) {
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Validate Provider config
-			provider := stackInfo.Outputs["provider"].(map[string]interface{})
+			provider := stackInfo.Outputs["provider"].(map[string]any)
 			enableSSA, ok, err := unstructured.NestedString(provider, "enableServerSideApply")
 			assert.True(t, ok)
 			assert.NoError(t, err)
@@ -1231,7 +1231,7 @@ func TestServerSideApplyUpgrade(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Validate Provider config
-					provider := stackInfo.Outputs["provider"].(map[string]interface{})
+					provider := stackInfo.Outputs["provider"].(map[string]any)
 					enableSSA, ok, err := unstructured.NestedString(provider, "enableServerSideApply")
 					assert.True(t, ok)
 					assert.NoError(t, err)
@@ -1246,7 +1246,7 @@ func TestServerSideApplyUpgrade(t *testing.T) {
 						if res.Type == "kubernetes:apps/v1:Deployment" {
 							containers, ok := openapi.Pluck(res.Outputs, "spec", "template", "spec", "containers")
 							assert.True(t, ok)
-							containerStatus := containers.([]interface{})[0].(map[string]interface{})
+							containerStatus := containers.([]any)[0].(map[string]any)
 							image := containerStatus["image"]
 							assert.Equalf(t, image.(string), "nginx:1.17", "image should be updated")
 						}
@@ -1330,7 +1330,7 @@ func TestServiceAccountTokenSecret(t *testing.T) {
 			_, err := json.Marshal(stackInfo.Deployment)
 			assert.NoError(t, err)
 
-			secretData := stackInfo.Outputs["data"].(map[string]interface{})
+			secretData := stackInfo.Outputs["data"].(map[string]any)
 
 			assert.Contains(t, secretData, "ca.crt")
 			assert.Contains(t, secretData, "token")

--- a/tests/sdk/python/python_test.go
+++ b/tests/sdk/python/python_test.go
@@ -148,8 +148,8 @@ func TestYaml(t *testing.T) {
 					fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
 			})
 
-			var name interface{}
-			var ns interface{}
+			var name any
+			var ns any
 			var namespaceName, namespace2Name string
 
 			// Verify CRD.
@@ -219,7 +219,7 @@ func TestYaml(t *testing.T) {
 				if res.Type == "kubernetes:core/v1:Pod" {
 					spec, has := res.Outputs["apiVersion"]
 					assert.True(t, has)
-					specMap, is := spec.(map[string]interface{})
+					specMap, is := spec.(map[string]any)
 					assert.True(t, is)
 					sigKey, has := specMap[resource.SigKey]
 					assert.True(t, has)
@@ -256,8 +256,8 @@ func TestGuestbook(t *testing.T) {
 							fmt.Sprintf("%s/%s/%s", rj.URN.Type(), rjnamespace, rjname)
 					})
 
-					var name interface{}
-					var status interface{}
+					var name any
+					var status any
 
 					// Verify frontend deployment.
 					frontendDepl := stackInfo.Deployment.Resources[0]
@@ -536,7 +536,7 @@ func TestServerSideApply(t *testing.T) {
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Validate patched CustomResource
-			crPatched := stackInfo.Outputs["crPatched"].(map[string]interface{})
+			crPatched := stackInfo.Outputs["crPatched"].(map[string]any)
 			fooV, ok, err := unstructured.NestedString(crPatched, "metadata", "labels", "foo")
 			assert.True(t, ok)
 			assert.NoError(t, err)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Go 1.18 introduced an alias for `interface{}` called `any` that is shorter and more descriptive. Replace all instances of `interface{}` in the provider and test code with `any`.

These changes were created using `gofmt -w -r 'interface{} -> any' .` and then manually reverting changes to the Go overlay generation templates so that the SDKs are not updated.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
