### PR TITLE
Fix StatefulSet await logic for OnDelete update 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix StatefulSet await logic for OnDelete update (https://github.com/pulumi/pulumi-kubernetes/pull/2473)
+
 ## 3.29.1 (June 14, 2023)
 
 - Fix provider handling of CustomResources with Patch suffix (https://github.com/pulumi/pulumi-kubernetes/pull/2438)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The await logic for StatefulSets previously only worked for the default RollingUpdate strategy. StatefulSets that were updated using the OnDelete strategy would incorrectly report that they were not ready because the provider was not accounting for differences in the status fields that depend on the update method. This change fixes the await logic so that both update strategies correctly report readiness.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1066 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
