### PR TITLE
Use correct EditDirs in preparation for pulumi/pulumi#14695

### DIFF
--- a/tests/sdk/python/get-old/step1/__main__.py
+++ b/tests/sdk/python/get-old/step1/__main__.py
@@ -22,7 +22,7 @@ service = Service.get("kube-api", "kubernetes")
 
 crd = CustomResourceDefinition(
     resource_name="foo",
-    metadata={"name": "gettests.python.test"},
+    metadata={"name": "gettestolds.python.test"},
     spec={
         "group": "python.test",
         "versions": [{
@@ -47,9 +47,9 @@ crd = CustomResourceDefinition(
         }],
         "scope": "Namespaced",
         "names": {
-            "plural": "gettests",
-            "singular": "gettest",
-            "kind": "GetTest",
+            "plural": "gettestolds",
+            "singular": "gettestold",
+            "kind": "GetTestOld",
         }
     })
 
@@ -58,7 +58,7 @@ ns = Namespace("ns")
 cr = CustomResource(
     resource_name="foo",
     api_version="python.test/v1",
-    kind="GetTest",
+    kind="GetTestOld",
     metadata={"namespace": ns.metadata["name"]},
     spec={"foo": "bar"},
     opts=pulumi.ResourceOptions(depends_on=[crd]))

--- a/tests/sdk/python/get-old/step2/__main__.py
+++ b/tests/sdk/python/get-old/step2/__main__.py
@@ -14,7 +14,7 @@
 
 import pulumi
 from pulumi_kubernetes.apiextensions.CustomResource import CustomResource
-from pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition import CustomResourceDefinition
+from pulumi_kubernetes.apiextensions.v1.CustomResourceDefinition import CustomResourceDefinition
 from pulumi_kubernetes.core.v1 import Service
 from pulumi_kubernetes.core.v1.Namespace import Namespace
 
@@ -22,7 +22,7 @@ service = Service.get("kube-api", "kubernetes")
 
 crd = CustomResourceDefinition(
     resource_name="foo",
-    metadata={"name": "gettests.python.test"},
+    metadata={"name": "gettestolds.python.test"},
     spec={
         "group": "python.test",
         "versions": [{
@@ -47,9 +47,9 @@ crd = CustomResourceDefinition(
         }],
         "scope": "Namespaced",
         "names": {
-            "plural": "gettests",
-            "singular": "gettest",
-            "kind": "GetTest",
+            "plural": "gettestolds",
+            "singular": "gettestold",
+            "kind": "GetTestOld",
         }
     })
 
@@ -58,9 +58,9 @@ ns = Namespace("ns")
 cr = CustomResource(
     resource_name="foo",
     api_version="python.test/v1",
-    kind="GetTest",
+    kind="GetTestOld",
     metadata={"namespace": ns.metadata["name"]},
     spec={"foo": "bar"},
     opts=pulumi.ResourceOptions(depends_on=[crd]))
 
-cr_get = CustomResource.get(resource_name="bar", api_version="python.test/v1", kind="GetTest", id=cr.id)
+cr_get = CustomResource.get(resource_name="bar", api_version="python.test/v1", kind="GetTestOld", id=cr.id)

--- a/tests/sdk/python/python_test.go
+++ b/tests/sdk/python/python_test.go
@@ -76,7 +76,7 @@ func TestGet(t *testing.T) {
 				NoParallel:           true,
 				EditDirs: []integration.EditDir{
 					{
-						Dir:      "step2",
+						Dir:      filepath.Join(cwd, dir, "step2"),
 						Additive: true,
 					},
 				},


### PR DESCRIPTION
The next Pulumi release containing pulumi/pulumi#14695 will fail tests when an `EditDir` is not found (which is the reasonable behavior). Code searched found one such case here.