### PR TITLE
Fix failing kustomize helm test

### DIFF
--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/index.ts
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/index.ts
@@ -13,23 +13,14 @@
 // limitations under the License.
 
 import * as k8s from "@pulumi/kubernetes";
+import * as random from "@pulumi/random";
 
 const provider = new k8s.Provider("k8s");
 
-// Create test namespace to allow test parallelism.
-const namespace = new k8s.core.v1.Namespace("test-namespace", {}, {provider});
+// Create random prefix to allow test parallelism.
+const prefix = new random.RandomPet("prefix", {length: 1}).id;
 
-new k8s.kustomize.Directory("moria", {
+prefix.apply(prefix => new k8s.kustomize.Directory("moria", {
     directory: "moria/base",
-    transformations: [
-        (obj: any) => {
-            if (obj !== undefined) {
-                if (obj.metadata !== undefined) {
-                    obj.metadata.namespace = namespace;
-                } else {
-                    obj.metadata = {namespace: namespace};
-                }
-            }
-        },
-    ]
-}, {provider});
+    resourcePrefix: prefix,
+}, {provider}));

--- a/tests/sdk/nodejs/kustomizeHelmChart/step1/package.json
+++ b/tests/sdk/nodejs/kustomizeHelmChart/step1/package.json
@@ -5,7 +5,8 @@
     "@pulumi/pulumi": "latest"
   },
   "devDependencies": {
-    "@types/node": "^9.3.0"
+    "@types/node": "^9.3.0",
+    "@pulumi/random": "^4.13.2"
   },
   "peerDependencies": {
     "@pulumi/kubernetes": "latest"


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
f1e790b caused TestKustomizeHelmChart to start failing, which is likely related to https://github.com/pulumi/pulumi-kubernetes/issues/2495. Updated the test to use a random prefix rather than a Namespace + transformation, which seems to work.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
