### PR TITLE
Add codecov to this repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,10 @@ jobs:
         retention-days: 30
     - name: Test Provider Library
       run: make test_provider
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -143,6 +143,10 @@ jobs:
         retention-days: 30
     - name: Test Provider Library
       run: make test_provider
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/.ionide
 .pulumi
 Pulumi.*.yaml
+provider/pkg/coverage.txt
 /provider/pkg/gen/openapi-specs
 /provider/cmd/pulumi-resource-kubernetes/schema.go
 /provider/cmd/pulumi-resource-kubernetes/schema-embed.json

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OPENAPI_FILE    := ${OPENAPI_DIR}/swagger-${KUBE_VERSION}.json
 SCHEMA_FILE     := provider/cmd/pulumi-resource-kubernetes/schema.json
 GOPATH			:= $(shell go env GOPATH)
 
-JAVA_GEN 		 := pulumi-java-gen
+JAVA_GEN		 := pulumi-java-gen
 JAVA_GEN_VERSION := v0.8.0
 
 WORKING_DIR     := $(shell pwd)
@@ -53,7 +53,7 @@ k8sprovider_debug::
 	(cd provider && CGO_ENABLED=0 go build -o $(WORKING_DIR)/bin/${PROVIDER} -gcflags="all=-N -l" -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 
 test_provider::
-	cd provider/pkg && go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} ./...
+	cd provider/pkg && go test -short -v -count=1 -coverprofile="coverage.txt" -timeout 2h -parallel ${TESTPARALLELISM} ./...
 
 dotnet_sdk:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 dotnet_sdk::
@@ -118,7 +118,7 @@ install:: install_nodejs_sdk install_dotnet_sdk
 	cp $(WORKING_DIR)/bin/${PROVIDER} ${GOPATH}/bin
 
 GO_TEST_FAST := go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
-GO_TEST 	 := go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
+GO_TEST		 := go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
 
 test_fast::
 # TODO: re-enable this test once https://github.com/pulumi/pulumi/issues/4954 is fixed.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This adds basic code coverage for our provider binaries as exercised by our unit tests. An example of the comment produced by the tool occurs on this PR; the coverage report is informational only (will not block PR checks). 


## Details
Generates a coverage report while running the `test` target; adds a ci step to upload the coverage report during PR acceptance tests and master builds

We don't want to over index on this metric - our more interesting issues arise from the interactions with the upstream service - however, this is a simple add and gives us a little bit of data we can use to encourage better quality. 