### PR TITLE
Use `ismethod` to detect methods used as a transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- [sdk/python] Fix bug with class methods for YAML transformations (https://github.com/pulumi/pulumi-kubernetes/pull/2469)
+
 ## 3.29.1 (June 14, 2023)
 
 - Fix provider handling of CustomResources with Patch suffix (https://github.com/pulumi/pulumi-kubernetes/pull/2438)

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -5,7 +5,7 @@ import json
 import warnings
 from copy import copy
 from glob import glob
-from inspect import getfullargspec
+from inspect import getfullargspec, ismethod
 from typing import Any, Callable, List, Mapping, Optional, Sequence
 
 import pulumi
@@ -446,7 +446,7 @@ def _parse_yaml_object(
     # Allow users to change API objects before any validation.
     if transformations is not None:
         for t in transformations:
-            if len(getfullargspec(t)[0]) == 2:
+            if len(getfullargspec(t)[0]) == (2 if not ismethod(t) else 3):
                 t(obj, opts)
             else:
                 t(obj)

--- a/sdk/python/pulumi_kubernetes/yaml/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml/yaml.py
@@ -5,7 +5,7 @@ import json
 import warnings
 from copy import copy
 from glob import glob
-from inspect import getfullargspec
+from inspect import getfullargspec, ismethod
 from typing import Any, Callable, List, Mapping, Optional, Sequence
 
 import pulumi
@@ -446,7 +446,7 @@ def _parse_yaml_object(
     # Allow users to change API objects before any validation.
     if transformations is not None:
         for t in transformations:
-            if len(getfullargspec(t)[0]) == 2:
+            if len(getfullargspec(t)[0]) == (2 if not ismethod(t) else 3):
                 t(obj, opts)
             else:
                 t(obj)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This changes the value that is used to compare against the number of args of a transformation callable's arg spec when determining whether or not to call the transformation with `t(obj, opts)` or just `t(obj)`.

The returned value from `len(getfullargspec(t)[0])` will include the `self` and `cls` args from a method, but when calling a method the first argument is implicitly added so if you use a method for `t` it will fail.

This changes the value to be 3 if `t` is a method.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix https://github.com/pulumi/pulumi-kubernetes/issues/2468
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
