### PR TITLE
Fix continuous diff for Secret stringData field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [sdk/python] Drop unused pyyaml dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2502)
+- Fix continuous diff for Secret stringData field (https://github.com/pulumi/pulumi-kubernetes/pull/2511)
 
 ## 4.0.1 (July 19, 2023)
 

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -246,6 +246,11 @@ func IsCRD(obj *unstructured.Unstructured) bool {
 		strings.HasPrefix(obj.GetAPIVersion(), "apiextensions.k8s.io/")
 }
 
+func IsSecret(obj *unstructured.Unstructured) bool {
+	gvk := obj.GroupVersionKind()
+	return (gvk.Group == corev1.GroupName || gvk.Group == "core") && gvk.Kind == string(kinds.Secret)
+}
+
 // IsConfigMap returns true if the resource is a configmap marked as immutable.
 func IsConfigMap(obj *unstructured.Unstructured) bool {
 	gvk := obj.GroupVersionKind()

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -220,13 +220,26 @@ var (
 		},
 	}
 
+	secretWithCreationTimestampUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"creationTimestamp": "2023-07-20T23:54:21Z",
+				"name":              "foo",
+			},
+			"stringData": map[string]any{
+				"foo": "bar",
+			},
+		},
+	}
+
 	secretNormalizedUnstructured = &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Secret",
 			"metadata": map[string]any{
-				"creationTimestamp": nil,
-				"name":              "foo",
+				"name": "foo",
 			},
 			"data": map[string]any{
 				"foo": "YmFy",
@@ -275,6 +288,9 @@ func TestNormalize(t *testing.T) {
 	}{
 		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK, false},
 		{"CRD with preserveUnknownFields", args{uns: crdPreserveUnknownFieldsUnstructured}, crdUnstructured, false},
+		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured, false},
+		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured, false},
+		{"Secret with creationTimestamp set on input", args{uns: secretWithCreationTimestampUnstructured}, secretNormalizedUnstructured, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -285,27 +301,6 @@ func TestNormalize(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Normalize() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_normalizeSecret(t *testing.T) {
-	type args struct {
-		uns *unstructured.Unstructured
-	}
-	tests := []struct {
-		name string
-		args args
-		want *unstructured.Unstructured
-	}{
-		{"secretData", args{uns: secretUnstructured}, secretNormalizedUnstructured},
-		{"data", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeSecret(tt.args.uns); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("normalizeSecret() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -207,6 +207,32 @@ var (
 			},
 		},
 	}
+
+	secretUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name": "foo"},
+			"stringData": map[string]any{
+				"foo": "bar",
+			},
+		},
+	}
+
+	secretNormalizedUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"creationTimestamp": nil,
+				"name":              "foo",
+			},
+			"data": map[string]any{
+				"foo": "YmFy",
+			},
+		},
+	}
 )
 
 func TestFromUnstructured(t *testing.T) {
@@ -259,6 +285,27 @@ func TestNormalize(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Normalize() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_normalizeSecret(t *testing.T) {
+	type args struct {
+		uns *unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want *unstructured.Unstructured
+	}{
+		{"secretData", args{uns: secretUnstructured}, secretNormalizedUnstructured},
+		{"data", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeSecret(tt.args.uns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("normalizeSecret() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -1051,8 +1051,7 @@ func TestSecrets(t *testing.T) {
 				Path:  true,
 			},
 		},
-		ExpectRefreshChanges: true,
-		Quick:                true,
+		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
 			state, err := json.Marshal(stackInfo.Deployment)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
If the `stringData` field is set on a Secret resource, then Kubernetes will automatically replace it with an equivalent `data` field. This is causing a continuous diff with the updated logic from 6e329f3. This change updates the input diff logic to include this rewrite.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2507 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
