### PR TITLE
Enable Helm plugin on pulumi-kustomize using krusty

### DIFF
--- a/provider/pkg/provider/invoke_kustomize.go
+++ b/provider/pkg/provider/invoke_kustomize.go
@@ -52,6 +52,7 @@ func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) (
 	opts := krusty.MakeDefaultOptions()
 	opts.DoLegacyResourceSort = true
 	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
+	opts.PluginConfig.HelmConfig.Command = "helm"
 
 	k := krusty.MakeKustomizer(opts)
 

--- a/provider/pkg/provider/invoke_kustomize.go
+++ b/provider/pkg/provider/invoke_kustomize.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"os"
+	"sigs.k8s.io/kustomize/api/types"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/clients"
@@ -50,6 +51,7 @@ func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) (
 	fSys := filesys.MakeFsOnDisk()
 	opts := krusty.MakeDefaultOptions()
 	opts.DoLegacyResourceSort = true
+	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
 
 	k := krusty.MakeKustomizer(opts)
 

--- a/provider/pkg/provider/invoke_kustomize.go
+++ b/provider/pkg/provider/invoke_kustomize.go
@@ -55,6 +55,7 @@ func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) (
 	opts.DoLegacyResourceSort = true
 
 	// Add support for helmCharts plugin
+	// See https://github.com/kubernetes-sigs/kustomize/blob/v3.3.1/examples/chart.md for more details.
 	helmPath := "helm" // TODO: support this as a parameter to kustomize.Directory; this won't work for Windows
 	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
 	opts.PluginConfig.HelmConfig.Command = helmPath

--- a/provider/pkg/provider/invoke_kustomize.go
+++ b/provider/pkg/provider/invoke_kustomize.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/clients"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -54,17 +55,25 @@ func kustomizeDirectory(directory string, clientSet *clients.DynamicClientSet) (
 	opts := krusty.MakeDefaultOptions()
 	opts.DoLegacyResourceSort = true
 
+	// TODO: kustomize helmChart support is currently enabled via an undocumented feature flag.
+	//       See https://github.com/pulumi/pulumi-kubernetes/issues/2470 for additional details.
+	enableHelmChartSupport := false
+	helmPath := "helm" // TODO: support this as a parameter to kustomize.Directory; this won't work for Windows
+	if v, ok := os.LookupEnv("PULUMI_K8S_KUSTOMIZE_HELM"); ok && cmdutil.IsTruthy(v) {
+		enableHelmChartSupport = true
+	}
 	// Add support for helmCharts plugin
 	// See https://github.com/kubernetes-sigs/kustomize/blob/v3.3.1/examples/chart.md for more details.
-	helmPath := "helm" // TODO: support this as a parameter to kustomize.Directory; this won't work for Windows
-	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
-	opts.PluginConfig.HelmConfig.Command = helmPath
+	if enableHelmChartSupport {
+		opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
+		opts.PluginConfig.HelmConfig.Command = helmPath
+	}
 
 	k := krusty.MakeKustomizer(opts)
 
 	rm, err := k.Run(fSys, path)
 	if err != nil {
-		if strings.Contains(err.Error(), `(is 'helm' installed?)`) {
+		if enableHelmChartSupport && strings.Contains(err.Error(), `(is 'helm' installed?)`) {
 			err = fmt.Errorf("the helmCharts feature requires %q binary to be on the system PATH", helmPath)
 		}
 		return nil, errors.Wrapf(err, "kustomize failed for directory %q", path)

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: kustomizeHelmChart
+runtime: nodejs
+description: Test kustomize helmChart support

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/index.ts
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/index.ts
@@ -1,0 +1,35 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const provider = new k8s.Provider("k8s");
+
+// Create test namespace to allow test parallelism.
+const namespace = new k8s.core.v1.Namespace("test-namespace", {}, {provider});
+
+new k8s.kustomize.Directory("moria", {
+    directory: "moria/base",
+    transformations: [
+        (obj: any) => {
+            if (obj !== undefined) {
+                if (obj.metadata !== undefined) {
+                    obj.metadata.namespace = namespace;
+                } else {
+                    obj.metadata = {namespace: namespace};
+                }
+            }
+        },
+    ]
+}, {provider});

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/moria/base/kustomization.yaml
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/moria/base/kustomization.yaml
@@ -1,0 +1,12 @@
+helmCharts:
+  - name: minecraft
+    includeCRDs: false
+    valuesInline:
+      minecraftServer:
+        eula: true
+        difficulty: hard
+        rcon:
+          enabled: true
+    releaseName: moria
+    version: 3.1.3
+    repo: https://itzg.github.io/minecraft-server-charts

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/package.json
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kustomize",
+  "version": "0.1.0",
+  "dependencies": {
+    "@pulumi/pulumi": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^9.3.0"
+  },
+  "peerDependencies": {
+    "@pulumi/kubernetes": "latest"
+  },
+  "license": "MIT"
+}

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/tsconfig.json
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -629,6 +629,27 @@ func TestKustomize(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+// TestKustomizeHelmChart verifies the helmChart plugin support for Kustomize. This requires the `helm` binary to be
+// on the system PATH to succeed.
+func TestKustomizeHelmChart(t *testing.T) {
+	test := baseOptions.With(integration.ProgramTestOptions{
+		Dir: filepath.Join("kustomizeHelmChart", "step1"),
+		// Just test that the plugin integration is working with preview
+		SkipUpdate:             true,
+		SkipRefresh:            true,
+		SkipEmptyPreviewUpdate: true,
+		SkipExportImport:       true,
+		OrderedConfig: []integration.ConfigValue{
+			{
+				Key:   "pulumi:disable-default-providers[0]",
+				Value: "kubernetes",
+				Path:  true,
+			},
+		},
+	})
+	integration.ProgramTest(t, &test)
+}
+
 func TestNamespace(t *testing.T) {
 	var nmPodName, defaultPodName string
 	test := baseOptions.With(integration.ProgramTestOptions{

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -631,6 +631,7 @@ func TestKustomize(t *testing.T) {
 
 // TestKustomizeHelmChart verifies the helmChart plugin support for Kustomize. This requires the `helm` binary to be
 // on the system PATH to succeed.
+// Example based on https://github.com/kubernetes-sigs/kustomize/blob/v3.3.1/examples/chart.md
 func TestKustomizeHelmChart(t *testing.T) {
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir: filepath.Join("kustomizeHelmChart", "step1"),

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -647,6 +647,9 @@ func TestKustomizeHelmChart(t *testing.T) {
 				Path:  true,
 			},
 		},
+		Env: []string{
+			"PULUMI_K8S_KUSTOMIZE_HELM=true", // This experimental feature is currently gated behind a feature flag.
+		},
 	})
 	integration.ProgramTest(t, &test)
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Pulumi's kustomize module doesn't enable the Helm plugin by default. Enabling the Helm plugin allows Helm Charts to be expanded by a kustomization.yaml file. I'm unaware of the tradeoffs by enabling this features, as it looks like it has no backwards compatibility issues, as it's just enabling an extra feature.

This PR enables the helm plugin using the statically linked mode, it's not super clear though if that's the helm enabling API, as it seems undocumented, but the impl of the `EnabledPluginConfig` being used is as follows:

```go
func EnabledPluginConfig(b BuiltinPluginLoadingOptions) (pc *PluginConfig) {
	pc = MakePluginConfig(PluginRestrictionsNone, b)
	pc.FnpLoadingOptions.EnableStar = true
	pc.HelmConfig.Enabled = true
	// If this command is not on PATH, tests needing it should skip.
	pc.HelmConfig.Command = "helmV3"
	return
}
```

Which seems to be related to helm.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
    
https://github.com/pulumi/pulumi-kubernetes/issues/2470
