### PR TITLE
Propagate cancellation to Helm Release provider action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- helm.v3.Release: Improved cancellation support (https://github.com/pulumi/pulumi-kubernetes/pull/2579)
+
 ## 4.3.0 (September 25, 2023)
 
 - helm.v3.Release: Detect changes to local charts (https://github.com/pulumi/pulumi-kubernetes/pull/2568)
@@ -7,6 +9,7 @@
 - Handle fields specified in ignoreChanges gracefully without needing a refresh when drift has occurred (https://github.com/pulumi/pulumi-kubernetes/pull/2566)
 
 ## 4.2.0 (September 14, 2023)
+
 - Reintroduce switching builds to pyproject.toml; when publishing the package to PyPI both
   source-based and wheel distributions are now published. For most users the installs will now favor
   the wheel distribution, but users invoking pip with `--no-binary :all:` will continue having

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -178,6 +178,7 @@ type ReleaseStatus struct {
 
 type helmReleaseProvider struct {
 	host                     *provider.HostClient
+	canceler                 *cancellationContext
 	helmDriver               string
 	apiConfig                *api.Config
 	defaultOverrides         *clientcmd.ConfigOverrides
@@ -193,6 +194,7 @@ type helmReleaseProvider struct {
 
 func newHelmReleaseProvider(
 	host *provider.HostClient,
+	canceler *cancellationContext,
 	apiConfig *api.Config,
 	defaultOverrides *clientcmd.ConfigOverrides,
 	restConfig *rest.Config,
@@ -216,6 +218,7 @@ func newHelmReleaseProvider(
 
 	return &helmReleaseProvider{
 		host:                     host,
+		canceler:                 canceler,
 		apiConfig:                apiConfig,
 		defaultOverrides:         defaultOverrides,
 		restConfig:               restConfig,
@@ -505,7 +508,7 @@ func (r *helmReleaseProvider) helmCreate(ctx context.Context, urn resource.URN, 
 	}
 
 	logger.V(9).Infof("install helm chart")
-	rel, err := client.Run(c, values)
+	rel, err := client.RunWithContext(r.canceler.context, c, values)
 	if err != nil && rel == nil {
 		return err
 	}
@@ -618,7 +621,7 @@ func (r *helmReleaseProvider) helmUpdate(newRelease, oldRelease *Release) error 
 		client.PostRenderer = pr
 	}
 
-	rel, err := client.Run(newRelease.Name, chart, values)
+	rel, err := client.RunWithContext(r.canceler.context, newRelease.Name, chart, values)
 	if err != nil && rel == nil {
 		return err
 	}

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1105,6 +1105,7 @@ func (r *helmReleaseProvider) Delete(ctx context.Context, req *pulumirpc.DeleteR
 		}
 		uninstall.Timeout = time.Duration(timeout) * time.Second
 	}
+	// TODO: once https://github.com/helm/helm/pull/12109 is merged, use uninstall.RunWithContext
 	res, err := uninstall.Run(name)
 	if err != nil {
 		return nil, err

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -798,6 +798,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 
 	k.helmReleaseProvider, err = newHelmReleaseProvider(
 		k.host,
+		k.canceler,
 		apiConfig,
 		overrides,
 		k.config,
@@ -2464,7 +2465,7 @@ func (k *kubeProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest)
 
 	config := await.DeleteConfig{
 		ProviderConfig: await.ProviderConfig{
-			Context:           k.canceler.context, // TODO: should this just be ctx from the args?
+			Context:           k.canceler.context,
 			Host:              k.host,
 			URN:               urn,
 			InitialAPIVersion: initialAPIVersion,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Closes #2485.

This PR implements cancelation for `Create` and `Update` operations on the Helm Release resource. When the user presses ctrl-c, the Helm operation is cancelled and the stack state is updated accordingly. This is an improvement over the current behavior where the Helm release may be orphaned by Pulumi.

A future enhancement would be to implement cancelation for the `Delete` operation, once it becomes possible in the Helm v3 library (see [PR](https://github.com/helm/helm/pull/12109) and the `RunWithContext` variants).

_Note: no new tests are provided because I don't see a way to simulate cancelation using the integration test framework._

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Related to https://github.com/pulumi/pulumi/issues/14057. It is safe to merge this PR beforehand.
