### PR TITLE
Improve deleteUnreachable workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Improve deleteUnreachable workflow for unreachable clusters (https://github.com/pulumi/pulumi-kubernetes/pull/2489)
+
 ## 3.30.1 (June 29, 2023)
 
 - Add experimental helmChart support to kustomize.Directory (https://github.com/pulumi/pulumi-kubernetes/pull/2471)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The provider includes a deleteUnreachable option that will delete unreachable cluster resources from state. This was added as an opt-in behavior to avoid accidental state deletion for a temporarily unreachable cluster. This change improves this workflow in two ways:

1. The error messages for both the refresh and destroy cases were revised for clarity, and suggest using the PULUMI_K8S_DELETE_UNREACHABLE environment variable to enable this behavior.
2. The destroy workflow was changed to succeed for unreachable resources when the deleteUnreachable option is set rather than requiring the user to refresh the state as a separate step.

Note that this behavior can also be enabled with the Provider's deleteUnreachable configuration, but we do not mention this in the error message since it could lead to undesired state changes in case of a temporarily unreachable cluster.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2463 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
