### PR TITLE
Skip wait for Pods on headless Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [sdk/python] Fix bug with class methods for YAML transformations (https://github.com/pulumi/pulumi-kubernetes/pull/2469)
 - Fix StatefulSet await logic for OnDelete update (https://github.com/pulumi/pulumi-kubernetes/pull/2473)
+- Skip wait for Pods on headless Service (https://github.com/pulumi/pulumi-kubernetes/pull/2475)
 
 ## 3.29.1 (June 14, 2023)
 

--- a/provider/pkg/await/service_test.go
+++ b/provider/pkg/await/service_test.go
@@ -202,7 +202,7 @@ func Test_Core_Service(t *testing.T) {
 			},
 		},
 		{
-			description:  "Should fail if non-empty headless service doesn't target any Pods",
+			description:  "Should succeed if non-empty headless service doesn't target any Pods",
 			serviceInput: headlessNonemptyServiceInput,
 			version:      cluster.ServerVersion{Major: 1, Minor: 12},
 			do: func(services, endpoints chan watch.Event, settled chan struct{}, timeout chan time.Time) {
@@ -211,11 +211,6 @@ func Test_Core_Service(t *testing.T) {
 				// Finally, time out.
 				timeout <- time.Now()
 			},
-			expectedError: &timeoutError{
-				object: headlessNonemptyServiceOutput("default", "foo-4setj4y6"),
-				subErrors: []string{
-					"Service does not target any Pods. Selected Pods may not be ready, or " +
-						"field '.spec.selector' may not match labels on any Pods"}},
 		},
 	}
 
@@ -284,13 +279,10 @@ func Test_Core_Service_Read(t *testing.T) {
 			version:      cluster.ServerVersion{Major: 1, Minor: 11},
 		},
 		{
-			description:  "Read fail if headless non-empty Service doesn't target any Pods",
+			description:  "Read succeed if headless non-empty Service doesn't target any Pods",
 			serviceInput: headlessNonemptyServiceInput,
 			service:      headlessNonemptyServiceInput,
 			version:      cluster.ServerVersion{Major: 1, Minor: 12},
-			expectedSubErrors: []string{
-				"Service does not target any Pods. Selected Pods may not be ready, or " +
-					"field '.spec.selector' may not match labels on any Pods"},
 		},
 	}
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The await logic for Service resources normally waits for selected Pods to be ready before marking the Service ready. This doesn't work correctly for StatefulSet resources, which use a "headless" Service (i.e., Service without a ClusterIP) to reference its Pods. This led to a circular dependency if the StatefulSet referenced the Service name in the Pulumi program, because the StatefulSet would not be created until after the Service was ready, but the Service was waiting on the StatefulSet to create Pods. This change fixes this dependency by skipping the Pod check for any headless Service, rather than only headless Services that don't have Pods selected.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #1974 
Fix #1995
Related #2001 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
