### PR TITLE
Provider config should be available as outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Other changes:
 - Update go module version to v4 (https://github.com/pulumi/pulumi-kubernetes/pull/2466)
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
+- Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
+- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Other changes:
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
 - Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
-- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
+- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2599)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix normalizing fields with empty objects/slices (https://github.com/pulumi/pulumi-kubernetes/pull/2576)
 - helm.v3.Release: Improved cancellation support (https://github.com/pulumi/pulumi-kubernetes/pull/2579)
 - Update Kubernetes client library to v0.28.2 (https://github.com/pulumi/pulumi-kubernetes/pull/2585)
+- Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
 
 ## 4.3.0 (September 25, 2023)
 
@@ -70,8 +71,6 @@ Other changes:
 - Update go module version to v4 (https://github.com/pulumi/pulumi-kubernetes/pull/2466)
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
-- Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
-- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2599)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Other changes:
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
 - Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
+- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ Other changes:
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
 - Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
-- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/provider/cmd/pulumi-gen-kubernetes/main.go
+++ b/provider/cmd/pulumi-gen-kubernetes/main.go
@@ -711,7 +711,7 @@ func buildPulumiFieldsFromTerraform(path string, block *TerraformBlockSchema) ma
 		if path == "kubernetes_deployment.spec.template.spec.container" && blockName == "port" {
 			field["name"] = "ports"
 		}
-		// 3. kubernetes_service has a field "port" wich is a list, but we call it "ports"
+		// 3. kubernetes_service has a field "port" which is a list, but we call it "ports"
 		if path == "kubernetes_service.spec" && blockName == "port" {
 			field["name"] = "ports"
 		}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -113,6 +113,7 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 			ObjectTypeSpec: pschema.ObjectTypeSpec{
 				Description: "The provider type for the kubernetes package.",
 				Type:        "object",
+				Properties:  map[string]pschema.PropertySpec{},
 			},
 			InputProperties: map[string]pschema.PropertySpec{
 				"kubeconfig": {
@@ -216,6 +217,13 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 		Language:  map[string]pschema.RawMessage{},
 	}
 
+	for name, inputProp := range pkg.Provider.InputProperties {
+		// p := pschema.PropertySpec{
+		// 	TypeSpec:    inputProp.TypeSpec,
+		// 	Description: inputProp.Description,
+		// }
+		pkg.Provider.Properties[name] = inputProp
+	}
 	goImportPath := "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 
 	csharpNamespaces := map[string]string{

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -218,6 +218,11 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 	}
 
 	for name, inputProp := range pkg.Provider.InputProperties {
+		// FIXME: provider outputs are limited to strings due to:
+		// https://github.com/pulumi/pulumi/issues/13435
+		if inputProp.TypeSpec.Type != "string" {
+			continue
+		}
 		pkg.Provider.Properties[name] = inputProp
 	}
 	goImportPath := "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -218,10 +218,6 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 	}
 
 	for name, inputProp := range pkg.Provider.InputProperties {
-		// p := pschema.PropertySpec{
-		// 	TypeSpec:    inputProp.TypeSpec,
-		// 	Description: inputProp.Description,
-		// }
 		pkg.Provider.Properties[name] = inputProp
 	}
 	goImportPath := "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -250,18 +250,9 @@ func (r *helmReleaseProvider) getActionConfig(namespace string) (*action.Configu
 	// explicitly set the namespace (e.g. through namespace: {{ .Release.Namespace }}).
 	overrides.Context.Namespace = namespace
 
-	var clientConfig clientcmd.ClientConfig
-	if r.apiConfig != nil {
-		clientConfig = clientcmd.NewDefaultClientConfig(*r.apiConfig, &overrides)
-	} else {
-		// Use client-go to resolve the final configuration values for the client. Typically these
-		// values would reside in the $KUBECONFIG file, but can also be altered in several
-		// places, including in env variables, client-go default values, and (if we allowed it) CLI
-		// flags.
-		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-		clientConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &overrides)
-	}
+	contract.Assertf(r.apiConfig != nil, "expected non-nil apiConfig")
+	contract.Assertf(r.restConfig != nil, "expected non-nil restConfig")
+	clientConfig := clientcmd.NewDefaultClientConfig(*r.apiConfig, &overrides)
 	kc := NewKubeConfig(r.restConfig, clientConfig)
 
 	if err := conf.Init(kc, namespace, r.helmDriver, debug); err != nil {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -405,6 +405,10 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 	}
 	failures := normalizeInputs()
 	if len(failures) > 0 {
+		if !providers.IsDefaultProvider(urn) {
+			return &pulumirpc.CheckResponse{Inputs: req.GetNews(), Failures: failures}, nil
+		}
+
 		// Rather than erroring out on an invalid k8s config, leave the original values in-place.
 		logger.V(9).Infof("%s: unable to normalize inputs: %v", label, failures)
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -364,6 +364,12 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 			return err
 		}
 
+		// double-check that the kubeconfig is semantically valid w.r.t. context and cluster configuration.
+		_, err = kubeconfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+
 		configurationNamespace, _, err := kubeconfig.Namespace()
 		if err != nil {
 			return err
@@ -411,7 +417,7 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 		if _, ok := news["cluster"]; !ok {
 			news["cluster"] = olds["cluster"]
 		}
-		_ = k.host.Log(ctx, diag.Warning, urn, fmt.Sprintf("the Kubernetes provider has a configuration problem: %v", err))
+		_ = k.host.Log(ctx, diag.Warning, urn, err.Error())
 	}
 
 	checked, err := plugin.MarshalProperties(

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -405,10 +405,6 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 	}
 	failures := normalizeInputs()
 	if len(failures) > 0 {
-		if !providers.IsDefaultProvider(urn) {
-			return &pulumirpc.CheckResponse{Inputs: req.GetNews(), Failures: failures}, nil
-		}
-
 		// Rather than erroring out on an invalid k8s config, leave the original values in-place.
 		logger.V(9).Infof("%s: unable to normalize inputs: %v", label, failures)
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -51,7 +51,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
@@ -393,13 +392,6 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 		}
 		news["cluster"] = resource.NewStringProperty(configurationCluster)
 
-		if v, ok := os.LookupEnv("PULUMI_K8S_NORMALIZE_KUBECONFIG"); ok && cmdutil.IsTruthy(v) {
-			configurationKubeconfig, err := clientcmd.Write(*apiConfig)
-			if err != nil {
-				return err
-			}
-			news["kubeconfig"] = resource.NewStringProperty(string(configurationKubeconfig))
-		}
 		return nil
 	}
 	err = normalizeInputs()
@@ -1450,8 +1442,8 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 		}
 	}
 
-	// If a default namespace is set on the provider for this resource, check if the resource has Namespaced
-	// or Global scope. For namespaced resources, set the namespace to the default value if unset.
+	// Check if the resource has Namespaced or Global scope. For namespaced resources,
+	// set the namespace to the default value if unset.
 	if len(newInputs.GetNamespace()) == 0 {
 		namespacedKind, err := clients.IsNamespacedKind(gvk, k.clientSet)
 		if err != nil {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/golang/protobuf/ptypes/empty"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	pkgerrors "github.com/pkg/errors"
@@ -1276,13 +1275,13 @@ func (k *kubeProvider) StreamInvoke(
 }
 
 // Attach sends the engine address to an already running plugin.
-func (k *kubeProvider) Attach(_ context.Context, req *pulumirpc.PluginAttach) (*empty.Empty, error) {
+func (k *kubeProvider) Attach(_ context.Context, req *pulumirpc.PluginAttach) (*pbempty.Empty, error) {
 	host, err := provider.NewHostClient(req.GetAddress())
 	if err != nil {
 		return nil, err
 	}
 	k.host = host
-	return &empty.Empty{}, nil
+	return &pbempty.Empty{}, nil
 }
 
 // Check validates that the given property bag is valid for a resource of the given type and returns

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -129,7 +129,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 	// flags.
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	kubeconfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 	apiConfig, err := kubeconfig.RawConfig()
 	if err != nil {
 		return nil, nil, err

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -129,7 +129,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 	// flags.
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+	kubeconfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
 	apiConfig, err := kubeconfig.RawConfig()
 	if err != nil {
 		return nil, nil, err

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -5,6 +5,9 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -78,6 +81,62 @@ func fqName(namespace, name string) string {
 // --------------------------------------------------------------------------
 // Kubeconfig helpers.
 // --------------------------------------------------------------------------
+
+func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides) (clientcmd.ClientConfig, *clientapi.Config, error) {
+	homeDir := func() string {
+		// Ignore errors. The filepath will be checked later, so we can handle failures there.
+		usr, _ := user.Current()
+		return usr.HomeDir
+	}
+
+	// Note: the Python SDK was setting the kubeconfig value to "" by default, so explicitly check for empty string.
+	if pathOrContents != "" {
+		var contents string
+
+		// Handle the '~' character if it is set in the config string. Normally, this would be expanded by the shell
+		// into the user's home directory, but we have to do that manually if it is set in a config value.
+		if pathOrContents == "~" {
+			// In case of "~", which won't be caught by the "else if"
+			pathOrContents = homeDir()
+		} else if strings.HasPrefix(pathOrContents, "~/") {
+			pathOrContents = filepath.Join(homeDir(), pathOrContents[2:])
+		}
+
+		// If the variable is a valid filepath, load the file and parse the contents as a k8s config.
+		_, err := os.Stat(pathOrContents)
+		if err == nil {
+			b, err := os.ReadFile(pathOrContents)
+			if err != nil {
+				return nil, nil, err
+			} else {
+				contents = string(b)
+			}
+		} else { // Assume the contents are a k8s config.
+			contents = pathOrContents
+		}
+
+		// Load the contents of the k8s config.
+		apiConfig, err := clientcmd.Load([]byte(contents))
+		if err != nil {
+			return nil, nil, err
+		}
+		kubeconfig := clientcmd.NewDefaultClientConfig(*apiConfig, overrides)
+		return kubeconfig, apiConfig, nil
+	} else {
+		// Use client-go to resolve the final configuration values for the client. Typically, these
+		// values would reside in the $KUBECONFIG file, but can also be altered in several
+		// places, including in env variables, client-go default values, and (if we allowed it) CLI
+		// flags.
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+		kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+		apiConfig, err := kubeconfig.RawConfig()
+		if err != nil {
+			return nil, nil, err
+		}
+		return kubeconfig, &apiConfig, nil
+	}
+}
 
 // parseKubeconfigPropertyValue takes a PropertyValue that possibly contains a raw kubeconfig
 // (YAML or JSON) string or map and attempts to unmarshal it into a Config struct. If the property value

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -104,7 +104,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 
 		// If the variable is a valid filepath, load the file and parse the contents as a k8s config.
 		_, err := os.Stat(pathOrContents)
-		if err == nil {
+		if err == nil || filepath.IsAbs(pathOrContents) || strings.HasPrefix(pathOrContents, ".") {
 			b, err := os.ReadFile(pathOrContents)
 			if err != nil {
 				return nil, nil, err

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -122,7 +122,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 		kubeconfig := clientcmd.NewDefaultClientConfig(*apiConfig, overrides)
 		return kubeconfig, apiConfig, nil
 	}
-	
+
 	// Use client-go to resolve the final configuration values for the client. Typically, these
 	// values would reside in the $KUBECONFIG file, but can also be altered in several
 	// places, including in env variables, client-go default values, and (if we allowed it) CLI

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -3,7 +3,6 @@
 package provider
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/user"
@@ -146,35 +145,6 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 		return nil, nil, err
 	}
 	return kubeconfig, &apiConfig, nil
-}
-
-// parseKubeconfigPropertyValue takes a PropertyValue that possibly contains a raw kubeconfig
-// (YAML or JSON) string or map and attempts to unmarshal it into a Config struct. If the property value
-// is empty, an empty Config is returned.
-func parseKubeconfigPropertyValue(kubeconfig resource.PropertyValue) (*clientapi.Config, error) {
-	if kubeconfig.IsNull() {
-		return &clientapi.Config{}, nil
-	}
-
-	var cfg []byte
-	if kubeconfig.IsString() {
-		cfg = []byte(kubeconfig.StringValue())
-	} else if kubeconfig.IsObject() {
-		raw := kubeconfig.ObjectValue().Mappable()
-		jsonBytes, err := json.Marshal(raw)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal kubeconfig: %v", err)
-		}
-		cfg = jsonBytes
-	} else {
-		return nil, fmt.Errorf("unexpected kubeconfig format, type: %v", kubeconfig.TypeString())
-	}
-	config, err := clientcmd.Load(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %v", err)
-	}
-
-	return config, nil
 }
 
 // pruneMap builds a pruned map by recursively copying elements from the source map that have a matching key in the

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -104,7 +104,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 
 		// If the variable is a valid filepath, load the file and parse the contents as a k8s config.
 		_, err := os.Stat(pathOrContents)
-		if err == nil || filepath.IsAbs(pathOrContents) || strings.HasPrefix(pathOrContents, ".") {
+		if err == nil {
 			b, err := os.ReadFile(pathOrContents)
 			if err != nil {
 				return nil, nil, err

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -16,13 +16,13 @@ package provider
 
 import (
 	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -188,7 +188,7 @@ func TestFqName(t *testing.T) {
 	}
 }
 
-func Test_getActiveClusterFromConfig(t *testing.T) {
+func Test_loadKubeconfig(t *testing.T) {
 	const validKubeconfig = `apiVersion: v1
 clusters:
 - cluster:
@@ -209,7 +209,7 @@ users:
     client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGVENDQWYyZ0F3SUJBZ0lJWnBUZjVmbTZDQW93RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBME1qY3hOVFEzTURWYUZ3MHlNakExTVRJeU16SXdNVEphTURZeApGekFWQmdOVkJBb1REbk41YzNSbGJUcHRZWE4wWlhKek1Sc3dHUVlEVlFRREV4SmtiMk5yWlhJdFptOXlMV1JsCmMydDBiM0F3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRENMaDZ3MWV5WGpOQ3AKSzI5ZFJJQ3o3eHd3K1ZPVXVYYlh2R2NJTEFxaElUdlR3WTJqUmVaTFFXK3B5Wm9XUUdWZm5EYVZ5TGxmUUVaOQpXQm9IcEkvWGVvVWl4Uy9mWmVPN1RTeXA1bFpLcExzaXBMSE1RazN1NHp2d1RqelJITFJ4Q3k3b2RWTUVxVWFyCkkveUxiVUMxL1RkaGc3WkVZTFVrbEE4bWVhWFpHMGx5ZjA4UEdTdTVLUUJuTFVlbXk5OHNqV2U3YTBvdlRZd3kKTUhveUhyS0VGV0xCTmYrTm5TMTY3ZFBONzhTNCtENThobGxZTmZEZDVHbXJYYUFBYzVxeHhCSW5VcmhkSDJQawo2YUZkZXduQjFRQlV6OWVlVUJEVlFoQmwwbXNoMmRUSWF3cGlnbENrTnR1RlhoTEhGMitaRjFCSzN5VnZaYURsCmsyOTNnanlwQWdNQkFBR2pTREJHTUE0R0ExVWREd0VCL3dRRUF3SUZvREFUQmdOVkhTVUVEREFLQmdnckJnRUYKQlFjREFqQWZCZ05WSFNNRUdEQVdnQlNGOHBIQ29IVytDVnc5eWtjMGlSNS9yMHdjc2pBTkJna3Foa2lHOXcwQgpBUXNGQUFPQ0FRRUFnT1dxR2Q0TnlCRzFDOUovb1NVTmxzdkxSWXp4eEluZ0VsT09MUmlNN2t2dTduRXV6SHBYCkViODh3di9SSU1qWlFlbDFOTmdLWFJvb0hOSmpXcVppOG5aMEIxangySnNmaldrZWlPUE1aTjZqNzhzdDBqWmsKZDErSW5Oem1raEo4ck92UjVCd2xFcDNUcUtTN3J6dzF4MnphRkxUVWtZblh6Wnp4TkU3VGZuZVJVSG4zVyt4SwpXMFFaS3RkUlcvV0M5M3AvckcvZXp2Z0o5dCthenZwa2V1bklTUm5lbFpGQzgrZTR3ZXdoZm15TmRtUFVySThkCnQyMzhxeVhaNzZMTERKTFFDSTRieFRSVVpJM2NDdFY4bzU0UThnVHAvNklaRXVkV3dPbEdXa0FackdaMXNCN2QKQ1RRbjRVTVBXV0JmTzBPcFdZS3hGcVg4U1FpQndQaWhDdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd2k0ZXNOWHNsNHpRcVN0dlhVU0FzKzhjTVBsVGxMbDIxN3huQ0N3S29TRTcwOEdOCm8wWG1TMEZ2cWNtYUZrQmxYNXcybGNpNVgwQkdmVmdhQjZTUDEzcUZJc1V2MzJYanUwMHNxZVpXU3FTN0lxU3gKekVKTjd1TTc4RTQ4MFJ5MGNRc3U2SFZUQktsR3F5UDhpMjFBdGYwM1lZTzJSR0MxSkpRUEpubWwyUnRKY245UApEeGtydVNrQVp5MUhwc3ZmTEkxbnUydEtMMDJNTWpCNk1oNnloQlZpd1RYL2paMHRldTNUemUvRXVQZytmSVpaCldEWHczZVJwcTEyZ0FIT2FzY1FTSjFLNFhSOWo1T21oWFhzSndkVUFWTS9YbmxBUTFVSVFaZEpySWRuVXlHc0sKWW9KUXBEYmJoVjRTeHhkdm1SZFFTdDhsYjJXZzVaTnZkNEk4cVFJREFRQUJBb0lCQVFDeitSY05BMW1EcFVvSQpZVytZWEZPRmNnc0pBUzJNWE5GZlp3bC9zNEl1a2FUbndTOUxzdytkbElxd0xXQ1pXeG9hSWFrZDdxcVJNL3VoClZUVGEvSlV0UEN1RmJJblFYcGxTRWxkaEtWRzFZVFRwQ1FpWnJxS1kxUmZLeEZqdDM5TUdLejFReXQwbEp0ZU8KNjQyNGxJd3pvUHZoYjdoUmEraTRmRm9HYVIxa09KN1dGcFNwM2pUa0pZckFpQWViL2IxUlZ5Rk9sNm9IcEozcQo3dmxoaHZibklJcXdrMHp4VU1ya1ArTDR2azhLdjhEcVZZMTg1M1B5UWJ3cm1EUnBkNWYvTmRwZ0lrMWNjUURZCk1OUUxPd3NaRThsdTJZMW9PcTVpRmhZZEFmM2o2Ykt2Vi92WFAxdXhtdlZSMEZ6eWU0L2JuaXBUcWdNYUI1ZnQKQWJ5MVJsL2hBb0dCQU5vRnBLVExmTGYvQUFqNGw4TmlvdjJ2OXhVWmlrQVhNL0NPREpDVzVEU2hZakNZV0tDNApYNm8vdlJ6bHF3NWNaMDEvKzBYZ2lRa0tBQUdacXlzRnRsYjgveDdkYThnVWVDRVhGcDUzNlRiZXdHaXJlSlRoCkNCSnhlQ0x1cjdLVmp6RnpHdFZlTzY4VzRHRjg0ZmlQaUk0ZVJETlExN0pYVVR2cGtZTGNCQ2RsQW9HQkFPUUIKU05hdS9GYVdHVG5DbkVKa2pqRm9JdWFGbnVLaHphd1FIUHVFSFV6TFMzT1Fqem54MVRmMGU5aWxkRHBoekJ0SQpoNUgrbzFvUmhNYlN5Z2g1SGQ5aE1nekM3cjcrNmdPU2hMOEdnNjJwNU13YzhSVUhnZWhOWmkxSEJaeUh0VGFFCmg3LzA2YjBOV3lyMDRVcGNSZXJIME44TWdSWXI2emZ4K25MblpGWDFBb0dBSE1kLzYwejlJcUNqbFl1VEpQU0IKUlhHVDhSSVZBTTdQU1dMRzM5TTdQb05MSGRVT1pmRFFsLzJmN2crWEcrY3dyN2RFS1A0eHVLSzhTM25JY1g1bwppbVVOSERyb1Bsb05YWGpad0lOZG9xT1d6SHBPQ1lFRytzQkZ0bjdCYkpaM2QzU1ZSek1RTjlXU091d3NQQTVlClhUdzdqbmFPY25rNlBPbGhEdUFTSUUwQ2dZRUFuNGpHam5DaDMzUG04cU5ZOHB1cFlxaWF3dkY3MnRlY01XaVUKM3VmeUdHbW13WlhFb2FhMHFoSkhGYSt2UTZwcVJpelpyeTJjM3NpalB2citvaThjMTlBS1ZTT1FLZFB6cWN3NwpWZTRZOU1xTGJNWlRhWU4zUWpQbDZvaG5STDh2N0pXTzVxRlhheENOV2VFK1FlbU9nbGlOcllQeVRyRXNSRmpzCkJMb2pXb0VDZ1lCaWMrWjJvSzNTTmpzL3J5ZFU1Lzg3T3NVbExHamxKbDI1NE0xaGl3RmVsd3pUWjNXWjFuZlkKcS80Mm5GR3VRQUQ3RFFwSTBCSnFWVTJCQlZySmlSeFhROVlXUStCb3Q5VU4yRVJQQmhFeityU0Y0MnhybnZobApsZTU2NHVmK3VBdCt2K2ZjZUtYVnVDRDN1ZGdxL2d5ejNCaHN5VkJxZkFoNy9oNndOTmhIb3c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 `
-	// Outdented contexts[0].context.name
+	// Malformed contexts[0]
 	const invalidKubeconfig = `apiVersion: v1
 clusters:
 - cluster:
@@ -217,10 +217,10 @@ clusters:
     server: https://kubernetes.docker.internal:6443
   name: docker-desktop
 contexts:
-- context:
+  context:
     cluster: docker-desktop
     user: docker-desktop
-name: docker-desktop
+    name: docker-desktop
 current-context: docker-desktop
 kind: Config
 preferences: {}
@@ -230,91 +230,113 @@ users:
     client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGVENDQWYyZ0F3SUJBZ0lJWnBUZjVmbTZDQW93RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBME1qY3hOVFEzTURWYUZ3MHlNakExTVRJeU16SXdNVEphTURZeApGekFWQmdOVkJBb1REbk41YzNSbGJUcHRZWE4wWlhKek1Sc3dHUVlEVlFRREV4SmtiMk5yWlhJdFptOXlMV1JsCmMydDBiM0F3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRENMaDZ3MWV5WGpOQ3AKSzI5ZFJJQ3o3eHd3K1ZPVXVYYlh2R2NJTEFxaElUdlR3WTJqUmVaTFFXK3B5Wm9XUUdWZm5EYVZ5TGxmUUVaOQpXQm9IcEkvWGVvVWl4Uy9mWmVPN1RTeXA1bFpLcExzaXBMSE1RazN1NHp2d1RqelJITFJ4Q3k3b2RWTUVxVWFyCkkveUxiVUMxL1RkaGc3WkVZTFVrbEE4bWVhWFpHMGx5ZjA4UEdTdTVLUUJuTFVlbXk5OHNqV2U3YTBvdlRZd3kKTUhveUhyS0VGV0xCTmYrTm5TMTY3ZFBONzhTNCtENThobGxZTmZEZDVHbXJYYUFBYzVxeHhCSW5VcmhkSDJQawo2YUZkZXduQjFRQlV6OWVlVUJEVlFoQmwwbXNoMmRUSWF3cGlnbENrTnR1RlhoTEhGMitaRjFCSzN5VnZaYURsCmsyOTNnanlwQWdNQkFBR2pTREJHTUE0R0ExVWREd0VCL3dRRUF3SUZvREFUQmdOVkhTVUVEREFLQmdnckJnRUYKQlFjREFqQWZCZ05WSFNNRUdEQVdnQlNGOHBIQ29IVytDVnc5eWtjMGlSNS9yMHdjc2pBTkJna3Foa2lHOXcwQgpBUXNGQUFPQ0FRRUFnT1dxR2Q0TnlCRzFDOUovb1NVTmxzdkxSWXp4eEluZ0VsT09MUmlNN2t2dTduRXV6SHBYCkViODh3di9SSU1qWlFlbDFOTmdLWFJvb0hOSmpXcVppOG5aMEIxangySnNmaldrZWlPUE1aTjZqNzhzdDBqWmsKZDErSW5Oem1raEo4ck92UjVCd2xFcDNUcUtTN3J6dzF4MnphRkxUVWtZblh6Wnp4TkU3VGZuZVJVSG4zVyt4SwpXMFFaS3RkUlcvV0M5M3AvckcvZXp2Z0o5dCthenZwa2V1bklTUm5lbFpGQzgrZTR3ZXdoZm15TmRtUFVySThkCnQyMzhxeVhaNzZMTERKTFFDSTRieFRSVVpJM2NDdFY4bzU0UThnVHAvNklaRXVkV3dPbEdXa0FackdaMXNCN2QKQ1RRbjRVTVBXV0JmTzBPcFdZS3hGcVg4U1FpQndQaWhDdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd2k0ZXNOWHNsNHpRcVN0dlhVU0FzKzhjTVBsVGxMbDIxN3huQ0N3S29TRTcwOEdOCm8wWG1TMEZ2cWNtYUZrQmxYNXcybGNpNVgwQkdmVmdhQjZTUDEzcUZJc1V2MzJYanUwMHNxZVpXU3FTN0lxU3gKekVKTjd1TTc4RTQ4MFJ5MGNRc3U2SFZUQktsR3F5UDhpMjFBdGYwM1lZTzJSR0MxSkpRUEpubWwyUnRKY245UApEeGtydVNrQVp5MUhwc3ZmTEkxbnUydEtMMDJNTWpCNk1oNnloQlZpd1RYL2paMHRldTNUemUvRXVQZytmSVpaCldEWHczZVJwcTEyZ0FIT2FzY1FTSjFLNFhSOWo1T21oWFhzSndkVUFWTS9YbmxBUTFVSVFaZEpySWRuVXlHc0sKWW9KUXBEYmJoVjRTeHhkdm1SZFFTdDhsYjJXZzVaTnZkNEk4cVFJREFRQUJBb0lCQVFDeitSY05BMW1EcFVvSQpZVytZWEZPRmNnc0pBUzJNWE5GZlp3bC9zNEl1a2FUbndTOUxzdytkbElxd0xXQ1pXeG9hSWFrZDdxcVJNL3VoClZUVGEvSlV0UEN1RmJJblFYcGxTRWxkaEtWRzFZVFRwQ1FpWnJxS1kxUmZLeEZqdDM5TUdLejFReXQwbEp0ZU8KNjQyNGxJd3pvUHZoYjdoUmEraTRmRm9HYVIxa09KN1dGcFNwM2pUa0pZckFpQWViL2IxUlZ5Rk9sNm9IcEozcQo3dmxoaHZibklJcXdrMHp4VU1ya1ArTDR2azhLdjhEcVZZMTg1M1B5UWJ3cm1EUnBkNWYvTmRwZ0lrMWNjUURZCk1OUUxPd3NaRThsdTJZMW9PcTVpRmhZZEFmM2o2Ykt2Vi92WFAxdXhtdlZSMEZ6eWU0L2JuaXBUcWdNYUI1ZnQKQWJ5MVJsL2hBb0dCQU5vRnBLVExmTGYvQUFqNGw4TmlvdjJ2OXhVWmlrQVhNL0NPREpDVzVEU2hZakNZV0tDNApYNm8vdlJ6bHF3NWNaMDEvKzBYZ2lRa0tBQUdacXlzRnRsYjgveDdkYThnVWVDRVhGcDUzNlRiZXdHaXJlSlRoCkNCSnhlQ0x1cjdLVmp6RnpHdFZlTzY4VzRHRjg0ZmlQaUk0ZVJETlExN0pYVVR2cGtZTGNCQ2RsQW9HQkFPUUIKU05hdS9GYVdHVG5DbkVKa2pqRm9JdWFGbnVLaHphd1FIUHVFSFV6TFMzT1Fqem54MVRmMGU5aWxkRHBoekJ0SQpoNUgrbzFvUmhNYlN5Z2g1SGQ5aE1nekM3cjcrNmdPU2hMOEdnNjJwNU13YzhSVUhnZWhOWmkxSEJaeUh0VGFFCmg3LzA2YjBOV3lyMDRVcGNSZXJIME44TWdSWXI2emZ4K25MblpGWDFBb0dBSE1kLzYwejlJcUNqbFl1VEpQU0IKUlhHVDhSSVZBTTdQU1dMRzM5TTdQb05MSGRVT1pmRFFsLzJmN2crWEcrY3dyN2RFS1A0eHVLSzhTM25JY1g1bwppbVVOSERyb1Bsb05YWGpad0lOZG9xT1d6SHBPQ1lFRytzQkZ0bjdCYkpaM2QzU1ZSek1RTjlXU091d3NQQTVlClhUdzdqbmFPY25rNlBPbGhEdUFTSUUwQ2dZRUFuNGpHam5DaDMzUG04cU5ZOHB1cFlxaWF3dkY3MnRlY01XaVUKM3VmeUdHbW13WlhFb2FhMHFoSkhGYSt2UTZwcVJpelpyeTJjM3NpalB2citvaThjMTlBS1ZTT1FLZFB6cWN3NwpWZTRZOU1xTGJNWlRhWU4zUWpQbDZvaG5STDh2N0pXTzVxRlhheENOV2VFK1FlbU9nbGlOcllQeVRyRXNSRmpzCkJMb2pXb0VDZ1lCaWMrWjJvSzNTTmpzL3J5ZFU1Lzg3T3NVbExHamxKbDI1NE0xaGl3RmVsd3pUWjNXWjFuZlkKcS80Mm5GR3VRQUQ3RFFwSTBCSnFWVTJCQlZySmlSeFhROVlXUStCb3Q5VU4yRVJQQmhFeityU0Y0MnhybnZobApsZTU2NHVmK3VBdCt2K2ZjZUtYVnVDRDN1ZGdxL2d5ejNCaHN5VkJxZkFoNy9oNndOTmhIb3c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 `
-	certAuthData := []byte(`-----BEGIN CERTIFICATE-----
-MIIC5zCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
-cm5ldGVzMB4XDTIxMDQyNzE1NDcwNVoXDTMxMDQyNTE1NDcwNVowFTETMBEGA1UE
-AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANeh
-BM9J0IY+dR9RfUJ29JTqb1vSt0eK143uiPqdIIGxbXQoVezd8QQyhIAlPougEVKH
-R4hLTkxFIKMWCQttcBvEZFvAFkryPsYO5Eh1F6Gw2Ml6/5koSZl3XS05r7XgMGVM
-yqRQh3/UbEqVdZDeEiAJxz7rPIC1sQTJUjU6TcbZDUXVGF1VLrOnFBeRh56L07db
-2SxgwtXf5SS0AebrkODDc50QGXsntRFN719byanVBsusZnffvHEk5nq55ALta4n7
-6FCGjQ4xXchla5o1ikz+r7jLzry6SltrPYNL/eX4x/EM1PQnVKeQihE2h74rjHKp
-bl4p66OJ8lydFkEJAeMCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB
-/wQFMAMBAf8wHQYDVR0OBBYEFIXykcKgdb4JXD3KRzSJHn+vTByyMA0GCSqGSIb3
-DQEBCwUAA4IBAQAwS5Z6oWNzZta4MDyg35bfr5Qi9HtnV7g9ceNvcTI+qwGxUHYP
-gg2RoT4eNL2EPWYARdkeSmSrX0kE/T2tTnxbEXCMtB6N8OFvbCugW6O+ZpH3p4tt
-UECE1OvbXwy2C/vi2irn9kDwr7JAUCaFEZireOMcCljzeDML0C9JjBRNRdjXulrb
-JTp/DbYRt8UI5m3iQHkinjDGVEaTr3jeBM6PjIu/nljCe+Z/WL2ozEo82w3vpzN5
-v0dohqdVlO32gd6+BQNF8fP29o0dOCAjV/4wBbccuHubvBgu4rqHsHog371ETul/
-9IlqkgafzeruPs6k5PaZPMb+ngo3YDngvHnH
------END CERTIFICATE-----
-`)
 
-	validConfig, _ := clientcmd.Load([]byte(validKubeconfig))
-	outdentedConfig, _ := clientcmd.Load([]byte(invalidKubeconfig))
+	validKubeconfigFile, _ := os.CreateTemp("", "kubeconfig-")
+	validKubeconfigFile.WriteString(validKubeconfig)
+	validKubeconfigFile.Close()
+	t.Cleanup(func() {
+		validKubeconfigFile.Close()
+		os.Remove(validKubeconfigFile.Name())
+	})
 
 	type args struct {
-		config    *clientapi.Config
-		overrides resource.PropertyMap
+		pathOrContents string
+		overrides      *clientcmd.ConfigOverrides
+	}
+	type env struct {
+		name  string
+		value string
 	}
 	tests := []struct {
-		name string
-		args args
-		want *clientapi.Cluster
+		name          string
+		args          args
+		envs          []env
+		expectedError string
 	}{
 		{
-			name: "nil",
+			name: "ambient",
 			args: args{
-				config:    nil,
-				overrides: map[resource.PropertyKey]resource.PropertyValue{},
+				pathOrContents: "",
+				overrides:      &clientcmd.ConfigOverrides{},
 			},
-			want: &clientapi.Cluster{},
+			envs: []env{
+				{name: "KUBECONFIG", value: validKubeconfigFile.Name()},
+			},
 		},
 		{
-			name: "valid",
+			name: "valid_content",
 			args: args{
-				config:    validConfig,
-				overrides: map[resource.PropertyKey]resource.PropertyValue{},
+				pathOrContents: validKubeconfig,
+				overrides:      &clientcmd.ConfigOverrides{},
 			},
-			want: &clientapi.Cluster{
-				Server:                   "https://kubernetes.docker.internal:6443",
-				CertificateAuthorityData: certAuthData,
-				Extensions:               map[string]runtime.Object{},
+		},
+		{
+			name: "valid_file",
+			args: args{
+				pathOrContents: validKubeconfigFile.Name(),
+				overrides:      &clientcmd.ConfigOverrides{},
 			},
+		},
+		{
+			name: "invalid_file",
+			args: args{
+				pathOrContents: "./invalid",
+				overrides:      &clientcmd.ConfigOverrides{},
+			},
+			expectedError: `open ./invalid: no such file or directory`,
 		},
 		{
 			name: "invalid_context_override",
 			args: args{
-				config: validConfig,
-				overrides: map[resource.PropertyKey]resource.PropertyValue{
-					resource.PropertyKey("context"): {V: "foo"},
+				pathOrContents: validKubeconfig,
+				overrides: &clientcmd.ConfigOverrides{
+					CurrentContext: "foo",
 				},
 			},
-			want: &clientapi.Cluster{},
+			expectedError: `context "foo" does not exist`,
 		},
 		{
 			name: "invalid_cluster_override",
 			args: args{
-				config: validConfig,
-				overrides: map[resource.PropertyKey]resource.PropertyValue{
-					resource.PropertyKey("cluster"): {V: "foo"},
+				pathOrContents: validKubeconfig,
+				overrides: &clientcmd.ConfigOverrides{
+					Context: clientapi.Context{
+						Cluster: "foo",
+					},
 				},
 			},
-			want: &clientapi.Cluster{},
+			expectedError: `cluster "foo" does not exist`,
 		},
 		{
-			name: "outdented_context_name",
+			name: "invalid_kubeconfig",
 			args: args{
-				config:    outdentedConfig,
-				overrides: map[resource.PropertyKey]resource.PropertyValue{},
+				pathOrContents: invalidKubeconfig,
+				overrides:      &clientcmd.ConfigOverrides{},
 			},
-			want: &clientapi.Cluster{},
+			expectedError: `json: cannot unmarshal object into Go struct field Config.contexts of type []v1.NamedContext`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getActiveClusterFromConfig(tt.args.config, tt.args.overrides); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getActiveClusterFromConfig() = %v, want %v", got, tt.want)
+			for _, env := range tt.envs {
+				e := env
+				old, ok := os.LookupEnv(e.name)
+				defer func() {
+					if ok {
+						os.Setenv(e.name, old)
+					} else {
+						os.Unsetenv(e.name)
+					}
+				}()
+				os.Setenv(e.name, e.value)
+			}
+			kubeconfig, apiconfig, err := loadKubeconfig(tt.args.pathOrContents, tt.args.overrides)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, kubeconfig, "kubeconfig")
+				assert.NotNil(t, apiconfig, "apiconfig")
 			}
 		})
 	}

--- a/provider/pkg/provider/util_test.go
+++ b/provider/pkg/provider/util_test.go
@@ -231,13 +231,16 @@ users:
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd2k0ZXNOWHNsNHpRcVN0dlhVU0FzKzhjTVBsVGxMbDIxN3huQ0N3S29TRTcwOEdOCm8wWG1TMEZ2cWNtYUZrQmxYNXcybGNpNVgwQkdmVmdhQjZTUDEzcUZJc1V2MzJYanUwMHNxZVpXU3FTN0lxU3gKekVKTjd1TTc4RTQ4MFJ5MGNRc3U2SFZUQktsR3F5UDhpMjFBdGYwM1lZTzJSR0MxSkpRUEpubWwyUnRKY245UApEeGtydVNrQVp5MUhwc3ZmTEkxbnUydEtMMDJNTWpCNk1oNnloQlZpd1RYL2paMHRldTNUemUvRXVQZytmSVpaCldEWHczZVJwcTEyZ0FIT2FzY1FTSjFLNFhSOWo1T21oWFhzSndkVUFWTS9YbmxBUTFVSVFaZEpySWRuVXlHc0sKWW9KUXBEYmJoVjRTeHhkdm1SZFFTdDhsYjJXZzVaTnZkNEk4cVFJREFRQUJBb0lCQVFDeitSY05BMW1EcFVvSQpZVytZWEZPRmNnc0pBUzJNWE5GZlp3bC9zNEl1a2FUbndTOUxzdytkbElxd0xXQ1pXeG9hSWFrZDdxcVJNL3VoClZUVGEvSlV0UEN1RmJJblFYcGxTRWxkaEtWRzFZVFRwQ1FpWnJxS1kxUmZLeEZqdDM5TUdLejFReXQwbEp0ZU8KNjQyNGxJd3pvUHZoYjdoUmEraTRmRm9HYVIxa09KN1dGcFNwM2pUa0pZckFpQWViL2IxUlZ5Rk9sNm9IcEozcQo3dmxoaHZibklJcXdrMHp4VU1ya1ArTDR2azhLdjhEcVZZMTg1M1B5UWJ3cm1EUnBkNWYvTmRwZ0lrMWNjUURZCk1OUUxPd3NaRThsdTJZMW9PcTVpRmhZZEFmM2o2Ykt2Vi92WFAxdXhtdlZSMEZ6eWU0L2JuaXBUcWdNYUI1ZnQKQWJ5MVJsL2hBb0dCQU5vRnBLVExmTGYvQUFqNGw4TmlvdjJ2OXhVWmlrQVhNL0NPREpDVzVEU2hZakNZV0tDNApYNm8vdlJ6bHF3NWNaMDEvKzBYZ2lRa0tBQUdacXlzRnRsYjgveDdkYThnVWVDRVhGcDUzNlRiZXdHaXJlSlRoCkNCSnhlQ0x1cjdLVmp6RnpHdFZlTzY4VzRHRjg0ZmlQaUk0ZVJETlExN0pYVVR2cGtZTGNCQ2RsQW9HQkFPUUIKU05hdS9GYVdHVG5DbkVKa2pqRm9JdWFGbnVLaHphd1FIUHVFSFV6TFMzT1Fqem54MVRmMGU5aWxkRHBoekJ0SQpoNUgrbzFvUmhNYlN5Z2g1SGQ5aE1nekM3cjcrNmdPU2hMOEdnNjJwNU13YzhSVUhnZWhOWmkxSEJaeUh0VGFFCmg3LzA2YjBOV3lyMDRVcGNSZXJIME44TWdSWXI2emZ4K25MblpGWDFBb0dBSE1kLzYwejlJcUNqbFl1VEpQU0IKUlhHVDhSSVZBTTdQU1dMRzM5TTdQb05MSGRVT1pmRFFsLzJmN2crWEcrY3dyN2RFS1A0eHVLSzhTM25JY1g1bwppbVVOSERyb1Bsb05YWGpad0lOZG9xT1d6SHBPQ1lFRytzQkZ0bjdCYkpaM2QzU1ZSek1RTjlXU091d3NQQTVlClhUdzdqbmFPY25rNlBPbGhEdUFTSUUwQ2dZRUFuNGpHam5DaDMzUG04cU5ZOHB1cFlxaWF3dkY3MnRlY01XaVUKM3VmeUdHbW13WlhFb2FhMHFoSkhGYSt2UTZwcVJpelpyeTJjM3NpalB2citvaThjMTlBS1ZTT1FLZFB6cWN3NwpWZTRZOU1xTGJNWlRhWU4zUWpQbDZvaG5STDh2N0pXTzVxRlhheENOV2VFK1FlbU9nbGlOcllQeVRyRXNSRmpzCkJMb2pXb0VDZ1lCaWMrWjJvSzNTTmpzL3J5ZFU1Lzg3T3NVbExHamxKbDI1NE0xaGl3RmVsd3pUWjNXWjFuZlkKcS80Mm5GR3VRQUQ3RFFwSTBCSnFWVTJCQlZySmlSeFhROVlXUStCb3Q5VU4yRVJQQmhFeityU0Y0MnhybnZobApsZTU2NHVmK3VBdCt2K2ZjZUtYVnVDRDN1ZGdxL2d5ejNCaHN5VkJxZkFoNy9oNndOTmhIb3c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 `
 
-	validKubeconfigFile, _ := os.CreateTemp("", "kubeconfig-")
-	validKubeconfigFile.WriteString(validKubeconfig)
-	validKubeconfigFile.Close()
-	t.Cleanup(func() {
-		validKubeconfigFile.Close()
-		os.Remove(validKubeconfigFile.Name())
-	})
+	makeTempFile := func(content string) string {
+		file, _ := os.CreateTemp("", "kubeconfig-")
+		defer file.Close()
+		t.Cleanup(func() {
+			os.Remove(file.Name())
+		})
+		_, _ = file.WriteString(validKubeconfig)
+		return file.Name()
+	}
+	validKubeconfigFile := makeTempFile(validKubeconfig)
 
 	type args struct {
 		pathOrContents string
@@ -260,7 +263,7 @@ users:
 				overrides:      &clientcmd.ConfigOverrides{},
 			},
 			envs: []env{
-				{name: "KUBECONFIG", value: validKubeconfigFile.Name()},
+				{name: "KUBECONFIG", value: validKubeconfigFile},
 			},
 		},
 		{
@@ -271,14 +274,14 @@ users:
 			},
 		},
 		{
-			name: "valid_file",
+			name: "valid_path",
 			args: args{
-				pathOrContents: validKubeconfigFile.Name(),
+				pathOrContents: validKubeconfigFile,
 				overrides:      &clientcmd.ConfigOverrides{},
 			},
 		},
 		{
-			name: "invalid_file",
+			name: "invalid_path",
 			args: args{
 				pathOrContents: "./invalid",
 				overrides:      &clientcmd.ConfigOverrides{},
@@ -308,7 +311,7 @@ users:
 			expectedError: `cluster "foo" does not exist`,
 		},
 		{
-			name: "invalid_kubeconfig",
+			name: "invalid_content",
 			args: args{
 				pathOrContents: invalidKubeconfig,
 				overrides:      &clientcmd.ConfigOverrides{},

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -16,6 +16,49 @@ namespace Pulumi.Kubernetes
     public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
+        /// If present, the name of the kubeconfig cluster to use.
+        /// </summary>
+        [Output("cluster")]
+        public Output<string> Cluster { get; private set; } = null!;
+
+        /// <summary>
+        /// If present, the name of the kubeconfig context to use.
+        /// </summary>
+        [Output("context")]
+        public Output<string> Context { get; private set; } = null!;
+
+        /// <summary>
+        /// The contents of a kubeconfig file or the path to a kubeconfig file.
+        /// </summary>
+        [Output("kubeconfig")]
+        public Output<string> Kubeconfig { get; private set; } = null!;
+
+        /// <summary>
+        /// If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+        /// 
+        /// A namespace can be specified in multiple places, and the precedence is as follows:
+        /// 1. `.metadata.namespace` set on the resource.
+        /// 2. This `namespace` parameter.
+        /// 3. `namespace` set for the active context in the kubeconfig.
+        /// </summary>
+        [Output("namespace")]
+        public Output<string> Namespace { get; private set; } = null!;
+
+        /// <summary>
+        /// BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+        /// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+        /// to the Pulumi program. This feature is in developer preview, and is disabled by default.
+        /// 
+        /// Note that some computed Outputs such as status fields will not be populated
+        /// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+        /// and may result in an error if they are referenced by other resources. Also note that any secret values
+        /// used in these resources will be rendered in plaintext to the resulting YAML.
+        /// </summary>
+        [Output("renderYamlToDirectory")]
+        public Output<string> RenderYamlToDirectory { get; private set; } = null!;
+
+
+        /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
         /// </summary>
         ///

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -15,6 +15,29 @@ import (
 // The provider type for the kubernetes package.
 type Provider struct {
 	pulumi.ProviderResourceState
+
+	// If present, the name of the kubeconfig cluster to use.
+	Cluster pulumi.StringPtrOutput `pulumi:"cluster"`
+	// If present, the name of the kubeconfig context to use.
+	Context pulumi.StringPtrOutput `pulumi:"context"`
+	// The contents of a kubeconfig file or the path to a kubeconfig file.
+	Kubeconfig pulumi.StringPtrOutput `pulumi:"kubeconfig"`
+	// If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+	//
+	// A namespace can be specified in multiple places, and the precedence is as follows:
+	// 1. `.metadata.namespace` set on the resource.
+	// 2. This `namespace` parameter.
+	// 3. `namespace` set for the active context in the kubeconfig.
+	Namespace pulumi.StringPtrOutput `pulumi:"namespace"`
+	// BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+	// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+	// to the Pulumi program. This feature is in developer preview, and is disabled by default.
+	//
+	// Note that some computed Outputs such as status fields will not be populated
+	// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+	// and may result in an error if they are referenced by other resources. Also note that any secret values
+	// used in these resources will be rendered in plaintext to the resulting YAML.
+	RenderYamlToDirectory pulumi.StringPtrOutput `pulumi:"renderYamlToDirectory"`
 }
 
 // NewProvider registers a new resource with the given unique name, arguments, and options.
@@ -216,6 +239,43 @@ func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] 
 	return pulumix.Output[*Provider]{
 		OutputState: o.OutputState,
 	}
+}
+
+// If present, the name of the kubeconfig cluster to use.
+func (o ProviderOutput) Cluster() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.Cluster }).(pulumi.StringPtrOutput)
+}
+
+// If present, the name of the kubeconfig context to use.
+func (o ProviderOutput) Context() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.Context }).(pulumi.StringPtrOutput)
+}
+
+// The contents of a kubeconfig file or the path to a kubeconfig file.
+func (o ProviderOutput) Kubeconfig() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.Kubeconfig }).(pulumi.StringPtrOutput)
+}
+
+// If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+//
+// A namespace can be specified in multiple places, and the precedence is as follows:
+// 1. `.metadata.namespace` set on the resource.
+// 2. This `namespace` parameter.
+// 3. `namespace` set for the active context in the kubeconfig.
+func (o ProviderOutput) Namespace() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.Namespace }).(pulumi.StringPtrOutput)
+}
+
+// BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+// be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+// to the Pulumi program. This feature is in developer preview, and is disabled by default.
+//
+// Note that some computed Outputs such as status fields will not be populated
+// since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+// and may result in an error if they are referenced by other resources. Also note that any secret values
+// used in these resources will be rendered in plaintext to the resulting YAML.
+func (o ProviderOutput) RenderYamlToDirectory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.RenderYamlToDirectory }).(pulumi.StringPtrOutput)
 }
 
 func init() {

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/Provider.java
@@ -4,10 +4,13 @@
 package com.pulumi.kubernetes;
 
 import com.pulumi.core.Output;
+import com.pulumi.core.annotations.Export;
 import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.kubernetes.ProviderArgs;
 import com.pulumi.kubernetes.Utilities;
+import java.lang.String;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -16,6 +19,101 @@ import javax.annotation.Nullable;
  */
 @ResourceType(type="pulumi:providers:kubernetes")
 public class Provider extends com.pulumi.resources.ProviderResource {
+    /**
+     * If present, the name of the kubeconfig cluster to use.
+     * 
+     */
+    @Export(name="cluster", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> cluster;
+
+    /**
+     * @return If present, the name of the kubeconfig cluster to use.
+     * 
+     */
+    public Output<Optional<String>> cluster() {
+        return Codegen.optional(this.cluster);
+    }
+    /**
+     * If present, the name of the kubeconfig context to use.
+     * 
+     */
+    @Export(name="context", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> context;
+
+    /**
+     * @return If present, the name of the kubeconfig context to use.
+     * 
+     */
+    public Output<Optional<String>> context() {
+        return Codegen.optional(this.context);
+    }
+    /**
+     * The contents of a kubeconfig file or the path to a kubeconfig file.
+     * 
+     */
+    @Export(name="kubeconfig", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> kubeconfig;
+
+    /**
+     * @return The contents of a kubeconfig file or the path to a kubeconfig file.
+     * 
+     */
+    public Output<Optional<String>> kubeconfig() {
+        return Codegen.optional(this.kubeconfig);
+    }
+    /**
+     * If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+     * 
+     * A namespace can be specified in multiple places, and the precedence is as follows:
+     * 1. `.metadata.namespace` set on the resource.
+     * 2. This `namespace` parameter.
+     * 3. `namespace` set for the active context in the kubeconfig.
+     * 
+     */
+    @Export(name="namespace", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> namespace;
+
+    /**
+     * @return If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+     * 
+     * A namespace can be specified in multiple places, and the precedence is as follows:
+     * 1. `.metadata.namespace` set on the resource.
+     * 2. This `namespace` parameter.
+     * 3. `namespace` set for the active context in the kubeconfig.
+     * 
+     */
+    public Output<Optional<String>> namespace() {
+        return Codegen.optional(this.namespace);
+    }
+    /**
+     * BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+     * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+     * to the Pulumi program. This feature is in developer preview, and is disabled by default.
+     * 
+     * Note that some computed Outputs such as status fields will not be populated
+     * since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+     * and may result in an error if they are referenced by other resources. Also note that any secret values
+     * used in these resources will be rendered in plaintext to the resulting YAML.
+     * 
+     */
+    @Export(name="renderYamlToDirectory", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> renderYamlToDirectory;
+
+    /**
+     * @return BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+     * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+     * to the Pulumi program. This feature is in developer preview, and is disabled by default.
+     * 
+     * Note that some computed Outputs such as status fields will not be populated
+     * since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+     * and may result in an error if they are referenced by other resources. Also note that any secret values
+     * used in these resources will be rendered in plaintext to the resulting YAML.
+     * 
+     */
+    public Output<Optional<String>> renderYamlToDirectory() {
+        return Codegen.optional(this.renderYamlToDirectory);
+    }
+
     /**
      *
      * @param name The _unique_ name of the resulting resource.

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -25,6 +25,38 @@ export class Provider extends pulumi.ProviderResource {
         return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
+    /**
+     * If present, the name of the kubeconfig cluster to use.
+     */
+    public readonly cluster!: pulumi.Output<string>;
+    /**
+     * If present, the name of the kubeconfig context to use.
+     */
+    public readonly context!: pulumi.Output<string>;
+    /**
+     * The contents of a kubeconfig file or the path to a kubeconfig file.
+     */
+    public readonly kubeconfig!: pulumi.Output<string>;
+    /**
+     * If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+     *
+     * A namespace can be specified in multiple places, and the precedence is as follows:
+     * 1. `.metadata.namespace` set on the resource.
+     * 2. This `namespace` parameter.
+     * 3. `namespace` set for the active context in the kubeconfig.
+     */
+    public readonly namespace!: pulumi.Output<string>;
+    /**
+     * BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+     * be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+     * to the Pulumi program. This feature is in developer preview, and is disabled by default.
+     *
+     * Note that some computed Outputs such as status fields will not be populated
+     * since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+     * and may result in an error if they are referenced by other resources. Also note that any secret values
+     * used in these resources will be rendered in plaintext to the resulting YAML.
+     */
+    public readonly renderYamlToDirectory!: pulumi.Output<string>;
 
     /**
      * Create a Provider resource with the given unique name, arguments, and options.

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -413,3 +413,55 @@ class Provider(pulumi.ProviderResource):
             __props__,
             opts)
 
+    @property
+    @pulumi.getter
+    def cluster(self) -> pulumi.Output[Optional[str]]:
+        """
+        If present, the name of the kubeconfig cluster to use.
+        """
+        return pulumi.get(self, "cluster")
+
+    @property
+    @pulumi.getter
+    def context(self) -> pulumi.Output[Optional[str]]:
+        """
+        If present, the name of the kubeconfig context to use.
+        """
+        return pulumi.get(self, "context")
+
+    @property
+    @pulumi.getter
+    def kubeconfig(self) -> pulumi.Output[Optional[str]]:
+        """
+        The contents of a kubeconfig file or the path to a kubeconfig file.
+        """
+        return pulumi.get(self, "kubeconfig")
+
+    @property
+    @pulumi.getter
+    def namespace(self) -> pulumi.Output[Optional[str]]:
+        """
+        If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
+
+        A namespace can be specified in multiple places, and the precedence is as follows:
+        1. `.metadata.namespace` set on the resource.
+        2. This `namespace` parameter.
+        3. `namespace` set for the active context in the kubeconfig.
+        """
+        return pulumi.get(self, "namespace")
+
+    @property
+    @pulumi.getter(name="renderYamlToDirectory")
+    def render_yaml_to_directory(self) -> pulumi.Output[Optional[str]]:
+        """
+        BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not
+        be created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes
+        to the Pulumi program. This feature is in developer preview, and is disabled by default.
+
+        Note that some computed Outputs such as status fields will not be populated
+        since the resources are not created on a Kubernetes cluster. These Output values will remain undefined,
+        and may result in an error if they are referenced by other resources. Also note that any secret values
+        used in these resources will be rendered in plaintext to the resulting YAML.
+        """
+        return pulumi.get(self, "render_yaml_to_directory")
+

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -473,6 +473,25 @@ func TestHelmReleaseNamespace(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+// TestHelmReleaseProviderNamespace tests how Helm Release inherits provider namespace.
+func TestHelmReleaseProviderNamespace(t *testing.T) {
+	tests.SkipIfShort(t)
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:         filepath.Join(getCwd(t), "helm-release-provider-namespace"),
+			SkipRefresh: true,
+			Verbose:     true,
+			Quick:       true,
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				assert.NotNil(t, stackInfo.Outputs["providerNamespace"])
+				assert.NotNil(t, stackInfo.Outputs["alertManagerNamespace"])
+				assert.Equal(t, stackInfo.Outputs["providerNamespace"], stackInfo.Outputs["alertManagerNamespace"])
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestHelmReleaseRedis(t *testing.T) {
 	expectKeyringInput := func(verifyVal bool, keyRingNonEmpty bool) func(t *testing.T,
 		stackInfo integration.RuntimeValidationStackInfo) {

--- a/tests/sdk/nodejs/examples/helm-no-default-provider/package.json
+++ b/tests/sdk/nodejs/examples/helm-no-default-provider/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "3.15.1",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/sdk/nodejs/examples/helm-release-crd/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-crd/step1/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "latest",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/sdk/nodejs/examples/helm-release-namespace/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-namespace/step1/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "latest",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/sdk/nodejs/examples/helm-release-provider-namespace/Pulumi.yaml
+++ b/tests/sdk/nodejs/examples/helm-release-provider-namespace/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: helm-no-default-provider
+runtime: nodejs
+description: A minimal Kubernetes TypeScript Pulumi program

--- a/tests/sdk/nodejs/examples/helm-release-provider-namespace/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-provider-namespace/index.ts
@@ -1,0 +1,36 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from '@pulumi/kubernetes'
+
+const namespace = new k8s.core.v1.Namespace("release-ns");
+
+const k8sProvider = new k8s.Provider(`k8s-provider`, {namespace: namespace.metadata.name})
+
+const alertManager = new k8s.helm.v3.Release("alertmanager", {
+    name: "alertmanager",
+    chart: "alertmanager",
+    version: "0.12.2",
+    repositoryOpts: {
+        repo: "https://prometheus-community.github.io/helm-charts",
+    },
+}, {provider: k8sProvider});
+
+// Ensure we get the expected namespace for the stateful set.
+export const alertManagerNamespace = k8s.apps.v1.StatefulSet.get(
+    "alertmanager-statefulset",
+    pulumi.interpolate`${alertManager.status.namespace}/alertmanager`).metadata.namespace;
+
+export const providerNamespace = k8sProvider.namespace;

--- a/tests/sdk/nodejs/examples/helm-release-provider-namespace/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-provider-namespace/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "3.15.1",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/sdk/nodejs/examples/helm-release-provider-namespace/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-provider-namespace/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "helm-def-prov",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "3.15.1",
+        "@pulumi/kubernetesx": "^0.1.5"
+    }
+}

--- a/tests/sdk/nodejs/examples/helm-release-provider-namespace/tsconfig.json
+++ b/tests/sdk/nodejs/examples/helm-release-provider-namespace/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/kubernetes": "latest",
-    "@pulumi/kubernetesx": "^0.1.5",
     "@pulumi/random": "^4.4.2"
   }
 }

--- a/tests/sdk/nodejs/examples/helm-release/step1/package.json
+++ b/tests/sdk/nodejs/examples/helm-release/step1/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "latest",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetes": "latest"
     }
 }

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -875,15 +875,16 @@ func TestProviderOutputs(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Verify that a change in the current kube context (context1a->context1b) produces various diffs.
+					// Note that context1b uses the same cluster as context1a, so we expect no replacements.
 					assert.Equal(t, "context1b", stackInfo.Outputs["k8s1Context"])
 					assert.Equal(t, "context1b", stackInfo.Outputs["k8s2Context"])
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
 					assert.Equal(t, "context1b", stackInfo.Outputs["k8s4Context"])
 					tests.AssertEvents(t, stackInfo,
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s1", Diffs: []string{"context", "kubeconfig", "namespace"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s2", Diffs: []string{"context", "kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s3", Diffs: []string{"kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"context", "kubeconfig", "namespace"}})
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s1", Diffs: []string{"context", "namespace"}},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s2", Diffs: []string{"context"}},
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s3"},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"context", "namespace"}})
 				},
 			},
 			{
@@ -891,15 +892,16 @@ func TestProviderOutputs(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Verify that a change in the current kube context (context1b->context2) produces various diffs.
+					// Since context2 uses cluster2, expect a few replacements.
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s1Context"])
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s2Context"])
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s4Context"])
 					tests.AssertEvents(t, stackInfo,
-						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s1", Keys: []string{"cluster", "context", "kubeconfig", "namespace"}, Diffs: []string{"cluster", "context", "kubeconfig", "namespace"}},
-						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s2", Keys: []string{"cluster", "context", "kubeconfig"}, Diffs: []string{"cluster", "context", "kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s3", Diffs: []string{"kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"context", "kubeconfig", "namespace"}})
+						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s1", Keys: []string{"cluster"}, Diffs: []string{"cluster", "context", "namespace"}},
+						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s2", Keys: []string{"cluster"}, Diffs: []string{"cluster", "context"}},
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s3"},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"context", "namespace"}})
 				},
 			},
 			{
@@ -912,10 +914,10 @@ func TestProviderOutputs(t *testing.T) {
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
 					assert.Equal(t, "context2", stackInfo.Outputs["k8s4Context"])
 					tests.AssertEvents(t, stackInfo,
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s1", Diffs: []string{"kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s2", Diffs: []string{"kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s3", Diffs: []string{"kubeconfig"}},
-						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"kubeconfig"}})
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s1"},
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s2"},
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s3"},
+						tests.ResOutputsEvent{Op: apitype.OpSame, Type: "pulumi:providers:kubernetes", Name: "k8s4"})
 				},
 			},
 		},

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -875,6 +875,10 @@ func TestProviderOutputs(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Verify that a change in the current kube context (context1a->context1b) produces various diffs.
+					assert.Equal(t, "context1b", stackInfo.Outputs["k8s1Context"])
+					assert.Equal(t, "context1b", stackInfo.Outputs["k8s2Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
+					assert.Equal(t, "context1b", stackInfo.Outputs["k8s4Context"])
 					tests.AssertEvents(t, stackInfo,
 						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s1", Diffs: []string{"context", "kubeconfig", "namespace"}},
 						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s2", Diffs: []string{"context", "kubeconfig"}},
@@ -887,11 +891,31 @@ func TestProviderOutputs(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Verify that a change in the current kube context (context1b->context2) produces various diffs.
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s1Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s2Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s4Context"])
 					tests.AssertEvents(t, stackInfo,
 						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s1", Keys: []string{"cluster", "context", "kubeconfig", "namespace"}, Diffs: []string{"cluster", "context", "kubeconfig", "namespace"}},
 						tests.ResOutputsEvent{Op: apitype.OpReplace, Type: "pulumi:providers:kubernetes", Name: "k8s2", Keys: []string{"cluster", "context", "kubeconfig"}, Diffs: []string{"cluster", "context", "kubeconfig"}},
 						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s3", Diffs: []string{"kubeconfig"}},
 						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"context", "kubeconfig", "namespace"}})
+				},
+			},
+			{
+				Dir:      filepath.Join("provider-outputs", "step4"),
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					// Verify that a bad kubeconfig leaves the existing outputs as-is.
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s1Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s2Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s3Context"])
+					assert.Equal(t, "context2", stackInfo.Outputs["k8s4Context"])
+					tests.AssertEvents(t, stackInfo,
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s1", Diffs: []string{"kubeconfig"}},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s2", Diffs: []string{"kubeconfig"}},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s3", Diffs: []string{"kubeconfig"}},
+						tests.ResOutputsEvent{Op: apitype.OpUpdate, Type: "pulumi:providers:kubernetes", Name: "k8s4", Diffs: []string{"kubeconfig"}})
 				},
 			},
 		},

--- a/tests/sdk/nodejs/provider-outputs/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/provider-outputs/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: provider
+description: Tests support for provider outputs.
+runtime: nodejs

--- a/tests/sdk/nodejs/provider-outputs/step1/index.ts
+++ b/tests/sdk/nodejs/provider-outputs/step1/index.ts
@@ -1,0 +1,65 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const ns1 = new k8s.core.v1.Namespace("ns1");
+
+// Create a new provider using the current context.
+const k8s1 = new k8s.Provider("k8s1", {
+    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+});
+
+// Create a new provider using an overridden namespace.
+const k8s2 = new k8s.Provider("k8s2", {
+    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    namespace: ns1.metadata.name,
+});
+
+// Create a new provider using an overridden context.
+const k8s3 = new k8s.Provider("k8s3", {
+    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    context: "context2"
+});
+
+// Create a new provider using an overridden cluster.
+const k8s4 = new k8s.Provider("k8s4", {
+    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    cluster: "cluster2"
+});
+
+export const ns1Name = ns1.metadata.name
+
+export const k8s1Namespace = k8s1.namespace
+export const k8s1Context = k8s1.context
+export const k8s1Config = k8s1.kubeconfig
+export const k8s1Cluster = k8s1.cluster
+
+export const k8s2Namespace = k8s2.namespace
+export const k8s2Context = k8s2.context
+export const k8s2Config = k8s2.kubeconfig
+export const k8s2Cluster = k8s2.cluster
+
+export const k8s3Namespace = k8s3.namespace
+export const k8s3Context = k8s3.context
+export const k8s3Config = k8s3.kubeconfig
+export const k8s3Cluster = k8s3.cluster
+
+export const k8s4Namespace = k8s4.namespace
+export const k8s4Context = k8s4.context
+export const k8s4Config = k8s4.kubeconfig
+export const k8s4Cluster = k8s4.cluster

--- a/tests/sdk/nodejs/provider-outputs/step1/index.ts
+++ b/tests/sdk/nodejs/provider-outputs/step1/index.ts
@@ -21,24 +21,24 @@ const ns1 = new k8s.core.v1.Namespace("ns1");
 
 // Create a new provider using the current context.
 const k8s1 = new k8s.Provider("k8s1", {
-    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    kubeconfig: "./kubeconfig",
 });
 
 // Create a new provider using an overridden namespace.
 const k8s2 = new k8s.Provider("k8s2", {
-    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    kubeconfig: "./kubeconfig",
     namespace: ns1.metadata.name,
 });
 
 // Create a new provider using an overridden context.
 const k8s3 = new k8s.Provider("k8s3", {
-    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    kubeconfig: "./kubeconfig",
     context: "context2"
 });
 
 // Create a new provider using an overridden cluster.
 const k8s4 = new k8s.Provider("k8s4", {
-    kubeconfig: fs.readFileSync("kubeconfig").toString(),
+    kubeconfig: "./kubeconfig",
     cluster: "cluster2"
 });
 

--- a/tests/sdk/nodejs/provider-outputs/step1/kubeconfig
+++ b/tests/sdk/nodejs/provider-outputs/step1/kubeconfig
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://cluster1.test:6443
+  name: cluster1
+- cluster:
+    server: https://cluster2.test:6443
+  name: cluster2
+contexts:
+- context:
+    cluster: cluster1
+    namespace: default1a
+    user: user1
+  name: context1a
+- context:
+    cluster: cluster1
+    namespace: default1b
+    user: user1
+  name: context1b
+- context:
+    cluster: cluster2
+    namespace: default2
+    user: user1
+  name: context2
+current-context: context1a
+kind: Config
+preferences: {}
+users:
+- name: user1
+  user:
+    token: dGVzdA==

--- a/tests/sdk/nodejs/provider-outputs/step1/package.json
+++ b/tests/sdk/nodejs/provider-outputs/step1/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "steps",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/provider-outputs/step1/tsconfig.json
+++ b/tests/sdk/nodejs/provider-outputs/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/provider-outputs/step2/kubeconfig
+++ b/tests/sdk/nodejs/provider-outputs/step2/kubeconfig
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://cluster1.test:6443
+  name: cluster1
+- cluster:
+    server: https://cluster2.test:6443
+  name: cluster2
+contexts:
+- context:
+    cluster: cluster1
+    namespace: default1a
+    user: user1
+  name: context1a
+- context:
+    cluster: cluster1
+    namespace: default1b
+    user: user1
+  name: context1b
+- context:
+    cluster: cluster2
+    namespace: default2
+    user: user1
+  name: context2
+current-context: context1b # <-- changed context (w/ same cluster, different namespace)
+kind: Config
+preferences: {}
+users:
+- name: user1
+  user:
+    token: dGVzdA==

--- a/tests/sdk/nodejs/provider-outputs/step3/kubeconfig
+++ b/tests/sdk/nodejs/provider-outputs/step3/kubeconfig
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://cluster1.test:6443
+  name: cluster1
+- cluster:
+    server: https://cluster2.test:6443
+  name: cluster2
+contexts:
+- context:
+    cluster: cluster1
+    namespace: default1a
+    user: user1
+  name: context1a
+- context:
+    cluster: cluster1
+    namespace: default1b
+    user: user1
+  name: context1b
+- context:
+    cluster: cluster2
+    namespace: default2
+    user: user1
+  name: context2
+current-context: context2 # <-- changed context (w/ different cluster, different namespace)
+kind: Config
+preferences: {}
+users:
+- name: user1
+  user:
+    token: dGVzdA==

--- a/tests/sdk/nodejs/provider-outputs/step4/kubeconfig
+++ b/tests/sdk/nodejs/provider-outputs/step4/kubeconfig
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://cluster1.test:6443
+  name: cluster1
+- cluster:
+    server: https://cluster2.test:6443
+  name: cluster2
+contexts:
+- context:
+    cluster: cluster1
+    namespace: default1a
+    user: user1
+  name: context1a
+- context:
+    cluster: cluster1
+    namespace: default1b
+    user: user1
+  name: context1b
+- context:
+    cluster: cluster2
+    namespace: default2
+    user: user1
+  name: context2
+current-context: contextbad # <-- changed to a non-existent context
+kind: Config
+preferences: {}
+users:
+- name: user1
+  user:
+    token: dGVzdA==

--- a/tests/sdk/nodejs/provider/step1/index.ts
+++ b/tests/sdk/nodejs/provider/step1/index.ts
@@ -58,7 +58,7 @@ new k8s.core.v1.Pod("nginx2", {
 
 // Create a Pod using the contents provider with a specified namespace.
 // The namespace should not be overridden by the provider default.
-new k8s.core.v1.Pod("namespaced-nginx", {
+new k8s.core.v1.Pod("namespaced-nginx1", {
     metadata: { namespace: ns2.metadata.name },
     spec: {
         containers: [{
@@ -68,6 +68,19 @@ new k8s.core.v1.Pod("namespaced-nginx", {
         }],
     },
 }, { provider: kubeconfigContentsProvider });
+
+// Create a Pod using the namespace output property of the contents provider.
+// use the default provider to ensure that the namespace isn't inherited by other means. 
+new k8s.core.v1.Pod("namespaced-nginx2", {
+    metadata: { namespace: kubeconfigContentsProvider.namespace },
+    spec: {
+        containers: [{
+            image: "nginx:1.7.9",
+            name: "nginx",
+            ports: [{ containerPort: 80 }],
+        }],
+    },
+});
 
 // Create a Namespace using the contents provider
 // The namespace should not be affected by the provider override since it is a cluster-scoped kind.

--- a/tests/util.go
+++ b/tests/util.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"encoding/json"
+	"fmt"
 	"os/exec"
 	"reflect"
 	"sort"
@@ -11,6 +13,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,8 +55,13 @@ Expected:
 				continue Expected
 			}
 		}
-		assert.Fail(t, "Expected an engine event", m)
+		assert.Fail(t, fmt.Sprintf("Expected an engine event: %+v", m))
 		success = false
+	}
+	if tt, ok := t.(*testing.T); ok && !success {
+		json, err := json.MarshalIndent(stackInfo.Events, "", "  ")
+		contract.AssertNoErrorf(err, "unexpected JSON error: %v", err)
+		tt.Logf("Actual engine events:\n%s\n", json)
 	}
 	return success
 }

--- a/tests/util.go
+++ b/tests/util.go
@@ -2,11 +2,16 @@ package tests
 
 import (
 	"os/exec"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
 )
 
 // SkipIfShort skips the test if the -short flag is passed to `go test`.
@@ -30,4 +35,59 @@ func Kubectl(args ...string) ([]byte, error) {
 	}
 
 	return exec.Command("kubectl", fmtArgs...).CombinedOutput()
+}
+
+// Matcher provides an interface for matching values.
+type Matcher[T any] interface {
+	Match(actual T) bool
+}
+
+// AssertEvents asserts that the stack info contains a set of events.
+func AssertEvents(t assert.TestingT, stackInfo integration.RuntimeValidationStackInfo, expected ...Matcher[apitype.EngineEvent]) (success bool) {
+	success = true
+Expected:
+	for _, m := range expected {
+		for _, evt := range stackInfo.Events {
+			if m.Match(evt) {
+				continue Expected
+			}
+		}
+		assert.Fail(t, "Expected an engine event", m)
+		success = false
+	}
+	return success
+}
+
+// ResOutputsEvent matches resource output events.
+type ResOutputsEvent struct {
+	// Op is the operation being performed.
+	Op apitype.OpType
+	// Type is the resource type of the event.
+	Type string
+	// Name is the resource name.
+	Name tokens.QName
+	// Keys causing a replacement (only applicable for "create" and "replace" Ops).
+	Keys []string
+	// Keys that changed with this step.
+	Diffs []string
+}
+
+func (e ResOutputsEvent) Match(actual apitype.EngineEvent) bool {
+	if actual.ResOutputsEvent == nil {
+		return false
+	}
+	urn, err := resource.ParseURN(actual.ResOutputsEvent.Metadata.URN)
+	if err != nil {
+		return false
+	}
+	a := ResOutputsEvent{
+		Op:    actual.ResOutputsEvent.Metadata.Op,
+		Type:  actual.ResOutputsEvent.Metadata.Type,
+		Name:  urn.Name(),
+		Keys:  actual.ResOutputsEvent.Metadata.Keys,
+		Diffs: actual.ResOutputsEvent.Metadata.Diffs,
+	}
+	sort.Strings(a.Keys)
+	sort.Strings(a.Diffs)
+	return reflect.DeepEqual(e, a)
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Closes #2486 

This PR exposes the provider input properties as outputs, and normalizes those inputs to provide the effective values. This opens up some new scenarios:
1. Use the provider's namespace as an input property, in a uniform way.
2. A better experience when the ambient kubeconfig is changed; Pulumi reports a diff to `namespace`, `context` or `cluster` as appropriate, which helps to explain why downstream changes may be occurring.

### Detailed Changes

The following provider inputs are normalized such that they contain the effective values in stack state:
1. `namespace` - normalized to contain the ambient namespace or `default`.
2. `context`- normalized to contain the ambient context name.
3. `cluster` normalized to contain the ambient cluster name.

The `kubeconfig` property is not normalized, which means that the application would need to manually load the ambient config. It seems like a bad idea to normalize the `kubeconfig` for a few reasons:
1. it bloats the stack state to include the entire kubeconfig contents.
2. the kubeconfig may contain a secret in rare situations but isn't modeled as a secret input.
6. the application can workaround it, since the raw output is now available.

The Helm provider was simplified to always take the merged kubeconfig (`apiConfig`) from the kube provider, as opposed to reloading it in some cases. This should have no effect on the behavior.

Some minor improvements to kubeconfig loading logic:
1. Use a non-interactive loader for the kubeconfig, since the provider is a non-interactive server (see [original PR](https://github.com/pulumi/pulumi-kubernetes/commit/e85e03360ab8b1657d47016b4d38365ebb30e077#diff-5e83e1a18ae8dd9641b49e491350ae5b8afaf7fdb60dfcf4d4447a17e334e473R26)). The rationale is to be consistent with the (newer) Helm code.
2. When the `kubeconfig` property is path-like, don't try to parse it as content. This improves the error message.
3. Fallback to using the `default` namespace (as opposed to undefined) for diff purposes when the config could not be loaded.

The special-case logic around 'replacement' was simplified to consider only the normalized server name.  That is, the provider recommends replacement when the `name` field of the active server has changed. The earlier code had major limitations - it didn't consider the ambient kubeconfig, and didn't support kubeconfig paths.

### Testing
New tests were added and/or updated:
1. `TestProvider` - updated to verify that the provider's `namespace` output property is useable as an input to other resources.
2. `TestProviderOutputs` - added to verify provider outputs and the normalization logic.
3. `Test_loadKubeconfig` - added to verify kubeconfig loading/parsing logic.

New utility code was developed for easily asserting that certain engine events occurred during `ExtraRuntimeValidation`; see `util.go#AssertEvents`.

### Example
Here's an example showing the use of the provider's new `namespace` output property, and showing the improved change detection related to the ambient namespace.

The program relies on the ambient kubeconfig, uses the ambient namespace to create a `Deployment`, and binds the provider's `namespace` output property to the stack outputs:
```yaml
name: issue-2486-yaml
runtime: yaml
description: A minimal Kubernetes Pulumi YAML program
outputs:
  namespace: ${k8s.namespace}
  deployment: ${deployment.metadata.namespace}/${deployment.metadata.name}
resources:
  k8s:
    type: pulumi:providers:kubernetes
  deployment:
    type: kubernetes:apps/v1:Deployment
    options:
      provider: ${k8s}
    properties:
      spec:
        replicas: 1
        selector:
          matchLabels:
            app: nginx
        template:
          metadata:
            labels:
              app: nginx
          spec:
            containers:
            - image: nginx
              name: nginx
```

The procedure deploys the stack, changes the ambient namespace, and then previews the changes:
```plain
❯ pulumi up -f
Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/eron-pulumi-corp/issue-2486-yaml/dev/updates/8

     Type                              Name                 Status              Info
 +   pulumi:pulumi:Stack               issue-2486-yaml-dev  created (3s)        4 warnings
 +   ├─ pulumi:providers:kubernetes    k8s                  created (0.12s)     
 +   └─ kubernetes:apps/v1:Deployment  deployment           created (2s)        

Outputs:
    deployment: "default/deployment-bf4abb76"
    namespace : "default"

Resources:
    + 3 created

Duration: 4s

❯ kubectl config set-context --current --namespace eron
Context "docker-desktop" modified.

❯ pulumi preview
Previewing update (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/eron-pulumi-corp/issue-2486-yaml/dev/previews/2cf2c42a-0a95-42b3-b193-ffca7f401fc7

     Type                              Name                 Plan        Info
     pulumi:pulumi:Stack               issue-2486-yaml-dev              4 warnings
 ~   ├─ pulumi:providers:kubernetes    k8s                  update      [diff: ~namespace]
 +-  └─ kubernetes:apps/v1:Deployment  deployment           replace     [diff: ~metadata]

Resources:
    ~ 1 to update
    +-1 to replace
    2 changes. 1 unchanged

```

The resultant stack state:
```json
            {
                "urn": "urn:pulumi:dev::issue-2486-yaml::pulumi:providers:kubernetes::k8s",
                "custom": true,
                "id": "78fe6e28-5f2e-4823-af95-df9021ce46f9",
                "type": "pulumi:providers:kubernetes",
                "inputs": {
                    "cluster": "docker-desktop",
                    "context": "docker-desktop",
                    "namespace": "default"
                },
                "outputs": {
                    "cluster": "docker-desktop",
                    "context": "docker-desktop",
                    "namespace": "default"
                },
                "parent": "urn:pulumi:dev::issue-2486-yaml::pulumi:pulumi:Stack::issue-2486-yaml-dev",
                "created": "2023-10-06T00:06:46.065029Z",
                "modified": "2023-10-06T00:06:46.065029Z"
            },
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
