### PR TITLE
Prune read-only fields from resource inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   installs based on the source distribution.
 - Return mapping information for terraform conversions (https://github.com/pulumi/pulumi-kubernetes/pull/2457)
 - feature: added skipUpdateUnreachable flag to proceed with the updates without failing (https://github.com/pulumi/pulumi-kubernetes/pull/2528)
-
 - helm.v3.Release: Detect changes to local charts (https://github.com/pulumi/pulumi-kubernetes/pull/2568)
+- Ignore read-only inputs in Kubernetes object metadata (https://github.com/pulumi/pulumi-kubernetes/pull/2571)
 
 ## 4.1.1 (August 23, 2023)
 

--- a/provider/pkg/clients/unstructured.go
+++ b/provider/pkg/clients/unstructured.go
@@ -85,9 +85,6 @@ func Normalize(uns *unstructured.Unstructured) (*unstructured.Unstructured, erro
 		}
 	}
 
-	// Remove output-only fields
-	unstructured.RemoveNestedField(result.Object, "metadata", "creationTimestamp")
-
 	return result, nil
 }
 

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -272,20 +272,6 @@ var (
 		},
 	}
 
-	secretWithCreationTimestampUnstructured = &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"creationTimestamp": "2023-07-20T23:54:21Z",
-				"name":              "foo",
-			},
-			"stringData": map[string]any{
-				"foo": "bar",
-			},
-		},
-	}
-
 	secretNormalizedUnstructured = &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -343,7 +329,6 @@ func TestNormalize(t *testing.T) {
 		{"CRD with status", args{uns: crdStatusUnstructured}, crdUnstructured, false},
 		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured, false},
 		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured, false},
-		{"Secret with creationTimestamp set on input", args{uns: secretWithCreationTimestampUnstructured}, secretNormalizedUnstructured, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2757,6 +2757,7 @@ func normalizeInputs(uns *unstructured.Unstructured) (*unstructured.Unstructured
 	}
 
 	// Remove read-only fields
+	// see: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta
 	unstructured.RemoveNestedField(uns.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(uns.Object, "metadata", "deletionGracePeriodSeconds")
 	unstructured.RemoveNestedField(uns.Object, "metadata", "deletionTimestamp")

--- a/tests/sdk/nodejs/metadata/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/metadata/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: metadata
+description: Tests object metadata handling.
+runtime: nodejs

--- a/tests/sdk/nodejs/metadata/step1/index.ts
+++ b/tests/sdk/nodejs/metadata/step1/index.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const appLabels = { app: "nginx" };
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    metadata: {
+        // this program attempts to set some read-only properties
+        creationTimestamp: "invalid-step1",
+        deletionTimestamp: "invalid-step1",
+        resourceVersion: "invalid-step1",
+        uid: "invalid-step1",
+        // and some good properties
+        annotations: {
+            "foo": "bar"
+        }
+    },
+    spec: {
+        selector: { matchLabels: appLabels },
+        replicas: 1,
+        template: {
+            metadata: { labels: appLabels },
+            spec: { containers: [{ name: "nginx", image: "nginx" }] }
+        }
+    }
+});
+export const name = deployment.metadata.name;
+export const resourceVersion = deployment.metadata.resourceVersion;

--- a/tests/sdk/nodejs/metadata/step1/package.json
+++ b/tests/sdk/nodejs/metadata/step1/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "metadata",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/metadata/step1/tsconfig.json
+++ b/tests/sdk/nodejs/metadata/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/metadata/step2/index.ts
+++ b/tests/sdk/nodejs/metadata/step2/index.ts
@@ -18,7 +18,7 @@ import * as k8s from "@pulumi/kubernetes";
 const appLabels = { app: "nginx" };
 const deployment = new k8s.apps.v1.Deployment("nginx", {
     metadata: {
-        // this program attempts to set some read-only properties
+        // step 2 has changed values that are expected to be ignored
         creationTimestamp: "invalid-step2",
         deletionTimestamp: "invalid-step2",
         resourceVersion: "invalid-step2",

--- a/tests/sdk/nodejs/metadata/step2/index.ts
+++ b/tests/sdk/nodejs/metadata/step2/index.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const appLabels = { app: "nginx" };
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    metadata: {
+        // this program attempts to set some read-only properties
+        creationTimestamp: "invalid-step2",
+        deletionTimestamp: "invalid-step2",
+        resourceVersion: "invalid-step2",
+        uid: "invalid-step2",
+        // and some good properties
+        annotations: {
+            "foo": "bar"
+        }
+    },
+    spec: {
+        selector: { matchLabels: appLabels },
+        replicas: 1,
+        template: {
+            metadata: { labels: appLabels },
+            spec: { containers: [{ name: "nginx", image: "nginx" }] }
+        }
+    }
+});
+export const name = deployment.metadata.name;
+export const resourceVersion = deployment.metadata.resourceVersion;

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -887,6 +887,28 @@ func TestQuery(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestReadonlyMetadata(t *testing.T) {
+
+	test := baseOptions.With(integration.ProgramTestOptions{
+		Dir:   filepath.Join("metadata", "step1"),
+		Quick: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// assert that the resourceVersion (a read-only property) is available as an output
+			resourceVersion, ok := stackInfo.Outputs["resourceVersion"]
+			assert.Truef(t, ok, "missing expected output \"resourceVersion\"")
+			assert.NotEmptyf(t, resourceVersion, "resourceVersion is empty")
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:             filepath.Join("metadata", "step2"),
+				Additive:        true,
+				ExpectNoChanges: true,
+			},
+		},
+	})
+	integration.ProgramTest(t, &test)
+}
+
 func TestRenderYAML(t *testing.T) {
 	// Create a temporary directory to hold rendered YAML manifests.
 	dir, err := ioutil.TempDir("", "")

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -887,21 +887,23 @@ func TestQuery(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+// TestReadonlyMetadata tests the behavior of read-only metadata fields.
 func TestReadonlyMetadata(t *testing.T) {
 
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:   filepath.Join("metadata", "step1"),
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			// assert that the resourceVersion (a read-only property) is available as an output
+			// Verify that the resourceVersion (a read-only property) is available as an output.
 			resourceVersion, ok := stackInfo.Outputs["resourceVersion"]
 			assert.Truef(t, ok, "missing expected output \"resourceVersion\"")
 			assert.NotEmptyf(t, resourceVersion, "resourceVersion is empty")
 		},
 		EditDirs: []integration.EditDir{
 			{
-				Dir:             filepath.Join("metadata", "step2"),
-				Additive:        true,
+				Dir:      filepath.Join("metadata", "step2"),
+				Additive: true,
+				// Verify that changes to some read-only values are ignored
 				ExpectNoChanges: true,
 			},
 		},

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -898,6 +898,7 @@ func TestReadonlyMetadata(t *testing.T) {
 			resourceVersion, ok := stackInfo.Outputs["resourceVersion"]
 			assert.Truef(t, ok, "missing expected output \"resourceVersion\"")
 			assert.NotEmptyf(t, resourceVersion, "resourceVersion is empty")
+			assert.NotEqual(t, "invalid-step1", resourceVersion)
 		},
 		EditDirs: []integration.EditDir{
 			{


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
<!--Give us a brief description of what you've done and what it solves. -->

This PR improves the handling of the read-only metadata fields of Kubernetes objects, such as `creationTimestamp` and `resourceVersion`.  The provider now ignores these fields when they appear as resource inputs, to address a few quirks:
1. Unparseable values do not cause an API Server error during preview.
2. A subsequent refresh does not show a difference to the `__inputs` property.
3. The behavior is now uniform for standard resource types and for custom resource types.

An integration test is provided to show that such fields are ignored as inputs, and are still available as outputs. Manual tests confirmed identical behavior for custom resource objects.

The resultant state shows that the read-only fields are not present in `"inputs"` nor in `"__inputs"`, and are present in `"outputs"`:
```json
{
                "urn": "urn:pulumi:dev::issue-2351-simple-ts::kubernetes:apps/v1:Deployment::nginx",
                "custom": true,
                "id": "default/nginx-78a03128",
                "type": "kubernetes:apps/v1:Deployment",
                "inputs": {
                    "apiVersion": "apps/v1",
                    "kind": "Deployment",
                    "metadata": {
                        "annotations": {
                            "pulumi.com/autonamed": "true"
                        },
                        "name": "nginx-78a03128",
                        "namespace": "default"
                    },
                },
                "outputs": {
                    "__fieldManager": "pulumi-kubernetes-42ad785a",
                    "__initialApiVersion": "apps/v1",
                    "__inputs": {
                        "apiVersion": "apps/v1",
                        "kind": "Deployment",
                        "metadata": {
                            "annotations": {
                                "pulumi.com/autonamed": "true"
                            },
                            "name": "nginx-78a03128",
                            "namespace": "default"
                        },
                    },
                    "apiVersion": "apps/v1",
                    "kind": "Deployment",
                    "metadata": {
                        "annotations": {
                            "deployment.kubernetes.io/revision": "1",
                            "pulumi.com/autonamed": "true"
                        },
                        "creationTimestamp": "2023-09-19T23:58:41Z",
                        "generation": 1,
                        "name": "nginx-78a03128",
                        "namespace": "default",
                        "resourceVersion": "559181",
                        "uid": "ec381c4d-92a7-470a-8fdc-824cd22a59dc"
                    },
                },
            }
```

### Related issues (optional)
Closes #2351

Related:
- https://github.com/pulumi/pulumi-kubernetes/pull/2511
- https://github.com/pulumi/pulumi-kubernetes/pull/2445

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
