### PR TITLE
Updating helm.v3.chart to use the new dict format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Unreleased
 
-- Fix: Update pulumi version to 3.91.1 to pick up fixes in python codegen (https://github.com/pulumi/pulumi-kubernetes/pull/2647)
+- Fix: Helm Chart to support new invoke returning dict
+
+## 4.5.4 (November 8, 2023)
 - Fix: Helm Release: chart requires kubeVersion (https://github.com/pulumi/pulumi-kubernetes/pull/2653)
+
+## 4.5.3 (October 31, 2023)
+- Fix: Update pulumi version to 3.91.1 to pick up fixes in python codegen (https://github.com/pulumi/pulumi-kubernetes/pull/2647)
 
 ## 4.5.2 (October 26, 2023)
 - Fix: Do not patch field managers for Patch resources (https://github.com/pulumi/pulumi-kubernetes/pull/2640)

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -619,6 +619,14 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     def invoke_helm_template(opts):
         inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
-        return inv.value['result'] if inv is not None and inv.value is not None else []
+        return (
+            inv.value["result"]
+            if inv is not None
+            and (
+                inv.value is not None
+                or (type(inv.value) == dict and len(inv.value) != 0)
+            )
+            else []
+        )
     objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -619,6 +619,14 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     def invoke_helm_template(opts):
         inv = pulumi.runtime.invoke('kubernetes:helm:template', {'jsonOpts': opts}, invoke_opts)
-        return inv.value['result'] if inv is not None and inv.value is not None else []
+        return (
+            inv.value["result"]
+            if inv is not None
+            and (
+                inv.value is not None
+                or (type(inv.value) == dict and len(inv.value) != 0)
+            )
+            else []
+        )
     objects = json_opts.apply(invoke_helm_template)
     return objects.apply(lambda x: _parse_yaml_document(x, opts, transformations))


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
As of pulumi 3.92.0 we no longer support None being returned from InvokeOptions. This pr supports the new dict {} being returned as well as None being returned by older versions of the python sdk.


### Related issues (optional)
[**https://github.com/pulumi/pulumi/issues/14508**](https://github.com/pulumi/pulumi/issues/14508)
