### PR TITLE
Remove unused `urn` output for helm Chart resources

### DIFF
--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -63,12 +63,6 @@ var helmV3ChartResource = pschema.ResourceSpec{
 				},
 				Description: "Resources created by the Chart.",
 			},
-			"urn": {
-				TypeSpec: pschema.TypeSpec{
-					Type: "string",
-				},
-				Description: "The stable logical URN used to distinctly address a resource, both before and after deployments.",
-			},
 		},
 		Type: "object",
 	},


### PR DESCRIPTION
### Proposed changes

Pulumi v3.95 enforces strict validation that reserves `urn` and `id` for their own usage. The `urn` output field in the helm Chart resource is actually unused, and being shadowed by the underlying Pulumi `urn` anyway. Removing this field will have no user facing impacts.

I have confirmed that running `pulumi --logtostderr package get-schema kubernetes` passes using the locally built provider binary from this PR.

### Related issues (optional)

Fixes: #2683 
