### PR TITLE
Test DaemonSetPatch with and without annotation conflicts

### DIFF
--- a/tests/cluster/kind.go
+++ b/tests/cluster/kind.go
@@ -1,0 +1,102 @@
+package cluster
+
+import (
+	"encoding/base32"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+)
+
+// KindVersion is a specific Kind version associated with a Kubernetes minor version.
+type KindVersion string
+
+const (
+	Kind1_27 KindVersion = "kindest/node:v1.27.3"
+
+	// Kubeconfig is the filename of the KUBECONFIG file.
+	Kubeconfig = "KUBECONFIG"
+
+	// maxCreateTries is the maximum number of times to try to create a Kind cluster.
+	maxCreateTries = 6
+)
+
+// newKindCluster creates a new Kind cluster for use in testing with the specified name.
+// func NewKindCluster(t *testing.T, name string) (*rest.Config, func()) {
+func NewKindCluster(t *testing.T, name string) string {
+	t.Helper()
+
+	// Create a new tmpdir to store the kubeconfig.
+	t.Log("Creating new Kind cluster")
+	tmpDir, err := os.MkdirTemp("", "pulumi-test-kind")
+	if err != nil {
+		t.Fatalf("failed to create tmpdir: %v", err)
+	}
+	KubeconfigPath := filepath.Join(tmpDir, Kubeconfig)
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	t.Logf("KubeconfigPath: %s\n", KubeconfigPath)
+
+	p := cluster.NewProvider()
+
+	name += "-" + randString()
+	name = normalizeName(name)
+	t.Logf("Creating cluster %q", name)
+	shutdown, err := createKindCluster(t, p, name, KubeconfigPath, Kind1_27)
+	if err != nil {
+		t.Fatalf("failed to create kind cluster: %v", err)
+	}
+
+	t.Cleanup(shutdown)
+
+	// return restConfig(t, KubeconfigPath), shutdown
+	return KubeconfigPath
+
+}
+
+// normalizeName returns a normalized name for the cluster that adheres
+// to the Kubernetes naming restrictions.
+func normalizeName(name string) string {
+	return strings.ToLower(name)
+}
+
+func randString() string {
+	rand.Seed(time.Now().UnixNano())
+	c := 10
+	b := make([]byte, c)
+	rand.Read(b)
+	length := 6
+	return strings.ToLower(base32.StdEncoding.EncodeToString(b)[:length])
+}
+
+// createKindCluster attempts to create a KinD cluster with retry.
+func createKindCluster(t *testing.T, p *cluster.Provider, name, kcfgPath string, version KindVersion) (func(), error) {
+	var err error
+	for i := 0; i < maxCreateTries; i++ {
+		t.Logf("Creating KinD cluster, attempt: %d", i+1)
+		err = p.Create(name,
+			cluster.CreateWithKubeconfigPath(kcfgPath),
+			cluster.CreateWithNodeImage(string(version)),
+			cluster.CreateWithWaitForReady(20*time.Second),
+		)
+		if err == nil {
+			return func() {
+				deleteKindCluster(p, name, kcfgPath)
+			}, nil
+		}
+	}
+
+	// We failed to create the cluster maxKindTries times, so fail out.
+	return nil, err
+}
+
+// deleteKindCluster deletes a specified kind cluster.
+func deleteKindCluster(p *cluster.Provider, name, kcfgPath string) error {
+	return p.Delete(name, kcfgPath)
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -17,6 +17,7 @@ require (
 	helm.sh/helm/v3 v3.12.1
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
+	sigs.k8s.io/kind v0.20.0
 )
 
 require (
@@ -53,6 +54,7 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/ahmetb/go-linq v3.0.0+incompatible // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -127,6 +129,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
+	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/google/wire v0.5.0 // indirect
@@ -202,6 +205,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -155,6 +155,7 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -235,6 +236,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
@@ -543,6 +546,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -967,6 +971,8 @@ github.com/google/pprof v0.0.0-20230406165453-00490a63f317/go.mod h1:79YE0hCXdHa
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
+github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 h1:SJ+NtwL6QaZ21U+IrK7d0gGgpjGGvd2kz+FzTHVzdqI=
+github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC9t8wNnpPdctvtSUOPUUg4SHeE6vR1Ir2hmg=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
@@ -1543,6 +1549,9 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1740,6 +1749,7 @@ github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -2714,6 +2724,7 @@ gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
@@ -2874,6 +2885,8 @@ sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNza
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=
+sigs.k8s.io/kind v0.20.0/go.mod h1:aBlbxg08cauDgZ612shr017/rZwqd7AS563FvpWKPVs=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 h1:XX3Ajgzov2RKUdc5jW3t5jwY7Bo7dcRm+tFxT+NfgY0=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3/go.mod h1:9n16EZKMhXBNSiUC5kSdFQJkdH3zbxS/JoO619G1VAY=
 sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 h1:W6cLQc5pnqM7vh3b7HvGNfXrJ/xL6BDMS0v1V/HHg5U=

--- a/tests/sdk/go/patch-force-patch-resource/step1/Pulumi.yaml
+++ b/tests/sdk/go/patch-force-patch-resource/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: server-side-apply-tests
+description: Tests Server-side Apply support
+runtime: go

--- a/tests/sdk/go/patch-force-patch-resource/step1/index.go
+++ b/tests/sdk/go/patch-force-patch-resource/step1/index.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		conf := config.New(ctx, "")
+		kubeconfig := conf.Require("kubeconfig")
+		provider, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
+			EnableServerSideApply: pulumi.BoolPtr(true),
+			Kubeconfig:            pulumi.StringPtr(kubeconfig),
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = appsv1.NewDaemonSetPatch(ctx, "kube-proxy-image", &appsv1.DaemonSetPatchArgs{
+			Metadata: metav1.ObjectMetaPatchArgs{
+				Name:      pulumi.String("kube-proxy"),
+				Namespace: pulumi.String("kube-system"),
+				// Annotations: pulumi.StringMap{
+				//     "pulumi.com/patchForce": pulumi.String("true"),
+				// },
+			},
+			Spec: appsv1.DaemonSetSpecPatchArgs{
+				Template: corev1.PodTemplateSpecPatchArgs{
+					Spec: corev1.PodSpecPatchArgs{
+						Containers: corev1.ContainerPatchArray{
+							corev1.ContainerPatchArgs{
+								Name:  pulumi.String("kube-proxy"),
+								Image: pulumi.String("registry.k8s.io/kube-proxy:v1.27.1"),
+								Command: pulumi.StringArray{
+									pulumi.String("/usr/local/bin/kube-proxy"),
+									pulumi.String("--config=/var/lib/kube-proxy/config.conf"),
+									pulumi.String("--hostname-override=$(NODE_NAME)"),
+									pulumi.String("--v=2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}, pulumi.Provider(provider), pulumi.RetainOnDelete(true))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/tests/sdk/go/patch-force-patch-resource/step2/index.go
+++ b/tests/sdk/go/patch-force-patch-resource/step2/index.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		conf := config.New(ctx, "")
+		kubeconfig := conf.Require("kubeconfig")
+		provider, err := kubernetes.NewProvider(ctx, "k8s", &kubernetes.ProviderArgs{
+			EnableServerSideApply: pulumi.BoolPtr(true),
+			Kubeconfig:            pulumi.StringPtr(kubeconfig),
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = appsv1.NewDaemonSetPatch(ctx, "kube-proxy-image", &appsv1.DaemonSetPatchArgs{
+			Metadata: metav1.ObjectMetaPatchArgs{
+				Name:      pulumi.String("kube-proxy"),
+				Namespace: pulumi.String("kube-system"),
+				Annotations: pulumi.StringMap{
+					"pulumi.com/patchForce": pulumi.String("true"),
+				},
+			},
+			Spec: appsv1.DaemonSetSpecPatchArgs{
+				Template: corev1.PodTemplateSpecPatchArgs{
+					Spec: corev1.PodSpecPatchArgs{
+						Containers: corev1.ContainerPatchArray{
+							corev1.ContainerPatchArgs{
+								Name:  pulumi.String("kube-proxy"),
+								Image: pulumi.String("registry.k8s.io/kube-proxy:v1.27.1"),
+								Command: pulumi.StringArray{
+									pulumi.String("/usr/local/bin/kube-proxy"),
+									pulumi.String("--config=/var/lib/kube-proxy/config.conf"),
+									pulumi.String("--hostname-override=$(NODE_NAME)"),
+									pulumi.String("--v=2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}, pulumi.Provider(provider), pulumi.RetainOnDelete(true))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -25,18 +25,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/openapi"
 	"github.com/pulumi/pulumi-kubernetes/tests/v4"
+	"github.com/pulumi/pulumi-kubernetes/tests/v4/cluster"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -2004,6 +2007,84 @@ func TestEmptyItemNormalization(t *testing.T) {
 			},
 		},
 		ExtraRuntimeValidation: validateProgram(false),
+	})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestPatchForceWithDaemonSet(t *testing.T) {
+	// Create and use a kind cluster since this test interacts with the kube-proxy resource.
+	kubecfg := cluster.NewKindCluster(t, t.Name())
+
+	// Create a tmp dir to store the kube-proxy manifest we'll fetch from the cluster.
+	tmpDir, err := os.MkdirTemp("", "test-daemon-set")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		log.Println("Deleting kubeconfig tmp dir")
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	})
+
+	// Fetch the kube-proxy manifest from the cluster.
+	kubeProxyManifest, err := tests.Kubectl("get daemonset kube-proxy -n kube-system -o yaml --kubeconfig", kubecfg)
+	require.NoError(t, err)
+
+	// Patch the kube-proxy manifest to a different container image.
+	regex := regexp.MustCompile(`registry.k8s.io\/kube-proxy:v\d\.\d+\.3`)
+	newManifest := regex.ReplaceAllString(string(kubeProxyManifest), "registry.k8s.io/kube-proxy:v1.27.2")
+	// Write the patched kube-proxy manifest to a file.
+	err = os.WriteFile(filepath.Join(tmpDir, "kube-proxy.yaml"), []byte(newManifest), 0644)
+	require.NoError(t, err)
+
+	// Patch the kube-proxy daemonset with the patched manifest using kubectl-client-side-apply.
+	_, err = tests.Kubectl("apply -f", filepath.Join(tmpDir, "kube-proxy.yaml"), "--kubeconfig", kubecfg)
+	require.NoError(t, err)
+
+	// Ensure the kube-proxy daemonset was updated with the new image.
+	kubeProxyImage, err := tests.Kubectl("get daemonset kube-proxy -n kube-system -o=jsonpath={.spec.template.spec.containers[0].image} --kubeconfig", kubecfg)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/kube-proxy:v1.27.2", string(kubeProxyImage))
+
+	kubeProxyManifest, err = tests.Kubectl("get daemonset kube-proxy -n kube-system -o yaml --show-managed-fields --kubeconfig", kubecfg)
+	assert.NoError(t, err)
+	t.Logf("Obtained kube-proxy manifest from cluster: %s", string(kubeProxyManifest))
+
+	t.Log("Starting Pulumi program test")
+
+	// PULUMI PROGRAM TEST
+	test := baseOptions.With(integration.ProgramTestOptions{
+		Dir:                  filepath.Join("patch-force-patch-resource", "step1"),
+		ExpectRefreshChanges: false,
+		// Expect a field conflict error here.
+		ExpectFailure: true,
+		OrderedConfig: []integration.ConfigValue{
+			{
+				Key:   "pulumi:disable-default-providers[0]",
+				Value: "kubernetes",
+				Path:  true,
+			},
+		},
+		Environments: []string{"PULUMI_K8S_ENABLE_PATCH_FORCE="},
+		Config: map[string]string{
+			"kubeconfig": kubecfg,
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Log("Validating that the kube-proxy daemonset was not updated with the new image.")
+			kubeProxyImage, err := tests.Kubectl("get daemonset kube-proxy -n kube-system -o=jsonpath={.spec.template.spec.containers[0].image} --kubeconfig", kubecfg)
+			assert.NoError(t, err)
+			assert.Equal(t, "registry.k8s.io/kube-proxy:v1.27.2", string(kubeProxyImage))
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      filepath.Join("patch-force-patch-resource", "step2"),
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Log("Validating that the kube-proxy daemonset was updated with the new image.")
+					kubeProxyImage, err := tests.Kubectl("get daemonset kube-proxy -n kube-system -o=jsonpath={.spec.template.spec.containers[0].image} --kubeconfig", kubecfg)
+					assert.NoError(t, err)
+					assert.Equal(t, "registry.k8s.io/kube-proxy:v1.27.1", string(kubeProxyImage))
+				},
+			},
+		},
 	})
 
 	integration.ProgramTest(t, &test)

--- a/tests/sdk/nodejs/patch-force-patch-resource/step1/Pulumi.yaml
+++ b/tests/sdk/nodejs/patch-force-patch-resource/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: server-side-apply-tests
+description: Tests Server-side Apply support
+runtime: nodejs

--- a/tests/sdk/nodejs/patch-force-patch-resource/step1/index.ts
+++ b/tests/sdk/nodejs/patch-force-patch-resource/step1/index.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    kubeconfig: new pulumi.Config().require("kubeconfig"),
+});
+
+// Do not apply the patchForce annotation, and this step will fail.
+const patch = new k8s.apps.v1.DaemonSetPatch("kube-proxy-image", {
+    metadata: {
+        name: "kube-proxy",
+        namespace: "kube-system",
+    },
+    spec: {
+        template: {
+            spec: {
+                containers: [
+                    {
+                        name: "kube-proxy",
+                        image: "registry.k8s.io/kube-proxy:v1.27.1",
+                        command: [
+                            "/usr/local/bin/kube-proxy",
+                            "--config=/var/lib/kube-proxy/config.conf",
+                            "--hostname-override=$(NODE_NAME)",
+                            "--v=2",
+                        ],
+                    },
+                ],
+            },
+        },
+    },
+}, { provider, retainOnDelete: true });

--- a/tests/sdk/nodejs/patch-force-patch-resource/step1/package.json
+++ b/tests/sdk/nodejs/patch-force-patch-resource/step1/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "server-side-apply",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/patch-force-patch-resource/step1/tsconfig.json
+++ b/tests/sdk/nodejs/patch-force-patch-resource/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/sdk/nodejs/patch-force-patch-resource/step2/index.ts
+++ b/tests/sdk/nodejs/patch-force-patch-resource/step2/index.ts
@@ -1,0 +1,51 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create provider with SSA enabled.
+const provider = new k8s.Provider("k8s", {
+    enableServerSideApply: true,
+    kubeconfig: new pulumi.Config().require("kubeconfig"),
+});
+
+// Enable the patchForce annotation, and this step will succeed.
+const patch = new k8s.apps.v1.DaemonSetPatch("kube-proxy-image", {
+    metadata: {
+        name: "kube-proxy",
+        namespace: "kube-system",
+        annotations: {
+            "pulumi.com/patchForce": "true",
+        }
+    },
+    spec: {
+        template: {
+            spec: {
+                containers: [
+                    {
+                        name: "kube-proxy",
+                        image: "registry.k8s.io/kube-proxy:v1.27.1",
+                        command: [
+                            "/usr/local/bin/kube-proxy",
+                            "--config=/var/lib/kube-proxy/config.conf",
+                            "--hostname-override=$(NODE_NAME)",
+                            "--v=2",
+                        ],
+                    },
+                ],
+            },
+        },
+    },
+}, { provider, retainOnDelete: true });


### PR DESCRIPTION
This PR adds a test (`TestPatchForceWithDaemonSet`) in nodejs which tests out a DaemonSetPatch on a `kube-proxy` DaemonSet object with conflicting field managers. This PR also includes code to spin up a KinD cluster. The test runs against kind since we are interacting with `kube-system` objects and this allows isolation from other tests.

Steps the test does:

1. Spin up KinD cluster for tests
2. Use kubectl to fetch the latest `kube-proxy` manifest from the live cluster
3. Update the `.spec.template.spec.containers[0].image` field and re-apply to cluster using kubectl client side apply to change field owners
4. Run step 1 of the Pulumi program test, this attempts to update `.spec.template.spec.containers[0].image` and `.spec.template.spec.containers[0].command` WITHOUT the `pulumi.com/patchForce=true` annotation.
5. Expect test failure
6. Run step 2 of the Pulumi program test which updates `.spec.template.spec.containers[0].image` and `.spec.template.spec.containers[0].command` WITH the `pulumi.com/patchForce=true` annotation.
7. Verify that the fields are successfully updated

This test confirms that without setting the patchForce annotation, the `pulumi up` step fails since there is a field conflict error. It is only with the patchForce annotation that `pulumi up` succeeds.


The field manager conflict error that occurs from step 2:
```
  kubernetes:apps/v1:DaemonSetPatch (kube-proxy-image):
    error: resource kube-system/kube-proxy was not successfully created by the Kubernetes API server : Server-Side Apply field conflict detected. see https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/#handle-field-conflicts-on-existing-resources for troubleshooting help
    : Apply failed with 2 conflicts: conflicts with "kubeadm" using apps/v1:
    - .spec.template.spec.containers[name="kube-proxy"].command
    conflicts with "kubectl-client-side-apply" using apps/v1:
    - .spec.template.spec.containers[name="kube-proxy"].image
```
Related: #2629