### PR TITLE
Strict mode for provider kubeconfig handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Other changes:
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
 - Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
-- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
+- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2599)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Other changes:
 - Upgrade to latest helm dependency (https://github.com/pulumi/pulumi-kubernetes/pull/2474)
 - Improve error handling for List resources (https://github.com/pulumi/pulumi-kubernetes/pull/2493)
 - Normalize provider inputs and make available as outputs (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
+- Improved error handling when loading kubeconfig (https://github.com/pulumi/pulumi-kubernetes/pull/2598)
 
 ## 3.30.2 (July 11, 2023)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -405,6 +405,10 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 	}
 	failures := normalizeInputs()
 	if len(failures) > 0 {
+		if !providers.IsDefaultProvider(urn) {
+			return &pulumirpc.CheckResponse{Inputs: req.GetNews(), Failures: failures}, nil
+		}
+
 		// Rather than erroring out on an invalid k8s config, leave the original values in-place.
 		logger.V(9).Infof("%s: unable to normalize inputs: %v", label, failures)
 	}

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -129,7 +129,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 	// flags.
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	kubeconfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 	apiConfig, err := kubeconfig.RawConfig()
 	if err != nil {
 		return nil, nil, err

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -104,7 +104,7 @@ func loadKubeconfig(pathOrContents string, overrides *clientcmd.ConfigOverrides)
 
 		// If the variable is a valid filepath, load the file and parse the contents as a k8s config.
 		_, err := os.Stat(pathOrContents)
-		if err == nil {
+		if err == nil || filepath.IsAbs(pathOrContents) || strings.HasPrefix(pathOrContents, ".") {
 			b, err := os.ReadFile(pathOrContents)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR tightens the kubeconfig loading logic of the provider.
1. ~Errors are not suppressed for the non-default provider (see https://github.com/pulumi/pulumi-kubernetes/pull/960). The rationale is to stabilize the diff when the inputs are unprocessable, without breaking the invoke use-case.~
2. Use a non-interactive loader for the kubeconfig, since the provider is a non-interactive server (see [original PR](https://github.com/pulumi/pulumi-kubernetes/commit/e85e03360ab8b1657d47016b4d38365ebb30e077#diff-5e83e1a18ae8dd9641b49e491350ae5b8afaf7fdb60dfcf4d4447a17e334e473R26)). The rationale is to be consistent with the (newer) Helm code.
3. When the `kubeconfig` property is path-like, don't try to parse it as content. This improves the error message.

TODO: fix test: `TestSkipUpdateUnreachableFlag`

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
