### PR TITLE
Improved search functionality for Helm Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - helm.v3.ChartOpts: Add KubeVersion field that can be passed to avoid asking the kubernetes API server for the version (https://github.com/pulumi/pulumi-kubernetes/pull/2593)
 - Fix for Helm Import regression (https://github.com/pulumi/pulumi-kubernetes/pull/2605)
+- Improved search functionality for Helm Import (https://github.com/pulumi/pulumi-kubernetes/pull/2610)
 
 ## 4.4.0 (October 12, 2023)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -48,6 +49,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/helmpath"
 	"helm.sh/helm/v3/pkg/postrender"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
@@ -1300,6 +1302,18 @@ func (r *helmReleaseProvider) importRelease(ctx context.Context, urn resource.UR
 
 	// note: setReleaseAttributes pre-populates some of the inputs
 
+	// Attempt to resolve the chart's origin in either a local or remote repository.
+	// Note that the local chart is not verified.
+	if name, _, found := searchProgramDirectory(hr.Chart.Metadata.Name, hr.Chart.Metadata.Version); found {
+		release.Chart = *name
+	} else if repo, chart, found := searchHelmRepositories(r.settings, hr.Chart.Metadata.Name, hr.Chart.Metadata.Version); found {
+		// use a local repository reference, rather than reconstructing all the repository opts
+		release.Chart = fmt.Sprintf("%s/%s", repo.Name, chart.Name)
+	} else {
+		// fallback to using a local chart reference
+		release.Chart = hr.Chart.Metadata.Name
+	}
+
 	err := r.setComputedInputs(ctx, urn, release)
 	if err != nil {
 		// Likely because the chart is not readily available (e.g. import of chart where no repo info is stored).
@@ -1419,6 +1433,54 @@ func mapToInterface(in any) any {
 		return out
 	}
 	return in
+}
+
+// searchProgramDirectory implements a best-effort search for a chart in the program directory.
+func searchProgramDirectory(name, version string) (*string, *helmchart.Metadata, bool) {
+	file := fmt.Sprintf("%s.tgz", name)
+	if c, err := loader.LoadFile(file); err == nil {
+		return &file, c.Metadata, true
+	}
+	file = fmt.Sprintf("%s-%s.tgz", name, version)
+	if c, err := loader.LoadFile(file); err == nil {
+		return &file, c.Metadata, true
+	}
+	dir := name
+	if c, err := loader.LoadDir(dir); err == nil {
+		return &dir, c.Metadata, true
+	}
+	return nil, nil, false
+}
+
+// searchHelmRepositories implements a best-effort search for a chart in the locally-configured repositories.
+func searchHelmRepositories(settings *cli.EnvSettings, name, version string) (*repo.Entry, *repo.ChartVersion, bool) {
+	repoFile := settings.RepositoryConfig
+	repoCacheDir := settings.RepositoryCache
+
+	// Load the repositories.yaml
+	rf, err := repo.LoadFile(repoFile)
+	if errors.Is(err, fs.ErrNotExist) || len(rf.Repositories) == 0 {
+		logger.V(9).Infof("no repositories configured")
+		return nil, nil, false
+	}
+
+	// Scan the repositories for a chart
+	for _, re := range rf.Repositories {
+		n := re.Name
+		f := filepath.Join(repoCacheDir, helmpath.CacheIndexFile(n))
+		ind, err := repo.LoadIndexFile(f)
+		if err != nil {
+			logger.V(9).Infof("Repo %q is corrupt or missing. Try 'helm repo update'.", n)
+			continue
+		}
+		chartVersion, err := ind.Get(name, version)
+		if err != nil {
+			logger.V(9).Infof("No such chart: %v", err)
+			continue
+		}
+		return re, chartVersion, true
+	}
+	return nil, nil, false
 }
 
 func getChart(cpo *action.ChartPathOptions, registryClient *registry.Client, settings *cli.EnvSettings,

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -170,7 +170,16 @@ func TestGo(t *testing.T) {
 
 		// 1. Import by searching the local chart repositories for a matching chart.
 		t.Run("chart reference", func(t *testing.T) {
-			t.Logf("Unsupported: import by chart reference")
+			options := baseOptions.With(integration.ProgramTestOptions{
+				Dir: filepath.Join(cwd, "helm-release-import", "step1-remote"),
+				Config: map[string]string{
+					"chart":   chart.ChartReference(), // bitnami/nginx
+					"version": chartVersion.Version,   // 15.3.4
+				},
+			})
+			run(t, options, runOptions{
+				InstallHelmRepository: true,
+			})
 		})
 
 		// 2. Import by searching for an unpacked chart in the program directory.
@@ -189,7 +198,16 @@ func TestGo(t *testing.T) {
 
 		// 3. Import by searching for a chart archive in the program directory.
 		t.Run("chart archive", func(t *testing.T) {
-			t.Logf("Unsupported: import by chart archive")
+			options := baseOptions.With(integration.ProgramTestOptions{
+				Dir: filepath.Join(cwd, "helm-release-import", "step1-local-tar"),
+				Config: map[string]string{
+					"chart":   fmt.Sprintf("%s-%s.tgz", chart.Name, chartVersion.Version), // nginx-15.3.4.tgz
+					"version": chartVersion.Version,
+				},
+			})
+			run(t, options, runOptions{
+				InstallHelmRepository: false,
+			})
 		})
 	})
 
@@ -274,7 +292,19 @@ func TestGo(t *testing.T) {
 
 		// 1. Import by searching the local chart repositories for a matching chart.
 		t.Run("chart reference", func(t *testing.T) {
-			t.Logf("Unsupported: import by chart reference")
+			options := baseOptions.With(integration.ProgramTestOptions{
+				Dir: filepath.Join(cwd, "helm-release-import", "step1-remote"),
+				Config: map[string]string{
+					"chart":   chart.ChartReference(), // bitnami/nginx
+					"version": chartVersion.Version,   // 15.3.4
+				},
+				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				},
+			})
+			run(t, options, runOptions{
+				InstallHelmRepository: true,
+				ExpectHelmUpgrade:     false,
+			})
 		})
 
 		// 2. Import by searching for an unpacked chart in the program directory.
@@ -294,7 +324,17 @@ func TestGo(t *testing.T) {
 
 		// 3. Import by searching for a chart archive in the program directory.
 		t.Run("chart archive", func(t *testing.T) {
-			t.Logf("Unsupported: import by chart archive")
+			options := baseOptions.With(integration.ProgramTestOptions{
+				Dir: filepath.Join(cwd, "helm-release-import", "step1-local-tar"),
+				Config: map[string]string{
+					"chart":   fmt.Sprintf("%s-%s.tgz", chart.Name, chartVersion.Version), // nginx-15.3.4.tgz
+					"version": chartVersion.Version,
+				},
+			})
+			run(t, options, runOptions{
+				InstallHelmRepository: false,
+				ExpectHelmUpgrade:     false,
+			})
 		})
 
 		// 4. Import without matching a chart. The tool gives a warning, and a subsequent deployment


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This PR enhances the `Release` resource to search harder for a matching chart when importing a release. When Helm installs a chart, it doesn't record any information about the chart location, simply its name. Pulumi attempts to locate a chart:
1. (existing) by looking for an expanded chart directory (e.g. `nginx/`) in the program directory.
2. (new) by looking for a chart archive in the program directory, with or without the version info (e.g. `nginx-15.3.4.tgz`).
3. (new) by looking in the local Helm repositories for a chart, matching the name and version.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
