### PR TITLE
Ensure CSA -> SSA works with removal of array elements

### DIFF
--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -351,6 +351,11 @@ func TestGo(t *testing.T) {
 	t.Run("switchSSADeleteContainer", func(t *testing.T) {
 		validation := func(expectedContainers string) func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			return func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				ns, ok := stack.Outputs["namespace"].(string)
+				if !ok {
+					t.Fatalf("expected a string namespace output")
+				}
+
 				// Check that the stack has the expected number of deployments/resources.
 				var count int
 				for _, res := range stack.Deployment.Resources {
@@ -362,7 +367,7 @@ func TestGo(t *testing.T) {
 					}
 
 					count++
-					out, err := exec.Command("kubectl", "get", "deployment", "-o", "jsonpath={.spec.template.spec.containers[*].name}", "-n", "default", "nginx").CombinedOutput()
+					out, err := exec.Command("kubectl", "get", "deployment", "-o", "jsonpath={.spec.template.spec.containers[*].name}", "-n", ns, "nginx").CombinedOutput()
 					assert.NoError(t, err)
 					assert.Equal(t, expectedContainers, string(out))
 				}

--- a/tests/sdk/go/switch-ssa-delete-container/step1/Pulumi.yaml
+++ b/tests/sdk/go/switch-ssa-delete-container/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: switch_ssa_delete-container
+description: A simple Go Kubernetes program.
+runtime: go

--- a/tests/sdk/go/switch-ssa-delete-container/step1/main.go
+++ b/tests/sdk/go/switch-ssa-delete-container/step1/main.go
@@ -17,6 +17,13 @@ func main() {
 			return err
 		}
 
+		ns, err := corev1.NewNamespace(ctx, "test", nil, pulumi.Provider(prov))
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("namespace", ns.Metadata.Name())
+
 		_, err = appsv1.NewDeployment(ctx, "deployment", &appsv1.DeploymentArgs{
 			ApiVersion: pulumi.String("apps/v1"),
 			Kind:       pulumi.String("Deployment"),
@@ -25,7 +32,7 @@ func main() {
 					"deployment.kubernetes.io/revision": pulumi.String("1"),
 				},
 				Name:      pulumi.String("nginx"),
-				Namespace: pulumi.String("default"),
+				Namespace: ns.Metadata.Name(),
 			},
 			Spec: &appsv1.DeploymentSpecArgs{
 				ProgressDeadlineSeconds: pulumi.Int(600),

--- a/tests/sdk/go/switch-ssa-delete-container/step1/main.go
+++ b/tests/sdk/go/switch-ssa-delete-container/step1/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		prov, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
+			EnableServerSideApply: pulumi.BoolPtr(false),
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = appsv1.NewDeployment(ctx, "deployment", &appsv1.DeploymentArgs{
+			ApiVersion: pulumi.String("apps/v1"),
+			Kind:       pulumi.String("Deployment"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Annotations: pulumi.StringMap{
+					"deployment.kubernetes.io/revision": pulumi.String("1"),
+				},
+				Name:      pulumi.String("nginx"),
+				Namespace: pulumi.String("default"),
+			},
+			Spec: &appsv1.DeploymentSpecArgs{
+				ProgressDeadlineSeconds: pulumi.Int(600),
+				Replicas:                pulumi.Int(1),
+				RevisionHistoryLimit:    pulumi.Int(10),
+				Selector: &metav1.LabelSelectorArgs{
+					MatchLabels: pulumi.StringMap{
+						"app": pulumi.String("nginx"),
+					},
+				},
+				Strategy: &appsv1.DeploymentStrategyArgs{
+					RollingUpdate: &appsv1.RollingUpdateDeploymentArgs{
+						MaxSurge:       pulumi.Any("25%"),
+						MaxUnavailable: pulumi.Any("25%"),
+					},
+					Type: pulumi.String("RollingUpdate"),
+				},
+				Template: &corev1.PodTemplateSpecArgs{
+					Metadata: &metav1.ObjectMetaArgs{
+						Labels: pulumi.StringMap{
+							"app": pulumi.String("nginx"),
+						},
+					},
+					Spec: &corev1.PodSpecArgs{
+						Containers: corev1.ContainerArray{
+							&corev1.ContainerArgs{
+								Image:                    pulumi.String("nginx:1.23"),
+								ImagePullPolicy:          pulumi.String("IfNotPresent"),
+								Name:                     pulumi.String("nginx"),
+								Resources:                nil,
+								TerminationMessagePath:   pulumi.String("/dev/termination-log"),
+								TerminationMessagePolicy: pulumi.String("File"),
+							},
+							&corev1.ContainerArgs{
+								Args: pulumi.StringArray{
+									pulumi.String("while true; do sleep 30; done;"),
+								},
+								Command: pulumi.StringArray{
+									pulumi.String("/bin/bash"),
+									pulumi.String("-c"),
+									pulumi.String("--"),
+								},
+								Image:                    pulumi.String("ubuntu:latest"),
+								ImagePullPolicy:          pulumi.String("Always"),
+								Name:                     pulumi.String("sidecar"),
+								Resources:                nil,
+								TerminationMessagePath:   pulumi.String("/dev/termination-log"),
+								TerminationMessagePolicy: pulumi.String("File"),
+							},
+						},
+						DnsPolicy:                     pulumi.String("ClusterFirst"),
+						RestartPolicy:                 pulumi.String("Always"),
+						SchedulerName:                 pulumi.String("default-scheduler"),
+						SecurityContext:               nil,
+						TerminationGracePeriodSeconds: pulumi.Int(30),
+					},
+				},
+			},
+		},
+			pulumi.Provider(prov),
+		)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/tests/sdk/go/switch-ssa-delete-container/step2/main.go
+++ b/tests/sdk/go/switch-ssa-delete-container/step2/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		prov, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
+			EnableServerSideApply: pulumi.BoolPtr(true),
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = appsv1.NewDeployment(ctx, "deployment", &appsv1.DeploymentArgs{
+			ApiVersion: pulumi.String("apps/v1"),
+			Kind:       pulumi.String("Deployment"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Annotations: pulumi.StringMap{
+					"deployment.kubernetes.io/revision": pulumi.String("1"),
+				},
+				Name:      pulumi.String("nginx"),
+				Namespace: pulumi.String("default"),
+			},
+			Spec: &appsv1.DeploymentSpecArgs{
+				ProgressDeadlineSeconds: pulumi.Int(600),
+				Replicas:                pulumi.Int(1),
+				RevisionHistoryLimit:    pulumi.Int(10),
+				Selector: &metav1.LabelSelectorArgs{
+					MatchLabels: pulumi.StringMap{
+						"app": pulumi.String("nginx"),
+					},
+				},
+				Strategy: &appsv1.DeploymentStrategyArgs{
+					RollingUpdate: &appsv1.RollingUpdateDeploymentArgs{
+						MaxSurge:       pulumi.Any("25%"),
+						MaxUnavailable: pulumi.Any("25%"),
+					},
+					Type: pulumi.String("RollingUpdate"),
+				},
+				Template: &corev1.PodTemplateSpecArgs{
+					Metadata: &metav1.ObjectMetaArgs{
+						Labels: pulumi.StringMap{
+							"app": pulumi.String("nginx"),
+						},
+					},
+					Spec: &corev1.PodSpecArgs{
+						Containers: corev1.ContainerArray{
+							&corev1.ContainerArgs{
+								Image:                    pulumi.String("nginx:1.23"),
+								ImagePullPolicy:          pulumi.String("IfNotPresent"),
+								Name:                     pulumi.String("nginx"),
+								Resources:                nil,
+								TerminationMessagePath:   pulumi.String("/dev/termination-log"),
+								TerminationMessagePolicy: pulumi.String("File"),
+							},
+							// &corev1.ContainerArgs{
+							// 	Args: pulumi.StringArray{
+							// 		pulumi.String("while true; do sleep 30; done;"),
+							// 	},
+							// 	Command: pulumi.StringArray{
+							// 		pulumi.String("/bin/bash"),
+							// 		pulumi.String("-c"),
+							// 		pulumi.String("--"),
+							// 	},
+							// 	Image:                    pulumi.String("ubuntu:latest"),
+							// 	ImagePullPolicy:          pulumi.String("Always"),
+							// 	Name:                     pulumi.String("sidecar"),
+							// 	Resources:                nil,
+							// 	TerminationMessagePath:   pulumi.String("/dev/termination-log"),
+							// 	TerminationMessagePolicy: pulumi.String("File"),
+							// },
+						},
+						DnsPolicy:                     pulumi.String("ClusterFirst"),
+						RestartPolicy:                 pulumi.String("Always"),
+						SchedulerName:                 pulumi.String("default-scheduler"),
+						SecurityContext:               nil,
+						TerminationGracePeriodSeconds: pulumi.Int(30),
+					},
+				},
+			},
+		},
+			pulumi.Provider(prov),
+		)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/tests/sdk/go/switch-ssa-delete-container/step2/main.go
+++ b/tests/sdk/go/switch-ssa-delete-container/step2/main.go
@@ -11,7 +11,8 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		prov, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
-			EnableServerSideApply: pulumi.BoolPtr(false),
+			// Enable server-side apply in second step to test CSA->SSA.
+			EnableServerSideApply: pulumi.BoolPtr(true),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds an additional test to validate that when we switch from CSA to SSA, we are able to update/remove array elements. In this example, we remove a container from a pod/deployment.

This PR verifies that #2336 is fixed in the `v4` branch.