### PR TITLE
[sdk/python] Drop unused pyyaml dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- [sdk/python] Drop unused pyyaml dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2502)
+
 ## 4.0.0 (July 19, 2023)
 
 Breaking changes:

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -507,7 +507,6 @@ Use the navigation below to see detailed documentation for each of the supported
 		"requires": map[string]string{
 			"pulumi":   ">=3.25.0,<4.0.0",
 			"requests": ">=2.21,<3.0",
-			"pyyaml":   ">=5.3.1",
 		},
 		"moduleNameOverrides": modToPkg,
 		"compatibility":       kubernetes20,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -62,7 +62,6 @@ setup(name='pulumi_kubernetes',
       install_requires=[
           'parver>=0.2.1',
           'pulumi>=3.25.0,<4.0.0',
-          'pyyaml>=5.3.1',
           'requests>=2.21,<3.0',
           'semver>=2.8.1'
       ],


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The pyyaml library was required in early versions of the provider for YAML resource support, but this logic was replaced with a provider invoke. Remove this unused dependency.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
