### PR TITLE
Fix diff for CRD .spec.preserveUnknownFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Gracefully handle undefined resource schemes (https://github.com/pulumi/pulumi-kubernetes/pull/2504)
+- Fix diff for CRD .spec.preserveUnknownFields (https://github.com/pulumi/pulumi-kubernetes/pull/2506)
 
 ## 4.0.0 (July 19, 2023)
 

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -65,12 +65,31 @@ func ToUnstructured(object metav1.Object) (*unstructured.Unstructured, error) {
 // This process normalizes semantically-equivalent resources into an identical output, which is important for diffing.
 // If the scheme is not defined, then return the original resource.
 func Normalize(uns *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if IsCRD(uns) {
+		return normalizeCRD(uns), nil
+	}
+
 	obj, err := FromUnstructured(uns)
 	// Return the input resource rather than an error if this operation fails.
 	if err != nil {
 		return uns, nil
 	}
 	return ToUnstructured(obj)
+}
+
+// normalizeCRD manually normalizes CRD resources, which require special handling due to the lack of defined conversion
+// scheme for CRDs.
+func normalizeCRD(uns *unstructured.Unstructured) *unstructured.Unstructured {
+	contract.Assertf(IsCRD(uns), "normalizeCRD called on a non-CRD resource: %s", uns.GetAPIVersion())
+
+	// .spec.preserveUnknownFields is deprecated, and will be removed by the apiserver on the created resource if the
+	// value is false. Normalize for diffing by removing this field if present and set to "false".
+	// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
+	preserve, found, err := unstructured.NestedBool(uns.Object, "spec", "preserveUnknownFields")
+	if err == nil && found && !preserve {
+		unstructured.RemoveNestedField(uns.Object, "spec", "preserveUnknownFields")
+	}
+	return uns
 }
 
 func PodFromUnstructured(uns *unstructured.Unstructured) (*corev1.Pod, error) {

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -118,6 +118,95 @@ var (
 			},
 		},
 	}
+
+	crdPreserveUnknownFieldsUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "foobars.stable.example.com",
+			},
+			"spec": map[string]any{
+				"group": "stable.example.com",
+				"names": map[string]any{
+					"kind":   "FooBar",
+					"plural": "foobars",
+					"shortNames": []string{
+						"fb",
+					},
+					"singular": "foobar",
+				},
+				"preserveUnknownFields": false,
+				"scope":                 "Namespaced",
+				"versions": []map[string]any{
+					{
+						"name": "v1",
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"properties": map[string]any{
+											"foo": map[string]any{
+												"type": "string",
+											},
+										},
+										"type": "object",
+									},
+								},
+								"type": "object",
+							},
+						},
+						"served":  true,
+						"storage": true,
+					},
+				},
+			},
+		},
+	}
+
+	crdUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "foobars.stable.example.com",
+			},
+			"spec": map[string]any{
+				"group": "stable.example.com",
+				"names": map[string]any{
+					"kind":   "FooBar",
+					"plural": "foobars",
+					"shortNames": []string{
+						"fb",
+					},
+					"singular": "foobar",
+				},
+				"scope": "Namespaced",
+				"versions": []map[string]any{
+					{
+						"name": "v1",
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"properties": map[string]any{
+											"foo": map[string]any{
+												"type": "string",
+											},
+										},
+										"type": "object",
+									},
+								},
+								"type": "object",
+							},
+						},
+						"served":  true,
+						"storage": true,
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestFromUnstructured(t *testing.T) {
@@ -159,6 +248,7 @@ func TestNormalize(t *testing.T) {
 		wantErr bool
 	}{
 		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK, false},
+		{"CRD with preserveUnknownFields", args{uns: crdPreserveUnknownFieldsUnstructured}, crdUnstructured, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2684,9 +2684,9 @@ func pruneLiveState(live, oldInputs *unstructured.Unstructured) *unstructured.Un
 	return oldLivePruned
 }
 
-// shouldNormalize returns false for CRDs and CustomResources, and true otherwise.
+// shouldNormalize returns false for CustomResources, and true otherwise.
 func shouldNormalize(uns *unstructured.Unstructured) bool {
-	return !clients.IsCRD(uns) && kinds.KnownGroupVersions.Has(uns.GetAPIVersion())
+	return kinds.KnownGroupVersions.Has(uns.GetAPIVersion())
 }
 
 // normalize converts an Unstructured resource into a normalized form so that semantically equivalent representations


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The v4 diffing logic relies on resource normalization to accurately compare input values to live state. Most resources are normalize by converting the Unstructured resource to its typed equivalent and then back, but this process requires a defined conversion scheme. However, CRDs do not have a conversion scheme defined.

CRD resources have a deprecated parameter ".spec.preserveUnknownFields" that the apiserver removes from the created CRD if the value is false. This causes problems for diffing, because the inputs and the live state are continuously out of sync.

This change adds CRD-specific normalization logic to avoid causing a continuous diff if this field is set in the resource definition.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2505 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
