### PR TITLE
[internal] Fix parallel test flake

### DIFF
--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -295,6 +295,15 @@ func TestAccPrometheusOperator(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:         filepath.Join(getCwd(t), "prometheus-operator"),
 			SkipRefresh: true,
+			// TODO: set to SSA false to fix https://github.com/pulumi/pulumi-kubernetes/issues/2482.
+			//       https://github.com/pulumi/pulumi-kubernetes/issues/2243 tracks work to split tests across different
+			//       clusters, which would fix this problem
+			OrderedConfig: []integration.ConfigValue{
+				{
+					Key:   "kubernetes:enableServerSideApply",
+					Value: "false",
+				},
+			},
 			ExtraRuntimeValidation: func(
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
@@ -499,6 +508,15 @@ func TestRancher(t *testing.T) {
 			SkipRefresh: true,
 			Verbose:     true,
 			NoParallel:  true,
+			// TODO: set to SSA false to fix https://github.com/pulumi/pulumi-kubernetes/issues/2482.
+			//       https://github.com/pulumi/pulumi-kubernetes/issues/2243 tracks work to split tests across different
+			//       clusters, which would fix this problem
+			OrderedConfig: []integration.ConfigValue{
+				{
+					Key:   "kubernetes:enableServerSideApply",
+					Value: "false",
+				},
+			},
 			EditDirs: []integration.EditDir{
 				{
 					Dir:      filepath.Join(getCwd(t), "rancher", "step2"),


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Two of the examples tests install different versions of the same CRD. This works in CSA mode because they overwrite each other, but cause a conflict in SSA mode. Since CRDs are cluster-scoped, it's nontrivial to fix since the tests run in parallel. Explicitly use CSA mode until we refactor the tests to run on separate clusters.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #2482 
Related to https://github.com/pulumi/pulumi-kubernetes/issues/2243
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
