### PR TITLE
Fix diff for CRD with status set on input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.0.2 (July 20, 2023)
+
 - [sdk/python] Drop unused pyyaml dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2502)
 - Fix continuous diff for Secret stringData field (https://github.com/pulumi/pulumi-kubernetes/pull/2511)
 - Fix diff for CRD with status set on input (https://github.com/pulumi/pulumi-kubernetes/pull/2512)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [sdk/python] Drop unused pyyaml dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2502)
 - Fix continuous diff for Secret stringData field (https://github.com/pulumi/pulumi-kubernetes/pull/2511)
+- Fix diff for CRD with status set on input (https://github.com/pulumi/pulumi-kubernetes/pull/2512)
 
 ## 4.0.1 (July 19, 2023)
 

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -83,6 +83,9 @@ func Normalize(uns *unstructured.Unstructured) (*unstructured.Unstructured, erro
 			return uns, err
 		}
 	}
+	if IsSecret(uns) {
+		return normalizeSecret(uns), nil
+	}
 
 	// Remove output-only fields
 	unstructured.RemoveNestedField(result.Object, "metadata", "creationTimestamp")

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -102,6 +102,11 @@ func normalizeCRD(uns *unstructured.Unstructured) *unstructured.Unstructured {
 	if err == nil && found && !preserve {
 		unstructured.RemoveNestedField(uns.Object, "spec", "preserveUnknownFields")
 	}
+
+	// status is an output field, so the apiserver will ignore it in the inputs. However, this can cause
+	// erroneous diffs, so preemptively remove it here.
+	unstructured.RemoveNestedField(uns.Object, "status")
+
 	return uns
 }
 

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -83,9 +83,6 @@ func Normalize(uns *unstructured.Unstructured) (*unstructured.Unstructured, erro
 			return uns, err
 		}
 	}
-	if IsSecret(uns) {
-		return normalizeSecret(uns), nil
-	}
 
 	// Remove output-only fields
 	unstructured.RemoveNestedField(result.Object, "metadata", "creationTimestamp")

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -305,24 +305,3 @@ func TestNormalize(t *testing.T) {
 		})
 	}
 }
-
-func Test_normalizeSecret(t *testing.T) {
-	type args struct {
-		uns *unstructured.Unstructured
-	}
-	tests := []struct {
-		name string
-		args args
-		want *unstructured.Unstructured
-	}{
-		{"secretData", args{uns: secretUnstructured}, secretNormalizedUnstructured},
-		{"data", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeSecret(tt.args.uns); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("normalizeSecret() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -164,6 +164,58 @@ var (
 		},
 	}
 
+	crdStatusUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "foobars.stable.example.com",
+			},
+			"spec": map[string]any{
+				"group": "stable.example.com",
+				"names": map[string]any{
+					"kind":   "FooBar",
+					"plural": "foobars",
+					"shortNames": []string{
+						"fb",
+					},
+					"singular": "foobar",
+				},
+				"scope": "Namespaced",
+				"versions": []map[string]any{
+					{
+						"name": "v1",
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"properties": map[string]any{
+											"foo": map[string]any{
+												"type": "string",
+											},
+										},
+										"type": "object",
+									},
+								},
+								"type": "object",
+							},
+						},
+						"served":  true,
+						"storage": true,
+					},
+				},
+			},
+			"status": map[string]any{
+				"accceptedNames": map[string]any{
+					"kind":   "",
+					"plural": "",
+				},
+				"conditions":     []any{},
+				"storedVersions": []any{},
+			},
+		},
+	}
+
 	crdUnstructured = &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "apiextensions.k8s.io/v1",
@@ -288,6 +340,7 @@ func TestNormalize(t *testing.T) {
 	}{
 		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK, false},
 		{"CRD with preserveUnknownFields", args{uns: crdPreserveUnknownFieldsUnstructured}, crdUnstructured, false},
+		{"CRD with status", args{uns: crdStatusUnstructured}, crdUnstructured, false},
 		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured, false},
 		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured, false},
 		{"Secret with creationTimestamp set on input", args{uns: secretWithCreationTimestampUnstructured}, secretNormalizedUnstructured, false},

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -305,3 +305,24 @@ func TestNormalize(t *testing.T) {
 		})
 	}
 }
+
+func Test_normalizeSecret(t *testing.T) {
+	type args struct {
+		uns *unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want *unstructured.Unstructured
+	}{
+		{"secretData", args{uns: secretUnstructured}, secretNormalizedUnstructured},
+		{"data", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeSecret(tt.args.uns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("normalizeSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The CRD status field is an output field, but the apiserver will ignore it if set. This is common with CRDs generated from helm charts. Preemptively remove the status field to avoid a continuous diff in this case.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
