### PR TITLE
Added skipUpdateUnreachable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
   source-based and wheel distributions are now published. For most users the installs will now favor
   the wheel distribution, but users invoking pip with `--no-binary :all:` will continue having
   installs based on the source distribution.
-
 - Return mapping information for terraform conversions (https://github.com/pulumi/pulumi-kubernetes/pull/2457)
 - feature: added skipUpdateUnreachable flag to proceed with the updates without failing (https://github.com/pulumi/pulumi-kubernetes/pull/2528)
+- 
 ## 4.1.1 (August 23, 2023)
 
 - Revert the switch to pyproject.toml and wheel-based PyPI publishing as it impacts users that run pip with --no-binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   installs based on the source distribution.
 
 - Return mapping information for terraform conversions (https://github.com/pulumi/pulumi-kubernetes/pull/2457)
-
+- feature: added skipUpdateUnreachable flag to proceed with the updates without failing (https://github.com/pulumi/pulumi-kubernetes/pull/2528)
 ## 4.1.1 (August 23, 2023)
 
 - Revert the switch to pyproject.toml and wheel-based PyPI publishing as it impacts users that run pip with --no-binary

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -73,6 +73,10 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 					Description: "If present and set to true, the provider will delete resources associated with an unreachable Kubernetes cluster from Pulumi state",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
+				"skipUpdateUnreachable": {
+					Description: "If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 				"enableServerSideApply": {
 					Description: "If present and set to false, disable Server-Side Apply mode.\nSee https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
@@ -139,6 +143,15 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 					DefaultInfo: &pschema.DefaultSpec{
 						Environment: []string{
 							"PULUMI_K8S_DELETE_UNREACHABLE",
+						},
+					},
+				},
+				"skipUpdateUnreachable": {
+					Description: "If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+					DefaultInfo: &pschema.DefaultSpec{
+						Environment: []string{
+							"PULUMI_K8S_SKIP_UPDATE_UNREACHABLE",
 						},
 					},
 				},

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -125,6 +125,7 @@ type kubeProvider struct {
 	defaultNamespace string
 
 	deleteUnreachable           bool
+	skipUpdateUnreachable       bool
 	enableConfigMapMutable      bool
 	enableSecrets               bool
 	suppressDeprecationWarnings bool
@@ -170,6 +171,7 @@ func makeKubeProvider(
 		enableSecrets:               false,
 		suppressDeprecationWarnings: false,
 		deleteUnreachable:           false,
+		skipUpdateUnreachable:       false,
 	}, nil
 }
 
@@ -468,6 +470,22 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 	}
 	if deleteUnreachable() {
 		k.deleteUnreachable = true
+	}
+
+	skipUpdateUnreachable := func() bool {
+		// If the provider flag is set, use that value to determine behavior. This will override the ENV var.
+		if enabled, exists := vars["kubernetes:config:skipUpdateUnreachable"]; exists {
+			return enabled == trueStr
+		}
+		// If the provider flag is not set, fall back to the ENV var.
+		if enabled, exists := os.LookupEnv("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE"); exists {
+			return enabled == trueStr
+		}
+		// Default to false.
+		return false
+	}
+	if skipUpdateUnreachable() {
+		k.skipUpdateUnreachable = true
 	}
 
 	enableServerSideApply := func() bool {
@@ -1262,6 +1280,16 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 	//
 
 	urn := resource.URN(req.GetUrn())
+
+	if k.clusterUnreachable {
+		if k.skipUpdateUnreachable {
+			_ = k.host.Log(ctx, diag.Warning, urn, "Cluster is unreachable but skipUpdateUnreachable flag is set to true, skipping...")
+			return &pulumirpc.CheckResponse{
+				Inputs: req.GetOlds(),
+			}, nil
+		}
+	}
+
 	if isHelmRelease(urn) {
 		return k.helmReleaseProvider.Check(ctx, req)
 	}
@@ -1681,7 +1709,7 @@ func (k *kubeProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*p
 	// Delete before replacement if we are forced to replace the old object, and the new version of
 	// that object MUST have the same name.
 	deleteBeforeReplace :=
-		// 1. We know resource must be replaced.
+	// 1. We know resource must be replaced.
 		len(replaces) > 0 &&
 			// 2. Object is NOT autonamed (i.e., user manually named it, and therefore we can't
 			// auto-generate the name).
@@ -1930,6 +1958,15 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 				"configured Kubernetes cluster is unreachable and the `deleteUnreachable` option is enabled. "+
 					"Deleting the unreachable resource from Pulumi state"))
 			return deleteResponse, nil
+		} else if k.skipUpdateUnreachable {
+			_ = k.host.Log(ctx, diag.Info, urn, fmt.Sprintf(
+				"configured Kubernetes cluster is unreachable and the `skipUnreachable` option is enabled. "+
+					"Returned data could not reflect the actual cluster configuration."))
+			return &pulumirpc.ReadResponse{
+				Id:         req.GetId(),
+				Properties: req.GetProperties(),
+				Inputs:     req.GetInputs(),
+			}, nil
 		}
 
 		return nil, fmt.Errorf("failed to read resource state due to unreachable cluster. If the cluster was " +

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1709,7 +1709,7 @@ func (k *kubeProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*p
 	// Delete before replacement if we are forced to replace the old object, and the new version of
 	// that object MUST have the same name.
 	deleteBeforeReplace :=
-	// 1. We know resource must be replaced.
+		// 1. We know resource must be replaced.
 		len(replaces) > 0 &&
 			// 2. Object is NOT autonamed (i.e., user manually named it, and therefore we can't
 			// auto-generate the name).
@@ -1958,7 +1958,8 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 				"configured Kubernetes cluster is unreachable and the `deleteUnreachable` option is enabled. "+
 					"Deleting the unreachable resource from Pulumi state"))
 			return deleteResponse, nil
-		} else if k.skipUpdateUnreachable {
+		}
+		if k.skipUpdateUnreachable {
 			_ = k.host.Log(ctx, diag.Info, urn, fmt.Sprintf(
 				"configured Kubernetes cluster is unreachable and the `skipUnreachable` option is enabled. "+
 					"Returned data could not reflect the actual cluster configuration."))

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -140,6 +140,16 @@ namespace Pulumi.Kubernetes
             set => _renderYamlToDirectory.Set(value);
         }
 
+        private static readonly __Value<bool?> _skipUpdateUnreachable = new __Value<bool?>(() => __config.GetBoolean("skipUpdateUnreachable"));
+        /// <summary>
+        /// If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+        /// </summary>
+        public static bool? SkipUpdateUnreachable
+        {
+            get => _skipUpdateUnreachable.Get();
+            set => _skipUpdateUnreachable.Set(value);
+        }
+
         private static readonly __Value<bool?> _strictMode = new __Value<bool?>(() => __config.GetBoolean("strictMode"));
         /// <summary>
         /// If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -125,6 +125,12 @@ namespace Pulumi.Kubernetes
         public Input<string>? RenderYamlToDirectory { get; set; }
 
         /// <summary>
+        /// If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+        /// </summary>
+        [Input("skipUpdateUnreachable", json: true)]
+        public Input<bool>? SkipUpdateUnreachable { get; set; }
+
+        /// <summary>
         /// If present and set to true, suppress apiVersion deprecation warnings from the CLI.
         /// </summary>
         [Input("suppressDeprecationWarnings", json: true)]
@@ -142,6 +148,7 @@ namespace Pulumi.Kubernetes
             EnableConfigMapMutable = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE");
             EnableServerSideApply = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY");
             KubeConfig = Utilities.GetEnv("KUBECONFIG");
+            SkipUpdateUnreachable = Utilities.GetEnvBoolean("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE");
             SuppressDeprecationWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS");
             SuppressHelmHookWarnings = Utilities.GetEnvBoolean("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS");
         }

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -76,6 +76,11 @@ func GetRenderYamlToDirectory(ctx *pulumi.Context) string {
 	return config.Get(ctx, "kubernetes:renderYamlToDirectory")
 }
 
+// If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+func GetSkipUpdateUnreachable(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:skipUpdateUnreachable")
+}
+
 // If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.
 func GetStrictMode(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:strictMode")

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -50,6 +50,11 @@ func NewProvider(ctx *pulumi.Context,
 			args.Kubeconfig = pulumi.StringPtr(d.(string))
 		}
 	}
+	if args.SkipUpdateUnreachable == nil {
+		if d := internal.GetEnvOrDefault(nil, internal.ParseEnvBool, "PULUMI_K8S_SKIP_UPDATE_UNREACHABLE"); d != nil {
+			args.SkipUpdateUnreachable = pulumi.BoolPtr(d.(bool))
+		}
+	}
 	if args.SuppressDeprecationWarnings == nil {
 		if d := internal.GetEnvOrDefault(nil, internal.ParseEnvBool, "PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS"); d != nil {
 			args.SuppressDeprecationWarnings = pulumi.BoolPtr(d.(bool))
@@ -108,6 +113,8 @@ type providerArgs struct {
 	// and may result in an error if they are referenced by other resources. Also note that any secret values
 	// used in these resources will be rendered in plaintext to the resulting YAML.
 	RenderYamlToDirectory *string `pulumi:"renderYamlToDirectory"`
+	// If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+	SkipUpdateUnreachable *bool `pulumi:"skipUpdateUnreachable"`
 	// If present and set to true, suppress apiVersion deprecation warnings from the CLI.
 	SuppressDeprecationWarnings *bool `pulumi:"suppressDeprecationWarnings"`
 	// If present and set to true, suppress unsupported Helm hook warnings from the CLI.
@@ -154,6 +161,8 @@ type ProviderArgs struct {
 	// and may result in an error if they are referenced by other resources. Also note that any secret values
 	// used in these resources will be rendered in plaintext to the resulting YAML.
 	RenderYamlToDirectory pulumi.StringPtrInput
+	// If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+	SkipUpdateUnreachable pulumi.BoolPtrInput
 	// If present and set to true, suppress apiVersion deprecation warnings from the CLI.
 	SuppressDeprecationWarnings pulumi.BoolPtrInput
 	// If present and set to true, suppress unsupported Helm hook warnings from the CLI.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
@@ -93,6 +93,13 @@ public final class Config {
         return Codegen.stringProp("renderYamlToDirectory").config(config).get();
     }
 /**
+ * If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+ * 
+ */
+    public Optional<Boolean> skipUpdateUnreachable() {
+        return Codegen.booleanProp("skipUpdateUnreachable").config(config).get();
+    }
+/**
  * If present and set to true, the provider will use strict configuration mode. Recommended for production stacks. In this mode, the default Kubernetes provider is disabled, and the `kubeconfig` and `context` settings are required for Provider configuration. These settings unambiguously ensure that every Kubernetes resource is associated with a particular cluster.
  * 
  */

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/ProviderArgs.java
@@ -206,6 +206,21 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+     * 
+     */
+    @Import(name="skipUpdateUnreachable", json=true)
+    private @Nullable Output<Boolean> skipUpdateUnreachable;
+
+    /**
+     * @return If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+     * 
+     */
+    public Optional<Output<Boolean>> skipUpdateUnreachable() {
+        return Optional.ofNullable(this.skipUpdateUnreachable);
+    }
+
+    /**
      * If present and set to true, suppress apiVersion deprecation warnings from the CLI.
      * 
      */
@@ -248,6 +263,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         this.kubeconfig = $.kubeconfig;
         this.namespace = $.namespace;
         this.renderYamlToDirectory = $.renderYamlToDirectory;
+        this.skipUpdateUnreachable = $.skipUpdateUnreachable;
         this.suppressDeprecationWarnings = $.suppressDeprecationWarnings;
         this.suppressHelmHookWarnings = $.suppressHelmHookWarnings;
     }
@@ -517,6 +533,27 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param skipUpdateUnreachable If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+         * 
+         * @return builder
+         * 
+         */
+        public Builder skipUpdateUnreachable(@Nullable Output<Boolean> skipUpdateUnreachable) {
+            $.skipUpdateUnreachable = skipUpdateUnreachable;
+            return this;
+        }
+
+        /**
+         * @param skipUpdateUnreachable If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+         * 
+         * @return builder
+         * 
+         */
+        public Builder skipUpdateUnreachable(Boolean skipUpdateUnreachable) {
+            return skipUpdateUnreachable(Output.of(skipUpdateUnreachable));
+        }
+
+        /**
          * @param suppressDeprecationWarnings If present and set to true, suppress apiVersion deprecation warnings from the CLI.
          * 
          * @return builder
@@ -563,6 +600,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
             $.enableConfigMapMutable = Codegen.booleanProp("enableConfigMapMutable").output().arg($.enableConfigMapMutable).env("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE").getNullable();
             $.enableServerSideApply = Codegen.booleanProp("enableServerSideApply").output().arg($.enableServerSideApply).env("PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY").getNullable();
             $.kubeconfig = Codegen.stringProp("kubeconfig").output().arg($.kubeconfig).env("KUBECONFIG").getNullable();
+            $.skipUpdateUnreachable = Codegen.booleanProp("skipUpdateUnreachable").output().arg($.skipUpdateUnreachable).env("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE").getNullable();
             $.suppressDeprecationWarnings = Codegen.booleanProp("suppressDeprecationWarnings").output().arg($.suppressDeprecationWarnings).env("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS").getNullable();
             $.suppressHelmHookWarnings = Codegen.booleanProp("suppressHelmHookWarnings").output().arg($.suppressHelmHookWarnings).env("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS").getNullable();
             return $;

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -47,6 +47,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["kubeconfig"] = (args ? args.kubeconfig : undefined) ?? utilities.getEnv("KUBECONFIG");
             resourceInputs["namespace"] = args ? args.namespace : undefined;
             resourceInputs["renderYamlToDirectory"] = args ? args.renderYamlToDirectory : undefined;
+            resourceInputs["skipUpdateUnreachable"] = pulumi.output((args ? args.skipUpdateUnreachable : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE")).apply(JSON.stringify);
             resourceInputs["suppressDeprecationWarnings"] = pulumi.output((args ? args.suppressDeprecationWarnings : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS")).apply(JSON.stringify);
             resourceInputs["suppressHelmHookWarnings"] = pulumi.output((args ? args.suppressHelmHookWarnings : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS")).apply(JSON.stringify);
         }
@@ -117,6 +118,10 @@ export interface ProviderArgs {
      * used in these resources will be rendered in plaintext to the resulting YAML.
      */
     renderYamlToDirectory?: pulumi.Input<string>;
+    /**
+     * If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+     */
+    skipUpdateUnreachable?: pulumi.Input<boolean>;
     /**
      * If present and set to true, suppress apiVersion deprecation warnings from the CLI.
      */

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -25,6 +25,7 @@ class ProviderArgs:
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
+                 skip_update_unreachable: Optional[pulumi.Input[bool]] = None,
                  suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
                  suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None):
         """
@@ -57,6 +58,7 @@ class ProviderArgs:
                since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
                and may result in an error if they are referenced by other resources. Also note that any secret values
                used in these resources will be rendered in plaintext to the resulting YAML.
+        :param pulumi.Input[bool] skip_update_unreachable: If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
         :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to true, suppress apiVersion deprecation warnings from the CLI.
         :param pulumi.Input[bool] suppress_helm_hook_warnings: If present and set to true, suppress unsupported Helm hook warnings from the CLI.
         """
@@ -88,6 +90,10 @@ class ProviderArgs:
             pulumi.set(__self__, "namespace", namespace)
         if render_yaml_to_directory is not None:
             pulumi.set(__self__, "render_yaml_to_directory", render_yaml_to_directory)
+        if skip_update_unreachable is None:
+            skip_update_unreachable = _utilities.get_env_bool('PULUMI_K8S_SKIP_UPDATE_UNREACHABLE')
+        if skip_update_unreachable is not None:
+            pulumi.set(__self__, "skip_update_unreachable", skip_update_unreachable)
         if suppress_deprecation_warnings is None:
             suppress_deprecation_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS')
         if suppress_deprecation_warnings is not None:
@@ -236,6 +242,18 @@ class ProviderArgs:
         pulumi.set(self, "render_yaml_to_directory", value)
 
     @property
+    @pulumi.getter(name="skipUpdateUnreachable")
+    def skip_update_unreachable(self) -> Optional[pulumi.Input[bool]]:
+        """
+        If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
+        """
+        return pulumi.get(self, "skip_update_unreachable")
+
+    @skip_update_unreachable.setter
+    def skip_update_unreachable(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "skip_update_unreachable", value)
+
+    @property
     @pulumi.getter(name="suppressDeprecationWarnings")
     def suppress_deprecation_warnings(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -275,6 +293,7 @@ class Provider(pulumi.ProviderResource):
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
+                 skip_update_unreachable: Optional[pulumi.Input[bool]] = None,
                  suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
                  suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
@@ -311,6 +330,7 @@ class Provider(pulumi.ProviderResource):
                since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
                and may result in an error if they are referenced by other resources. Also note that any secret values
                used in these resources will be rendered in plaintext to the resulting YAML.
+        :param pulumi.Input[bool] skip_update_unreachable: If present and set to true, the provider will skip resources update associated with an unreachable Kubernetes cluster from Pulumi state
         :param pulumi.Input[bool] suppress_deprecation_warnings: If present and set to true, suppress apiVersion deprecation warnings from the CLI.
         :param pulumi.Input[bool] suppress_helm_hook_warnings: If present and set to true, suppress unsupported Helm hook warnings from the CLI.
         """
@@ -348,6 +368,7 @@ class Provider(pulumi.ProviderResource):
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
+                 skip_update_unreachable: Optional[pulumi.Input[bool]] = None,
                  suppress_deprecation_warnings: Optional[pulumi.Input[bool]] = None,
                  suppress_helm_hook_warnings: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
@@ -377,6 +398,9 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["kubeconfig"] = kubeconfig
             __props__.__dict__["namespace"] = namespace
             __props__.__dict__["render_yaml_to_directory"] = render_yaml_to_directory
+            if skip_update_unreachable is None:
+                skip_update_unreachable = _utilities.get_env_bool('PULUMI_K8S_SKIP_UPDATE_UNREACHABLE')
+            __props__.__dict__["skip_update_unreachable"] = pulumi.Output.from_input(skip_update_unreachable).apply(pulumi.runtime.to_json) if skip_update_unreachable is not None else None
             if suppress_deprecation_warnings is None:
                 suppress_deprecation_warnings = _utilities.get_env_bool('PULUMI_K8S_SUPPRESS_DEPRECATION_WARNINGS')
             __props__.__dict__["suppress_deprecation_warnings"] = pulumi.Output.from_input(suppress_deprecation_warnings).apply(pulumi.runtime.to_json) if suppress_deprecation_warnings is not None else None

--- a/tests/sdk/nodejs/skip-update-unreachable/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/skip-update-unreachable/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: skip-update-unreachable-tests
+description: Tests skipUpdateUnreachable flag
+runtime: nodejs

--- a/tests/sdk/nodejs/skip-update-unreachable/step1/index.ts
+++ b/tests/sdk/nodejs/skip-update-unreachable/step1/index.ts
@@ -1,0 +1,59 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Read the cluster kubeconfig.
+
+// Create 2 Kubernetes providers with to simulate 2 clusters. The KUBECONFIG is obtained from the environment
+// variables `KUBECONFIG_CLUSTER_0` and `KUBECONFIG_CLUSTER_1` respectively.
+const provider0 = new k8s.Provider("k8s", {
+  kubeconfig: process.env.KUBECONFIG_CLUSTER_0,
+  enableConfigMapMutable: true,
+});
+const provider1 = new k8s.Provider("k8s2", {
+  kubeconfig: process.env.KUBECONFIG_CLUSTER_1,
+  enableConfigMapMutable: true,
+});
+
+// Create a namespace and a configmap in the provided cluster.
+function createCM(clusterNumber: number, provider: k8s.Provider): [k8s.core.v1.Namespace, k8s.core.v1.ConfigMap] {
+  const ns = new k8s.core.v1.Namespace(
+    `test-cluster-${clusterNumber}`,
+    undefined,
+    { provider }
+  );
+
+  const cm = new k8s.core.v1.ConfigMap(
+    `test-cluster-${clusterNumber}`,
+    {
+      metadata: {
+        namespace: ns.metadata.name,
+      },
+      data: { foo: "step1" },
+    },
+    { provider }
+  );
+
+    return [ns, cm];  
+}
+
+const [ns0, cm0] = createCM(0, provider0);
+const [ns1, cm1] = createCM(1, provider1);
+
+// Export the resource names.
+export const nsName0 = ns0.metadata.name;
+export const cmName0 = cm0.metadata.name;
+export const nsName1 = ns1.metadata.name;
+export const cmName1 = cm1.metadata.name;

--- a/tests/sdk/nodejs/skip-update-unreachable/step1/package.json
+++ b/tests/sdk/nodejs/skip-update-unreachable/step1/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "skip-update-unreachable",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/skip-update-unreachable/step1/tsconfig.json
+++ b/tests/sdk/nodejs/skip-update-unreachable/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/skip-update-unreachable/step2/index.ts
+++ b/tests/sdk/nodejs/skip-update-unreachable/step2/index.ts
@@ -1,0 +1,59 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Read the cluster kubeconfig.
+
+// Create 2 Kubernetes providers with to simulate 2 clusters. The KUBECONFIG is obtained from the environment
+// variables `KUBECONFIG_CLUSTER_0` and `KUBECONFIG_CLUSTER_1` respectively.
+const provider0 = new k8s.Provider("k8s", {
+  kubeconfig: process.env.KUBECONFIG_CLUSTER_0,
+  enableConfigMapMutable: true,
+});
+const provider1 = new k8s.Provider("k8s2", {
+  kubeconfig: process.env.KUBECONFIG_CLUSTER_1,
+  enableConfigMapMutable: true,
+});
+
+// Create a namespace and a configmap in the provided cluster.
+function createCM(clusterNumber: number, provider: k8s.Provider): [k8s.core.v1.Namespace, k8s.core.v1.ConfigMap] {
+  const ns = new k8s.core.v1.Namespace(
+    `test-cluster-${clusterNumber}`,
+    undefined,
+    { provider }
+  );
+
+  const cm = new k8s.core.v1.ConfigMap(
+    `test-cluster-${clusterNumber}`,
+    {
+      metadata: {
+        namespace: ns.metadata.name,
+      },
+      data: { foo: "step2" }, // Change the value from "step1" to "step2".
+    },
+    { provider }
+  );
+
+    return [ns, cm];  
+}
+
+const [ns0, cm0] = createCM(0, provider0);
+const [ns1, cm1] = createCM(1, provider1);
+
+// Export the resource names.
+export const nsName0 = ns0.metadata.name;
+export const cmName0 = cm0.metadata.name;
+export const nsName1 = ns1.metadata.name;
+export const cmName1 = cm1.metadata.name;


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
The Pulumi ```deleteUnreachable``` flag is great when a cluster is removed but there is no way to proceed with applying the changes on multiple K8s clusters if there is just one not available, in this case the full update will fail (.e.g updating charts over multiple K8s clusters where 1+ are not currently available). 

The proposed feature introduce a new variable called **```skipUpdateUnreachable```** and allow to run ```pulumi up``` without failing if one or more Kubernetes cluster are unreachable (showing warning messages). 
The feature allows to make changes on an existing system which might consist of multiple K8 clusters and at that specific moment has some clusters down.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

Fixes: #2565 
