### PR TITLE
Helm OCI chart deployment fails in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix: Helm OCI chart deployment fails in Windows (https://github.com/pulumi/pulumi-kubernetes/pull/2648)
 
 ## 4.5.4 (November 8, 2023)
 - Fix: Helm Release: chart requires kubeVersion (https://github.com/pulumi/pulumi-kubernetes/pull/2653)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1536,15 +1536,12 @@ func getChart(cpo *action.ChartPathOptions, registryClient *registry.Client, set
 func localChart(name string, verify bool, keyring string) (string, bool, error) {
 	fi, err := os.Stat(name)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", false, nil
-		}
-
-		return "", false, err
+		// Helm eats all errors at this point.
+		return "", false, nil
 	}
 
 	// If a folder is of the same name as a chart, use the folder if it contains a Chart.yaml.
-	if err == nil && fi.IsDir() {
+	if fi.IsDir() {
 		if _, err := os.Stat(filepath.Join(name, "Chart.yaml")); err != nil {
 			// This is not a chart directory, so do not error as Helm could still
 			// resolve this as a locally added chart repository, eg. `helm repo add`.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Closes #2644 

This PR fixes support for OCI charts on Windows, by making the code be more consistent with Helm (see [code](https://github.com/helm/helm/blob/main/pkg/action/install.go#L724)). I believe the error comes from the call to `os.Stat` (see Golang implementation which is based on CreateFile, [here](https://go.dev/src/os/stat_windows.go)).

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
