### PR TITLE
Improve status message for Deployment awaiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix provider handling of CustomResources with Patch suffix (https://github.com/pulumi/pulumi-kubernetes/pull/2438)
+- Improve status message for Deployment awaiter (https://github.com/pulumi/pulumi-kubernetes/pull/2456)
 
 ## 3.29.0 (June 2, 2023)
 

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -337,8 +337,6 @@ func (dia *deploymentInitAwaiter) await(
 	timeout,
 	aggregateErrorTicker <-chan time.Time,
 ) error {
-	dia.config.logStatus(diag.Info, "[1/2] Waiting for app ReplicaSet be marked available")
-
 	for {
 		if dia.checkAndLogStatus() {
 			return nil
@@ -676,7 +674,7 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 	if !dia.updatedReplicaSetReady {
 		dia.config.logStatus(
 			diag.Info,
-			fmt.Sprintf("[1/2] Waiting for app ReplicaSet be marked available (%d/%d Pods available)",
+			fmt.Sprintf("Waiting for app ReplicaSet to be available (%d/%d Pods available)",
 				readyReplicas, specReplicas))
 	}
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Fix a grammatical error and remove the [1/2] prefix from the Deployment await status message.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
