### PR TITLE
Helm Release detect changes to local chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Return mapping information for terraform conversions (https://github.com/pulumi/pulumi-kubernetes/pull/2457)
 
+- helm.v3.Release: Detect changes to local charts (https://github.com/pulumi/pulumi-kubernetes/pull/2568)
+
 ## 4.1.1 (August 23, 2023)
 
 - Revert the switch to pyproject.toml and wheel-based PyPI publishing as it impacts users that run pip with --no-binary

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -683,6 +683,13 @@ func (r *helmReleaseProvider) Diff(ctx context.Context, req *pulumirpc.DiffReque
 	// Extract old inputs from the `__inputs` field of the old state.
 	oldInputs, _ := parseCheckpointRelease(olds)
 
+	// apply ignoreChanges
+	for _, ignore := range req.GetIgnoreChanges() {
+		if ignore == "checksum" {
+			news["checksum"] = oldInputs["checksum"]
+		}
+	}
+
 	// Calculate the diff between the old and new inputs
 	diff := oldInputs.Diff(news)
 	if diff == nil {

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -941,7 +941,14 @@ func (r *helmReleaseProvider) Read(ctx context.Context, req *pulumirpc.ReadReque
 	oldInputs, _ := parseCheckpointRelease(oldState)
 	if oldInputs == nil {
 		// No old inputs suggests this is an import. Hydrate the imports from the current live object
-		logger.V(9).Infof("existingRelease: %#v", existingRelease)
+		resourceInfo, err := r.computeResourceInfo(existingRelease, r.clientSet)
+		if err != nil {
+			return nil, err
+		}
+		existingRelease.Checksum = resourceInfo.checksum
+		existingRelease.ResourceNames = resourceInfo.resourceNames
+		logger.V(9).Infof("%s Imported release: %#v", label, existingRelease)
+
 		oldInputs = r.serializeImportInputs(existingRelease)
 		r.setDefaults(oldInputs)
 	}

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -683,13 +683,6 @@ func (r *helmReleaseProvider) Diff(ctx context.Context, req *pulumirpc.DiffReque
 	// Extract old inputs from the `__inputs` field of the old state.
 	oldInputs, _ := parseCheckpointRelease(olds)
 
-	// if the checkpointed inputs have no checksum, then assume no change since checksums were introduced,
-	// to avoid making a spurious release.
-	checksum, ok := oldInputs["checksum"]
-	if !ok || (checksum.IsString() && checksum.StringValue() == "") {
-		oldInputs["checksum"] = news["checksum"]
-	}
-
 	// Calculate the diff between the old and new inputs
 	diff := oldInputs.Diff(news)
 	if diff == nil {

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -112,7 +112,7 @@ func TestGo(t *testing.T) {
 		integration.ProgramTest(t, &options)
 	})
 
-	t.Run("Helm Import", func(t *testing.T) {
+	t.Run("Helm Release Import", func(t *testing.T) {
 		baseDir := filepath.Join(cwd, "helm-release-import", "step1")
 		namespace := getRandomNamespace("importtest")
 		require.NoError(t, createRelease("mynginx", namespace, baseDir, true))

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -209,6 +209,17 @@ func TestGo(t *testing.T) {
 					Dir:      filepath.Join("helm-release-local", "step2"),
 					Additive: true,
 					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+						// expect the change in values.yaml (replicaCount: 2) to be detected
+						validateReplicas(t, stack, 2)
+					},
+					ExpectFailure: false,
+				},
+				{
+					Dir:      filepath.Join("helm-release-local", "step3"),
+					Additive: true,
+					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+						// note the resource option: pulumi.IgnoreChanges([]string{"checksum"})
+						// expect the change in values.yaml (replicaCount: 3) to be ignored
 						validateReplicas(t, stack, 2)
 					},
 					ExpectFailure: false,

--- a/tests/sdk/go/helm-release-local/step1/Pulumi.yaml
+++ b/tests/sdk/go/helm-release-local/step1/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: go_helm_release
-description: Test Kubernetes Helm Release resource with remote Chart.
+description: Test Kubernetes Helm Release resource with local Chart.
 runtime: go

--- a/tests/sdk/go/helm-release-local/step2/nginx/values.yaml
+++ b/tests/sdk/go/helm-release-local/step2/nginx/values.yaml
@@ -1,0 +1,510 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+
+## Bitnami NGINX image version
+## ref: https://hub.docker.com/r/bitnami/nginx/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/nginx
+  tag: 1.19.1-debian-10-r23
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override nginx.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override nginx.fullname template
+##
+# fullnameOverride:
+
+## Name of existing ConfigMap with the server static site content
+##
+# staticSiteConfigmap
+
+## Name of existing PVC with the server static site content
+## NOTE: This will override staticSiteConfigmap
+##
+# staticSitePVC
+
+## Get the server static content from a git repository
+## NOTE: This will override staticSiteConfigmap and staticSitePVC
+##
+cloneStaticSiteFromGit:
+  enabled: false
+  ## Bitnami Git image version
+  ## ref: https://hub.docker.com/r/bitnami/git/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/git
+    tag: 2.28.0-debian-10-r6
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Repository to clone static content from
+  ##
+  # repository:
+  ## Branch inside the git repository
+  ##
+  # branch:
+  ## Interval for sidecar container pull from the repository
+  ##
+  interval: 60
+
+## Custom server block to be added to NGINX configuration
+## PHP-FPM example server block:
+## serverBlock: |-
+##   server {
+##     listen 0.0.0.0:8080;
+##     root /app;
+##     location / {
+##       index index.html index.php;
+##     }
+##     location ~ \.php$ {
+##       fastcgi_pass phpfpm-server:9000;
+##       fastcgi_index index.php;
+##       include fastcgi.conf;
+##     }
+##   }
+##
+# serverBlock:
+
+## ConfigMap with custom server block to be added to NGINX configuration
+## NOTE: This will override serverBlock
+##
+# existingServerBlockConfigmap:
+
+## Number of replicas to deploy
+##
+replicaCount: 2
+
+## Deployment Container Port
+##
+containerPort: 8080
+
+## If you would like to serve tls in the cluster set containerTlsPort
+##   This is required for extra serverBlocks that serve https.
+##
+## containerTlsPort: 8443
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: {}
+
+## NGINX containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## NGINX containers' liveness and readiness probes
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 5
+
+## NGINX Service properties
+##
+service:
+  ## Service type
+  ##
+  type: LoadBalancer
+
+  ## HTTP Port
+  ##
+  port: 80
+
+  ## HTTPS Port
+  ##
+  httpsPort: 443
+
+  ## Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ""
+    https: ""
+
+  ## Set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  # loadBalancerIP:
+
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+
+
+## LDAP Auth Daemon Properties
+##
+## Daemon that will proxy LDAP requests
+## between NGINX and a given LDAP Server
+##
+ldapDaemon:
+
+  enabled: false
+
+  ## Bitnami NGINX LDAP Auth Daemon image
+  ## ref: https://hub.docker.com/r/bitnami/nginx-ldap-auth-daemon/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/nginx-ldap-auth-daemon
+    tag: 0.20200116.0-debian-10-r83
+    pullPolicy: IfNotPresent
+
+  ## LDAP Daemon port
+  ##
+  port: 8888
+
+  ## LDAP Auth Daemon Configuration
+  ##
+  ## These different properties define the form of requests performed
+  ## against the given LDAP server
+  ##
+  ## BEWARE THAT THESE VALUES WILL BE IGNORED IF A CUSTOM LDAP SERVER BLOCK
+  ## ALREADY SPECIFIES THEM.
+  ##
+  ##
+  ldapConfig:
+
+    ## LDAP URI where to query the server
+    ## Must follow the pattern -> ldap[s]:/<hostname>:<port>
+    uri: ""
+
+    ## LDAP search base DN
+    baseDN: ""
+
+    ## LDAP bind DN
+    bindDN: ""
+
+    ## LDAP bind Password
+    bindPassword: ""
+
+    ## LDAP search filter
+    filter: ""
+
+    ## LDAP auth realm
+    httpRealm: ""
+
+    ## LDAP cookie name
+    httpCookieName: ""
+
+  ## NGINX Configuration File containing the directives (that define
+  ## how LDAP requests are performed) and tells NGINX to use the LDAP Daemon
+  ## as proxy. Besides, it defines the routes that will require of LDAP auth
+  ## in order to be accessed.
+  ##
+  ## If LDAP directives are provided, they will take precedence over
+  ## the ones specified in ldapConfig.
+  ##
+  ## This will be evaluated as a template.
+  ##
+  ##
+
+  nginxServerBlock: |-
+    server {
+    listen 0.0.0.0:{{ .Values.containerPort }};
+
+    # You can provide a special subPath or the root
+    location = / {
+        auth_request /auth-proxy;
+    }
+
+    location = /auth-proxy {
+        internal;
+
+        proxy_pass http://127.0.0.1:{{ .Values.ldapDaemon.port }};
+
+        ###############################################################
+        # YOU SHOULD CHANGE THE FOLLOWING TO YOUR LDAP CONFIGURATION  #
+        ###############################################################
+
+        # URL and port for connecting to the LDAP server
+        proxy_set_header X-Ldap-URL "ldap://YOUR_LDAP_SERVER_IP:YOUR_LDAP_SERVER_PORT";
+
+        # Base DN
+        proxy_set_header X-Ldap-BaseDN "dc=example,dc=org";
+
+        # Bind DN
+        proxy_set_header X-Ldap-BindDN "cn=admin,dc=example,dc=org";
+
+        # Bind password
+        proxy_set_header X-Ldap-BindPass "adminpassword";
+    }
+    }
+
+  ## Use an existing Secret holding an NGINX Configuration file that
+  ## configures LDAP requests. (will be evaluated as a template)
+  ##
+  ## If provided, both nginxServerBlock and ldapConfig properties are ignored.
+  ##
+  existingNginxServerBlockSecret:
+
+  ## LDAP Auth Daemon's liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    tcpSocket:
+      port: ldap-daemon
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  readinessProbe:
+    tcpSocket:
+      port: ldap-daemon
+    initialDelaySeconds: 5
+    timeoutSeconds: 3
+    periodSeconds: 5
+
+## Ingress paramaters
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  # hostname: example.local
+
+  ## The list of hosts and paths to be covered into ingress rules if more than one hosts
+  ## or only a host with a path is needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The tls configuration for the ingress
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ##
+  tls:
+    - hosts:
+        - example.local
+      secretName: example.local-tls
+
+
+healthIngress:
+  ## Set to true to enable health ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the health ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: example.local
+
+  ## Health Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The list of additional hostnames to be covered with this health ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
+
+  ## The tls configuration for the health ingress
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ##
+  tls:
+    - hosts:
+        - example.local
+      secretName: example.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: example.local-tls
+  #   key:
+  #   certificate:
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+
+  ## Bitnami NGINX Prometheus Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/nginx-exporter/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/nginx-exporter
+    tag: 0.8.0-debian-10-r41
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Prometheus exporter pods' annotation and labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9113"
+
+  ## Prometheus exporter service parameters
+  ##
+  service:
+    ## NGINX Prometheus exporter port
+    ##
+    port: 9113
+    ## Annotations for the Prometheus exporter service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+
+  ## NGINX Prometheus exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: false
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+    ## ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # selector:
+    #   prometheus: my-prometheus
+
+## Autoscaling parameters
+##
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 10
+  # targetCPU: 50
+  # targetMemory: 50
+
+## Array to add extra volumes (evaluated as a template)
+##
+extraVolumes: []
+
+## Array to add extra mounts (normally used with extraVolumes, evaluated as a template)
+##
+extraVolumeMounts: []

--- a/tests/sdk/go/helm-release-local/step3/main.go
+++ b/tests/sdk/go/helm-release-local/step3/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ns, err := corev1.NewNamespace(ctx, "test", &corev1.NamespaceArgs{})
+		if err != nil {
+			return err
+		}
+
+		rel, err := helm.NewRelease(ctx, "test", &helm.ReleaseArgs{
+			Chart:     pulumi.String("nginx"),
+			Namespace: ns.Metadata.Name(),
+			Values:    pulumi.Map{"service": pulumi.StringMap{"type": pulumi.String("ClusterIP")}},
+			Timeout:   pulumi.Int(300),
+		}, pulumi.IgnoreChanges([]string{"checksum"}))
+		if err != nil {
+			return err
+		}
+
+		replicas := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
+				namespace := arr[0].(*string)
+				name := arr[1].(*string)
+				svc, err := appsv1.GetDeployment(ctx, "deployment", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)
+				if err != nil {
+					return "", nil
+				}
+				return svc.Spec.Replicas(), nil
+			})
+		ctx.Export("replicas", replicas)
+
+		svc := pulumi.All(rel.Status.Namespace(), rel.Status.Name()).
+			ApplyT(func(r any) (any, error) {
+				arr := r.([]any)
+				namespace := arr[0].(*string)
+				name := arr[1].(*string)
+				svc, err := corev1.GetService(ctx, "svc", pulumi.ID(fmt.Sprintf("%s/%s-nginx", *namespace, *name)), nil)
+				if err != nil {
+					return "", nil
+				}
+				return svc.Spec.ClusterIP(), nil
+			})
+		ctx.Export("svc_ip", svc)
+
+		return nil
+	})
+}

--- a/tests/sdk/go/helm-release-local/step3/nginx/values.yaml
+++ b/tests/sdk/go/helm-release-local/step3/nginx/values.yaml
@@ -1,0 +1,510 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+
+## Bitnami NGINX image version
+## ref: https://hub.docker.com/r/bitnami/nginx/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/nginx
+  tag: 1.19.1-debian-10-r23
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override nginx.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override nginx.fullname template
+##
+# fullnameOverride:
+
+## Name of existing ConfigMap with the server static site content
+##
+# staticSiteConfigmap
+
+## Name of existing PVC with the server static site content
+## NOTE: This will override staticSiteConfigmap
+##
+# staticSitePVC
+
+## Get the server static content from a git repository
+## NOTE: This will override staticSiteConfigmap and staticSitePVC
+##
+cloneStaticSiteFromGit:
+  enabled: false
+  ## Bitnami Git image version
+  ## ref: https://hub.docker.com/r/bitnami/git/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/git
+    tag: 2.28.0-debian-10-r6
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Repository to clone static content from
+  ##
+  # repository:
+  ## Branch inside the git repository
+  ##
+  # branch:
+  ## Interval for sidecar container pull from the repository
+  ##
+  interval: 60
+
+## Custom server block to be added to NGINX configuration
+## PHP-FPM example server block:
+## serverBlock: |-
+##   server {
+##     listen 0.0.0.0:8080;
+##     root /app;
+##     location / {
+##       index index.html index.php;
+##     }
+##     location ~ \.php$ {
+##       fastcgi_pass phpfpm-server:9000;
+##       fastcgi_index index.php;
+##       include fastcgi.conf;
+##     }
+##   }
+##
+# serverBlock:
+
+## ConfigMap with custom server block to be added to NGINX configuration
+## NOTE: This will override serverBlock
+##
+# existingServerBlockConfigmap:
+
+## Number of replicas to deploy
+##
+replicaCount: 3
+
+## Deployment Container Port
+##
+containerPort: 8080
+
+## If you would like to serve tls in the cluster set containerTlsPort
+##   This is required for extra serverBlocks that serve https.
+##
+## containerTlsPort: 8443
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: {}
+
+## NGINX containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## NGINX containers' liveness and readiness probes
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 5
+
+## NGINX Service properties
+##
+service:
+  ## Service type
+  ##
+  type: LoadBalancer
+
+  ## HTTP Port
+  ##
+  port: 80
+
+  ## HTTPS Port
+  ##
+  httpsPort: 443
+
+  ## Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ""
+    https: ""
+
+  ## Set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  # loadBalancerIP:
+
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+
+
+## LDAP Auth Daemon Properties
+##
+## Daemon that will proxy LDAP requests
+## between NGINX and a given LDAP Server
+##
+ldapDaemon:
+
+  enabled: false
+
+  ## Bitnami NGINX LDAP Auth Daemon image
+  ## ref: https://hub.docker.com/r/bitnami/nginx-ldap-auth-daemon/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/nginx-ldap-auth-daemon
+    tag: 0.20200116.0-debian-10-r83
+    pullPolicy: IfNotPresent
+
+  ## LDAP Daemon port
+  ##
+  port: 8888
+
+  ## LDAP Auth Daemon Configuration
+  ##
+  ## These different properties define the form of requests performed
+  ## against the given LDAP server
+  ##
+  ## BEWARE THAT THESE VALUES WILL BE IGNORED IF A CUSTOM LDAP SERVER BLOCK
+  ## ALREADY SPECIFIES THEM.
+  ##
+  ##
+  ldapConfig:
+
+    ## LDAP URI where to query the server
+    ## Must follow the pattern -> ldap[s]:/<hostname>:<port>
+    uri: ""
+
+    ## LDAP search base DN
+    baseDN: ""
+
+    ## LDAP bind DN
+    bindDN: ""
+
+    ## LDAP bind Password
+    bindPassword: ""
+
+    ## LDAP search filter
+    filter: ""
+
+    ## LDAP auth realm
+    httpRealm: ""
+
+    ## LDAP cookie name
+    httpCookieName: ""
+
+  ## NGINX Configuration File containing the directives (that define
+  ## how LDAP requests are performed) and tells NGINX to use the LDAP Daemon
+  ## as proxy. Besides, it defines the routes that will require of LDAP auth
+  ## in order to be accessed.
+  ##
+  ## If LDAP directives are provided, they will take precedence over
+  ## the ones specified in ldapConfig.
+  ##
+  ## This will be evaluated as a template.
+  ##
+  ##
+
+  nginxServerBlock: |-
+    server {
+    listen 0.0.0.0:{{ .Values.containerPort }};
+
+    # You can provide a special subPath or the root
+    location = / {
+        auth_request /auth-proxy;
+    }
+
+    location = /auth-proxy {
+        internal;
+
+        proxy_pass http://127.0.0.1:{{ .Values.ldapDaemon.port }};
+
+        ###############################################################
+        # YOU SHOULD CHANGE THE FOLLOWING TO YOUR LDAP CONFIGURATION  #
+        ###############################################################
+
+        # URL and port for connecting to the LDAP server
+        proxy_set_header X-Ldap-URL "ldap://YOUR_LDAP_SERVER_IP:YOUR_LDAP_SERVER_PORT";
+
+        # Base DN
+        proxy_set_header X-Ldap-BaseDN "dc=example,dc=org";
+
+        # Bind DN
+        proxy_set_header X-Ldap-BindDN "cn=admin,dc=example,dc=org";
+
+        # Bind password
+        proxy_set_header X-Ldap-BindPass "adminpassword";
+    }
+    }
+
+  ## Use an existing Secret holding an NGINX Configuration file that
+  ## configures LDAP requests. (will be evaluated as a template)
+  ##
+  ## If provided, both nginxServerBlock and ldapConfig properties are ignored.
+  ##
+  existingNginxServerBlockSecret:
+
+  ## LDAP Auth Daemon's liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    tcpSocket:
+      port: ldap-daemon
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  readinessProbe:
+    tcpSocket:
+      port: ldap-daemon
+    initialDelaySeconds: 5
+    timeoutSeconds: 3
+    periodSeconds: 5
+
+## Ingress paramaters
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  # hostname: example.local
+
+  ## The list of hosts and paths to be covered into ingress rules if more than one hosts
+  ## or only a host with a path is needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The tls configuration for the ingress
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ##
+  tls:
+    - hosts:
+        - example.local
+      secretName: example.local-tls
+
+
+healthIngress:
+  ## Set to true to enable health ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the health ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: example.local
+
+  ## Health Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The list of additional hostnames to be covered with this health ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
+
+  ## The tls configuration for the health ingress
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ##
+  tls:
+    - hosts:
+        - example.local
+      secretName: example.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: example.local-tls
+  #   key:
+  #   certificate:
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+
+  ## Bitnami NGINX Prometheus Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/nginx-exporter/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/nginx-exporter
+    tag: 0.8.0-debian-10-r41
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Prometheus exporter pods' annotation and labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9113"
+
+  ## Prometheus exporter service parameters
+  ##
+  service:
+    ## NGINX Prometheus exporter port
+    ##
+    port: 9113
+    ## Annotations for the Prometheus exporter service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+
+  ## NGINX Prometheus exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: false
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+    ## ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # selector:
+    #   prometheus: my-prometheus
+
+## Autoscaling parameters
+##
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 10
+  # targetCPU: 50
+  # targetMemory: 50
+
+## Array to add extra volumes (evaluated as a template)
+##
+extraVolumes: []
+
+## Array to add extra mounts (normally used with extraVolumes, evaluated as a template)
+##
+extraVolumeMounts: []


### PR DESCRIPTION
### Proposed changes

This PR fixes a usability problem with the `kubernetes:helm.sh/v3:Release` resource when using a local chart.  With this fix, Pulumi automatically detects changes to the rendered output of the chart and performs a Helm upgrade accordingly. It does this by persisting a SHA256 checksum of the chart output into the Pulumi stack state.

Users may suppress change detection with the `ignoreChanges` option, i.e. `ignoreChanges: ["checksum"]`.

**Upgrade considerations**: after upgrading the provider, users should expect to see a diff (`checksum` property) and a corresponding Helm upgrade. Helm upgrades are generally idempotent.

### Related issues (optional)
Closes #2118 

