### PR TITLE
Update guestbook frontend image used for testing

### DIFF
--- a/provider/pkg/await/deployment_test.go
+++ b/provider/pkg/await/deployment_test.go
@@ -2136,7 +2136,7 @@ func regressionDeploymentScaled3Input() *unstructured.Unstructured {
             "metadata": { "labels": { "app": "frontend" } },
             "spec": { "containers": [{
                 "name": "php-redis",
-                "image": "gcr.io/google-samples/gb-frontend:v4",
+                "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                 "resources": { "requests": { "cpu": "100m", "memory": "100Mi" } },
                 "env": [{ "name": "GET_HOSTS_FROM", "value": "dns" }],
                 "ports": [{ "containerPort": 80 }]
@@ -2202,7 +2202,7 @@ func regressionDeploymentScaled3() *unstructured.Unstructured {
                                 "value": "dns"
                             }
                         ],
-                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "php-redis",
                         "ports": [
@@ -2314,7 +2314,7 @@ func regressionDeploymentScaled5() *unstructured.Unstructured {
                                 "value": "dns"
                             }
                         ],
-                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "php-redis",
                         "ports": [
@@ -2432,7 +2432,7 @@ func regressionReplicaSetScaled3() *unstructured.Unstructured {
                                 "value": "dns"
                             }
                         ],
-                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "php-redis",
                         "ports": [
@@ -2531,7 +2531,7 @@ func regressionReplicaSetScaled5() *unstructured.Unstructured {
                                 "value": "dns"
                             }
                         ],
-                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "php-redis",
                         "ports": [

--- a/tests/sdk/dotnet/guestbook/Program.cs
+++ b/tests/sdk/dotnet/guestbook/Program.cs
@@ -200,7 +200,7 @@ class Program
                                 new ContainerArgs
                                 {
                                     Name = "php-redis",
-                                    Image = "gcr.io/google-samples/gb-frontend:v4",
+                                    Image = "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                                     Resources = new ResourceRequirementsArgs
                                     {
                                         Requests = {

--- a/tests/sdk/dotnet/yaml-url/Program.cs
+++ b/tests/sdk/dotnet/yaml-url/Program.cs
@@ -36,7 +36,8 @@ class YamlStack : Stack
     {
         return new ConfigFile(name, new ConfigFileArgs
         {
-            File = "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml",
+            // TODO: Switch back to master branch once the guestbook.yaml file is merged into mainline branch.
+            File = "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/ba8fac3f69fc8de02695da56e3f557c90be20446/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml",
             ResourcePrefix = resourcePrefix,
             Transformations =
             {

--- a/tests/sdk/go/yaml/guestbook-all-in-one.yaml
+++ b/tests/sdk/go/yaml/guestbook-all-in-one.yaml
@@ -130,7 +130,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/tests/sdk/nodejs/examples/guestbook/index.ts
+++ b/tests/sdk/nodejs/examples/guestbook/index.ts
@@ -154,7 +154,7 @@ let frontendDeployment = new k8s.apps.v1.Deployment("frontend", {
             spec: {
                 containers: [{
                     name: "php-redis",
-                    image: "gcr.io/google-samples/gb-frontend:v4",
+                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     resources: {
                         requests: {
                             cpu: "100m",

--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -277,7 +277,7 @@ let frontendDeployment = new k8s.apps.v1.Deployment("frontend", {
             spec: {
                 containers: [{
                     name: "php-redis",
-                    image: "gcr.io/google-samples/gb-frontend:v4",
+                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     resources: {
                         requests: {
                             cpu: "100m",

--- a/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml
+++ b/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml
@@ -130,7 +130,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/tests/sdk/nodejs/yaml-url/step1/index.ts
+++ b/tests/sdk/nodejs/yaml-url/step1/index.ts
@@ -22,7 +22,8 @@ const namespace2 = new k8s.core.v1.Namespace("test-namespace2", {}, {provider});
 
 function configFile(name: string, namespace: string, resourcePrefix?: string): k8s.yaml.ConfigFile {
     return new k8s.yaml.ConfigFile(name, {
-        file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml",
+        // TODO: Switch back to master branch once the guestbook.yaml file is merged into mainline branch.
+        file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/ba8fac3f69fc8de02695da56e3f557c90be20446/tests/sdk/nodejs/examples/yaml-guestbook/yaml/guestbook.yaml",
         resourcePrefix: resourcePrefix,
         transformations: [
             (obj: any) => {

--- a/tests/sdk/python/guestbook-old/__main__.py
+++ b/tests/sdk/python/guestbook-old/__main__.py
@@ -166,7 +166,7 @@ frontend_deployment = Deployment(
             "spec": {
                 "containers": [{
                     "name": "php-redis",
-                    "image": "gcr.io/google-samples/gb-frontend:v4",
+                    "image": "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     "resources": {
                         "requests": {
                             "cpu": "100m",

--- a/tests/sdk/python/guestbook/__main__.py
+++ b/tests/sdk/python/guestbook/__main__.py
@@ -178,7 +178,7 @@ frontend_deployment = Deployment(
             spec=PodSpecArgs(
                 containers=[ContainerArgs(
                     name="php-redis",
-                    image="gcr.io/google-samples/gb-frontend:v4",
+                    image="us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     resources=ResourceRequirementsArgs(
                         requests={
                             "cpu": "100m",


### PR DESCRIPTION
The `gcr.io/google-samples/gb-frontend:v4` image was deleted from the container registry. The new image was obtained from the GoogleCloudPlatform repository: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples.

Ref: https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook