### PR TITLE
Helm Release: populate ApiVersions and KubeVersion during templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix: Update pulumi version to 3.91.1 to pick up fixes in python codegen (https://github.com/pulumi/pulumi-kubernetes/pull/2647)
+- Fix: Helm Release: chart requires kubeVersion (https://github.com/pulumi/pulumi-kubernetes/pull/2653)
 
 ## 4.5.2 (October 26, 2023)
 - Fix: Do not patch field managers for Patch resources (https://github.com/pulumi/pulumi-kubernetes/pull/2640)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -522,6 +522,10 @@ func (r *helmReleaseProvider) helmTemplate(ctx context.Context, urn resource.URN
 		client.PostRenderer = pr
 	}
 
+	if r.clientSet != nil {
+		setKubeVersionAndAPIVersions(r.clientSet, client)
+	}
+
 	logger.V(9).Infof("template helm chart")
 	rel, err := client.RunWithContext(r.canceler.context, c, values)
 	if err != nil {

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -523,7 +523,10 @@ func (r *helmReleaseProvider) helmTemplate(ctx context.Context, urn resource.URN
 	}
 
 	if r.clientSet != nil {
-		setKubeVersionAndAPIVersions(r.clientSet, client)
+		err = setKubeVersionAndAPIVersions(r.clientSet, client)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	logger.V(9).Infof("template helm chart")

--- a/provider/pkg/provider/invoke_helm_template.go
+++ b/provider/pkg/provider/invoke_helm_template.go
@@ -258,7 +258,10 @@ func (c *chart) template(clientSet *clients.DynamicClientSet) (string, error) {
 	}
 
 	if clientSet != nil {
-		setKubeVersionAndAPIVersions(clientSet, installAction)
+		err = setKubeVersionAndAPIVersions(clientSet, installAction)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	chartName, err := func() (string, error) {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR passes kubeVersion and apiVersions info from the server to Helm to fix a regression that occurred in https://github.com/pulumi/pulumi-kubernetes/pull/2568.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2631