### PR TITLE
Deepcopy unstructured objects for normalization

### DIFF
--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -131,15 +131,15 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"preserveUnknownFields": false,
 				"scope":                 "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{
@@ -176,14 +176,14 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"scope": "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{
@@ -228,14 +228,14 @@ var (
 				"names": map[string]any{
 					"kind":   "FooBar",
 					"plural": "foobars",
-					"shortNames": []string{
+					"shortNames": []any{
 						"fb",
 					},
 					"singular": "foobar",
 				},
 				"scope": "Namespaced",
-				"versions": []map[string]any{
-					{
+				"versions": []any{
+					map[string]any{
 						"name": "v1",
 						"schema": map[string]any{
 							"openAPIV3Schema": map[string]any{


### PR DESCRIPTION
### Proposed changes

The logic for normalizing Unstructured resources was inadvertently modifying resources in place because the argument was a pointer type. Change the logic to make a copy of the resource and then return a normalized version of the copy. This avoids returning a partially-modified version of the resource if normalization fails partway through the process.

As part of this change, the following updates were made:

1. Make a deep copy of the Unstructured resource rather than modifying the original in-place.
3. Fix invalid unstructured test data. Unstructured objects should be slices of interfaces, not concrete types.