### PR TITLE
fix: ensure data is not dropped when normalizing Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 4.0.3 (July 21, 2023)
+
+- fix: ensure data is not dropped when normalizing Secrets (https://github.com/pulumi/pulumi-kubernetes/pull/2514)
+
 ## 4.0.2 (July 20, 2023)
 
 - [sdk/python] Drop unused pyyaml dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2502)

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -123,7 +123,7 @@ func normalizeSecret(uns *unstructured.Unstructured) *unstructured.Unstructured 
 
 	data, found, err := unstructured.NestedMap(uns.Object, "data")
 	if err != nil || !found {
-		data = map[string]interface{}{}
+		data = map[string]any{}
 	}
 
 	// See https://github.com/kubernetes/kubernetes/blob/v1.27.4/pkg/apis/core/v1/conversion.go#L406-L414
@@ -133,7 +133,7 @@ func normalizeSecret(uns *unstructured.Unstructured) *unstructured.Unstructured 
 			data[k] = base64.StdEncoding.EncodeToString([]byte(v))
 		}
 
-		unstructured.SetNestedMap(uns.Object, data, "data")
+		contract.IgnoreError(unstructured.SetNestedMap(uns.Object, data, "data"))
 		unstructured.RemoveNestedField(uns.Object, "stringData")
 	}
 

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -15,6 +15,7 @@
 package clients
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/kinds"
@@ -115,30 +116,28 @@ func normalizeCRD(uns *unstructured.Unstructured) *unstructured.Unstructured {
 func normalizeSecret(uns *unstructured.Unstructured) *unstructured.Unstructured {
 	contract.Assertf(IsSecret(uns), "normalizeSecret called on a non-Secret resource: %s:%s", uns.GetAPIVersion(), uns.GetKind())
 
-	obj, err := FromUnstructured(uns)
-	if err != nil {
-		return uns // If the operation fails, just return the original object
+	stringData, found, err := unstructured.NestedStringMap(uns.Object, "stringData")
+	if err != nil || !found {
+		return uns
 	}
-	secret := obj.(*corev1.Secret)
+
+	data, found, err := unstructured.NestedMap(uns.Object, "data")
+	if err != nil || !found {
+		data = map[string]interface{}{}
+	}
 
 	// See https://github.com/kubernetes/kubernetes/blob/v1.27.4/pkg/apis/core/v1/conversion.go#L406-L414
 	// StringData overwrites Data
-	if len(secret.StringData) > 0 {
-		if secret.Data == nil {
-			secret.Data = map[string][]byte{}
-		}
-		for k, v := range secret.StringData {
-			secret.Data[k] = []byte(v)
+	if len(stringData) > 0 {
+		for k, v := range stringData {
+			data[k] = base64.StdEncoding.EncodeToString([]byte(v))
 		}
 
-		secret.StringData = nil
+		unstructured.SetNestedMap(uns.Object, data, "data")
+		unstructured.RemoveNestedField(uns.Object, "stringData")
 	}
 
-	updated, err := ToUnstructured(secret)
-	if err != nil {
-		return uns // If the operation fails, just return the original object
-	}
-	return updated
+	return uns
 }
 
 func PodFromUnstructured(uns *unstructured.Unstructured) (*corev1.Pod, error) {

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -1057,11 +1057,48 @@ func TestSecrets(t *testing.T) {
 			state, err := json.Marshal(stackInfo.Deployment)
 			assert.NoError(t, err)
 
+			ssStringDataData, ok := stackInfo.Outputs["ssStringDataData"]
+			assert.Truef(t, ok, "missing expected output \"ssStringDataData\"")
+
+			ssStringDataStringData, ok := stackInfo.Outputs["ssStringDataStringData"]
+			assert.Truef(t, ok, "missing expected output \"ssStringDataStringData\"")
+
+			assert.NotEmptyf(t, ssStringDataData, "data field is empty")
+			assert.NotEmptyf(t, ssStringDataStringData, "stringData field is empty")
+
 			assert.NotContains(t, string(state), secretMessage)
 
 			// The program converts the secret message to base64, to make a ConfigMap from it, so the state
 			// should also not contain the base64 encoding of secret message.
 			assert.NotContains(t, string(state), b64.StdEncoding.EncodeToString([]byte(secretMessage)))
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      filepath.Join("secrets", "step2"),
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					secretMessage += "updated"
+
+					assert.NotNil(t, stackInfo.Deployment)
+					state, err := json.Marshal(stackInfo.Deployment)
+					assert.NoError(t, err)
+
+					ssStringDataData, ok := stackInfo.Outputs["ssStringDataData"]
+					assert.Truef(t, ok, "missing expected output \"ssStringDataData\"")
+
+					ssStringDataStringData, ok := stackInfo.Outputs["ssStringDataStringData"]
+					assert.Truef(t, ok, "missing expected output \"ssStringDataStringData\"")
+
+					assert.NotEmptyf(t, ssStringDataData, "data field is empty")
+					assert.NotEmptyf(t, ssStringDataStringData, "stringData field is empty")
+
+					assert.NotContains(t, string(state), secretMessage)
+
+					// The program converts the secret message to base64, to make a ConfigMap from it, so the state
+					// should also not contain the base64 encoding of secret message.
+					assert.NotContains(t, string(state), b64.StdEncoding.EncodeToString([]byte(secretMessage)))
+				},
+			},
 		},
 	})
 	integration.ProgramTest(t, &test)

--- a/tests/sdk/nodejs/secrets/step2/index.ts
+++ b/tests/sdk/nodejs/secrets/step2/index.ts
@@ -18,7 +18,7 @@ import * as k8s from "@pulumi/kubernetes";
 const config = new pulumi.Config();
 
 const pw = config.requireSecret("message");
-const rawPW = config.require("message");
+const rawPW = config.require("message")+"updated"; // Add suffix
 
 const provider = new k8s.Provider("k8s");
 
@@ -63,7 +63,7 @@ const cg = new k8s.yaml.ConfigGroup("example", {
 
 export const cmDataData = cmData.data;
 export const cmBinaryDataData = cmBinaryData.binaryData;
-export const ssStringDataStringData = ssStringData.stringData;
 export const ssStringDataData = ssStringData.data;
+export const ssStringDataStringData = ssStringData.stringData;
 export const ssDataData = ssData.data;
 export const cgSecret = cg.getResource("v1/Secret", name).stringData;


### PR DESCRIPTION
Fixes: #2513 

Normalize secrets using the raw unstructured data, rather than trying to do it via the typed Secret object route. I haven't dug down into the specifics as to why it fails when we do the unstructured->typed->unstructured dance, but have verified that this PR fixes this regression.