### PR TITLE
Fix: Helm Release fails with "the server could not find the requested resource"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Fix: compute version field in Check for content detection (https://github.com/pulumi/pulumi-kubernetes/pull/2672)
 
+- Fix: Fix: Helm Release fails with "the server could not find the requested resource" (https://github.com/pulumi/pulumi-kubernetes/pull/2677)
+
 ## 4.5.4 (November 8, 2023)
 - Fix: Helm Release: chart requires kubeVersion (https://github.com/pulumi/pulumi-kubernetes/pull/2653)
 

--- a/provider/pkg/provider/kubeconfig.go
+++ b/provider/pkg/provider/kubeconfig.go
@@ -19,17 +19,19 @@ type KubeConfig struct {
 
 // ToDiscoveryClient implemented interface method
 func (k *KubeConfig) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	c := rest.CopyConfig(k.restConfig)
+
 	// The more groups you have, the more discovery requests you need to make.
 	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
-	k.restConfig.Burst = 100
+	c.Burst = 100
 
-	return clients.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(k.restConfig)), nil
+	return clients.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(c)), nil
 }
 
 // ToRESTConfig implemented interface method
 func (k *KubeConfig) ToRESTConfig() (*rest.Config, error) {
-	return k.restConfig, nil
+	return rest.CopyConfig(k.restConfig), nil
 }
 
 // ToRESTMapper implemented interface method


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

_Kudos to @cbley-da for identifying the root cause and to @pdf for suggesting a fix, [here](https://github.com/pulumi/pulumi-kubernetes/issues/2481#issuecomment-1628879174)!_

This PR fixes an intermittent problem that resembles:
```
 kubernetes:helm.sh/v3:Release (mongodb):
    error: 1 error occurred:
    	* Helm release "mongodb/mongodb-456643ba" failed to initialize completely. Use Helm CLI to investigate.: failed to become available within allocated timeout. Error: 
          Helm Release mongodb/mongodb-456643ba: release mongodb-456643ba failed, and has been rolled back due to atomic being set: 
          failed to create resource: the server could not find the requested resource
```

The problem was that a Go struct (containing a client-go rest config) was being shared and mutated by numerous independent routines.  The solution was to copy the struct.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #2481
