### PR TITLE
Helm Release: kubeVersion/apiVersions properties

### DIFF
--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -679,6 +679,21 @@ var helmV3ReleaseResource = pschema.ResourceSpec{
 				},
 				Description: "Whether to allow Null values in helm chart configs.",
 			},
+			"apiVersions": {
+				TypeSpec: pschema.TypeSpec{
+					Type: "array",
+					Items: &pschema.TypeSpec{
+						Type: "string",
+					},
+				},
+				Description: "The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.",
+			},
+			"kubeVersion": {
+				TypeSpec: pschema.TypeSpec{
+					Type: "string",
+				},
+				Description: "Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.",
+			},
 		},
 		Type: "object",
 		Required: []string{
@@ -950,6 +965,21 @@ var helmV3ReleaseResource = pschema.ResourceSpec{
 				Type: "boolean",
 			},
 			Description: "Whether to allow Null values in helm chart configs.",
+		},
+		"apiVersions": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "array",
+				Items: &pschema.TypeSpec{
+					Type: "string",
+				},
+			},
+			Description: "The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.",
+		},
+		"kubeVersion": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "string",
+			},
+			Description: "Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.",
 		},
 	},
 	RequiredInputs: []string{

--- a/sdk/dotnet/Helm/V3/Release.cs
+++ b/sdk/dotnet/Helm/V3/Release.cs
@@ -260,6 +260,12 @@ namespace Pulumi.Kubernetes.Helm.V3
         public Output<bool> AllowNullValues { get; private set; } = null!;
 
         /// <summary>
+        /// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+        /// </summary>
+        [Output("apiVersions")]
+        public Output<ImmutableArray<string>> ApiVersions { get; private set; } = null!;
+
+        /// <summary>
         /// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         /// </summary>
         [Output("atomic")]
@@ -330,6 +336,12 @@ namespace Pulumi.Kubernetes.Helm.V3
         /// </summary>
         [Output("keyring")]
         public Output<string> Keyring { get; private set; } = null!;
+
+        /// <summary>
+        /// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+        /// </summary>
+        [Output("kubeVersion")]
+        public Output<string> KubeVersion { get; private set; } = null!;
 
         /// <summary>
         /// Run helm lint when planning.
@@ -528,6 +540,18 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
         [Input("allowNullValues")]
         public Input<bool>? AllowNullValues { get; set; }
 
+        [Input("apiVersions")]
+        private InputList<string>? _apiVersions;
+
+        /// <summary>
+        /// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+        /// </summary>
+        public InputList<string> ApiVersions
+        {
+            get => _apiVersions ?? (_apiVersions = new InputList<string>());
+            set => _apiVersions = value;
+        }
+
         /// <summary>
         /// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         /// </summary>
@@ -602,6 +626,12 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
         /// </summary>
         [Input("keyring")]
         public Input<string>? Keyring { get; set; }
+
+        /// <summary>
+        /// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+        /// </summary>
+        [Input("kubeVersion")]
+        public Input<string>? KubeVersion { get; set; }
 
         /// <summary>
         /// Run helm lint when planning.

--- a/sdk/go/kubernetes/helm/v3/release.go
+++ b/sdk/go/kubernetes/helm/v3/release.go
@@ -300,6 +300,8 @@ type Release struct {
 
 	// Whether to allow Null values in helm chart configs.
 	AllowNullValues pulumi.BoolPtrOutput `pulumi:"allowNullValues"`
+	// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+	ApiVersions pulumi.StringArrayOutput `pulumi:"apiVersions"`
 	// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 	Atomic pulumi.BoolPtrOutput `pulumi:"atomic"`
 	// Chart name to be installed. A path may be used.
@@ -324,6 +326,8 @@ type Release struct {
 	ForceUpdate pulumi.BoolPtrOutput `pulumi:"forceUpdate"`
 	// Location of public keys used for verification. Used only if `verify` is true
 	Keyring pulumi.StringPtrOutput `pulumi:"keyring"`
+	// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+	KubeVersion pulumi.StringPtrOutput `pulumi:"kubeVersion"`
 	// Run helm lint when planning.
 	Lint pulumi.BoolPtrOutput `pulumi:"lint"`
 	// The rendered manifests as JSON. Not yet supported.
@@ -416,6 +420,8 @@ func (ReleaseState) ElementType() reflect.Type {
 type releaseArgs struct {
 	// Whether to allow Null values in helm chart configs.
 	AllowNullValues *bool `pulumi:"allowNullValues"`
+	// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+	ApiVersions []string `pulumi:"apiVersions"`
 	// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 	Atomic *bool `pulumi:"atomic"`
 	// Chart name to be installed. A path may be used.
@@ -441,6 +447,8 @@ type releaseArgs struct {
 	ForceUpdate *bool `pulumi:"forceUpdate"`
 	// Location of public keys used for verification. Used only if `verify` is true
 	Keyring *string `pulumi:"keyring"`
+	// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+	KubeVersion *string `pulumi:"kubeVersion"`
 	// Run helm lint when planning.
 	Lint *bool `pulumi:"lint"`
 	// The rendered manifests as JSON. Not yet supported.
@@ -489,6 +497,8 @@ type releaseArgs struct {
 type ReleaseArgs struct {
 	// Whether to allow Null values in helm chart configs.
 	AllowNullValues pulumi.BoolPtrInput
+	// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+	ApiVersions pulumi.StringArrayInput
 	// If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 	Atomic pulumi.BoolPtrInput
 	// Chart name to be installed. A path may be used.
@@ -514,6 +524,8 @@ type ReleaseArgs struct {
 	ForceUpdate pulumi.BoolPtrInput
 	// Location of public keys used for verification. Used only if `verify` is true
 	Keyring pulumi.StringPtrInput
+	// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+	KubeVersion pulumi.StringPtrInput
 	// Run helm lint when planning.
 	Lint pulumi.BoolPtrInput
 	// The rendered manifests as JSON. Not yet supported.
@@ -674,6 +686,11 @@ func (o ReleaseOutput) AllowNullValues() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Release) pulumi.BoolPtrOutput { return v.AllowNullValues }).(pulumi.BoolPtrOutput)
 }
 
+// The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+func (o ReleaseOutput) ApiVersions() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Release) pulumi.StringArrayOutput { return v.ApiVersions }).(pulumi.StringArrayOutput)
+}
+
 // If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
 func (o ReleaseOutput) Atomic() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Release) pulumi.BoolPtrOutput { return v.Atomic }).(pulumi.BoolPtrOutput)
@@ -732,6 +749,11 @@ func (o ReleaseOutput) ForceUpdate() pulumi.BoolPtrOutput {
 // Location of public keys used for verification. Used only if `verify` is true
 func (o ReleaseOutput) Keyring() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Release) pulumi.StringPtrOutput { return v.Keyring }).(pulumi.StringPtrOutput)
+}
+
+// Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+func (o ReleaseOutput) KubeVersion() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Release) pulumi.StringPtrOutput { return v.KubeVersion }).(pulumi.StringPtrOutput)
 }
 
 // Run helm lint when planning.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/Release.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/Release.java
@@ -57,6 +57,20 @@ public class Release extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.allowNullValues);
     }
     /**
+     * The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     * 
+     */
+    @Export(name="apiVersions", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> apiVersions;
+
+    /**
+     * @return The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     * 
+     */
+    public Output<Optional<List<String>>> apiVersions() {
+        return Codegen.optional(this.apiVersions);
+    }
+    /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      * 
      */
@@ -223,6 +237,20 @@ public class Release extends com.pulumi.resources.CustomResource {
      */
     public Output<Optional<String>> keyring() {
         return Codegen.optional(this.keyring);
+    }
+    /**
+     * Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     * 
+     */
+    @Export(name="kubeVersion", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> kubeVersion;
+
+    /**
+     * @return Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     * 
+     */
+    public Output<Optional<String>> kubeVersion() {
+        return Codegen.optional(this.kubeVersion);
     }
     /**
      * Run helm lint when planning.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
@@ -39,6 +39,21 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     * 
+     */
+    @Import(name="apiVersions")
+    private @Nullable Output<List<String>> apiVersions;
+
+    /**
+     * @return The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     * 
+     */
+    public Optional<Output<List<String>>> apiVersions() {
+        return Optional.ofNullable(this.apiVersions);
+    }
+
+    /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      * 
      */
@@ -223,6 +238,21 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<String>> keyring() {
         return Optional.ofNullable(this.keyring);
+    }
+
+    /**
+     * Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     * 
+     */
+    @Import(name="kubeVersion")
+    private @Nullable Output<String> kubeVersion;
+
+    /**
+     * @return Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     * 
+     */
+    public Optional<Output<String>> kubeVersion() {
+        return Optional.ofNullable(this.kubeVersion);
     }
 
     /**
@@ -544,6 +574,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
 
     private ReleaseArgs(ReleaseArgs $) {
         this.allowNullValues = $.allowNullValues;
+        this.apiVersions = $.apiVersions;
         this.atomic = $.atomic;
         this.chart = $.chart;
         this.cleanupOnFail = $.cleanupOnFail;
@@ -557,6 +588,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
         this.disableWebhooks = $.disableWebhooks;
         this.forceUpdate = $.forceUpdate;
         this.keyring = $.keyring;
+        this.kubeVersion = $.kubeVersion;
         this.lint = $.lint;
         this.manifest = $.manifest;
         this.maxHistory = $.maxHistory;
@@ -617,6 +649,37 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder allowNullValues(Boolean allowNullValues) {
             return allowNullValues(Output.of(allowNullValues));
+        }
+
+        /**
+         * @param apiVersions The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder apiVersions(@Nullable Output<List<String>> apiVersions) {
+            $.apiVersions = apiVersions;
+            return this;
+        }
+
+        /**
+         * @param apiVersions The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder apiVersions(List<String> apiVersions) {
+            return apiVersions(Output.of(apiVersions));
+        }
+
+        /**
+         * @param apiVersions The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder apiVersions(String... apiVersions) {
+            return apiVersions(List.of(apiVersions));
         }
 
         /**
@@ -878,6 +941,27 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder keyring(String keyring) {
             return keyring(Output.of(keyring));
+        }
+
+        /**
+         * @param kubeVersion Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeVersion(@Nullable Output<String> kubeVersion) {
+            $.kubeVersion = kubeVersion;
+            return this;
+        }
+
+        /**
+         * @param kubeVersion Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeVersion(String kubeVersion) {
+            return kubeVersion(Output.of(kubeVersion));
         }
 
         /**

--- a/sdk/nodejs/helm/v3/release.ts
+++ b/sdk/nodejs/helm/v3/release.ts
@@ -190,6 +190,10 @@ export class Release extends pulumi.CustomResource {
      */
     public readonly allowNullValues!: pulumi.Output<boolean>;
     /**
+     * The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     */
+    public readonly apiVersions!: pulumi.Output<string[]>;
+    /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      */
     public readonly atomic!: pulumi.Output<boolean>;
@@ -237,6 +241,10 @@ export class Release extends pulumi.CustomResource {
      * Location of public keys used for verification. Used only if `verify` is true
      */
     public readonly keyring!: pulumi.Output<string>;
+    /**
+     * Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     */
+    public readonly kubeVersion!: pulumi.Output<string>;
     /**
      * Run helm lint when planning.
      */
@@ -341,6 +349,7 @@ export class Release extends pulumi.CustomResource {
                 throw new Error("Missing required property 'chart'");
             }
             resourceInputs["allowNullValues"] = args ? args.allowNullValues : undefined;
+            resourceInputs["apiVersions"] = args ? args.apiVersions : undefined;
             resourceInputs["atomic"] = args ? args.atomic : undefined;
             resourceInputs["chart"] = args ? args.chart : undefined;
             resourceInputs["cleanupOnFail"] = args ? args.cleanupOnFail : undefined;
@@ -354,6 +363,7 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["disableWebhooks"] = args ? args.disableWebhooks : undefined;
             resourceInputs["forceUpdate"] = args ? args.forceUpdate : undefined;
             resourceInputs["keyring"] = args ? args.keyring : undefined;
+            resourceInputs["kubeVersion"] = args ? args.kubeVersion : undefined;
             resourceInputs["lint"] = args ? args.lint : undefined;
             resourceInputs["manifest"] = args ? args.manifest : undefined;
             resourceInputs["maxHistory"] = args ? args.maxHistory : undefined;
@@ -378,6 +388,7 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["status"] = undefined /*out*/;
         } else {
             resourceInputs["allowNullValues"] = undefined /*out*/;
+            resourceInputs["apiVersions"] = undefined /*out*/;
             resourceInputs["atomic"] = undefined /*out*/;
             resourceInputs["chart"] = undefined /*out*/;
             resourceInputs["cleanupOnFail"] = undefined /*out*/;
@@ -390,6 +401,7 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["disableWebhooks"] = undefined /*out*/;
             resourceInputs["forceUpdate"] = undefined /*out*/;
             resourceInputs["keyring"] = undefined /*out*/;
+            resourceInputs["kubeVersion"] = undefined /*out*/;
             resourceInputs["lint"] = undefined /*out*/;
             resourceInputs["manifest"] = undefined /*out*/;
             resourceInputs["maxHistory"] = undefined /*out*/;
@@ -426,6 +438,10 @@ export interface ReleaseArgs {
      * Whether to allow Null values in helm chart configs.
      */
     allowNullValues?: pulumi.Input<boolean>;
+    /**
+     * The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+     */
+    apiVersions?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
      */
@@ -475,6 +491,10 @@ export interface ReleaseArgs {
      * Location of public keys used for verification. Used only if `verify` is true
      */
     keyring?: pulumi.Input<string>;
+    /**
+     * Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+     */
+    kubeVersion?: pulumi.Input<string>;
     /**
      * Run helm lint when planning.
      */

--- a/sdk/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/Release.py
@@ -18,6 +18,7 @@ class ReleaseArgs:
     def __init__(__self__, *,
                  chart: pulumi.Input[str],
                  allow_null_values: Optional[pulumi.Input[bool]] = None,
+                 api_versions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
                  compat: Optional[pulumi.Input[str]] = None,
@@ -30,6 +31,7 @@ class ReleaseArgs:
                  disable_webhooks: Optional[pulumi.Input[bool]] = None,
                  force_update: Optional[pulumi.Input[bool]] = None,
                  keyring: Optional[pulumi.Input[str]] = None,
+                 kube_version: Optional[pulumi.Input[str]] = None,
                  lint: Optional[pulumi.Input[bool]] = None,
                  manifest: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  max_history: Optional[pulumi.Input[int]] = None,
@@ -55,6 +57,7 @@ class ReleaseArgs:
         The set of arguments for constructing a Release resource.
         :param pulumi.Input[str] chart: Chart name to be installed. A path may be used.
         :param pulumi.Input[bool] allow_null_values: Whether to allow Null values in helm chart configs.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] api_versions: The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
         :param pulumi.Input[bool] atomic: If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         :param pulumi.Input[bool] cleanup_on_fail: Allow deletion of new resources created in this upgrade when upgrade fails.
         :param pulumi.Input[bool] create_namespace: Create the namespace if it does not exist.
@@ -66,6 +69,7 @@ class ReleaseArgs:
         :param pulumi.Input[bool] disable_webhooks: Prevent hooks from running.
         :param pulumi.Input[bool] force_update: Force resource update through delete/recreate if needed.
         :param pulumi.Input[str] keyring: Location of public keys used for verification. Used only if `verify` is true
+        :param pulumi.Input[str] kube_version: Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
         :param pulumi.Input[bool] lint: Run helm lint when planning.
         :param pulumi.Input[Mapping[str, Any]] manifest: The rendered manifests as JSON. Not yet supported.
         :param pulumi.Input[int] max_history: Limit the maximum number of revisions saved per release. Use 0 for no limit.
@@ -91,6 +95,8 @@ class ReleaseArgs:
         pulumi.set(__self__, "chart", chart)
         if allow_null_values is not None:
             pulumi.set(__self__, "allow_null_values", allow_null_values)
+        if api_versions is not None:
+            pulumi.set(__self__, "api_versions", api_versions)
         if atomic is not None:
             pulumi.set(__self__, "atomic", atomic)
         if cleanup_on_fail is not None:
@@ -115,6 +121,8 @@ class ReleaseArgs:
             pulumi.set(__self__, "force_update", force_update)
         if keyring is not None:
             pulumi.set(__self__, "keyring", keyring)
+        if kube_version is not None:
+            pulumi.set(__self__, "kube_version", kube_version)
         if lint is not None:
             pulumi.set(__self__, "lint", lint)
         if manifest is not None:
@@ -181,6 +189,18 @@ class ReleaseArgs:
     @allow_null_values.setter
     def allow_null_values(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "allow_null_values", value)
+
+    @property
+    @pulumi.getter(name="apiVersions")
+    def api_versions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+        """
+        return pulumi.get(self, "api_versions")
+
+    @api_versions.setter
+    def api_versions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "api_versions", value)
 
     @property
     @pulumi.getter
@@ -322,6 +342,18 @@ class ReleaseArgs:
     @keyring.setter
     def keyring(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "keyring", value)
+
+    @property
+    @pulumi.getter(name="kubeVersion")
+    def kube_version(self) -> Optional[pulumi.Input[str]]:
+        """
+        Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+        """
+        return pulumi.get(self, "kube_version")
+
+    @kube_version.setter
+    def kube_version(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "kube_version", value)
 
     @property
     @pulumi.getter
@@ -582,6 +614,7 @@ class Release(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_null_values: Optional[pulumi.Input[bool]] = None,
+                 api_versions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  chart: Optional[pulumi.Input[str]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
@@ -595,6 +628,7 @@ class Release(pulumi.CustomResource):
                  disable_webhooks: Optional[pulumi.Input[bool]] = None,
                  force_update: Optional[pulumi.Input[bool]] = None,
                  keyring: Optional[pulumi.Input[str]] = None,
+                 kube_version: Optional[pulumi.Input[str]] = None,
                  lint: Optional[pulumi.Input[bool]] = None,
                  manifest: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  max_history: Optional[pulumi.Input[int]] = None,
@@ -783,6 +817,7 @@ class Release(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] allow_null_values: Whether to allow Null values in helm chart configs.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] api_versions: The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
         :param pulumi.Input[bool] atomic: If set, installation process purges chart on fail. `skipAwait` will be disabled automatically if atomic is used.
         :param pulumi.Input[str] chart: Chart name to be installed. A path may be used.
         :param pulumi.Input[bool] cleanup_on_fail: Allow deletion of new resources created in this upgrade when upgrade fails.
@@ -795,6 +830,7 @@ class Release(pulumi.CustomResource):
         :param pulumi.Input[bool] disable_webhooks: Prevent hooks from running.
         :param pulumi.Input[bool] force_update: Force resource update through delete/recreate if needed.
         :param pulumi.Input[str] keyring: Location of public keys used for verification. Used only if `verify` is true
+        :param pulumi.Input[str] kube_version: Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
         :param pulumi.Input[bool] lint: Run helm lint when planning.
         :param pulumi.Input[Mapping[str, Any]] manifest: The rendered manifests as JSON. Not yet supported.
         :param pulumi.Input[int] max_history: Limit the maximum number of revisions saved per release. Use 0 for no limit.
@@ -1002,6 +1038,7 @@ class Release(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_null_values: Optional[pulumi.Input[bool]] = None,
+                 api_versions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  atomic: Optional[pulumi.Input[bool]] = None,
                  chart: Optional[pulumi.Input[str]] = None,
                  cleanup_on_fail: Optional[pulumi.Input[bool]] = None,
@@ -1015,6 +1052,7 @@ class Release(pulumi.CustomResource):
                  disable_webhooks: Optional[pulumi.Input[bool]] = None,
                  force_update: Optional[pulumi.Input[bool]] = None,
                  keyring: Optional[pulumi.Input[str]] = None,
+                 kube_version: Optional[pulumi.Input[str]] = None,
                  lint: Optional[pulumi.Input[bool]] = None,
                  manifest: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  max_history: Optional[pulumi.Input[int]] = None,
@@ -1046,6 +1084,7 @@ class Release(pulumi.CustomResource):
             __props__ = ReleaseArgs.__new__(ReleaseArgs)
 
             __props__.__dict__["allow_null_values"] = allow_null_values
+            __props__.__dict__["api_versions"] = api_versions
             __props__.__dict__["atomic"] = atomic
             if chart is None and not opts.urn:
                 raise TypeError("Missing required property 'chart'")
@@ -1061,6 +1100,7 @@ class Release(pulumi.CustomResource):
             __props__.__dict__["disable_webhooks"] = disable_webhooks
             __props__.__dict__["force_update"] = force_update
             __props__.__dict__["keyring"] = keyring
+            __props__.__dict__["kube_version"] = kube_version
             __props__.__dict__["lint"] = lint
             __props__.__dict__["manifest"] = manifest
             __props__.__dict__["max_history"] = max_history
@@ -1106,6 +1146,7 @@ class Release(pulumi.CustomResource):
         __props__ = ReleaseArgs.__new__(ReleaseArgs)
 
         __props__.__dict__["allow_null_values"] = None
+        __props__.__dict__["api_versions"] = None
         __props__.__dict__["atomic"] = None
         __props__.__dict__["chart"] = None
         __props__.__dict__["cleanup_on_fail"] = None
@@ -1118,6 +1159,7 @@ class Release(pulumi.CustomResource):
         __props__.__dict__["disable_webhooks"] = None
         __props__.__dict__["force_update"] = None
         __props__.__dict__["keyring"] = None
+        __props__.__dict__["kube_version"] = None
         __props__.__dict__["lint"] = None
         __props__.__dict__["manifest"] = None
         __props__.__dict__["max_history"] = None
@@ -1149,6 +1191,14 @@ class Release(pulumi.CustomResource):
         Whether to allow Null values in helm chart configs.
         """
         return pulumi.get(self, "allow_null_values")
+
+    @property
+    @pulumi.getter(name="apiVersions")
+    def api_versions(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        """
+        The optional Kubernetes API versions used for Capabilities.APIVersions. By default is detected from the server.
+        """
+        return pulumi.get(self, "api_versions")
 
     @property
     @pulumi.getter
@@ -1245,6 +1295,14 @@ class Release(pulumi.CustomResource):
         Location of public keys used for verification. Used only if `verify` is true
         """
         return pulumi.get(self, "keyring")
+
+    @property
+    @pulumi.getter(name="kubeVersion")
+    def kube_version(self) -> pulumi.Output[Optional[str]]:
+        """
+        Overrides the Kubernetes version used for Capabilities.KubeVersion. By default is detected from the server.
+        """
+        return pulumi.get(self, "kube_version")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR is a follow-up to https://github.com/pulumi/pulumi-kubernetes/pull/2593 to add `kubeVersion` and `apiVersions` to the Helm Release object.

Note that the properties are applicable only during templating; Helm seems to always use server detection in the actual install/upgrade operation.

~A possible enhancement to be considered is to automatically incorporate the CRD information into the `Capabiltiies.APIVersions` that are used during templating. Imagine that the chart includes some CRDs that aren't yet installed on the server, what is the templating behavior?  Helm itself doesn't seem to solve it.~

<!--Give us a brief description of what you've done and what it solves. -->
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2563

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
