### PR TITLE
Example test case to showcase using Patch Resources and field ownership conflicts

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2796,6 +2796,7 @@ func normalizeInputs(uns *unstructured.Unstructured) (*unstructured.Unstructured
 	unstructured.RemoveNestedField(uns.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(uns.Object, "metadata", "resourceVersion")
 	unstructured.RemoveNestedField(uns.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(uns.Object, "spec", "template", "metadata", "creationTimestamp")
 
 	return uns, nil
 }

--- a/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ignoreChanges-patch-deployment-stack
+description: Creates a deployment objects to test ignoreChanges with patch resources.
+runtime: nodejs

--- a/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/index.ts
+++ b/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/index.ts
@@ -1,0 +1,50 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
+
+const ns = new k8s.core.v1.Namespace("test-ignore-changes-patch", undefined, { provider });
+
+const deployment = new k8s.apps.v1.Deployment(
+  "test-ignore-changes",
+  {
+    metadata: {
+      namespace: ns.metadata.name,
+    },
+    spec: {
+      selector: { matchLabels: { app: "test-ignore-changes" } },
+      replicas: 1,
+      template: {
+        metadata: {
+          labels: { app: "test-ignore-changes" },
+        },
+        spec: {
+          containers: [
+            {
+              name: "nginx",
+              image: "nginx:1.25.2",
+            },
+          ],
+        },
+      },
+    },
+  },
+  { provider: provider }
+);
+
+export const deploymentName = deployment.metadata.name;
+export const deploymentNamespace = deployment.metadata.namespace;

--- a/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/package.json
+++ b/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "skip-update-unreachable",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/tsconfig.json
+++ b/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step2/index.ts
+++ b/tests/sdk/nodejs/ignore-changes-patch/deployment-stack/step2/index.ts
@@ -1,0 +1,51 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
+
+const ns = new k8s.core.v1.Namespace("test-ignore-changes-patch", undefined, { provider });
+
+const deployment = new k8s.apps.v1.Deployment(
+  "test-ignore-changes",
+  {
+    metadata: {
+      namespace: ns.metadata.name,
+    },
+    spec: {
+      selector: { matchLabels: { app: "test-ignore-changes" } },
+      replicas: 1,
+      template: {
+        // Uncomment the following lines to transfer ownership of .spec.template.metadata to the patch stack.
+        // metadata: {
+        //   labels: { app: "test-ignore-changes" },
+        // },
+        spec: {
+          containers: [
+            {
+              name: "nginx",
+              image: "nginx:1.25.2",
+            },
+          ],
+        },
+      },
+    },
+  },
+  { provider: provider, ignoreChanges: ["spec.replicas"] }
+);
+
+export const deploymentName = deployment.metadata.name;
+export const deploymentNamespace = deployment.metadata.namespace;

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ignoreChanges-patch-stack
+description: Creates a deployment patch resource to test ignoreChanges.
+runtime: nodejs

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/index.ts
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/index.ts
@@ -1,0 +1,50 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create provider with SSA enabled.
+let config = new pulumi.Config();
+const ns = config.require("DEPLOYMENT_NAMESPACE");
+const name = config.require("DEPLOYMENT_NAME");
+
+const provider = new k8s.Provider("k8s", { enableServerSideApply: true });
+
+// Create a patch that changes the number of replicas for the deployment created in
+// the deployment-stack example. We are also setting the app labels here to simulate
+// shared ownership of the app labels between the deployment stack and this set.
+const appLabels = { app: "test-ignore-changes" };
+const patch = new k8s.apps.v1.DeploymentPatch(
+  "test-ignore-changes-patch",
+  {
+    metadata: {
+      namespace: ns,
+      name: name,
+      annotations: {
+        "pulumi.com/patchForce": "true",
+      },
+    },
+    spec: {
+      selector: { matchLabels: appLabels },
+      replicas: 2,
+      template: {
+        metadata: {
+          labels: appLabels,
+        },
+      },
+    },
+  },
+  { provider }
+);

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/package.json
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "skip-update-unreachable",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/tsconfig.json
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step2/index.ts
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step2/index.ts
@@ -1,0 +1,46 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create provider with SSA enabled.
+let config = new pulumi.Config();
+const ns = config.require("DEPLOYMENT_NAMESPACE");
+const name = config.require("DEPLOYMENT_NAME");
+
+const provider = new k8s.Provider("k8s", {enableServerSideApply: true});
+
+// Update the patch to reduce replicas back to 1, and also drop specifying the 
+// app labels. We drop labels here to simulate a strategic merge patch where
+// we just want to update the replicas field, and not update the app labels. However,
+// this is not possible as Pulumi Kubernetes Patch resources use SSA so this step
+// WILL fail since SSA will attempt to unset the app label fields (.spec.template.metadata.labels
+// and .spec.selector) since they are not specified in the SSA patch.
+const patch = new k8s.apps.v1.DeploymentPatch(
+  "test-ignore-changes-patch",
+  {
+    metadata: {
+      namespace: ns,
+      name: name,
+      annotations: {
+        "pulumi.com/patchForce": "true",
+      },
+    },
+    spec: {
+      replicas: 1,
+    },
+  },
+  { provider }
+);

--- a/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step3/index.ts
+++ b/tests/sdk/nodejs/ignore-changes-patch/patch-stack/step3/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create provider with SSA enabled.
+let config = new pulumi.Config();
+const ns = config.require("DEPLOYMENT_NAMESPACE");
+const name = config.require("DEPLOYMENT_NAME");
+
+const provider = new k8s.Provider("k8s", { enableServerSideApply: true });
+
+// Add the required paths to the ignoreChanges array, and this step will succeed.
+const patch = new k8s.apps.v1.DeploymentPatch(
+  "test-ignore-changes-patch",
+  {
+    metadata: {
+      namespace: ns,
+      name: name,
+      annotations: {
+        "pulumi.com/patchForce": "true",
+      },
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        metadata: {},
+      },
+    },
+  },
+  {
+    provider,
+    ignoreChanges: ["spec.selector", "spec.template.metadata.labels"],
+  }
+);


### PR DESCRIPTION
TestIgnoreChangesPatchResources tests that we can successfully ignore changes to a Patch Resource without SSA conflicts, and accidentally unsetting a field of interest when the Patch resource is declared as the field manager. This allows a user to use a SSA Patch resource like a strategic merge patch resource.
This test uses 2 stacks:
 1. The "deployment stack" creates a Deployment object on cluster.
 2. The "patch stack" uses a DeploymentPatch resource to patch the Deployment object on cluster.

Steps:
 1. Create the deployment stack and let it run in the background with a goroutine.
 2. Wait for the deployment stack to finish creating the deployment object.
 3. Create the patch stack and patch the deployment object to scale to 2 replicas and have shared field
    owner ship of the .metadata.labels.app field.
 4. Validate that the deployment was scaled to 2 replica.
 5. Unblock the last step of the deploymnet step to run, and block the second step of the patch stack from running.
 6. Run the second and final step of the deployment stack to relinquish field ownership of the .metadata.labels.app field
    to the patch stack.
 7. Unblock the second step of the patch stack to run.
 8. Run the second step of the patch stack, which we expect to fail.
 9. Add the .metadata.labels.app field to the ignoreChanges list of the DeploymentPatch resource in step 3 of the patch stack.
 10. Run the third step of the patch stack which we expect to succeed.