### PR TITLE
Fix Helm Chart resource lookup key handling for objects in default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## Unreleased
 - Fix: Helm OCI chart deployment fails in Windows (https://github.com/pulumi/pulumi-kubernetes/pull/2648)
-
 - Fix: compute version field in Check for content detection (https://github.com/pulumi/pulumi-kubernetes/pull/2672)
-
 - Fix: Fix: Helm Release fails with "the server could not find the requested resource" (https://github.com/pulumi/pulumi-kubernetes/pull/2677)
-
+- Fix Helm Chart resource lookup key handling for objects in default namespace (https://github.com/pulumi/pulumi-kubernetes/pull/2655)
 
 ## 4.5.5 (November 28, 2023)
 - Fix: Make the invoke calls for Helm charts and YAML config resilient to the value being None or an empty dict (https://github.com/pulumi/pulumi-kubernetes/pull/2665)

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -769,4 +769,21 @@ func TestGo(t *testing.T) {
 		})
 		integration.ProgramTest(t, &test)
 	})
+
+	// Test to ensure that we can get a resource from the default namespace. This uses the wordpress chart as it requires the
+	// default namespace to be present in the GVK get request.
+	t.Run("ChartGetResource", func(t *testing.T) {
+		options := baseOptions.With(integration.ProgramTestOptions{
+			Dir:   filepath.Join(cwd, "helm-get-default-namespace", "step1"),
+			Quick: true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:             filepath.Join(cwd, "helm-get-default-namespace", "step2"),
+					Additive:        true,
+					ExpectNoChanges: false,
+				},
+			},
+		})
+		integration.ProgramTest(t, &options)
+	})
 }

--- a/tests/sdk/go/helm-get-default-namespace/step1/Pulumi.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: go_helm_local_kubernetes
+description: Test Kubernetes Helm package with local Chart.
+runtime: go

--- a/tests/sdk/go/helm-get-default-namespace/step1/local-chart/.helmignore
+++ b/tests/sdk/go/helm-get-default-namespace/step1/local-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tests/sdk/go/helm-get-default-namespace/step1/local-chart/Chart.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step1/local-chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: local-test-chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/tests/sdk/go/helm-get-default-namespace/step1/local-chart/templates/_helpers.tpl
+++ b/tests/sdk/go/helm-get-default-namespace/step1/local-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "local-test-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "local-test-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "local-test-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "local-test-chart.labels" -}}
+helm.sh/chart: {{ include "local-test-chart.chart" . }}
+{{ include "local-test-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "local-test-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "local-test-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "local-test-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "local-test-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tests/sdk/go/helm-get-default-namespace/step1/local-chart/templates/deployment.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step1/local-chart/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "local-test-chart.fullname" . }}
+  labels:
+    {{- include "local-test-chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "local-test-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "local-test-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http

--- a/tests/sdk/go/helm-get-default-namespace/step1/local-chart/values.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step1/local-chart/values.yaml
@@ -1,0 +1,15 @@
+# Default values for local-test-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""

--- a/tests/sdk/go/helm-get-default-namespace/step1/main.go
+++ b/tests/sdk/go/helm-get-default-namespace/step1/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		chart, err := helm.NewChart(ctx, "test-get-default-object", helm.ChartArgs{
+			Path:    pulumi.String("local-chart"),
+			Version: pulumi.String("0.1.0"),
+		})
+		if err != nil {
+			return err
+		}
+
+		// // Get the deployment spec from the chart, with implicit default namespace.
+		_ = chart.GetResource("apps/v1/Deployment", "test-get-default-object-local-test-chart", "").
+			ApplyT(func(r any) (any, error) {
+				dep := r.(*appsv1.Deployment)
+				return dep.Spec, nil
+			})
+
+		// Get the deployment spec from the chart, with explicit default namespace.
+		_ = chart.GetResource("apps/v1/Deployment", "test-get-default-object-local-test-chart", "default").
+			ApplyT(func(r any) (any, error) {
+				dep := r.(*appsv1.Deployment)
+				return dep.Spec, nil
+			})
+
+		return nil
+	})
+}

--- a/tests/sdk/go/helm-get-default-namespace/step2/Pulumi.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step2/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: go_helm_local_kubernetes
+description: Test Kubernetes Helm package with local Chart.
+runtime: go

--- a/tests/sdk/go/helm-get-default-namespace/step2/local-chart/Chart.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step2/local-chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: local-test-chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/tests/sdk/go/helm-get-default-namespace/step2/local-chart/templates/deployment.yaml
+++ b/tests/sdk/go/helm-get-default-namespace/step2/local-chart/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "local-test-chart.fullname" . }}-new
+  namespace: {{ .Release.Namespace }} # This is what causes the difference when needing to specify a namespace or not during templating.
+  labels:
+    {{- include "local-test-chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "local-test-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "local-test-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http

--- a/tests/sdk/go/helm-get-default-namespace/step2/main.go
+++ b/tests/sdk/go/helm-get-default-namespace/step2/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		chart, err := helm.NewChart(ctx, "test-get-default-object", helm.ChartArgs{
+			Path:    pulumi.String("local-chart"),
+			Version: pulumi.String("0.1.1"), // Trigger a Helm upgrade. This version contains the explicit default namespace for the resource manifest.
+		})
+		if err != nil {
+			return err
+		}
+
+		// Get the deployment spec from the chart, with implicit default namespace.
+		_ = chart.GetResource("apps/v1/Deployment", "test-get-default-object-local-test-chart-new", "").
+			ApplyT(func(r any) (any, error) {
+				dep := r.(*appsv1.Deployment)
+				return dep.Spec, nil
+			})
+
+		// Get the deployment spec from the chart, with explicit default namespace.
+		_ = chart.GetResource("apps/v1/Deployment", "test-get-default-object-local-test-chart-new", "default").
+			ApplyT(func(r any) (any, error) {
+				dep := r.(*appsv1.Deployment)
+				return dep.Spec, nil
+			})
+
+		return nil
+	})
+}


### PR DESCRIPTION
### Proposed changes

This pull request modifies the `GetResource` Go method for the Helm Chart resource. Previously, when a resource was deployed to the default namespace, the `default` namespace was always omitted from the resource lookup key. However, in cases where the namespace is explicitly defined in the Helm chart template, the `default` namespace was inadvertently excluded from the resource lookup key despite it being needed. This behavior in Helm is documented in the upstream issue: https://github.com/helm/helm/issues/3553.

**Changes Made:**
- Implemented a fallback mechanism to include the `default` namespace in the resource lookup key when necessary for the `GetResource` method.

**Test Added:**
- Added a test (`ChartGetResource`) to verify the `GetResource` method for both types of Helm charts—those with the explicitly defined default namespace and those without.

**Verification:**
- Verified that the modified `GetResource` method successfully handles scenarios where the namespace is explicitly defined in the Helm chart template.
- Confirmed that the added test covers both types of Helm charts and fails when the fallback logic is reverted.

### Related issues (optional)

Fixes: #2638