### PR TITLE
Gracefully handle undefined resource schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Gracefully handle undefined resource schemes (https://github.com/pulumi/pulumi-kubernetes/pull/2504)
+
 ## 4.0.0 (July 19, 2023)
 
 Breaking changes:

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -63,10 +63,12 @@ func ToUnstructured(object metav1.Object) (*unstructured.Unstructured, error) {
 
 // Normalize converts an Unstructured Kubernetes resource into the typed equivalent and then back to Unstructured.
 // This process normalizes semantically-equivalent resources into an identical output, which is important for diffing.
+// If the scheme is not defined, then return the original resource.
 func Normalize(uns *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	obj, err := FromUnstructured(uns)
+	// Return the input resource rather than an error if this operation fails.
 	if err != nil {
-		return nil, err
+		return uns, nil
 	}
 	return ToUnstructured(obj)
 }

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -147,3 +147,29 @@ func TestFromUnstructured(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalize(t *testing.T) {
+	type args struct {
+		uns *unstructured.Unstructured
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *unstructured.Unstructured
+		wantErr bool
+	}{
+		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Normalize(tt.args.uns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Normalize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Normalize() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The provider includes normalization logic that converts Unstructured resource definitions to their typed equivalents and back. This conversion process requires a defined scheme, and will not work for extension resource types (CRDs, CustomResources, apiregistration, etc). If the scheme is not registered, skip this process rather than returning an error.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2503 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
