### PR TITLE
Improve resource normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Improve resource normalization for diffing (https://github.com/pulumi/pulumi-kubernetes/pull/2516)
+
 ## 4.0.3 (July 21, 2023)
 
 - fix: ensure data is not dropped when normalizing Secrets (https://github.com/pulumi/pulumi-kubernetes/pull/2514)

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -131,15 +131,15 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"preserveUnknownFields": false,
 				"scope":                 "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{
@@ -176,14 +176,14 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"scope": "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{
@@ -228,14 +228,14 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"scope": "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{
@@ -333,25 +333,20 @@ func TestNormalize(t *testing.T) {
 		uns *unstructured.Unstructured
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *unstructured.Unstructured
-		wantErr bool
+		name string
+		args args
+		want *unstructured.Unstructured
 	}{
-		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK, false},
-		{"CRD with preserveUnknownFields", args{uns: crdPreserveUnknownFieldsUnstructured}, crdUnstructured, false},
-		{"CRD with status", args{uns: crdStatusUnstructured}, crdUnstructured, false},
-		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured, false},
-		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured, false},
-		{"Secret with creationTimestamp set on input", args{uns: secretWithCreationTimestampUnstructured}, secretNormalizedUnstructured, false},
+		{"unregistered GVK", args{uns: unregisteredGVK}, unregisteredGVK},
+		{"CRD with preserveUnknownFields", args{uns: crdPreserveUnknownFieldsUnstructured}, crdUnstructured},
+		{"CRD with status", args{uns: crdStatusUnstructured}, crdUnstructured},
+		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured},
+		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured},
+		{"Secret with creationTimestamp set on input", args{uns: secretWithCreationTimestampUnstructured}, secretNormalizedUnstructured},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Normalize(tt.args.uns)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Normalize() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := Normalize(tt.args.uns)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Normalize() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The logic for normalizing Unstructured resources was inadvertently modifying resources in place because the argument was a pointer type. Change the logic to make a copy of the resource and then return a normalized version of the copy. This avoids returning a partially-modified version of the resource if normalization fails partway through the process.

As part of this change, the following updates were made:
1. Make a copy of the Unstructured resource rather than modifying the original directly.
2. Remove error return and related handling since normalization returns the input resource in case of failure.
3. Proactively remove output-only metadata fields as part of normalization.
4. Remove post-normalization pruning step. This was erroneously pruning identical input and output due to the pointer type, and is no longer needed.
5. Fix invalid CRD test data.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
