### PR TITLE
Use Kubernetes v1.28 for CI cluster

### DIFF
--- a/tests/ci-cluster/gke.ts
+++ b/tests/ci-cluster/gke.ts
@@ -26,8 +26,8 @@ export class GkeCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("pulumi-kubernetes:ci:GkeCluster", name, {}, opts);
 
-        // Use the latest 1.24.x engine version.
-        const engineVersion = "1.24";
+        // Use the latest 1.28.x engine version.
+        const engineVersion = "1.28";
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("ephemeral-ci-cluster", {

--- a/tests/sdk/nodejs/istio/step1/yaml/bookinfo-gateway.yaml
+++ b/tests/sdk/nodejs/istio/step1/yaml/bookinfo-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: bookinfo-gateway
@@ -13,7 +13,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: bookinfo

--- a/tests/sdk/nodejs/istio/step1/yaml/bookinfo.yaml
+++ b/tests/sdk/nodejs/istio/step1/yaml/bookinfo.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 Istio Authors
+# Copyright Istio Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,6 +13,20 @@
 #   limitations under the License.
 
 ##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
 # Details service
 ##################################################################################################
 apiVersion: v1
@@ -21,6 +35,7 @@ metadata:
   name: details
   labels:
     app: details
+    service: details
 spec:
   ports:
   - port: 9080
@@ -28,25 +43,36 @@ spec:
   selector:
     app: details
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-details
+  labels:
+    account: details
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
+  labels:
+    app: details
+    version: v1
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: details
       version: v1
-  replicas: 1
   template:
     metadata:
       labels:
         app: details
         version: v1
     spec:
+      serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.9.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.18.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -60,6 +86,7 @@ metadata:
   name: ratings
   labels:
     app: ratings
+    service: ratings
 spec:
   ports:
   - port: 9080
@@ -67,25 +94,36 @@ spec:
   selector:
     app: ratings
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-ratings
+  labels:
+    account: ratings
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
+  labels:
+    app: ratings
+    version: v1
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: ratings
       version: v1
-  replicas: 1
   template:
     metadata:
       labels:
         app: ratings
         version: v1
     spec:
+      serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.9.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.18.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -99,6 +137,7 @@ metadata:
   name: reviews
   labels:
     app: reviews
+    service: reviews
 spec:
   ports:
   - port: 9080
@@ -106,74 +145,132 @@ spec:
   selector:
     app: reviews
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-reviews
+  labels:
+    account: reviews
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
+  labels:
+    app: reviews
+    version: v1
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: reviews
       version: v1
-  replicas: 1
   template:
     metadata:
       labels:
         app: reviews
         version: v1
     spec:
+      serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.9.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.18.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: reviews
       version: v2
-  replicas: 1
   template:
     metadata:
       labels:
         app: reviews
         version: v2
     spec:
+      serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.9.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.18.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3
+  labels:
+    app: reviews
+    version: v3
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: reviews
       version: v3
-  replicas: 1
   template:
     metadata:
       labels:
         app: reviews
         version: v3
     spec:
+      serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.9.0
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.18.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 ##################################################################################################
 # Productpage services
@@ -184,6 +281,7 @@ metadata:
   name: productpage
   labels:
     app: productpage
+    service: productpage
 spec:
   ports:
   - port: 9080
@@ -191,26 +289,47 @@ spec:
   selector:
     app: productpage
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-productpage
+  labels:
+    account: productpage
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1
+  labels:
+    app: productpage
+    version: v1
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: productpage
       version: v1
-  replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9080"
+        prometheus.io/path: "/metrics"
       labels:
         app: productpage
         version: v1
     spec:
+      serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.9.0
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.18.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---

--- a/tests/sdk/nodejs/istio/step1/yaml/istio.yaml
+++ b/tests/sdk/nodejs/istio/step1/yaml/istio.yaml
@@ -1,8 +1,16 @@
+# Create the istio-system namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    istio-injection: enabled
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -22,6 +30,203 @@ spec:
     singular: authorizationpolicy
   scope: Namespaced
   versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration for access control on workloads. See more
+              details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+            oneOf:
+            - not:
+                anyOf:
+                - required:
+                  - provider
+            - required:
+              - provider
+            properties:
+              action:
+                description: Optional.
+                enum:
+                - ALLOW
+                - DENY
+                - AUDIT
+                - CUSTOM
+                type: string
+              provider:
+                description: Specifies detailed configuration of the CUSTOM action.
+                properties:
+                  name:
+                    description: Specifies the name of the extension provider.
+                    type: string
+                type: object
+              rules:
+                description: Optional.
+                items:
+                  properties:
+                    from:
+                      description: Optional.
+                      items:
+                        properties:
+                          source:
+                            description: Source specifies the source of a request.
+                            properties:
+                              ipBlocks:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              namespaces:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notIpBlocks:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notNamespaces:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notPrincipals:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notRemoteIpBlocks:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notRequestPrincipals:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              principals:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              remoteIpBlocks:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              requestPrincipals:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    to:
+                      description: Optional.
+                      items:
+                        properties:
+                          operation:
+                            description: Operation specifies the operation of a request.
+                            properties:
+                              hosts:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              methods:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notHosts:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notMethods:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notPaths:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              notPorts:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              paths:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                              ports:
+                                description: Optional.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    when:
+                      description: Optional.
+                      items:
+                        properties:
+                          key:
+                            description: The name of an Istio attribute.
+                            type: string
+                          notValues:
+                            description: Optional.
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Optional.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
   - name: v1beta1
     schema:
       openAPIV3Schema:
@@ -50,7 +255,6 @@ spec:
                 properties:
                   name:
                     description: Specifies the name of the extension provider.
-                    format: string
                     type: string
                 type: object
               rules:
@@ -67,61 +271,51 @@ spec:
                               ipBlocks:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               namespaces:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notIpBlocks:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notNamespaces:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notPrincipals:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notRemoteIpBlocks:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notRequestPrincipals:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               principals:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               remoteIpBlocks:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               requestPrincipals:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                             type: object
@@ -137,49 +331,41 @@ spec:
                               hosts:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               methods:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notHosts:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notMethods:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notPaths:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               notPorts:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               paths:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                               ports:
                                 description: Optional.
                                 items:
-                                  format: string
                                   type: string
                                 type: array
                             type: object
@@ -191,20 +377,19 @@ spec:
                         properties:
                           key:
                             description: The name of an Istio attribute.
-                            format: string
                             type: string
                           notValues:
                             description: Optional.
                             items:
-                              format: string
                               type: string
                             type: array
                           values:
                             description: Optional.
                             items:
-                              format: string
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -214,9 +399,21 @@ spec:
                 properties:
                   matchLabels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
                     type: object
+                type: object
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
             type: object
           status:
@@ -227,12 +424,13 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -278,24 +476,24 @@ spec:
                 description: A list of namespaces to which this destination rule is
                   exported.
                 items:
-                  format: string
                   type: string
                 type: array
               host:
                 description: The name of a service from the service registry.
-                format: string
                 type: string
               subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
                 items:
                   properties:
                     labels:
                       additionalProperties:
-                        format: string
                         type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
                       type: object
                     name:
                       description: Name of the subset.
-                      format: string
                       type: string
                     trafficPolicy:
                       description: Traffic policies that apply to this subset.
@@ -314,12 +512,14 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -332,6 +532,9 @@ spec:
                                   format: int32
                                   type: integer
                                 maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
@@ -345,6 +548,9 @@ spec:
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
                                   type: string
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
@@ -360,8 +566,14 @@ spec:
                                         probes.
                                       type: string
                                     probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
                                       type: integer
                                     time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
                                       type: string
                                   type: object
                               type: object
@@ -373,34 +585,16 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
                                 - not:
                                     anyOf:
                                     - required:
@@ -419,37 +613,60 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
                                   properties:
                                     name:
                                       description: Name of the cookie.
-                                      format: string
                                       type: string
                                     path:
                                       description: Path to set for the cookie.
-                                      format: string
                                       type: string
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
-                                  format: string
                                   type: string
                                 httpQueryParameterName:
                                   description: Hash based on a specific HTTP query
                                     parameter.
-                                  format: string
                                   type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      type: integer
+                                  type: object
                                 minimumRingSize:
+                                  description: Deprecated.
                                   type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      type: integer
+                                  type: object
                                 useSourceIp:
                                   description: Hash based on the source IP address.
                                   type: boolean
@@ -457,14 +674,13 @@ spec:
                             localityLbSetting:
                               properties:
                                 distribute:
-                                  description: 'Optional: only one of distribute or
-                                    failover can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating locality, '/' separated,
                                           e.g.
-                                        format: string
                                         type: string
                                       to:
                                         additionalProperties:
@@ -481,26 +697,39 @@ spec:
                                   nullable: true
                                   type: boolean
                                 failover:
-                                  description: 'Optional: only failover or distribute
-                                    can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating region.
-                                        format: string
                                         type: string
                                       to:
-                                        format: string
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
                                         type: string
                                     type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                             simple:
                               enum:
-                              - ROUND_ROBIN
+                              - UNSPECIFIED
                               - LEAST_CONN
                               - RANDOM
                               - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmupDurationSecs:
+                              description: Represents the warmup duration of Service.
                               type: string
                           type: object
                         outlierDetection:
@@ -521,15 +750,29 @@ spec:
                                 is ejected from the connection pool.
                               nullable: true
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
                             maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                min_health_percent hosts in healthy mode.
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                           type: object
                         portLevelSettings:
                           description: Traffic policies specific to individual ports.
@@ -550,13 +793,14 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
+                                        description: Maximum number of active requests
+                                          to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
@@ -569,6 +813,9 @@ spec:
                                         format: int32
                                         type: integer
                                       maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
                                         format: int32
                                         type: integer
                                       useClientProtocol:
@@ -584,6 +831,9 @@ spec:
                                       connectTimeout:
                                         description: TCP connection timeout.
                                         type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
@@ -598,8 +848,14 @@ spec:
                                               keep-alive probes.
                                             type: string
                                           probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
                                             type: integer
                                           time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
                                             type: string
                                         type: object
                                     type: object
@@ -612,34 +868,16 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          oneOf:
-                                          - not:
-                                              anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
                                       - not:
                                           anyOf:
                                           - required:
@@ -658,38 +896,63 @@ spec:
                                         - useSourceIp
                                       - required:
                                         - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
                                         properties:
                                           name:
                                             description: Name of the cookie.
-                                            format: string
                                             type: string
                                           path:
                                             description: Path to set for the cookie.
-                                            format: string
                                             type: string
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
                                           header.
-                                        format: string
                                         type: string
                                       httpQueryParameterName:
                                         description: Hash based on a specific HTTP
                                           query parameter.
-                                        format: string
                                         type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            type: integer
+                                        type: object
                                       minimumRingSize:
+                                        description: Deprecated.
                                         type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            type: integer
+                                        type: object
                                       useSourceIp:
                                         description: Hash based on the source IP address.
                                         type: boolean
@@ -697,14 +960,13 @@ spec:
                                   localityLbSetting:
                                     properties:
                                       distribute:
-                                        description: 'Optional: only one of distribute
-                                          or failover can be set.'
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
                                         items:
                                           properties:
                                             from:
                                               description: Originating locality, '/'
                                                 separated, e.g.
-                                              format: string
                                               type: string
                                             to:
                                               additionalProperties:
@@ -721,26 +983,40 @@ spec:
                                         nullable: true
                                         type: boolean
                                       failover:
-                                        description: 'Optional: only failover or distribute
-                                          can be set.'
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
                                         items:
                                           properties:
                                             from:
                                               description: Originating region.
-                                              format: string
                                               type: string
                                             to:
-                                              format: string
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
                                               type: string
                                           type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
                                         type: array
                                     type: object
                                   simple:
                                     enum:
-                                    - ROUND_ROBIN
+                                    - UNSPECIFIED
                                     - LEAST_CONN
                                     - RANDOM
                                     - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmupDurationSecs:
+                                    description: Represents the warmup duration of
+                                      Service.
                                     type: string
                                 type: object
                               outlierDetection:
@@ -761,18 +1037,36 @@ spec:
                                       host is ejected from the connection pool.
                                     nullable: true
                                     type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    nullable: true
+                                    type: integer
                                   interval:
                                     description: Time interval between ejection sweep
                                       analysis.
                                     type: string
                                   maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
                                     format: int32
                                     type: integer
                                   minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least min_health_percent hosts in healthy
+                                      mode.
                                     format: int32
                                     type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
                                 type: object
                               port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
                                 properties:
                                   number:
                                     type: integer
@@ -782,16 +1076,28 @@ spec:
                                   to the upstream service.
                                 properties:
                                   caCertificates:
-                                    format: string
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
                                     type: string
                                   clientCertificate:
                                     description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
                                     type: string
                                   credentialName:
-                                    format: string
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
                                     type: string
+                                  insecureSkipVerify:
+                                    description: InsecureSkipVerify specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.
+                                    nullable: true
+                                    type: boolean
                                   mode:
+                                    description: Indicates whether connections to
+                                      this port should be secured using TLS.
                                     enum:
                                     - DISABLE
                                     - SIMPLE
@@ -800,16 +1106,15 @@ spec:
                                     type: string
                                   privateKey:
                                     description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
                                     type: string
                                   sni:
                                     description: SNI string to present to the server
                                       during TLS handshake.
-                                    format: string
                                     type: string
                                   subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                 type: object
@@ -820,16 +1125,26 @@ spec:
                             upstream service.
                           properties:
                             caCertificates:
-                              format: string
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
                               type: string
                             clientCertificate:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             credentialName:
-                              format: string
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
                               type: string
+                            insecureSkipVerify:
+                              description: InsecureSkipVerify specifies whether the
+                                proxy should skip verifying the CA signature and SAN
+                                for the server certificate corresponding to the host.
+                              nullable: true
+                              type: boolean
                             mode:
+                              description: Indicates whether connections to this port
+                                should be secured using TLS.
                               enum:
                               - DISABLE
                               - SIMPLE
@@ -838,23 +1153,46 @@ spec:
                               type: string
                             privateKey:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             sni:
                               description: SNI string to present to the server during
                                 TLS handshake.
-                              format: string
                               type: string
                             subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
                               items:
-                                format: string
                                 type: string
                               type: array
                           type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
                 properties:
                   connectionPool:
                     properties:
@@ -870,12 +1208,12 @@ spec:
                             - UPGRADE
                             type: string
                           http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of requests to a backend.
+                            description: Maximum number of active requests to a destination.
                             format: int32
                             type: integer
                           idleTimeout:
@@ -888,6 +1226,8 @@ spec:
                             format: int32
                             type: integer
                           maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
                             format: int32
                             type: integer
                           useClientProtocol:
@@ -901,6 +1241,9 @@ spec:
                         properties:
                           connectTimeout:
                             description: TCP connection timeout.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
                             type: string
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
@@ -916,8 +1259,14 @@ spec:
                                   probes.
                                 type: string
                               probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
                                 type: integer
                               time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
                                 type: string
                             type: object
                         type: object
@@ -929,34 +1278,16 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
                           - not:
                               anyOf:
                               - required:
@@ -975,36 +1306,59 @@ spec:
                             - useSourceIp
                           - required:
                             - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
                             properties:
                               name:
                                 description: Name of the cookie.
-                                format: string
                                 type: string
                               path:
                                 description: Path to set for the cookie.
-                                format: string
                                 type: string
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
-                            format: string
                             type: string
                           httpQueryParameterName:
                             description: Hash based on a specific HTTP query parameter.
-                            format: string
                             type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                type: integer
+                            type: object
                           minimumRingSize:
+                            description: Deprecated.
                             type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                type: integer
+                            type: object
                           useSourceIp:
                             description: Hash based on the source IP address.
                             type: boolean
@@ -1012,14 +1366,13 @@ spec:
                       localityLbSetting:
                         properties:
                           distribute:
-                            description: 'Optional: only one of distribute or failover
-                              can be set.'
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
                             items:
                               properties:
                                 from:
                                   description: Originating locality, '/' separated,
                                     e.g.
-                                  format: string
                                   type: string
                                 to:
                                   additionalProperties:
@@ -1035,26 +1388,38 @@ spec:
                             nullable: true
                             type: boolean
                           failover:
-                            description: 'Optional: only failover or distribute can
-                              be set.'
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
                             items:
                               properties:
                                 from:
                                   description: Originating region.
-                                  format: string
                                   type: string
                                 to:
-                                  format: string
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
                                   type: string
                               type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
                             type: array
                         type: object
                       simple:
                         enum:
-                        - ROUND_ROBIN
+                        - UNSPECIFIED
                         - LEAST_CONN
                         - RANDOM
                         - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmupDurationSecs:
+                        description: Represents the warmup duration of Service.
                         type: string
                     type: object
                   outlierDetection:
@@ -1075,15 +1440,29 @@ spec:
                           from the connection pool.
                         nullable: true
                         type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        nullable: true
+                        type: integer
                       interval:
                         description: Time interval between ejection sweep analysis.
                         type: string
                       maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
                         format: int32
                         type: integer
                       minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least min_health_percent
+                          hosts in healthy mode.
                         format: int32
                         type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
                     type: object
                   portLevelSettings:
                     description: Traffic policies specific to individual ports.
@@ -1103,12 +1482,14 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -1121,6 +1502,9 @@ spec:
                                   format: int32
                                   type: integer
                                 maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
@@ -1134,6 +1518,9 @@ spec:
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
                                   type: string
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
@@ -1149,8 +1536,14 @@ spec:
                                         probes.
                                       type: string
                                     probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
                                       type: integer
                                     time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
                                       type: string
                                   type: object
                               type: object
@@ -1162,34 +1555,16 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
                                 - not:
                                     anyOf:
                                     - required:
@@ -1208,37 +1583,60 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
                                   properties:
                                     name:
                                       description: Name of the cookie.
-                                      format: string
                                       type: string
                                     path:
                                       description: Path to set for the cookie.
-                                      format: string
                                       type: string
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
-                                  format: string
                                   type: string
                                 httpQueryParameterName:
                                   description: Hash based on a specific HTTP query
                                     parameter.
-                                  format: string
                                   type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      type: integer
+                                  type: object
                                 minimumRingSize:
+                                  description: Deprecated.
                                   type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      type: integer
+                                  type: object
                                 useSourceIp:
                                   description: Hash based on the source IP address.
                                   type: boolean
@@ -1246,14 +1644,13 @@ spec:
                             localityLbSetting:
                               properties:
                                 distribute:
-                                  description: 'Optional: only one of distribute or
-                                    failover can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating locality, '/' separated,
                                           e.g.
-                                        format: string
                                         type: string
                                       to:
                                         additionalProperties:
@@ -1270,26 +1667,39 @@ spec:
                                   nullable: true
                                   type: boolean
                                 failover:
-                                  description: 'Optional: only failover or distribute
-                                    can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating region.
-                                        format: string
                                         type: string
                                       to:
-                                        format: string
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
                                         type: string
                                     type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                             simple:
                               enum:
-                              - ROUND_ROBIN
+                              - UNSPECIFIED
                               - LEAST_CONN
                               - RANDOM
                               - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmupDurationSecs:
+                              description: Represents the warmup duration of Service.
                               type: string
                           type: object
                         outlierDetection:
@@ -1310,17 +1720,33 @@ spec:
                                 is ejected from the connection pool.
                               nullable: true
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
                             maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                min_health_percent hosts in healthy mode.
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                           type: object
                         port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
                           properties:
                             number:
                               type: integer
@@ -1330,16 +1756,26 @@ spec:
                             upstream service.
                           properties:
                             caCertificates:
-                              format: string
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
                               type: string
                             clientCertificate:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             credentialName:
-                              format: string
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
                               type: string
+                            insecureSkipVerify:
+                              description: InsecureSkipVerify specifies whether the
+                                proxy should skip verifying the CA signature and SAN
+                                for the server certificate corresponding to the host.
+                              nullable: true
+                              type: boolean
                             mode:
+                              description: Indicates whether connections to this port
+                                should be secured using TLS.
                               enum:
                               - DISABLE
                               - SIMPLE
@@ -1348,16 +1784,15 @@ spec:
                               type: string
                             privateKey:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             sni:
                               description: SNI string to present to the server during
                                 TLS handshake.
-                              format: string
                               type: string
                             subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
                               items:
-                                format: string
                                 type: string
                               type: array
                           type: object
@@ -1368,16 +1803,26 @@ spec:
                       service.
                     properties:
                       caCertificates:
-                        format: string
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
                         type: string
                       clientCertificate:
                         description: REQUIRED if mode is `MUTUAL`.
-                        format: string
                         type: string
                       credentialName:
-                        format: string
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
                         type: string
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.
+                        nullable: true
+                        type: boolean
                       mode:
+                        description: Indicates whether connections to this port should
+                          be secured using TLS.
                         enum:
                         - DISABLE
                         - SIMPLE
@@ -1386,20 +1831,52 @@ spec:
                         type: string
                       privateKey:
                         description: REQUIRED if mode is `MUTUAL`.
-                        format: string
                         type: string
                       sni:
                         description: SNI string to present to the server during TLS
                           handshake.
-                        format: string
                         type: string
                       subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
                         items:
-                          format: string
                           type: string
                         type: array
                     type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
                 type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -1434,24 +1911,24 @@ spec:
                 description: A list of namespaces to which this destination rule is
                   exported.
                 items:
-                  format: string
                   type: string
                 type: array
               host:
                 description: The name of a service from the service registry.
-                format: string
                 type: string
               subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
                 items:
                   properties:
                     labels:
                       additionalProperties:
-                        format: string
                         type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
                       type: object
                     name:
                       description: Name of the subset.
-                      format: string
                       type: string
                     trafficPolicy:
                       description: Traffic policies that apply to this subset.
@@ -1470,12 +1947,14 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -1488,6 +1967,9 @@ spec:
                                   format: int32
                                   type: integer
                                 maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
@@ -1501,6 +1983,9 @@ spec:
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
                                   type: string
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
@@ -1516,8 +2001,14 @@ spec:
                                         probes.
                                       type: string
                                     probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
                                       type: integer
                                     time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
                                       type: string
                                   type: object
                               type: object
@@ -1529,34 +2020,16 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
                                 - not:
                                     anyOf:
                                     - required:
@@ -1575,37 +2048,60 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
                                   properties:
                                     name:
                                       description: Name of the cookie.
-                                      format: string
                                       type: string
                                     path:
                                       description: Path to set for the cookie.
-                                      format: string
                                       type: string
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
-                                  format: string
                                   type: string
                                 httpQueryParameterName:
                                   description: Hash based on a specific HTTP query
                                     parameter.
-                                  format: string
                                   type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      type: integer
+                                  type: object
                                 minimumRingSize:
+                                  description: Deprecated.
                                   type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      type: integer
+                                  type: object
                                 useSourceIp:
                                   description: Hash based on the source IP address.
                                   type: boolean
@@ -1613,14 +2109,13 @@ spec:
                             localityLbSetting:
                               properties:
                                 distribute:
-                                  description: 'Optional: only one of distribute or
-                                    failover can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating locality, '/' separated,
                                           e.g.
-                                        format: string
                                         type: string
                                       to:
                                         additionalProperties:
@@ -1637,26 +2132,39 @@ spec:
                                   nullable: true
                                   type: boolean
                                 failover:
-                                  description: 'Optional: only failover or distribute
-                                    can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating region.
-                                        format: string
                                         type: string
                                       to:
-                                        format: string
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
                                         type: string
                                     type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                             simple:
                               enum:
-                              - ROUND_ROBIN
+                              - UNSPECIFIED
                               - LEAST_CONN
                               - RANDOM
                               - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmupDurationSecs:
+                              description: Represents the warmup duration of Service.
                               type: string
                           type: object
                         outlierDetection:
@@ -1677,15 +2185,29 @@ spec:
                                 is ejected from the connection pool.
                               nullable: true
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
                             maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                min_health_percent hosts in healthy mode.
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                           type: object
                         portLevelSettings:
                           description: Traffic policies specific to individual ports.
@@ -1706,13 +2228,14 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
+                                        description: Maximum number of active requests
+                                          to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
@@ -1725,6 +2248,9 @@ spec:
                                         format: int32
                                         type: integer
                                       maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
                                         format: int32
                                         type: integer
                                       useClientProtocol:
@@ -1740,6 +2266,9 @@ spec:
                                       connectTimeout:
                                         description: TCP connection timeout.
                                         type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
@@ -1754,8 +2283,14 @@ spec:
                                               keep-alive probes.
                                             type: string
                                           probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
                                             type: integer
                                           time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
                                             type: string
                                         type: object
                                     type: object
@@ -1768,34 +2303,16 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          oneOf:
-                                          - not:
-                                              anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
                                       - not:
                                           anyOf:
                                           - required:
@@ -1814,38 +2331,63 @@ spec:
                                         - useSourceIp
                                       - required:
                                         - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
                                         properties:
                                           name:
                                             description: Name of the cookie.
-                                            format: string
                                             type: string
                                           path:
                                             description: Path to set for the cookie.
-                                            format: string
                                             type: string
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
                                           header.
-                                        format: string
                                         type: string
                                       httpQueryParameterName:
                                         description: Hash based on a specific HTTP
                                           query parameter.
-                                        format: string
                                         type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            type: integer
+                                        type: object
                                       minimumRingSize:
+                                        description: Deprecated.
                                         type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            type: integer
+                                        type: object
                                       useSourceIp:
                                         description: Hash based on the source IP address.
                                         type: boolean
@@ -1853,14 +2395,13 @@ spec:
                                   localityLbSetting:
                                     properties:
                                       distribute:
-                                        description: 'Optional: only one of distribute
-                                          or failover can be set.'
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
                                         items:
                                           properties:
                                             from:
                                               description: Originating locality, '/'
                                                 separated, e.g.
-                                              format: string
                                               type: string
                                             to:
                                               additionalProperties:
@@ -1877,26 +2418,40 @@ spec:
                                         nullable: true
                                         type: boolean
                                       failover:
-                                        description: 'Optional: only failover or distribute
-                                          can be set.'
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
                                         items:
                                           properties:
                                             from:
                                               description: Originating region.
-                                              format: string
                                               type: string
                                             to:
-                                              format: string
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
                                               type: string
                                           type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
                                         type: array
                                     type: object
                                   simple:
                                     enum:
-                                    - ROUND_ROBIN
+                                    - UNSPECIFIED
                                     - LEAST_CONN
                                     - RANDOM
                                     - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmupDurationSecs:
+                                    description: Represents the warmup duration of
+                                      Service.
                                     type: string
                                 type: object
                               outlierDetection:
@@ -1917,18 +2472,36 @@ spec:
                                       host is ejected from the connection pool.
                                     nullable: true
                                     type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    nullable: true
+                                    type: integer
                                   interval:
                                     description: Time interval between ejection sweep
                                       analysis.
                                     type: string
                                   maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
                                     format: int32
                                     type: integer
                                   minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least min_health_percent hosts in healthy
+                                      mode.
                                     format: int32
                                     type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
                                 type: object
                               port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
                                 properties:
                                   number:
                                     type: integer
@@ -1938,16 +2511,28 @@ spec:
                                   to the upstream service.
                                 properties:
                                   caCertificates:
-                                    format: string
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
                                     type: string
                                   clientCertificate:
                                     description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
                                     type: string
                                   credentialName:
-                                    format: string
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
                                     type: string
+                                  insecureSkipVerify:
+                                    description: InsecureSkipVerify specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.
+                                    nullable: true
+                                    type: boolean
                                   mode:
+                                    description: Indicates whether connections to
+                                      this port should be secured using TLS.
                                     enum:
                                     - DISABLE
                                     - SIMPLE
@@ -1956,16 +2541,15 @@ spec:
                                     type: string
                                   privateKey:
                                     description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
                                     type: string
                                   sni:
                                     description: SNI string to present to the server
                                       during TLS handshake.
-                                    format: string
                                     type: string
                                   subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                 type: object
@@ -1976,16 +2560,26 @@ spec:
                             upstream service.
                           properties:
                             caCertificates:
-                              format: string
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
                               type: string
                             clientCertificate:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             credentialName:
-                              format: string
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
                               type: string
+                            insecureSkipVerify:
+                              description: InsecureSkipVerify specifies whether the
+                                proxy should skip verifying the CA signature and SAN
+                                for the server certificate corresponding to the host.
+                              nullable: true
+                              type: boolean
                             mode:
+                              description: Indicates whether connections to this port
+                                should be secured using TLS.
                               enum:
                               - DISABLE
                               - SIMPLE
@@ -1994,23 +2588,46 @@ spec:
                               type: string
                             privateKey:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             sni:
                               description: SNI string to present to the server during
                                 TLS handshake.
-                              format: string
                               type: string
                             subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
                               items:
-                                format: string
                                 type: string
                               type: array
                           type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
                 properties:
                   connectionPool:
                     properties:
@@ -2026,12 +2643,12 @@ spec:
                             - UPGRADE
                             type: string
                           http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of requests to a backend.
+                            description: Maximum number of active requests to a destination.
                             format: int32
                             type: integer
                           idleTimeout:
@@ -2044,6 +2661,8 @@ spec:
                             format: int32
                             type: integer
                           maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
                             format: int32
                             type: integer
                           useClientProtocol:
@@ -2057,6 +2676,9 @@ spec:
                         properties:
                           connectTimeout:
                             description: TCP connection timeout.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
                             type: string
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
@@ -2072,8 +2694,14 @@ spec:
                                   probes.
                                 type: string
                               probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
                                 type: integer
                               time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
                                 type: string
                             type: object
                         type: object
@@ -2085,34 +2713,16 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
                           - not:
                               anyOf:
                               - required:
@@ -2131,36 +2741,59 @@ spec:
                             - useSourceIp
                           - required:
                             - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
                             properties:
                               name:
                                 description: Name of the cookie.
-                                format: string
                                 type: string
                               path:
                                 description: Path to set for the cookie.
-                                format: string
                                 type: string
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
-                            format: string
                             type: string
                           httpQueryParameterName:
                             description: Hash based on a specific HTTP query parameter.
-                            format: string
                             type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                type: integer
+                            type: object
                           minimumRingSize:
+                            description: Deprecated.
                             type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                type: integer
+                            type: object
                           useSourceIp:
                             description: Hash based on the source IP address.
                             type: boolean
@@ -2168,14 +2801,13 @@ spec:
                       localityLbSetting:
                         properties:
                           distribute:
-                            description: 'Optional: only one of distribute or failover
-                              can be set.'
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
                             items:
                               properties:
                                 from:
                                   description: Originating locality, '/' separated,
                                     e.g.
-                                  format: string
                                   type: string
                                 to:
                                   additionalProperties:
@@ -2191,26 +2823,38 @@ spec:
                             nullable: true
                             type: boolean
                           failover:
-                            description: 'Optional: only failover or distribute can
-                              be set.'
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
                             items:
                               properties:
                                 from:
                                   description: Originating region.
-                                  format: string
                                   type: string
                                 to:
-                                  format: string
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
                                   type: string
                               type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
                             type: array
                         type: object
                       simple:
                         enum:
-                        - ROUND_ROBIN
+                        - UNSPECIFIED
                         - LEAST_CONN
                         - RANDOM
                         - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmupDurationSecs:
+                        description: Represents the warmup duration of Service.
                         type: string
                     type: object
                   outlierDetection:
@@ -2231,15 +2875,29 @@ spec:
                           from the connection pool.
                         nullable: true
                         type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        nullable: true
+                        type: integer
                       interval:
                         description: Time interval between ejection sweep analysis.
                         type: string
                       maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
                         format: int32
                         type: integer
                       minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least min_health_percent
+                          hosts in healthy mode.
                         format: int32
                         type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
                     type: object
                   portLevelSettings:
                     description: Traffic policies specific to individual ports.
@@ -2259,12 +2917,14 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -2277,6 +2937,9 @@ spec:
                                   format: int32
                                   type: integer
                                 maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
@@ -2290,6 +2953,9 @@ spec:
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
                                   type: string
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
@@ -2305,8 +2971,14 @@ spec:
                                         probes.
                                       type: string
                                     probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
                                       type: integer
                                     time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
                                       type: string
                                   type: object
                               type: object
@@ -2318,34 +2990,16 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
                                 - not:
                                     anyOf:
                                     - required:
@@ -2364,37 +3018,60 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
                                   properties:
                                     name:
                                       description: Name of the cookie.
-                                      format: string
                                       type: string
                                     path:
                                       description: Path to set for the cookie.
-                                      format: string
                                       type: string
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
-                                  format: string
                                   type: string
                                 httpQueryParameterName:
                                   description: Hash based on a specific HTTP query
                                     parameter.
-                                  format: string
                                   type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      type: integer
+                                  type: object
                                 minimumRingSize:
+                                  description: Deprecated.
                                   type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      type: integer
+                                  type: object
                                 useSourceIp:
                                   description: Hash based on the source IP address.
                                   type: boolean
@@ -2402,14 +3079,13 @@ spec:
                             localityLbSetting:
                               properties:
                                 distribute:
-                                  description: 'Optional: only one of distribute or
-                                    failover can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating locality, '/' separated,
                                           e.g.
-                                        format: string
                                         type: string
                                       to:
                                         additionalProperties:
@@ -2426,26 +3102,39 @@ spec:
                                   nullable: true
                                   type: boolean
                                 failover:
-                                  description: 'Optional: only failover or distribute
-                                    can be set.'
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
                                   items:
                                     properties:
                                       from:
                                         description: Originating region.
-                                        format: string
                                         type: string
                                       to:
-                                        format: string
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
                                         type: string
                                     type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                             simple:
                               enum:
-                              - ROUND_ROBIN
+                              - UNSPECIFIED
                               - LEAST_CONN
                               - RANDOM
                               - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmupDurationSecs:
+                              description: Represents the warmup duration of Service.
                               type: string
                           type: object
                         outlierDetection:
@@ -2466,17 +3155,33 @@ spec:
                                 is ejected from the connection pool.
                               nullable: true
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
                             maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                min_health_percent hosts in healthy mode.
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                           type: object
                         port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
                           properties:
                             number:
                               type: integer
@@ -2486,16 +3191,26 @@ spec:
                             upstream service.
                           properties:
                             caCertificates:
-                              format: string
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
                               type: string
                             clientCertificate:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             credentialName:
-                              format: string
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
                               type: string
+                            insecureSkipVerify:
+                              description: InsecureSkipVerify specifies whether the
+                                proxy should skip verifying the CA signature and SAN
+                                for the server certificate corresponding to the host.
+                              nullable: true
+                              type: boolean
                             mode:
+                              description: Indicates whether connections to this port
+                                should be secured using TLS.
                               enum:
                               - DISABLE
                               - SIMPLE
@@ -2504,16 +3219,15 @@ spec:
                               type: string
                             privateKey:
                               description: REQUIRED if mode is `MUTUAL`.
-                              format: string
                               type: string
                             sni:
                               description: SNI string to present to the server during
                                 TLS handshake.
-                              format: string
                               type: string
                             subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
                               items:
-                                format: string
                                 type: string
                               type: array
                           type: object
@@ -2524,16 +3238,26 @@ spec:
                       service.
                     properties:
                       caCertificates:
-                        format: string
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
                         type: string
                       clientCertificate:
                         description: REQUIRED if mode is `MUTUAL`.
-                        format: string
                         type: string
                       credentialName:
-                        format: string
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
                         type: string
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.
+                        nullable: true
+                        type: boolean
                       mode:
+                        description: Indicates whether connections to this port should
+                          be secured using TLS.
                         enum:
                         - DISABLE
                         - SIMPLE
@@ -2542,20 +3266,52 @@ spec:
                         type: string
                       privateKey:
                         description: REQUIRED if mode is `MUTUAL`.
-                        format: string
                         type: string
                       sni:
                         description: SNI string to present to the server during TLS
                           handshake.
-                        format: string
                         type: string
                       subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
                         items:
-                          format: string
                           type: string
                         type: array
                     type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
                 type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -2565,12 +3321,13 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -2602,6 +3359,8 @@ spec:
                 items:
                   properties:
                     applyTo:
+                      description: Specifies where in the Envoy configuration, the
+                        patch should be applied.
                       enum:
                       - INVALID
                       - LISTENER
@@ -2613,6 +3372,8 @@ spec:
                       - HTTP_ROUTE
                       - CLUSTER
                       - EXTENSION_CONFIG
+                      - BOOTSTRAP
+                      - LISTENER_FILTER
                       type: string
                     match:
                       description: Match on listener/route configuration/cluster.
@@ -2637,7 +3398,6 @@ spec:
                           properties:
                             name:
                               description: The exact name of the cluster to match.
-                              format: string
                               type: string
                             portNumber:
                               description: The service port for which this cluster
@@ -2646,11 +3406,9 @@ spec:
                             service:
                               description: The fully qualified service name for this
                                 cluster.
-                              format: string
                               type: string
                             subset:
                               description: The subset associated with the service.
-                              format: string
                               type: string
                           type: object
                         context:
@@ -2670,7 +3428,6 @@ spec:
                               properties:
                                 applicationProtocols:
                                   description: Applies only to sidecars.
-                                  format: string
                                   type: string
                                 destinationPort:
                                   description: The destination_port value used by
@@ -2682,38 +3439,38 @@ spec:
                                   properties:
                                     name:
                                       description: The filter name to match on.
-                                      format: string
                                       type: string
                                     subFilter:
+                                      description: The next level filter within this
+                                        filter to match upon.
                                       properties:
                                         name:
                                           description: The filter name to match on.
-                                          format: string
                                           type: string
                                       type: object
                                   type: object
                                 name:
                                   description: The name assigned to the filter chain.
-                                  format: string
                                   type: string
                                 sni:
                                   description: The SNI value used by a filter chain's
                                     match condition.
-                                  format: string
                                   type: string
                                 transportProtocol:
                                   description: Applies only to `SIDECAR_INBOUND` context.
-                                  format: string
                                   type: string
                               type: object
+                            listenerFilter:
+                              description: Match a specific listener filter.
+                              type: string
                             name:
                               description: Match a specific listener by its name.
-                              format: string
                               type: string
                             portName:
-                              format: string
                               type: string
                             portNumber:
+                              description: The service port/gateway port to which
+                                traffic is being sent/received.
                               type: integer
                           type: object
                         proxy:
@@ -2721,33 +3478,44 @@ spec:
                           properties:
                             metadata:
                               additionalProperties:
-                                format: string
                                 type: string
+                              description: Match on the node metadata supplied by
+                                a proxy when connecting to Istio Pilot.
                               type: object
                             proxyVersion:
-                              format: string
+                              description: A regular expression in golang regex format
+                                (RE2) that can be used to select proxies using a specific
+                                version of istio proxy.
                               type: string
                           type: object
                         routeConfiguration:
                           description: Match on envoy HTTP route configuration attributes.
                           properties:
                             gateway:
-                              format: string
+                              description: The Istio gateway config's namespace/name
+                                for which this route configuration was generated.
                               type: string
                             name:
                               description: Route configuration name to match on.
-                              format: string
                               type: string
                             portName:
                               description: Applicable only for GATEWAY context.
-                              format: string
                               type: string
                             portNumber:
+                              description: The service port number or gateway server
+                                port number for which this route configuration was
+                                generated.
                               type: integer
                             vhost:
+                              description: Match a specific virtual host in a route
+                                configuration and apply the patch to the virtual host.
                               properties:
                                 name:
-                                  format: string
+                                  description: The VirtualHosts objects generated
+                                    by Istio are named as host:port, where the host
+                                    typically corresponds to the VirtualService's
+                                    host field or the hostname of a service in the
+                                    registry.
                                   type: string
                                 route:
                                   description: Match a specific route within the virtual
@@ -2763,7 +3531,8 @@ spec:
                                       - DIRECT_RESPONSE
                                       type: string
                                     name:
-                                      format: string
+                                      description: The Route objects generated by
+                                        default are named as default.
                                       type: string
                                   type: object
                               type: object
@@ -2799,12 +3568,20 @@ spec:
                       type: object
                   type: object
                 type: array
+              priority:
+                description: Priority defines the order in which patch sets are applied
+                  within a context.
+                format: int32
+                type: integer
               workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this patch configuration should be applied.
                 properties:
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
             type: object
@@ -2816,12 +3593,13 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -2852,65 +3630,71 @@ spec:
             properties:
               selector:
                 additionalProperties:
-                  format: string
                   type: string
+                description: One or more labels that indicate a specific set of pods/VMs
+                  on which this gateway configuration should be applied.
                 type: object
               servers:
                 description: A list of server specifications.
                 items:
                   properties:
                     bind:
-                      format: string
+                      description: The ip or the Unix domain socket to which the listener
+                        should be bound to.
                       type: string
                     defaultEndpoint:
-                      format: string
                       type: string
                     hosts:
                       description: One or more hosts exposed by this gateway.
                       items:
-                        format: string
                         type: string
                       type: array
                     name:
                       description: An optional name of the server, when set must be
                         unique across all servers.
-                      format: string
                       type: string
                     port:
+                      description: The Port on which the proxy should listen for incoming
+                        connections.
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          format: string
+                          description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                           type: string
                         cipherSuites:
                           description: 'Optional: If specified, only support the specified
                             cipher list.'
                           items:
-                            format: string
                             type: string
                           type: array
                         credentialName:
-                          format: string
+                          description: For gateways running on Kubernetes, the name
+                            of the secret that holds the TLS certs including the CA
+                            certificates.
                           type: string
                         httpsRedirect:
+                          description: If set to true, the load balancer will send
+                            a 301 redirect for all http connections, asking the clients
+                            to use HTTPS.
                           type: boolean
                         maxProtocolVersion:
                           description: 'Optional: Maximum TLS protocol version.'
@@ -2931,37 +3715,44 @@ spec:
                           - TLSV1_3
                           type: string
                         mode:
+                          description: 'Optional: Indicates whether connections to
+                            this port should be secured using TLS.'
                           enum:
                           - PASSTHROUGH
                           - SIMPLE
                           - MUTUAL
                           - AUTO_PASSTHROUGH
                           - ISTIO_MUTUAL
+                          - OPTIONAL_MUTUAL
                           type: string
                         privateKey:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
                           type: string
                         serverCertificate:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
                           type: string
                         subjectAltNames:
+                          description: A list of alternate names to verify the subject
+                            identity in the certificate presented by the client.
                           items:
-                            format: string
                             type: string
                           type: array
                         verifyCertificateHash:
+                          description: An optional list of hex-encoded SHA-256 hashes
+                            of the authorized client certificates.
                           items:
-                            format: string
                             type: string
                           type: array
                         verifyCertificateSpki:
+                          description: An optional list of base64-encoded SHA-256
+                            hashes of the SPKIs of authorized client certificates.
                           items:
-                            format: string
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -2983,65 +3774,71 @@ spec:
             properties:
               selector:
                 additionalProperties:
-                  format: string
                   type: string
+                description: One or more labels that indicate a specific set of pods/VMs
+                  on which this gateway configuration should be applied.
                 type: object
               servers:
                 description: A list of server specifications.
                 items:
                   properties:
                     bind:
-                      format: string
+                      description: The ip or the Unix domain socket to which the listener
+                        should be bound to.
                       type: string
                     defaultEndpoint:
-                      format: string
                       type: string
                     hosts:
                       description: One or more hosts exposed by this gateway.
                       items:
-                        format: string
                         type: string
                       type: array
                     name:
                       description: An optional name of the server, when set must be
                         unique across all servers.
-                      format: string
                       type: string
                     port:
+                      description: The Port on which the proxy should listen for incoming
+                        connections.
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          format: string
+                          description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                           type: string
                         cipherSuites:
                           description: 'Optional: If specified, only support the specified
                             cipher list.'
                           items:
-                            format: string
                             type: string
                           type: array
                         credentialName:
-                          format: string
+                          description: For gateways running on Kubernetes, the name
+                            of the secret that holds the TLS certs including the CA
+                            certificates.
                           type: string
                         httpsRedirect:
+                          description: If set to true, the load balancer will send
+                            a 301 redirect for all http connections, asking the clients
+                            to use HTTPS.
                           type: boolean
                         maxProtocolVersion:
                           description: 'Optional: Maximum TLS protocol version.'
@@ -3062,37 +3859,44 @@ spec:
                           - TLSV1_3
                           type: string
                         mode:
+                          description: 'Optional: Indicates whether connections to
+                            this port should be secured using TLS.'
                           enum:
                           - PASSTHROUGH
                           - SIMPLE
                           - MUTUAL
                           - AUTO_PASSTHROUGH
                           - ISTIO_MUTUAL
+                          - OPTIONAL_MUTUAL
                           type: string
                         privateKey:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
                           type: string
                         serverCertificate:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
                           type: string
                         subjectAltNames:
+                          description: A list of alternate names to verify the subject
+                            identity in the certificate presented by the client.
                           items:
-                            format: string
                             type: string
                           type: array
                         verifyCertificateHash:
+                          description: An optional list of hex-encoded SHA-256 hashes
+                            of the authorized client certificates.
                           items:
-                            format: string
                             type: string
                           type: array
                         verifyCertificateSpki:
+                          description: An optional list of base64-encoded SHA-256
+                            hashes of the SPKIs of authorized client certificates.
                           items:
-                            format: string
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -3104,13 +3908,14 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -3119,10 +3924,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
     - iop
     - io
+    singular: istiooperator
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -3142,8 +3947,6 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    subresources:
-      status: {}
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -3151,12 +3954,15 @@ spec:
         x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -3196,8 +4002,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or
-              not) to the sidecar.
+            description: 'Peer authentication configuration for workloads. See more
+              details at: https://istio.io/docs/reference/config/security/peer_authentication.html'
             properties:
               mtls:
                 description: Mutual TLS settings for workload.
@@ -3231,8 +4037,9 @@ spec:
                 properties:
                   matchLabels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
                     type: object
                 type: object
             type: object
@@ -3244,12 +4051,81 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: proxyconfigs.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: ProxyConfig
+    listKind: ProxyConfigList
+    plural: proxyconfigs
+    singular: proxyconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Provides configuration for individual workloads. See more
+              details at: https://istio.io/docs/reference/config/networking/proxy-config.html'
+            properties:
+              concurrency:
+                description: The number of worker threads to run.
+                nullable: true
+                type: integer
+              environmentVariables:
+                additionalProperties:
+                  type: string
+                description: Additional environment variables for the proxy.
+                type: object
+              image:
+                description: Specifies the details of the proxy image.
+                properties:
+                  imageType:
+                    description: The image type of the image.
+                    type: string
+                type: object
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -3271,13 +4147,13 @@ spec:
     singular: requestauthentication
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - name: v1
     schema:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -3285,13 +4161,14 @@ spec:
                 items:
                   properties:
                     audiences:
+                      description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3)
+                        that are allowed to access.
                       items:
-                        format: string
                         type: string
                       type: array
                     forwardOriginalToken:
-                      description: If set to true, the orginal token will be kept
-                        for the ustream request.
+                      description: If set to true, the original token will be kept
+                        for the upstream request.
                       type: boolean
                     fromHeaders:
                       description: List of header locations from which JWT is expected.
@@ -3299,50 +4176,185 @@ spec:
                         properties:
                           name:
                             description: The HTTP header name.
-                            format: string
                             type: string
                           prefix:
                             description: The prefix that should be stripped before
                               decoding the token.
-                            format: string
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
                       description: List of query parameters from which JWT is expected.
                       items:
-                        format: string
                         type: string
                       type: array
                     issuer:
                       description: Identifies the issuer that issued the JWT.
-                      format: string
                       type: string
                     jwks:
                       description: JSON Web Key Set of public keys to validate signature
                         of the JWT.
-                      format: string
                       type: string
                     jwks_uri:
-                      format: string
+                      description: URL of the provider's public key set to validate
+                        signature of the JWT.
                       type: string
                     jwksUri:
-                      format: string
+                      description: URL of the provider's public key set to validate
+                        signature of the JWT.
                       type: string
+                    outputClaimToHeaders:
+                      description: This field specifies a list of operations to copy
+                        the claim to HTTP headers on a successfully verified token.
+                      items:
+                        properties:
+                          claim:
+                            description: The name of the claim to be copied from.
+                            type: string
+                          header:
+                            description: The name of the header to be created.
+                            type: string
+                        type: object
+                      type: array
                     outputPayloadToHeader:
-                      format: string
+                      description: This field specifies the header name to output
+                        a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
-                description: The selector determines the workloads to apply the RequestAuthentication
-                  on.
+                description: Optional.
                 properties:
                   matchLabels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
                     type: object
+                type: object
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
+            properties:
+              jwtRules:
+                description: Define the list of JWTs that can be validated at the
+                  selected workloads' proxy.
+                items:
+                  properties:
+                    audiences:
+                      description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3)
+                        that are allowed to access.
+                      items:
+                        type: string
+                      type: array
+                    forwardOriginalToken:
+                      description: If set to true, the original token will be kept
+                        for the upstream request.
+                      type: boolean
+                    fromHeaders:
+                      description: List of header locations from which JWT is expected.
+                      items:
+                        properties:
+                          name:
+                            description: The HTTP header name.
+                            type: string
+                          prefix:
+                            description: The prefix that should be stripped before
+                              decoding the token.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    fromParams:
+                      description: List of query parameters from which JWT is expected.
+                      items:
+                        type: string
+                      type: array
+                    issuer:
+                      description: Identifies the issuer that issued the JWT.
+                      type: string
+                    jwks:
+                      description: JSON Web Key Set of public keys to validate signature
+                        of the JWT.
+                      type: string
+                    jwks_uri:
+                      description: URL of the provider's public key set to validate
+                        signature of the JWT.
+                      type: string
+                    jwksUri:
+                      description: URL of the provider's public key set to validate
+                        signature of the JWT.
+                      type: string
+                    outputClaimToHeaders:
+                      description: This field specifies a list of operations to copy
+                        the claim to HTTP headers on a successfully verified token.
+                      items:
+                        properties:
+                          claim:
+                            description: The name of the claim to be copied from.
+                            type: string
+                          header:
+                            description: The name of the header to be created.
+                            type: string
+                        type: object
+                      type: array
+                    outputPayloadToHeader:
+                      description: This field specifies the header name to output
+                        a successfully verified JWT payload to the backend.
+                      type: string
+                  required:
+                  - issuer
+                  type: object
+                type: array
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
             type: object
           status:
@@ -3353,12 +4365,13 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -3389,7 +4402,7 @@ spec:
       jsonPath: .spec.location
       name: Location
       type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
       jsonPath: .spec.resolution
       name: Resolution
       type: string
@@ -3412,7 +4425,6 @@ spec:
               addresses:
                 description: The virtual IP addresses associated with the service.
                 items:
-                  format: string
                   type: string
                 type: array
               endpoints:
@@ -3420,20 +4432,20 @@ spec:
                 items:
                   properties:
                     address:
-                      format: string
+                      description: Address associated with the network endpoint without
+                        the port.
                       type: string
                     labels:
                       additionalProperties:
-                        format: string
                         type: string
                       description: One or more labels associated with the endpoint.
                       type: object
                     locality:
                       description: The locality associated with the endpoint.
-                      format: string
                       type: string
                     network:
-                      format: string
+                      description: Network enables Istio to group endpoints resident
+                        in the same L3 domain/network.
                       type: string
                     ports:
                       additionalProperties:
@@ -3441,7 +4453,8 @@ spec:
                       description: Set of ports associated with the endpoint.
                       type: object
                     serviceAccount:
-                      format: string
+                      description: The service account associated with the workload
+                        if a sidecar is present in the workload.
                       type: string
                     weight:
                       description: The load balancing weight associated with the endpoint.
@@ -3451,16 +4464,16 @@ spec:
               exportTo:
                 description: A list of namespaces to which this service is exported.
                 items:
-                  format: string
                   type: string
                 type: array
               hosts:
                 description: The hosts associated with the ServiceEntry.
                 items:
-                  format: string
                   type: string
                 type: array
               location:
+                description: Specify whether the service should be considered external
+                  to the mesh or part of the mesh.
                 enum:
                 - MESH_EXTERNAL
                 - MESH_INTERNAL
@@ -3471,29 +4484,34 @@ spec:
                   properties:
                     name:
                       description: Label assigned to the port.
-                      format: string
                       type: string
                     number:
                       description: A valid non-negative integer port number.
                       type: integer
                     protocol:
                       description: The protocol exposed on the port.
-                      format: string
                       type: string
                     targetPort:
+                      description: The port number on the endpoint where the traffic
+                        will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
-                description: Service discovery mode for the hosts.
+                description: Service resolution mode for the hosts.
                 enum:
                 - NONE
                 - STATIC
                 - DNS
+                - DNS_ROUND_ROBIN
                 type: string
               subjectAltNames:
+                description: If specified, the proxy will verify that the server certificate's
+                  subject alternate name matches one of the specified values.
                 items:
-                  format: string
                   type: string
                 type: array
               workloadSelector:
@@ -3501,10 +4519,13 @@ spec:
                 properties:
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -3524,7 +4545,7 @@ spec:
       jsonPath: .spec.location
       name: Location
       type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
       jsonPath: .spec.resolution
       name: Resolution
       type: string
@@ -3547,7 +4568,6 @@ spec:
               addresses:
                 description: The virtual IP addresses associated with the service.
                 items:
-                  format: string
                   type: string
                 type: array
               endpoints:
@@ -3555,20 +4575,20 @@ spec:
                 items:
                   properties:
                     address:
-                      format: string
+                      description: Address associated with the network endpoint without
+                        the port.
                       type: string
                     labels:
                       additionalProperties:
-                        format: string
                         type: string
                       description: One or more labels associated with the endpoint.
                       type: object
                     locality:
                       description: The locality associated with the endpoint.
-                      format: string
                       type: string
                     network:
-                      format: string
+                      description: Network enables Istio to group endpoints resident
+                        in the same L3 domain/network.
                       type: string
                     ports:
                       additionalProperties:
@@ -3576,7 +4596,8 @@ spec:
                       description: Set of ports associated with the endpoint.
                       type: object
                     serviceAccount:
-                      format: string
+                      description: The service account associated with the workload
+                        if a sidecar is present in the workload.
                       type: string
                     weight:
                       description: The load balancing weight associated with the endpoint.
@@ -3586,16 +4607,16 @@ spec:
               exportTo:
                 description: A list of namespaces to which this service is exported.
                 items:
-                  format: string
                   type: string
                 type: array
               hosts:
                 description: The hosts associated with the ServiceEntry.
                 items:
-                  format: string
                   type: string
                 type: array
               location:
+                description: Specify whether the service should be considered external
+                  to the mesh or part of the mesh.
                 enum:
                 - MESH_EXTERNAL
                 - MESH_INTERNAL
@@ -3606,29 +4627,34 @@ spec:
                   properties:
                     name:
                       description: Label assigned to the port.
-                      format: string
                       type: string
                     number:
                       description: A valid non-negative integer port number.
                       type: integer
                     protocol:
                       description: The protocol exposed on the port.
-                      format: string
                       type: string
                     targetPort:
+                      description: The port number on the endpoint where the traffic
+                        will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
-                description: Service discovery mode for the hosts.
+                description: Service resolution mode for the hosts.
                 enum:
                 - NONE
                 - STATIC
                 - DNS
+                - DNS_ROUND_ROBIN
                 type: string
               subjectAltNames:
+                description: If specified, the proxy will verify that the server certificate's
+                  subject alternate name matches one of the specified values.
                 items:
-                  format: string
                   type: string
                 type: array
               workloadSelector:
@@ -3636,10 +4662,13 @@ spec:
                 properties:
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -3649,12 +4678,13 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -3682,20 +4712,28 @@ spec:
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
             properties:
               egress:
+                description: Egress specifies the configuration of the sidecar for
+                  processing outbound traffic from the attached workload instance
+                  to other services in the mesh.
                 items:
                   properties:
                     bind:
-                      format: string
+                      description: The IP(IPv4 or IPv6) or the Unix domain socket
+                        to which the listener should be bound to.
                       type: string
                     captureMode:
+                      description: When the bind address is an IP, the captureMode
+                        option dictates how traffic to the listener is expected to
+                        be captured (or not).
                       enum:
                       - DEFAULT
                       - IPTABLES
                       - NONE
                       type: string
                     hosts:
+                      description: One or more service hosts exposed by the listener
+                        in `namespace/dnsName` format.
                       items:
-                        format: string
                         type: string
                       type: array
                     port:
@@ -3703,53 +4741,291 @@ spec:
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
+                description: Ingress specifies the configuration of the sidecar for
+                  processing inbound traffic to the attached workload instance.
                 items:
                   properties:
                     bind:
-                      description: The IP to which the listener should be bound.
-                      format: string
+                      description: The IP(IPv4 or IPv6) to which the listener should
+                        be bound.
                       type: string
                     captureMode:
+                      description: The captureMode option dictates how traffic to
+                        the listener is expected to be captured (or not).
                       enum:
                       - DEFAULT
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
-                      format: string
+                      description: The IP endpoint or Unix domain socket to which
+                        traffic should be forwarded to.
                       type: string
                     port:
                       description: The port associated with the listener.
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
                       type: object
+                    tls:
+                      description: Set of TLS related options that will enable TLS
+                        termination on the sidecar for requests originating from outside
+                        the mesh.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                          items:
+                            type: string
+                          type: array
+                        credentialName:
+                          description: For gateways running on Kubernetes, the name
+                            of the secret that holds the TLS certs including the CA
+                            certificates.
+                          type: string
+                        httpsRedirect:
+                          description: If set to true, the load balancer will send
+                            a 301 redirect for all http connections, asking the clients
+                            to use HTTPS.
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          description: 'Optional: Indicates whether connections to
+                            this port should be secured using TLS.'
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          - OPTIONAL_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          type: string
+                        subjectAltNames:
+                          description: A list of alternate names to verify the subject
+                            identity in the certificate presented by the client.
+                          items:
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          description: An optional list of hex-encoded SHA-256 hashes
+                            of the authorized client certificates.
+                          items:
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          description: An optional list of base64-encoded SHA-256
+                            hashes of the SPKIs of authorized client certificates.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -3759,7 +5035,6 @@ spec:
                     properties:
                       host:
                         description: The name of a service from the service registry.
-                        format: string
                         type: string
                       port:
                         description: Specifies the port on the host that is being
@@ -3770,8 +5045,9 @@ spec:
                         type: object
                       subset:
                         description: The name of a subset within the service.
-                        format: string
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -3780,11 +5056,14 @@ spec:
                     type: string
                 type: object
               workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `Sidecar` configuration should be applied.
                 properties:
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
             type: object
@@ -3805,20 +5084,28 @@ spec:
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
             properties:
               egress:
+                description: Egress specifies the configuration of the sidecar for
+                  processing outbound traffic from the attached workload instance
+                  to other services in the mesh.
                 items:
                   properties:
                     bind:
-                      format: string
+                      description: The IP(IPv4 or IPv6) or the Unix domain socket
+                        to which the listener should be bound to.
                       type: string
                     captureMode:
+                      description: When the bind address is an IP, the captureMode
+                        option dictates how traffic to the listener is expected to
+                        be captured (or not).
                       enum:
                       - DEFAULT
                       - IPTABLES
                       - NONE
                       type: string
                     hosts:
+                      description: One or more service hosts exposed by the listener
+                        in `namespace/dnsName` format.
                       items:
-                        format: string
                         type: string
                       type: array
                     port:
@@ -3826,53 +5113,291 @@ spec:
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
+                description: Ingress specifies the configuration of the sidecar for
+                  processing inbound traffic to the attached workload instance.
                 items:
                   properties:
                     bind:
-                      description: The IP to which the listener should be bound.
-                      format: string
+                      description: The IP(IPv4 or IPv6) to which the listener should
+                        be bound.
                       type: string
                     captureMode:
+                      description: The captureMode option dictates how traffic to
+                        the listener is expected to be captured (or not).
                       enum:
                       - DEFAULT
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
-                      format: string
+                      description: The IP endpoint or Unix domain socket to which
+                        traffic should be forwarded to.
                       type: string
                     port:
                       description: The port associated with the listener.
                       properties:
                         name:
                           description: Label assigned to the port.
-                          format: string
                           type: string
                         number:
                           description: A valid non-negative integer port number.
                           type: integer
                         protocol:
                           description: The protocol exposed on the port.
-                          format: string
                           type: string
                         targetPort:
                           type: integer
                       type: object
+                    tls:
+                      description: Set of TLS related options that will enable TLS
+                        termination on the sidecar for requests originating from outside
+                        the mesh.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                          items:
+                            type: string
+                          type: array
+                        credentialName:
+                          description: For gateways running on Kubernetes, the name
+                            of the secret that holds the TLS certs including the CA
+                            certificates.
+                          type: string
+                        httpsRedirect:
+                          description: If set to true, the load balancer will send
+                            a 301 redirect for all http connections, asking the clients
+                            to use HTTPS.
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          description: 'Optional: Indicates whether connections to
+                            this port should be secured using TLS.'
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          - OPTIONAL_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          type: string
+                        subjectAltNames:
+                          description: A list of alternate names to verify the subject
+                            identity in the certificate presented by the client.
+                          items:
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          description: An optional list of hex-encoded SHA-256 hashes
+                            of the authorized client certificates.
+                          items:
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          description: An optional list of base64-encoded SHA-256
+                            hashes of the SPKIs of authorized client certificates.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -3882,7 +5407,6 @@ spec:
                     properties:
                       host:
                         description: The name of a service from the service registry.
-                        format: string
                         type: string
                       port:
                         description: Specifies the port on the host that is being
@@ -3893,8 +5417,9 @@ spec:
                         type: object
                       subset:
                         description: The name of a subset within the service.
-                        format: string
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -3903,11 +5428,14 @@ spec:
                     type: string
                 type: object
               workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `Sidecar` configuration should be applied.
                 properties:
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
             type: object
@@ -3919,12 +5447,13 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -3960,17 +5489,161 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: Telemetry defines how the telemetry is generated for workloads
-              within a mesh.
+            description: 'Telemetry configuration for workloads. See more details
+              at: https://istio.io/docs/reference/config/telemetry.html'
             properties:
+              accessLogging:
+                description: Optional.
+                items:
+                  properties:
+                    disabled:
+                      description: Controls logging.
+                      nullable: true
+                      type: boolean
+                    filter:
+                      description: Optional.
+                      properties:
+                        expression:
+                          description: CEL expression for selecting when requests/connections
+                            should be logged.
+                          type: string
+                      type: object
+                    match:
+                      description: Allows tailoring of logging behavior to specific
+                        conditions.
+                      properties:
+                        mode:
+                          description: This determines whether or not to apply the
+                            access logging configuration based on the direction of
+                            traffic relative to the proxied workload.
+                          enum:
+                          - CLIENT_AND_SERVER
+                          - CLIENT
+                          - SERVER
+                          type: string
+                      type: object
+                    providers:
+                      description: Optional.
+                      items:
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              metrics:
+                description: Optional.
+                items:
+                  properties:
+                    overrides:
+                      description: Optional.
+                      items:
+                        properties:
+                          disabled:
+                            description: Optional.
+                            nullable: true
+                            type: boolean
+                          match:
+                            description: Match allows provides the scope of the override.
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - metric
+                                - required:
+                                  - customMetric
+                            - required:
+                              - metric
+                            - required:
+                              - customMetric
+                            properties:
+                              customMetric:
+                                description: Allows free-form specification of a metric.
+                                type: string
+                              metric:
+                                description: One of the well-known Istio Standard
+                                  Metrics.
+                                enum:
+                                - ALL_METRICS
+                                - REQUEST_COUNT
+                                - REQUEST_DURATION
+                                - REQUEST_SIZE
+                                - RESPONSE_SIZE
+                                - TCP_OPENED_CONNECTIONS
+                                - TCP_CLOSED_CONNECTIONS
+                                - TCP_SENT_BYTES
+                                - TCP_RECEIVED_BYTES
+                                - GRPC_REQUEST_MESSAGES
+                                - GRPC_RESPONSE_MESSAGES
+                                type: string
+                              mode:
+                                description: 'Controls which mode of metrics generation
+                                  is selected: CLIENT and/or SERVER.'
+                                enum:
+                                - CLIENT_AND_SERVER
+                                - CLIENT
+                                - SERVER
+                                type: string
+                            type: object
+                          tagOverrides:
+                            additionalProperties:
+                              properties:
+                                operation:
+                                  description: Operation controls whether or not to
+                                    update/add a tag, or to remove it.
+                                  enum:
+                                  - UPSERT
+                                  - REMOVE
+                                  type: string
+                                value:
+                                  description: Value is only considered if the operation
+                                    is `UPSERT`.
+                                  type: string
+                              type: object
+                            description: Optional.
+                            type: object
+                        type: object
+                      type: array
+                    providers:
+                      description: Optional.
+                      items:
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    reportingInterval:
+                      description: Optional.
+                      type: string
+                  type: object
+                type: array
               selector:
                 description: Optional.
                 properties:
                   matchLabels:
                     additionalProperties:
-                      format: string
                       type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
                     type: object
+                type: object
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
               tracing:
                 description: Optional.
@@ -4000,12 +5673,10 @@ spec:
                             properties:
                               defaultValue:
                                 description: Optional.
-                                format: string
                                 type: string
                               name:
                                 description: Name of the environment variable from
                                   which to extract the tag value.
-                                format: string
                                 type: string
                             type: object
                           header:
@@ -4014,12 +5685,10 @@ spec:
                             properties:
                               defaultValue:
                                 description: Optional.
-                                format: string
                                 type: string
                               name:
                                 description: Name of the header from which to extract
                                   the tag value.
-                                format: string
                                 type: string
                             type: object
                           literal:
@@ -4028,7 +5697,6 @@ spec:
                             properties:
                               value:
                                 description: The tag value to use.
-                                format: string
                                 type: string
                             type: object
                         type: object
@@ -4038,19 +5706,38 @@ spec:
                       description: Controls span reporting.
                       nullable: true
                       type: boolean
+                    match:
+                      description: Allows tailoring of behavior to specific conditions.
+                      properties:
+                        mode:
+                          description: This determines whether or not to apply the
+                            tracing configuration based on the direction of traffic
+                            relative to the proxied workload.
+                          enum:
+                          - CLIENT_AND_SERVER
+                          - CLIENT
+                          - SERVER
+                          type: string
+                      type: object
                     providers:
                       description: Optional.
                       items:
                         properties:
                           name:
                             description: Required.
-                            format: string
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     randomSamplingPercentage:
+                      description: Controls the rate at which traffic will be selected
+                        for tracing if no prior sampling decision has been made.
                       nullable: true
                       type: number
+                    useRequestIdForTraceSampling:
+                      nullable: true
+                      type: boolean
                   type: object
                 type: array
             type: object
@@ -4062,12 +5749,13 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -4117,20 +5805,17 @@ spec:
                 description: A list of namespaces to which this virtual service is
                   exported.
                 items:
-                  format: string
                   type: string
                 type: array
               gateways:
                 description: The names of gateways and sidecars that should apply
                   these routes.
                 items:
-                  format: string
                   type: string
                 type: array
               hosts:
                 description: The destination hosts to which traffic is being sent.
                 items:
-                  format: string
                   type: string
                 type: array
               http:
@@ -4141,25 +5826,24 @@ spec:
                       description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
                         allowCredentials:
+                          description: Indicates whether the caller is allowed to
+                            send the actual request (not the preflight) using credentials.
                           nullable: true
                           type: boolean
                         allowHeaders:
+                          description: List of HTTP headers that can be used when
+                            requesting the resource.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowMethods:
                           description: List of HTTP methods allowed to access the
                             resource.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowOrigins:
@@ -4182,42 +5866,76 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           type: array
                         exposeHeaders:
+                          description: A list of HTTP headers that the browsers are
+                            allowed to access.
                           items:
-                            format: string
                             type: string
                           type: array
                         maxAge:
+                          description: Specifies how long the results of a preflight
+                            request can be cached.
                           type: string
                       type: object
                     delegate:
+                      description: Delegate is used to specify the particular VirtualService
+                        which can be used to define delegate HTTPRoute.
                       properties:
                         name:
                           description: Name specifies the name of the delegate VirtualService.
-                          format: string
                           type: string
                         namespace:
                           description: Namespace specifies the namespace where the
                             delegate VirtualService resides.
-                          format: string
                           type: string
+                      type: object
+                    directResponse:
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
+                      properties:
+                        body:
+                          description: Specifies the content of the response body.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - string
+                              - required:
+                                - bytes
+                          - required:
+                            - string
+                          - required:
+                            - bytes
+                          properties:
+                            bytes:
+                              description: response body as base64 encoded bytes.
+                              format: binary
+                              type: string
+                            string:
+                              type: string
+                          type: object
+                        status:
+                          description: Specifies the HTTP response status to be returned.
+                          type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
                         at the client side.
                       properties:
                         abort:
+                          description: Abort Http request attempts and return error
+                            codes back to downstream service, giving the impression
+                            that the upstream service is faulty.
                           oneOf:
                           - not:
                               anyOf:
@@ -4235,10 +5953,9 @@ spec:
                             - http2Error
                           properties:
                             grpcStatus:
-                              format: string
+                              description: GRPC status code to use to abort the request.
                               type: string
                             http2Error:
-                              format: string
                               type: string
                             httpStatus:
                               description: HTTP status code to use to abort the Http
@@ -4255,6 +5972,9 @@ spec:
                               type: object
                           type: object
                         delay:
+                          description: Delay requests before forwarding, emulating
+                            various failures such as network issues, overloaded upstream
+                            service, etc.
                           oneOf:
                           - not:
                               anyOf:
@@ -4294,17 +6014,14 @@ spec:
                           properties:
                             add:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                             remove:
                               items:
-                                format: string
                                 type: string
                               type: array
                             set:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                           type: object
@@ -4312,25 +6029,28 @@ spec:
                           properties:
                             add:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                             remove:
                               items:
-                                format: string
                                 type: string
                               type: array
                             set:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                           type: object
                       type: object
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           authority:
+                            description: 'HTTP Authority values are case-sensitive
+                              and formatted as follows: - `exact: "value"` for exact
+                              string match - `prefix: "value"` for prefix-based match
+                              - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -4348,21 +6068,17 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           headers:
@@ -4384,22 +6100,25 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
+                            description: The header keys must be lowercase and use
+                              hyphen as the separator, e.g.
                             type: object
                           ignoreUriCase:
                             description: Flag to specify whether the URI matching
                               should be case-insensitive.
                             type: boolean
                           method:
+                            description: 'HTTP Method values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -4417,19 +6136,15 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           name:
                             description: The name assigned to a match.
-                            format: string
                             type: string
                           port:
                             description: Specifies the ports on the host that is being
@@ -4454,19 +6169,20 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
                             description: Query parameters for matching.
                             type: object
                           scheme:
+                            description: 'URI Scheme values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -4484,27 +6200,33 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to source (client) workloads with the given
+                              labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
+                            type: string
+                          statPrefix:
+                            description: The human readable prefix to use when emitting
+                              statistics for this route.
                             type: string
                           uri:
+                            description: 'URI to match values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -4522,14 +6244,11 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           withoutHeaders:
@@ -4551,14 +6270,11 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
                             description: withoutHeader has the same syntax with the
@@ -4567,10 +6283,11 @@ spec:
                         type: object
                       type: array
                     mirror:
+                      description: Mirror HTTP traffic to a another destination in
+                        addition to forwarding the requests to the intended destination.
                       properties:
                         host:
                           description: The name of a service from the service registry.
-                          format: string
                           type: string
                         port:
                           description: Specifies the port on the host that is being
@@ -4581,17 +6298,14 @@ spec:
                           type: object
                         subset:
                           description: The name of a subset within the service.
-                          format: string
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
                       nullable: true
                       type: integer
                     mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
                       nullable: true
                       type: integer
                     mirrorPercentage:
@@ -4602,21 +6316,89 @@ spec:
                           format: double
                           type: number
                       type: object
+                    mirrors:
+                      description: Specifies the destinations to mirror HTTP traffic
+                        in addition to the original destination.
+                      items:
+                        properties:
+                          destination:
+                            description: Destination specifies the target of the mirror
+                              operation.
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            required:
+                            - host
+                            type: object
+                          percentage:
+                            description: Percentage of the traffic to be mirrored
+                              by the `destination` field.
+                            properties:
+                              value:
+                                format: double
+                                type: number
+                            type: object
+                        required:
+                        - destination
+                        type: object
+                      type: array
                     name:
                       description: The name assigned to the route for debugging purposes.
-                      format: string
                       type: string
                     redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - port
+                          - required:
+                            - derivePort
+                      - required:
+                        - port
+                      - required:
+                        - derivePort
                       properties:
                         authority:
-                          format: string
+                          description: On a redirect, overwrite the Authority/Host
+                            portion of the URL with this value.
                           type: string
-                        redirectCode:
+                        derivePort:
+                          description: 'On a redirect, dynamically set the port: *
+                            FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP
+                            and 443 for HTTPS.'
+                          enum:
+                          - FROM_PROTOCOL_DEFAULT
+                          - FROM_REQUEST_PORT
+                          type: string
+                        port:
+                          description: On a redirect, overwrite the port portion of
+                            the URL with this value.
                           type: integer
+                        redirectCode:
+                          description: On a redirect, Specifies the HTTP status code
+                            to use in the redirect response.
+                          type: integer
+                        scheme:
+                          description: On a redirect, overwrite the scheme portion
+                            of the URL with this value.
+                          type: string
                         uri:
-                          format: string
+                          description: On a redirect, overwrite the Path portion of
+                            the URL with this value.
                           type: string
                       type: object
                     retries:
@@ -4634,7 +6416,6 @@ spec:
                         retryOn:
                           description: Specifies the conditions under which retry
                             takes place.
-                          format: string
                           type: string
                         retryRemoteLocalities:
                           description: Flag to specify whether the retries should
@@ -4648,23 +6429,37 @@ spec:
                         authority:
                           description: rewrite the Authority/Host header with this
                             value.
-                          format: string
                           type: string
                         uri:
-                          format: string
+                          description: rewrite the path (or the prefix) portion of
+                            the URI with this value.
                           type: string
+                        uriRegexRewrite:
+                          description: rewrite the path portion of the URI with the
+                            specified regex.
+                          properties:
+                            match:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              type: string
+                            rewrite:
+                              description: The string that should replace into matching
+                                portions of original URI.
+                              type: string
+                          type: object
                       type: object
                     route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -4675,8 +6470,9 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -4684,17 +6480,14 @@ spec:
                                 properties:
                                   add:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                   remove:
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                   set:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                 type: object
@@ -4702,24 +6495,25 @@ spec:
                                 properties:
                                   add:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                   remove:
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                   set:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                 type: object
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -4732,20 +6526,20 @@ spec:
                 items:
                   properties:
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           destinationSubnets:
                             description: IPv4 or IPv6 ip addresses of destination
                               with optional subnet.
                             items:
-                              format: string
                               type: string
                             type: array
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           port:
@@ -4754,18 +6548,15 @@ spec:
                             type: integer
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to workloads with the given labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
                             type: string
                           sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
-                            format: string
                             type: string
                         type: object
                       type: array
@@ -4775,11 +6566,13 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -4790,34 +6583,41 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
                 type: array
               tls:
+                description: An ordered list of route rule for non-terminated TLS
+                  & HTTPS traffic.
                 items:
                   properties:
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           destinationSubnets:
                             description: IPv4 or IPv6 ip addresses of destination
                               with optional subnet.
                             items:
-                              format: string
                               type: string
                             type: array
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           port:
@@ -4827,19 +6627,20 @@ spec:
                           sniHosts:
                             description: SNI (server name indicator) to match on.
                             items:
-                              format: string
                               type: string
                             type: array
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to workloads with the given labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -4848,11 +6649,13 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -4863,14 +6666,21 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -4911,20 +6721,17 @@ spec:
                 description: A list of namespaces to which this virtual service is
                   exported.
                 items:
-                  format: string
                   type: string
                 type: array
               gateways:
                 description: The names of gateways and sidecars that should apply
                   these routes.
                 items:
-                  format: string
                   type: string
                 type: array
               hosts:
                 description: The destination hosts to which traffic is being sent.
                 items:
-                  format: string
                   type: string
                 type: array
               http:
@@ -4935,25 +6742,24 @@ spec:
                       description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
                         allowCredentials:
+                          description: Indicates whether the caller is allowed to
+                            send the actual request (not the preflight) using credentials.
                           nullable: true
                           type: boolean
                         allowHeaders:
+                          description: List of HTTP headers that can be used when
+                            requesting the resource.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowMethods:
                           description: List of HTTP methods allowed to access the
                             resource.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
                           items:
-                            format: string
                             type: string
                           type: array
                         allowOrigins:
@@ -4976,42 +6782,76 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           type: array
                         exposeHeaders:
+                          description: A list of HTTP headers that the browsers are
+                            allowed to access.
                           items:
-                            format: string
                             type: string
                           type: array
                         maxAge:
+                          description: Specifies how long the results of a preflight
+                            request can be cached.
                           type: string
                       type: object
                     delegate:
+                      description: Delegate is used to specify the particular VirtualService
+                        which can be used to define delegate HTTPRoute.
                       properties:
                         name:
                           description: Name specifies the name of the delegate VirtualService.
-                          format: string
                           type: string
                         namespace:
                           description: Namespace specifies the namespace where the
                             delegate VirtualService resides.
-                          format: string
                           type: string
+                      type: object
+                    directResponse:
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
+                      properties:
+                        body:
+                          description: Specifies the content of the response body.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - string
+                              - required:
+                                - bytes
+                          - required:
+                            - string
+                          - required:
+                            - bytes
+                          properties:
+                            bytes:
+                              description: response body as base64 encoded bytes.
+                              format: binary
+                              type: string
+                            string:
+                              type: string
+                          type: object
+                        status:
+                          description: Specifies the HTTP response status to be returned.
+                          type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
                         at the client side.
                       properties:
                         abort:
+                          description: Abort Http request attempts and return error
+                            codes back to downstream service, giving the impression
+                            that the upstream service is faulty.
                           oneOf:
                           - not:
                               anyOf:
@@ -5029,10 +6869,9 @@ spec:
                             - http2Error
                           properties:
                             grpcStatus:
-                              format: string
+                              description: GRPC status code to use to abort the request.
                               type: string
                             http2Error:
-                              format: string
                               type: string
                             httpStatus:
                               description: HTTP status code to use to abort the Http
@@ -5049,6 +6888,9 @@ spec:
                               type: object
                           type: object
                         delay:
+                          description: Delay requests before forwarding, emulating
+                            various failures such as network issues, overloaded upstream
+                            service, etc.
                           oneOf:
                           - not:
                               anyOf:
@@ -5088,17 +6930,14 @@ spec:
                           properties:
                             add:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                             remove:
                               items:
-                                format: string
                                 type: string
                               type: array
                             set:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                           type: object
@@ -5106,25 +6945,28 @@ spec:
                           properties:
                             add:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                             remove:
                               items:
-                                format: string
                                 type: string
                               type: array
                             set:
                               additionalProperties:
-                                format: string
                                 type: string
                               type: object
                           type: object
                       type: object
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           authority:
+                            description: 'HTTP Authority values are case-sensitive
+                              and formatted as follows: - `exact: "value"` for exact
+                              string match - `prefix: "value"` for prefix-based match
+                              - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -5142,21 +6984,17 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           headers:
@@ -5178,22 +7016,25 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
+                            description: The header keys must be lowercase and use
+                              hyphen as the separator, e.g.
                             type: object
                           ignoreUriCase:
                             description: Flag to specify whether the URI matching
                               should be case-insensitive.
                             type: boolean
                           method:
+                            description: 'HTTP Method values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -5211,19 +7052,15 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           name:
                             description: The name assigned to a match.
-                            format: string
                             type: string
                           port:
                             description: Specifies the ports on the host that is being
@@ -5248,19 +7085,20 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
                             description: Query parameters for matching.
                             type: object
                           scheme:
+                            description: 'URI Scheme values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -5278,27 +7116,33 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to source (client) workloads with the given
+                              labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
+                            type: string
+                          statPrefix:
+                            description: The human readable prefix to use when emitting
+                              statistics for this route.
                             type: string
                           uri:
+                            description: 'URI to match values are case-sensitive and
+                              formatted as follows: - `exact: "value"` for exact string
+                              match - `prefix: "value"` for prefix-based match - `regex:
+                              "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).'
                             oneOf:
                             - not:
                                 anyOf:
@@ -5316,14 +7160,11 @@ spec:
                               - regex
                             properties:
                               exact:
-                                format: string
                                 type: string
                               prefix:
-                                format: string
                                 type: string
                               regex:
                                 description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
                                 type: string
                             type: object
                           withoutHeaders:
@@ -5345,14 +7186,11 @@ spec:
                                 - regex
                               properties:
                                 exact:
-                                  format: string
                                   type: string
                                 prefix:
-                                  format: string
                                   type: string
                                 regex:
                                   description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
                                   type: string
                               type: object
                             description: withoutHeader has the same syntax with the
@@ -5361,10 +7199,11 @@ spec:
                         type: object
                       type: array
                     mirror:
+                      description: Mirror HTTP traffic to a another destination in
+                        addition to forwarding the requests to the intended destination.
                       properties:
                         host:
                           description: The name of a service from the service registry.
-                          format: string
                           type: string
                         port:
                           description: Specifies the port on the host that is being
@@ -5375,17 +7214,14 @@ spec:
                           type: object
                         subset:
                           description: The name of a subset within the service.
-                          format: string
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
                       nullable: true
                       type: integer
                     mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
                       nullable: true
                       type: integer
                     mirrorPercentage:
@@ -5396,21 +7232,89 @@ spec:
                           format: double
                           type: number
                       type: object
+                    mirrors:
+                      description: Specifies the destinations to mirror HTTP traffic
+                        in addition to the original destination.
+                      items:
+                        properties:
+                          destination:
+                            description: Destination specifies the target of the mirror
+                              operation.
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            required:
+                            - host
+                            type: object
+                          percentage:
+                            description: Percentage of the traffic to be mirrored
+                              by the `destination` field.
+                            properties:
+                              value:
+                                format: double
+                                type: number
+                            type: object
+                        required:
+                        - destination
+                        type: object
+                      type: array
                     name:
                       description: The name assigned to the route for debugging purposes.
-                      format: string
                       type: string
                     redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - port
+                          - required:
+                            - derivePort
+                      - required:
+                        - port
+                      - required:
+                        - derivePort
                       properties:
                         authority:
-                          format: string
+                          description: On a redirect, overwrite the Authority/Host
+                            portion of the URL with this value.
                           type: string
-                        redirectCode:
+                        derivePort:
+                          description: 'On a redirect, dynamically set the port: *
+                            FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP
+                            and 443 for HTTPS.'
+                          enum:
+                          - FROM_PROTOCOL_DEFAULT
+                          - FROM_REQUEST_PORT
+                          type: string
+                        port:
+                          description: On a redirect, overwrite the port portion of
+                            the URL with this value.
                           type: integer
+                        redirectCode:
+                          description: On a redirect, Specifies the HTTP status code
+                            to use in the redirect response.
+                          type: integer
+                        scheme:
+                          description: On a redirect, overwrite the scheme portion
+                            of the URL with this value.
+                          type: string
                         uri:
-                          format: string
+                          description: On a redirect, overwrite the Path portion of
+                            the URL with this value.
                           type: string
                       type: object
                     retries:
@@ -5428,7 +7332,6 @@ spec:
                         retryOn:
                           description: Specifies the conditions under which retry
                             takes place.
-                          format: string
                           type: string
                         retryRemoteLocalities:
                           description: Flag to specify whether the retries should
@@ -5442,23 +7345,37 @@ spec:
                         authority:
                           description: rewrite the Authority/Host header with this
                             value.
-                          format: string
                           type: string
                         uri:
-                          format: string
+                          description: rewrite the path (or the prefix) portion of
+                            the URI with this value.
                           type: string
+                        uriRegexRewrite:
+                          description: rewrite the path portion of the URI with the
+                            specified regex.
+                          properties:
+                            match:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              type: string
+                            rewrite:
+                              description: The string that should replace into matching
+                                portions of original URI.
+                              type: string
+                          type: object
                       type: object
                     route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
+                      description: A HTTP rule can either return a direct_response,
+                        redirect or forward (default) traffic.
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -5469,8 +7386,9 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -5478,17 +7396,14 @@ spec:
                                 properties:
                                   add:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                   remove:
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                   set:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                 type: object
@@ -5496,24 +7411,25 @@ spec:
                                 properties:
                                   add:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                   remove:
                                     items:
-                                      format: string
                                       type: string
                                     type: array
                                   set:
                                     additionalProperties:
-                                      format: string
                                       type: string
                                     type: object
                                 type: object
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -5526,20 +7442,20 @@ spec:
                 items:
                   properties:
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           destinationSubnets:
                             description: IPv4 or IPv6 ip addresses of destination
                               with optional subnet.
                             items:
-                              format: string
                               type: string
                             type: array
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           port:
@@ -5548,18 +7464,15 @@ spec:
                             type: integer
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to workloads with the given labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
                             type: string
                           sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
-                            format: string
                             type: string
                         type: object
                       type: array
@@ -5569,11 +7482,13 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -5584,34 +7499,41 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
                 type: array
               tls:
+                description: An ordered list of route rule for non-terminated TLS
+                  & HTTPS traffic.
                 items:
                   properties:
                     match:
+                      description: Match conditions to be satisfied for the rule to
+                        be activated.
                       items:
                         properties:
                           destinationSubnets:
                             description: IPv4 or IPv6 ip addresses of destination
                               with optional subnet.
                             items:
-                              format: string
                               type: string
                             type: array
                           gateways:
                             description: Names of gateways where the rule should be
                               applied.
                             items:
-                              format: string
                               type: string
                             type: array
                           port:
@@ -5621,19 +7543,20 @@ spec:
                           sniHosts:
                             description: SNI (server name indicator) to match on.
                             items:
-                              format: string
                               type: string
                             type: array
                           sourceLabels:
                             additionalProperties:
-                              format: string
                               type: string
+                            description: One or more labels that constrain the applicability
+                              of a rule to workloads with the given labels.
                             type: object
                           sourceNamespace:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
-                            format: string
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -5642,11 +7565,13 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination uniquely identifies the instances
+                              of a service to which the request/connection should
+                              be forwarded to.
                             properties:
                               host:
                                 description: The name of a service from the service
                                   registry.
-                                format: string
                                 type: string
                               port:
                                 description: Specifies the port on the host that is
@@ -5657,14 +7582,21 @@ spec:
                                 type: object
                               subset:
                                 description: The name of a subset within the service.
-                                format: string
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -5676,12 +7608,224 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: wasmplugins.extensions.istio.io
+spec:
+  group: extensions.istio.io
+  names:
+    categories:
+    - istio-io
+    - extensions-istio-io
+    kind: WasmPlugin
+    listKind: WasmPluginList
+    plural: wasmplugins
+    singular: wasmplugin
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Extend the functionality provided by the Istio proxy through
+              WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
+            properties:
+              failStrategy:
+                description: Specifies the failure behavior for the plugin due to
+                  fatal errors.
+                enum:
+                - FAIL_CLOSE
+                - FAIL_OPEN
+                type: string
+              imagePullPolicy:
+                description: The pull behaviour to be applied when fetching Wasm module
+                  by either OCI image or http/https.
+                enum:
+                - UNSPECIFIED_POLICY
+                - IfNotPresent
+                - Always
+                type: string
+              imagePullSecret:
+                description: Credentials to use for OCI image pulling.
+                maxLength: 253
+                minLength: 1
+                type: string
+              match:
+                description: Specifies the criteria to determine which traffic is
+                  passed to WasmPlugin.
+                items:
+                  properties:
+                    mode:
+                      description: Criteria for selecting traffic by their direction.
+                      enum:
+                      - UNDEFINED
+                      - CLIENT
+                      - SERVER
+                      - CLIENT_AND_SERVER
+                      type: string
+                    ports:
+                      description: Criteria for selecting traffic by their destination
+                        port.
+                      items:
+                        properties:
+                          number:
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - number
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - number
+                      x-kubernetes-list-type: map
+                  type: object
+                type: array
+              phase:
+                description: Determines where in the filter chain this `WasmPlugin`
+                  is to be injected.
+                enum:
+                - UNSPECIFIED_PHASE
+                - AUTHN
+                - AUTHZ
+                - STATS
+                type: string
+              pluginConfig:
+                description: The configuration that will be passed on to the plugin.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              pluginName:
+                description: The plugin name to be used in the Envoy configuration
+                  (used to be called `rootID`).
+                maxLength: 256
+                minLength: 1
+                type: string
+              priority:
+                description: Determines ordering of `WasmPlugins` in the same `phase`.
+                nullable: true
+                type: integer
+              selector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this plugin configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    type: object
+                type: object
+              sha256:
+                description: SHA256 checksum that will be used to verify Wasm module
+                  or OCI container.
+                pattern: (^$|^[a-f0-9]{64}$)
+                type: string
+              targetRef:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              type:
+                description: Specifies the type of Wasm Extension to be used.
+                enum:
+                - UNSPECIFIED_PLUGIN_TYPE
+                - HTTP
+                - NETWORK
+                type: string
+              url:
+                description: URL of a Wasm module or OCI container.
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: url must have schema one of [http, https, file, oci]
+                  rule: 'isURL(self) ? (url(self).getScheme() in ['''', ''http'',
+                    ''https'', ''oci'', ''file'']) : (isURL(''http://'' + self) &&
+                    url(''http://'' +self).getScheme() in ['''', ''http'', ''https'',
+                    ''oci'', ''file''])'
+              verificationKey:
+                type: string
+              vmConfig:
+                description: Configuration for a Wasm VM.
+                properties:
+                  env:
+                    description: Specifies environment variables to be injected to
+                      this VM.
+                    items:
+                      properties:
+                        name:
+                          description: Name of the environment variable.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Value for the environment variable.
+                          maxLength: 2048
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                          enum:
+                          - INLINE
+                          - HOST
+                          type: string
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: value may only be set when valueFrom is INLINE
+                        rule: '(has(self.valueFrom) ? self.valueFrom : '''') != ''HOST''
+                          || !has(self.value)'
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+            required:
+            - url
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio
@@ -5724,20 +7868,20 @@ spec:
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
             properties:
               address:
-                format: string
+                description: Address associated with the network endpoint without
+                  the port.
                 type: string
               labels:
                 additionalProperties:
-                  format: string
                   type: string
                 description: One or more labels associated with the endpoint.
                 type: object
               locality:
                 description: The locality associated with the endpoint.
-                format: string
                 type: string
               network:
-                format: string
+                description: Network enables Istio to group endpoints resident in
+                  the same L3 domain/network.
                 type: string
               ports:
                 additionalProperties:
@@ -5745,7 +7889,8 @@ spec:
                 description: Set of ports associated with the endpoint.
                 type: object
               serviceAccount:
-                format: string
+                description: The service account associated with the workload if a
+                  sidecar is present in the workload.
                 type: string
               weight:
                 description: The load balancing weight associated with the endpoint.
@@ -5781,20 +7926,20 @@ spec:
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
             properties:
               address:
-                format: string
+                description: Address associated with the network endpoint without
+                  the port.
                 type: string
               labels:
                 additionalProperties:
-                  format: string
                   type: string
                 description: One or more labels associated with the endpoint.
                 type: object
               locality:
                 description: The locality associated with the endpoint.
-                format: string
                 type: string
               network:
-                format: string
+                description: Network enables Istio to group endpoints resident in
+                  the same L3 domain/network.
                 type: string
               ports:
                 additionalProperties:
@@ -5802,7 +7947,8 @@ spec:
                 description: Set of ports associated with the endpoint.
                 type: object
               serviceAccount:
-                format: string
+                description: The service account associated with the workload if a
+                  sidecar is present in the workload.
                 type: string
               weight:
                 description: The load balancing weight associated with the endpoint.
@@ -5816,6 +7962,7 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5862,12 +8009,10 @@ spec:
                 properties:
                   annotations:
                     additionalProperties:
-                      format: string
                       type: string
                     type: object
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
                     type: object
                 type: object
@@ -5897,7 +8042,6 @@ spec:
                       command:
                         description: Command to run.
                         items:
-                          format: string
                           type: string
                         type: array
                     type: object
@@ -5907,34 +8051,33 @@ spec:
                     format: int32
                     type: integer
                   httpGet:
+                    description: '`httpGet` is performed to a given endpoint and the
+                      status/able to connect determines health.'
                     properties:
                       host:
                         description: Host name to connect to, defaults to the pod
                           IP.
-                        format: string
                         type: string
                       httpHeaders:
                         description: Headers the proxy will pass on to make the request.
                         items:
                           properties:
                             name:
-                              format: string
                               type: string
                             value:
-                              format: string
                               type: string
                           type: object
                         type: array
                       path:
                         description: Path to access on the HTTP server.
-                        format: string
                         type: string
                       port:
                         description: Port on which the endpoint lives.
                         type: integer
                       scheme:
-                        format: string
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -5954,10 +8097,11 @@ spec:
                     description: Health is determined by if the proxy is able to connect.
                     properties:
                       host:
-                        format: string
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -5969,20 +8113,20 @@ spec:
                   resources that belong to this `WorkloadGroup`.
                 properties:
                   address:
-                    format: string
+                    description: Address associated with the network endpoint without
+                      the port.
                     type: string
                   labels:
                     additionalProperties:
-                      format: string
                       type: string
                     description: One or more labels associated with the endpoint.
                     type: object
                   locality:
                     description: The locality associated with the endpoint.
-                    format: string
                     type: string
                   network:
-                    format: string
+                    description: Network enables Istio to group endpoints resident
+                      in the same L3 domain/network.
                     type: string
                   ports:
                     additionalProperties:
@@ -5990,12 +8134,15 @@ spec:
                     description: Set of ports associated with the endpoint.
                     type: object
                   serviceAccount:
-                    format: string
+                    description: The service account associated with the workload
+                      if a sidecar is present in the workload.
                     type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -6005,1059 +8152,641 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: '`WorkloadGroup` enables specifying the properties of a single
+              workload for bootstrap and provides a template for `WorkloadEntry`,
+              similar to how `Deployment` specifies properties of workloads via `Pod`
+              templates.'
+            properties:
+              metadata:
+                description: Metadata that will be used for all corresponding `WorkloadEntries`.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              probe:
+                description: '`ReadinessProbe` describes the configuration the user
+                  must provide for healthchecking on their workload.'
+                oneOf:
+                - not:
+                    anyOf:
+                    - required:
+                      - httpGet
+                    - required:
+                      - tcpSocket
+                    - required:
+                      - exec
+                - required:
+                  - httpGet
+                - required:
+                  - tcpSocket
+                - required:
+                  - exec
+                properties:
+                  exec:
+                    description: Health is determined by how the command that is executed
+                      exited.
+                    properties:
+                      command:
+                        description: Command to run.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: '`httpGet` is performed to a given endpoint and the
+                      status/able to connect determines health.'
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP.
+                        type: string
+                      httpHeaders:
+                        description: Headers the proxy will pass on to make the request.
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        description: Port on which the endpoint lives.
+                        type: integer
+                      scheme:
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started
+                      before readiness probes are initiated.
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: Health is determined by if the proxy is able to connect.
+                    properties:
+                      host:
+                        type: string
+                      port:
+                        type: integer
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out.
+                    format: int32
+                    type: integer
+                type: object
+              template:
+                description: Template to be used for the generation of `WorkloadEntry`
+                  resources that belong to this `WorkloadGroup`.
+                properties:
+                  address:
+                    description: Address associated with the network endpoint without
+                      the port.
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: One or more labels associated with the endpoint.
+                    type: object
+                  locality:
+                    description: The locality associated with the endpoint.
+                    type: string
+                  network:
+                    description: Network enables Istio to group endpoints resident
+                      in the same L3 domain/network.
+                    type: string
+                  ports:
+                    additionalProperties:
+                      type: integer
+                    description: Set of ports associated with the endpoint.
+                    type: object
+                  serviceAccount:
+                    description: The service account associated with the workload
+                      if a sidecar is present in the workload.
+                    type: string
+                  weight:
+                    description: The load balancing weight associated with the endpoint.
+                    type: integer
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istio-reader
+    release: istio
   name: istio-reader-service-account
   namespace: istio-system
-  labels:
-    app: istio-reader
-    release: istio
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istiod-service-account
+  labels:
+    app: istiod
+    release: istio
+  name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
-  - apiGroups:
-      - "config.istio.io"
-      - "security.istio.io"
-      - "networking.istio.io"
-      - "authentication.istio.io"
-      - "rbac.istio.io"
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.istio.io"]
-    verbs: [ "get", "watch", "list" ]
-    resources: [ "workloadentries" ]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]
-  - apiGroups: ["authorization.k8s.io"]
-    resources: ["subjectaccessreviews"]
-    verbs: ["create"]
+- apiGroups:
+  - config.istio.io
+  - security.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  - nodes
+  - replicationcontrollers
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - workloadentries
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.x-k8s.io
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
-  # sidecar injection controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - config.istio.io
+  - security.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - telemetry.istio.io
+  - extensions.istio.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - workloadentries
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - workloadentries/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - services
+  - namespaces
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - networking.x-k8s.io
+  - gateway.networking.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.x-k8s.io
+  - gateway.networking.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - delete
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - watch
+  - list
 
-  # configuration validation webhook controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod-gateway-controller-istio-system
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
 
-  # istio configuration
-  # removing CRD permissions can break older versions of Istio running alongside this control plane (https://github.com/istio/istio/issues/29382)
-  # please proceed with caution
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
-    verbs: ["get", "watch", "list"]
-    resources: ["*"]
-  - apiGroups: ["networking.istio.io"]
-    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
-    resources: [ "workloadentries" ]
-  - apiGroups: ["networking.istio.io"]
-    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
-    resources: [ "workloadentries/status" ]
-
-  # auto-detect installed CRD definitions
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-
-  # discovery and routing
-  - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["get", "list", "watch"]
-
-  # ingress controller
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "ingressclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses/status"]
-    verbs: ["*"]
-
-  # required for CA's namespace controller
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create", "get", "list", "watch", "update"]
-
-  # Istiod and bootstrap.
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "certificatesigningrequests"
-      - "certificatesigningrequests/approval"
-      - "certificatesigningrequests/status"
-    verbs: ["update", "create", "get", "delete", "watch"]
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "signers"
-    resourceNames:
-    - "kubernetes.io/legacy-unknown"
-    verbs: ["approve"]
-
-  # Used by Istiod to verify the JWT tokens
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]
-
-  # Used by Istiod to verify gateway SDS
-  - apiGroups: ["authorization.k8s.io"]
-    resources: ["subjectaccessreviews"]
-    verbs: ["create"]
-
-  # Use for Kubernetes Service APIs
-  - apiGroups: ["networking.x-k8s.io"]
-    resources: ["*"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: ["networking.x-k8s.io"]
-    resources: ["*"] # TODO: should be on just */status but wildcard is not supported
-    verbs: ["update"]
-
-  # Needed for multicluster secret reading, possibly ingress certs in the future
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "watch", "list"]
-
-  # Used for MCS serviceexport management
-  - apiGroups: ["multicluster.x-k8s.io"]
-    resources: ["serviceexports"]
-    verbs: ["get", "watch", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-istio-system
+  name: istio-reader-clusterrole-istio-system
 subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
+- kind: ServiceAccount
+  name: istio-reader-service-account
+  namespace: istio-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-istio-system
+  name: istiod-clusterrole-istio-system
 subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
-    namespace: istio-system
+- kind: ServiceAccount
+  name: istiod
+  namespace: istio-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod-gateway-controller-istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istiod-gateway-controller-istio-system
+subjects:
+- kind: ServiceAccount
+  name: istiod
+  namespace: istio-system
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
+    istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: validation.istio.io
-    clientConfig:
-      service:
-        name: istiod
-        namespace: istio-system
-        path: "/validate"
-      caBundle: "" # patched at runtime when the webhook is ready.
-    rules:
-      - operations:
-        - CREATE
-        - UPDATE
-        apiGroups:
-        - security.istio.io
-        - networking.istio.io
-        apiVersions:
-        - "*"
-        resources:
-        - "*"
-    # Fail open until the validation webhook is ready. The webhook controller
-    # will update this to `Fail` and patch in the `caBundle` when the webhook
-    # endpoint is ready.
-    failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: metadata-exchange-1.10
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-spec:
-  configPatches:
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: metadata-exchange-1.9
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-spec:
-  configPatches:
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: stats-filter-1.10
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "destination_cluster": "node.metadata['CLUSTER_ID']",
-                            "source_cluster": "downstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: stats-filter-1.9
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "source_cluster": "node.metadata['CLUSTER_ID']",
-                            "destination_cluster": "upstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "destination_cluster": "node.metadata['CLUSTER_ID']",
-                            "source_cluster": "downstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true,
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "source_cluster": "node.metadata['CLUSTER_ID']",
-                            "destination_cluster": "upstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: tcp-metadata-exchange-1.10
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener: {}
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
-    - applyTo: CLUSTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        cluster: {}
-      patch:
-        operation: MERGE
-        value:
-          filters:
-          - name: istio.metadata_exchange
-            typed_config:
-              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-              value:
-                protocol: istio-peer-exchange
-    - applyTo: CLUSTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.10.*'
-        cluster: {}
-      patch:
-        operation: MERGE
-        value:
-          filters:
-          - name: istio.metadata_exchange
-            typed_config:
-              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-              value:
-                protocol: istio-peer-exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: tcp-metadata-exchange-1.9
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener: {}
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
-    - applyTo: CLUSTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        cluster: {}
-      patch:
-        operation: MERGE
-        value:
-          filters:
-          - name: istio.metadata_exchange
-            typed_config:
-              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-              value:
-                protocol: istio-peer-exchange
-    - applyTo: CLUSTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.9.*'
-        cluster: {}
-      patch:
-        operation: MERGE
-        value:
-          filters:
-          - name: istio.metadata_exchange
-            typed_config:
-              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-              value:
-                protocol: istio-peer-exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: tcp-stats-filter-1.10
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "destination_cluster": "node.metadata['CLUSTER_ID']",
-                            "source_cluster": "downstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: tcp_stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-    - applyTo: NETWORK_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.10.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: tcp-stats-filter-1.9
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "destination_cluster": "node.metadata['CLUSTER_ID']",
-                            "source_cluster": "downstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: tcp_stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "source_cluster": "node.metadata['CLUSTER_ID']",
-                            "destination_cluster": "upstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-    - applyTo: NETWORK_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.9.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.stats
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-            value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "metrics": [
-                        {
-                          "dimensions": {
-                            "source_cluster": "node.metadata['CLUSTER_ID']",
-                            "destination_cluster": "upstream_peer.cluster_id"
-                          }
-                        }
-                      ]
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: /validate
+  failurePolicy: Ignore
+  name: rev.validation.istio.io
+  objectSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - default
+  rules:
+  - apiGroups:
+    - security.istio.io
+    - networking.istio.io
+    - telemetry.istio.io
+    - extensions.istio.io
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+  sideEffects: None
+
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    release: istio
 data:
-
-  # Configuration file for the mesh networks to be used by the Split Horizon EDS.
-  meshNetworks: |-
-    networks: {}
-
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7065,161 +8794,26 @@ data:
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
+    defaultProviders:
+      metrics:
+      - prometheus
     enablePrometheusMerge: true
     rootNamespace: istio-system
     trustDomain: cluster.local
----
-apiVersion: v1
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio
+  namespace: istio-system
+
+---
+apiVersion: v1
 data:
-
-  values: |-
-    {
-      "global": {
-        "caAddress": "",
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "holdApplicationUntilProxyStarts": false,
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2",
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "10m",
-              "memory": "10Mi"
-            }
-          }
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.10.1",
-        "tracer": {
-          "datadog": {
-            "address": "$(HOST_IP):8126"
-          },
-          "lightstep": {
-            "accessToken": "",
-            "address": ""
-          },
-          "stackdriver": {
-            "debug": false,
-            "maxNumberOfAnnotations": 200,
-            "maxNumberOfAttributes": 200,
-            "maxNumberOfMessageEvents": 200
-          },
-          "zipkin": {
-            "address": ""
-          }
-        },
-        "useMCP": false
-      },
-      "istio_cni": {
-        "enabled": false
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "objectSelector": {
-          "autoInject": true,
-          "enabled": true
-        },
-        "rewriteAppHTTPProbe": true,
-        "templates": {},
-        "useLegacySelectors": false
-      }
-    }
-
-  # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching
-  # and istiod webhook functionality.
-  #
-  # New fields should not use Values - it is a 'primary' config object, users should be able
-  # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7232,98 +8826,7 @@ data:
     template: "{{ Template_Version_And_Istio_Version_Mismatched_Check_Installation }}"
     templates:
       sidecar: |
-        {{- $containers := list }}
-        {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
-        metadata:
-          labels:
-            security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio"  | quote }}
-            service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
-            service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
-            istio.io/rev: {{ .Revision | default "default" | quote }}
-          annotations: {
-            {{- if eq (len $containers) 1 }}
-            kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
-            kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
-            {{ end }}
-        {{- if .Values.istio_cni.enabled }}
-            {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
-            {{- end }}
-            sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
-            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
-            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-            traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
-            traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
-            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-            traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
-            {{- end }}
-            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-            traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
-            {{- end }}
-            {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
-        {{- end }}
-          }
-        spec:
-          {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-          initContainers:
-          {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.istio_cni.enabled -}}
-          - name: istio-validation
-          {{ else -}}
-          - name: istio-init
-          {{ end -}}
-          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
-            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
-          {{- else }}
-            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-          {{- end }}
-            args:
-            - istio-iptables
-            - "-p"
-            - "15001"
-            - "-z"
-            - "15006"
-            - "-u"
-            - "1337"
-            - "-m"
-            - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
-            - "-i"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
-            - "-x"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-            - "-b"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
-            - "-d"
-          {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
-          {{- else }}
-            - "15090,15021"
-          {{- end }}
-            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
-            - "-q"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
-            {{ end -}}
-            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
-            - "-o"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
-            {{ end -}}
-            {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
-            - "-k"
-            - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
-            {{ end -}}
-            {{ if .Values.istio_cni.enabled -}}
-            - "--run-validation"
-            - "--skip-rule-apply"
-            {{ end -}}
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-          {{- if .ProxyConfig.ProxyMetadata }}
-            env:
-            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
-          {{- end }}
-            resources:
+        {{- define "resources"  }}
           {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
             {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
               requests:
@@ -7348,6 +8851,117 @@ data:
               {{ toYaml .Values.global.proxy.resources | indent 6 }}
             {{- end }}
           {{- end }}
+        {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
+        {{- $containers := list }}
+        {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+        metadata:
+          labels:
+            security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio"  | quote }}
+            {{- if eq (index .ProxyConfig.ProxyMetadata "ISTIO_META_ENABLE_HBONE") "true" }}
+            networking.istio.io/tunnel: {{ index .ObjectMeta.Labels `networking.istio.io/tunnel` | default "http"  | quote }}
+            {{- end }}
+            service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
+            service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
+          annotations: {
+            istio.io/rev: {{ .Revision | default "default" | quote }},
+            {{- if ge (len $containers) 1 }}
+            {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
+            kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            {{- end }}
+            {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-container`) }}
+            kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
+            {{- end }}
+            {{- end }}
+        {{- if .Values.istio_cni.enabled }}
+            {{- if not .Values.istio_cni.chained }}
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
+            {{- end }}
+            sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` .Values.global.proxy.includeInboundPorts }}traffic.sidecar.istio.io/includeInboundPorts: "{{.}}",{{ end }}
+            traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+            traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
+            {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+            traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
+            {{- end }}
+            {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
+            {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeInterfaces` }}traffic.sidecar.istio.io/excludeInterfaces: "{{.}}",{{ end }}
+        {{- end }}
+          }
+        spec:
+          {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+          initContainers:
+          {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
+          {{ if .Values.istio_cni.enabled -}}
+          - name: istio-validation
+          {{ else -}}
+          - name: istio-init
+          {{ end -}}
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+          {{- else }}
+            image: "{{ .ProxyImage }}"
+          {{- end }}
+            args:
+            - istio-iptables
+            - "-p"
+            - {{ .MeshConfig.ProxyListenPort | default "15001" | quote }}
+            - "-z"
+            - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
+            - "-u"
+            - {{ .ProxyUID | default "1337" | quote }}
+            - "-m"
+            - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+            - "-i"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
+            - "-x"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
+            - "-b"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` .Values.global.proxy.includeInboundPorts }}"
+            - "-d"
+          {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
+            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+          {{- else }}
+            - "15090,15021"
+          {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+            - "-q"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+            {{ end -}}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+            - "-o"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+            {{ end -}}
+            {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
+            - "-k"
+            - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+            {{ end -}}
+             {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeInterfaces`) -}}
+            - "-c"
+            - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeInterfaces` }}"
+            {{ end -}}
+            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+            {{ if .Values.global.logAsJson -}}
+            - "--log_as_json"
+            {{ end -}}
+            {{ if .Values.istio_cni.enabled -}}
+            - "--run-validation"
+            - "--skip-rule-apply"
+            {{ end -}}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+          {{- if .ProxyConfig.ProxyMetadata }}
+            env:
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end }}
+            resources:
+          {{ template "resources" . }}
             securityContext:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
@@ -7366,13 +8980,12 @@ data:
               runAsUser: 0
             {{- else }}
               readOnlyRootFilesystem: true
-              runAsGroup: 1337
-              runAsUser: 1337
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- end }}
-            restartPolicy: Always
           {{ end -}}
-          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           - name: enable-core-dump
             args:
             - -c
@@ -7382,10 +8995,11 @@ data:
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
           {{- else }}
-            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+            image: "{{ .ProxyImage }}"
           {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            resources: {}
+            resources:
+          {{ template "resources" . }}
             securityContext:
               allowPrivilegeEscalation: true
               capabilities:
@@ -7399,13 +9013,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
-            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+            image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -7415,12 +9032,6 @@ data:
             - sidecar
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -7430,10 +9041,6 @@ data:
           {{- if .Values.global.logAsJson }}
             - --log_as_json
           {{- end }}
-          {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
-            - --concurrency
-            - "{{ .ProxyConfig.Concurrency.GetValue }}"
-          {{- end -}}
           {{- if .Values.global.proxy.lifecycle }}
             lifecycle:
               {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
@@ -7480,14 +9087,10 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
+            - name: ISTIO_CPU_LIMIT
               valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -7506,19 +9109,26 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+            - name: ISTIO_META_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
             {{- if .Values.global.network }}
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7554,6 +9164,16 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if .Values.global.proxy.startupProbe.enabled }}
+            startupProbe:
+              httpGet:
+                path: /healthz/ready
+                port: 15021
+              initialDelaySeconds: 0
+              periodSeconds: 1
+              timeoutSeconds: 3
+              failureThreshold: {{ .Values.global.proxy.startupProbe.failureThreshold }}
+          {{ end }}
             readinessProbe:
               httpGet:
                 path: /healthz/ready
@@ -7564,6 +9184,19 @@ data:
               failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
             {{ end -}}
             securityContext:
+              {{- if eq (index .ProxyConfig.ProxyMetadata "IPTABLES_TRACE_LOGGING") "true" }}
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - NET_ADMIN
+                drop:
+                - ALL
+              privileged: true
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: false
+              runAsUser: 0
+              {{- else }}
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               capabilities:
                 {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -7578,45 +9211,38 @@ data:
                 drop:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
-              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
-              runAsGroup: 1337
-              fsGroup: 1337
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
               runAsNonRoot: false
               runAsUser: 0
               {{- else -}}
               runAsNonRoot: true
-              runAsUser: 1337
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              {{- end }}
               {{- end }}
             resources:
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-              requests:
-                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-                {{ end }}
-                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-                {{ end }}
-            {{- end }}
-            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-              limits:
-                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-                {{ end }}
-                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-                {{ end }}
-            {{- end }}
-          {{- else }}
-            {{- if .Values.global.proxy.resources }}
-              {{ toYaml .Values.global.proxy.resources | indent 6 }}
-            {{- end }}
-          {{- end }}
+          {{ template "resources" . }}
             volumeMounts:
+            - name: workload-socket
+              mountPath: /var/run/secrets/workload-spiffe-uds
+            - name: credential-socket
+              mountPath: /var/run/secrets/credential-uds
+            {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+            - name: gke-workload-certificate
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+              readOnly: true
+            {{- else }}
+            - name: workload-certs
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+            {{- end }}
             {{- if eq .Values.global.pilotCertProvider "istiod" }}
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
+            {{- end }}
+            {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+            - mountPath: /var/run/secrets/istio/kubernetes
+              name: kube-ca-cert
             {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
@@ -7651,6 +9277,18 @@ data:
               {{ end }}
               {{- end }}
           volumes:
+          - emptyDir:
+            name: workload-socket
+          - emptyDir:
+            name: credential-socket
+          {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+          - name: gke-workload-certificate
+            csi:
+              driver: workloadcertificates.security.cloud.google.com
+          {{- else }}
+          - emptyDir:
+            name: workload-certs
+          {{- end }}
           {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
           - name: custom-bootstrap-volume
             configMap:
@@ -7671,16 +9309,6 @@ data:
                 - path: "annotations"
                   fieldRef:
                     fieldPath: metadata.annotations
-                - path: "cpu-limit"
-                  resourceFieldRef:
-                    containerName: istio-proxy
-                    resource: limits.cpu
-                    divisor: 1m
-                - path: "cpu-request"
-                  resourceFieldRef:
-                    containerName: istio-proxy
-                    resource: requests.cpu
-                    divisor: 1m
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
           - name: istio-token
             projected:
@@ -7694,6 +9322,11 @@ data:
           - name: istiod-ca-cert
             configMap:
               name: istio-ca-root-cert
+          {{- end }}
+          {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+          - name: kube-ca-cert
+            configMap:
+              name: kube-root-ca.crt
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
@@ -7724,10 +9357,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -7735,8 +9364,8 @@ data:
           labels:
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
-            istio.io/rev: {{ .Revision | default "default" | quote }}
           annotations: {
+            istio.io/rev: {{ .Revision | default "default" | quote }},
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -7748,7 +9377,7 @@ data:
           {{- if contains "/" .Values.global.proxy.image }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
-            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+            image: "{{ .ProxyImage }}"
           {{- end }}
             ports:
             - containerPort: 15090
@@ -7759,12 +9388,6 @@ data:
             - router
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -7778,6 +9401,9 @@ data:
             lifecycle:
               {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
           {{- end }}
+            securityContext:
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
             env:
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}
@@ -7809,14 +9435,10 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
+            - name: ISTIO_CPU_LIMIT
               valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -7833,21 +9455,28 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+            - name: ISTIO_META_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
             {{- if .Values.global.network }}
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7881,6 +9510,18 @@ data:
               timeoutSeconds: 3
               failureThreshold: {{ .Values.global.proxy.readinessFailureThreshold }}
             volumeMounts:
+            - name: workload-socket
+              mountPath: /var/run/secrets/workload-spiffe-uds
+            - name: credential-socket
+              mountPath: /var/run/secrets/credential-uds
+            {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+            - name: gke-workload-certificate
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+              readOnly: true
+            {{- else }}
+            - name: workload-certs
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+            {{- end }}
             {{- if eq .Values.global.pilotCertProvider "istiod" }}
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
@@ -7903,6 +9544,18 @@ data:
             - name: istio-podinfo
               mountPath: /etc/istio/pod
           volumes:
+          - emptyDir: {}
+            name: workload-socket
+          - emptyDir: {}
+            name: credential-socket
+          {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+          - name: gke-workload-certificate
+            csi:
+              driver: workloadcertificates.security.cloud.google.com
+          {{- else}}
+          - emptyDir: {}
+            name: workload-certs
+          {{- end }}
           # SDS channel between istioagent and Envoy
           - emptyDir:
               medium: Memory
@@ -7918,16 +9571,6 @@ data:
                 - path: "annotations"
                   fieldRef:
                     fieldPath: metadata.annotations
-                - path: "cpu-limit"
-                  resourceFieldRef:
-                    containerName: istio-proxy
-                    resource: limits.cpu
-                    divisor: 1m
-                - path: "cpu-request"
-                  resourceFieldRef:
-                    containerName: istio-proxy
-                    resource: requests.cpu
-                    divisor: 1m
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
           - name: istio-token
             projected:
@@ -7959,44 +9602,1144 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-          securityContext:
-            fsGroup: 1337
+      grpc-simple: |
+        metadata:
+          annotations:
+            sidecar.istio.io/rewriteAppHTTPProbers: "false"
+        spec:
+          initContainers:
+            - name: grpc-bootstrap-init
+              image: busybox:1.28
+              volumeMounts:
+                - mountPath: /var/lib/grpc/data/
+                  name: grpc-io-proxyless-bootstrap
+              env:
+                - name: INSTANCE_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ISTIO_NAMESPACE
+                  value: |
+                     {{ .Values.global.istioNamespace }}
+              command:
+                - sh
+                - "-c"
+                - |-
+                  NODE_ID="sidecar~${INSTANCE_IP}~${POD_NAME}.${POD_NAMESPACE}~cluster.local"
+                  SERVER_URI="dns:///istiod.${ISTIO_NAMESPACE}.svc:15010"
+                  echo '
+                  {
+                    "xds_servers": [
+                      {
+                        "server_uri": "'${SERVER_URI}'",
+                        "channel_creds": [{"type": "insecure"}],
+                        "server_features" : ["xds_v3"]
+                      }
+                    ],
+                    "node": {
+                      "id": "'${NODE_ID}'",
+                      "metadata": {
+                        "GENERATOR": "grpc"
+                      }
+                    }
+                  }' > /var/lib/grpc/data/bootstrap.json
+          containers:
+          {{- range $index, $container := .Spec.Containers }}
+          - name: {{ $container.Name }}
+            env:
+              - name: GRPC_XDS_BOOTSTRAP
+                value: /var/lib/grpc/data/bootstrap.json
+              - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+                value: "99"
+              - name: GRPC_GO_LOG_SEVERITY_LEVEL
+                value: info
+            volumeMounts:
+              - mountPath: /var/lib/grpc/data/
+                name: grpc-io-proxyless-bootstrap
           {{- end }}
+          volumes:
+            - name: grpc-io-proxyless-bootstrap
+              emptyDir: {}
+      grpc-agent: |
+        {{- define "resources"  }}
+          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+              requests:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ end }}
+            {{- end }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+              limits:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ end }}
+            {{- end }}
+          {{- else }}
+            {{- if .Values.global.proxy.resources }}
+              {{ toYaml .Values.global.proxy.resources | indent 6 }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- $containers := list }}
+        {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+        metadata:
+          labels:
+            {{/* security.istio.io/tlsMode: istio must be set by user, if gRPC is using mTLS initialization code. We can't set it automatically. */}}
+            service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
+            service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
+          annotations: {
+            istio.io/rev: {{ .Revision | default "default" }},
+            {{- if ge (len $containers) 1 }}
+            {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
+            kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            {{- end }}
+            {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-container`) }}
+            kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
+            {{- end }}
+            {{- end }}
+            sidecar.istio.io/rewriteAppHTTPProbers: "false",
+          }
+        spec:
+          containers:
+          - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
+            image: "{{ .ProxyImage }}"
+          {{- end }}
+            ports:
+            - containerPort: 15020
+              protocol: TCP
+              name: mesh-metrics
+            args:
+            - proxy
+            - sidecar
+            - --domain
+            - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+            - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
+            - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
+            - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
+          {{- if .Values.global.sts.servicePort }}
+            - --stsPort={{ .Values.global.sts.servicePort }}
+          {{- end }}
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                  - pilot-agent
+                  - wait
+                  - --url=http://localhost:15020/healthz/ready
+            env:
+            - name: ISTIO_META_GENERATOR
+              value: grpc
+            - name: OUTPUT_CERTS
+              value: /var/lib/istio/data
+            {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+            - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+              value: "true"
+            {{- end }}
+            - name: JWT_POLICY
+              value: {{ .Values.global.jwtPolicy }}
+            - name: PILOT_CERT_PROVIDER
+              value: {{ .Values.global.pilotCertProvider }}
+            - name: CA_ADDR
+            {{- if .Values.global.caAddress }}
+              value: {{ .Values.global.caAddress }}
+            {{- else }}
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            {{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: PROXY_CONFIG
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
+            - name: ISTIO_META_POD_PORTS
+              value: |-
+                [
+                {{- $first := true }}
+                {{- range $index1, $c := .Spec.Containers }}
+                  {{- range $index2, $p := $c.Ports }}
+                    {{- if (structToJSON $p) }}
+                    {{if not $first}},{{end}}{{ structToJSON $p }}
+                    {{- $first = false }}
+                    {{- end }}
+                  {{- end}}
+                {{- end}}
+                ]
+            - name: ISTIO_META_APP_CONTAINERS
+              value: "{{ $containers | join "," }}"
+            - name: ISTIO_META_CLUSTER_ID
+              value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+            - name: ISTIO_META_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- if .Values.global.network }}
+            - name: ISTIO_META_NETWORK
+              value: "{{ .Values.global.network }}"
+            {{- end }}
+            {{- if .DeploymentMeta.Name }}
+            - name: ISTIO_META_WORKLOAD_NAME
+              value: "{{ .DeploymentMeta.Name }}"
+            {{ end }}
+            {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+            - name: ISTIO_META_OWNER
+              value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+            {{- end}}
+            {{- if .Values.global.meshID }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ .Values.global.meshID }}"
+            {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+            {{- end }}
+            {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+            - name: TRUST_DOMAIN
+              value: "{{ . }}"
+            {{- end }}
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            # grpc uses xds:/// to resolve – no need to resolve VIP
+            - name: ISTIO_META_DNS_CAPTURE
+              value: "false"
+            - name: DISABLE_ENVOY
+              value: "true"
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+            readinessProbe:
+              httpGet:
+                path: /healthz/ready
+                port: 15020
+              initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+              periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+              timeoutSeconds: 3
+              failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+            resources:
+          {{ template "resources" . }}
+            volumeMounts:
+            - name: workload-socket
+              mountPath: /var/run/secrets/workload-spiffe-uds
+            {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+            - name: gke-workload-certificate
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+              readOnly: true
+            {{- else }}
+            - name: workload-certs
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+            {{- end }}
+            {{- if eq .Values.global.pilotCertProvider "istiod" }}
+            - mountPath: /var/run/secrets/istio
+              name: istiod-ca-cert
+            {{- end }}
+            - mountPath: /var/lib/istio/data
+              name: istio-data
+            # UDS channel between istioagent and gRPC client for XDS/SDS
+            - mountPath: /etc/istio/proxy
+              name: istio-xds
+            {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
+            {{- end }}
+            {{- if .Values.global.mountMtlsCerts }}
+            # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
+            {{- end }}
+            - name: istio-podinfo
+              mountPath: /etc/istio/pod
+            {{- end }}
+              {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
+              {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
+            - name: "{{  $index }}"
+              {{ toYaml $value | indent 6 }}
+              {{ end }}
+              {{- end }}
+        {{- range $index, $container := .Spec.Containers  }}
+        {{ if not (eq $container.Name "istio-proxy") }}
+          - name: {{ $container.Name }}
+            env:
+              - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+                value: "true"
+              - name: "GRPC_XDS_BOOTSTRAP"
+                value: "/etc/istio/proxy/grpc-bootstrap.json"
+            volumeMounts:
+              - mountPath: /var/lib/istio/data
+                name: istio-data
+              # UDS channel between istioagent and gRPC client for XDS/SDS
+              - mountPath: /etc/istio/proxy
+                name: istio-xds
+              {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
+              - name: gke-workload-certificate
+                mountPath: /var/run/secrets/workload-spiffe-credentials
+                readOnly: true
+              {{- else }}
+              - name: workload-certs
+                mountPath: /var/run/secrets/workload-spiffe-credentials
+              {{- end }}
+        {{- end }}
+        {{- end }}
+          volumes:
+          - emptyDir:
+            name: workload-socket
+          {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+          - name: gke-workload-certificate
+            csi:
+              driver: workloadcertificates.security.cloud.google.com
+          {{- else }}
+          - emptyDir:
+            name: workload-certs
+          {{- end }}
+          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+          - name: custom-bootstrap-volume
+            configMap:
+              name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
+          {{- end }}
+          # SDS channel between istioagent and Envoy
+          - emptyDir:
+              medium: Memory
+            name: istio-xds
+          - name: istio-data
+            emptyDir: {}
+          - name: istio-podinfo
+            downwardAPI:
+              items:
+                - path: "labels"
+                  fieldRef:
+                    fieldPath: metadata.labels
+                - path: "annotations"
+                  fieldRef:
+                    fieldPath: metadata.annotations
+          {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+          - name: istio-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: istio-token
+                  expirationSeconds: 43200
+                  audience: {{ .Values.global.sds.token.aud }}
+          {{- end }}
+          {{- if eq .Values.global.pilotCertProvider "istiod" }}
+          - name: istiod-ca-cert
+            configMap:
+              name: istio-ca-root-cert
+          {{- end }}
+          {{- if .Values.global.mountMtlsCerts }}
+          # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+          - name: istio-certs
+            secret:
+              optional: true
+              {{ if eq .Spec.ServiceAccountName "" }}
+              secretName: istio.default
+              {{ else -}}
+              secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
+              {{  end -}}
+          {{- end }}
+            {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
+            {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
+          - name: "{{ $index }}"
+            {{ toYaml $value | indent 4 }}
+            {{ end }}
+            {{ end }}
+          {{- if .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- range .Values.global.imagePullSecrets }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+      waypoint: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: {{.ServiceAccount | quote}}
+          namespace: {{.Namespace | quote}}
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap .Labels | nindent 4 }}
+          ownerReferences:
+          - apiVersion: gateway.networking.k8s.io/v1beta1
+            kind: Gateway
+            name: "{{.Name}}"
+            uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              istio.io/gateway-name: "{{.Name}}"
+          template:
+            metadata:
+              annotations:
+                {{- toJsonMap
+                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+                  (strdict "istio.io/rev" (.Revision | default "default"))
+                  (strdict
+                    "ambient.istio.io/redirection" "disabled"
+                    "prometheus.io/path" "/stats/prometheus"
+                    "prometheus.io/port" "15020"
+                    "prometheus.io/scrape" "true"
+                  ) | nindent 8 }}
+              labels:
+                {{- toJsonMap
+                  (strdict
+                    "sidecar.istio.io/inject" "false"
+                    "service.istio.io/canonical-name" .DeploymentName
+                    "service.istio.io/canonical-revision" "latest"
+                   )
+                  .Labels
+                  (strdict
+                    "istio.io/gateway-name" .Name
+                    "gateway.istio.io/managed" "istio.io-mesh-controller"
+                  ) | nindent 8}}
+            spec:
+              terminationGracePeriodSeconds: 2
+              serviceAccountName: {{.ServiceAccount | quote}}
+              containers:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+                image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+                {{- else }}
+                image: "{{ .ProxyImage }}"
+                {{- end }}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
+                - proxy
+                - waypoint
+                - --domain
+                - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+                - --serviceCluster
+                - {{.ServiceAccount}}.$(POD_NAMESPACE)
+                - --proxyLogLevel
+                - {{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel | quote}}
+                - --proxyComponentLogLevel
+                - {{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel | quote}}
+                - --log_output_level
+                - {{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level | quote}}
+                {{- if .Values.global.logAsJson }}
+                - --log_as_json
+                {{- end }}
+                env:
+                - name: ISTIO_META_SERVICE_ACCOUNT
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.serviceAccountName
+                - name: ISTIO_META_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: JWT_POLICY
+                  value: {{ .Values.global.jwtPolicy }}
+                - name: PILOT_CERT_PROVIDER
+                  value: {{ .Values.global.pilotCertProvider }}
+                - name: CA_ADDR
+                {{- if .Values.global.caAddress }}
+                  value: {{ .Values.global.caAddress }}
+                {{- else }}
+                  value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+                {{- end }}
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: INSTANCE_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: SERVICE_ACCOUNT
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.serviceAccountName
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: ISTIO_CPU_LIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
+                - name: PROXY_CONFIG
+                  value: |
+                         {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
+                - name: ISTIO_META_CLUSTER_ID
+                  value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+                {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+                {{- if $network }}
+                - name: ISTIO_META_NETWORK
+                  value: "{{ $network }}"
+                {{- end }}
+                - name: ISTIO_META_INTERCEPTION_MODE
+                  value: REDIRECT
+                - name: ISTIO_META_WORKLOAD_NAME
+                  value: {{.DeploymentName}}
+                - name: ISTIO_META_OWNER
+                  value: kubernetes://apis/apps/v1/namespaces/{{.Namespace}}/deployments/{{.DeploymentName}}
+                {{- if .Values.global.meshID }}
+                - name: ISTIO_META_MESH_ID
+                  value: "{{ .Values.global.meshID }}"
+                {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+                - name: ISTIO_META_MESH_ID
+                  value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+                {{- end }}
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                startupProbe:
+                  failureThreshold: 30
+                  httpGet:
+                    path: /healthz/ready
+                    port: 15021
+                    scheme: HTTP
+                  initialDelaySeconds: 1
+                  periodSeconds: 1
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                readinessProbe:
+                  failureThreshold: 4
+                  httpGet:
+                    path: /healthz/ready
+                    port: 15021
+                    scheme: HTTP
+                  initialDelaySeconds: 0
+                  periodSeconds: 15
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                securityContext:
+                  privileged: true
+                  runAsGroup: 1337
+                  runAsUser: 0
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                volumeMounts:
+                - mountPath: /var/run/secrets/istio
+                  name: istiod-ca-cert
+                - mountPath: /var/lib/istio/data
+                  name: istio-data
+                - mountPath: /etc/istio/proxy
+                  name: istio-envoy
+                - mountPath: /var/run/secrets/tokens
+                  name: istio-token
+                - mountPath: /etc/istio/pod
+                  name: istio-podinfo
+              volumes:
+              - emptyDir:
+                  medium: Memory
+                name: istio-envoy
+              - emptyDir:
+                  medium: Memory
+                name: go-proxy-envoy
+              - emptyDir: {}
+                name: istio-data
+              - emptyDir: {}
+                name: go-proxy-data
+              - downwardAPI:
+                  items:
+                  - fieldRef:
+                      fieldPath: metadata.labels
+                    path: labels
+                  - fieldRef:
+                      fieldPath: metadata.annotations
+                    path: annotations
+                name: istio-podinfo
+              - name: istio-token
+                projected:
+                  sources:
+                  - serviceAccountToken:
+                      audience: istio-ca
+                      expirationSeconds: 43200
+                      path: istio-token
+              - configMap:
+                  name: istio-ca-root-cert
+                name: istiod-ca-cert
+              {{- if .Values.global.imagePullSecrets }}
+              imagePullSecrets:
+                {{- range .Values.global.imagePullSecrets }}
+                - name: {{ . }}
+                {{- end }}
+              {{- end }}
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{ toJsonMap .Labels | nindent 4}}
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          ownerReferences:
+          - apiVersion: gateway.networking.k8s.io/v1beta1
+            kind: Gateway
+            name: "{{.Name}}"
+            uid: "{{.UID}}"
+        spec:
+          ports:
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
+            protocol: TCP
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
+          selector:
+            istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
+        ---
+      kube-gateway: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: {{.ServiceAccount | quote}}
+          namespace: {{.Namespace | quote}}
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap .Labels | nindent 4 }}
+          ownerReferences:
+          - apiVersion: gateway.networking.k8s.io/v1beta1
+            kind: Gateway
+            name: {{.Name}}
+            uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              istio.io/gateway-name: {{.Name}}
+          template:
+            metadata:
+              annotations:
+                {{- toJsonMap
+                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+                  (strdict "istio.io/rev" (.Revision | default "default"))
+                  (strdict
+                    "prometheus.io/path" "/stats/prometheus"
+                    "prometheus.io/port" "15020"
+                    "prometheus.io/scrape" "true"
+                  ) | nindent 8 }}
+              labels:
+                {{- toJsonMap
+                  (strdict
+                    "sidecar.istio.io/inject" "false"
+                    "service.istio.io/canonical-name" .DeploymentName
+                    "service.istio.io/canonical-revision" "latest"
+                   )
+                  .Labels
+                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+            spec:
+              {{- if .KubeVersion122 }}
+              {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
+              securityContext:
+                sysctls:
+                - name: net.ipv4.ip_unprivileged_port_start
+                  value: "0"
+              {{- end }}
+              serviceAccountName: {{.ServiceAccount | quote}}
+              containers:
+              - name: istio-proxy
+              {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+                image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+              {{- else }}
+                image: "{{ .ProxyImage }}"
+              {{- end }}
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                securityContext:
+                {{- if .KubeVersion122 }}
+                  # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+                  capabilities:
+                    drop:
+                    - ALL
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsUser: {{ .ProxyUID | default "1337" }}
+                  runAsGroup: {{ .ProxyGID | default "1337" }}
+                  runAsNonRoot: true
+                {{- else }}
+                  capabilities:
+                    drop:
+                    - ALL
+                    add:
+                    - NET_BIND_SERVICE
+                  runAsUser: 0
+                  runAsGroup: 1337
+                  runAsNonRoot: false
+                  allowPrivilegeEscalation: true
+                  readOnlyRootFilesystem: true
+                {{- end }}
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                args:
+                - proxy
+                - router
+                - --domain
+                - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+                - --proxyLogLevel
+                - {{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel | quote}}
+                - --proxyComponentLogLevel
+                - {{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel | quote}}
+                - --log_output_level
+                - {{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level | quote}}
+              {{- if .Values.global.sts.servicePort }}
+                - --stsPort={{ .Values.global.sts.servicePort }}
+              {{- end }}
+              {{- if .Values.global.logAsJson }}
+                - --log_as_json
+              {{- end }}
+              {{- if .Values.global.proxy.lifecycle }}
+                lifecycle:
+                  {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+              {{- end }}
+                env:
+                - name: JWT_POLICY
+                  value: {{ .Values.global.jwtPolicy }}
+                - name: PILOT_CERT_PROVIDER
+                  value: {{ .Values.global.pilotCertProvider }}
+                - name: CA_ADDR
+                {{- if .Values.global.caAddress }}
+                  value: {{ .Values.global.caAddress }}
+                {{- else }}
+                  value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+                {{- end }}
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: INSTANCE_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: SERVICE_ACCOUNT
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.serviceAccountName
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: ISTIO_CPU_LIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
+                - name: PROXY_CONFIG
+                  value: |
+                         {{ protoToJSON .ProxyConfig }}
+                - name: ISTIO_META_POD_PORTS
+                  value: "[]"
+                - name: ISTIO_META_APP_CONTAINERS
+                  value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
+                - name: ISTIO_META_CLUSTER_ID
+                  value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
+                - name: ISTIO_META_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: ISTIO_META_INTERCEPTION_MODE
+                  value: "{{ .ProxyConfig.InterceptionMode.String }}"
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+                - name: ISTIO_META_NETWORK
+                  value: {{.|quote}}
+                {{- end }}
+                - name: ISTIO_META_WORKLOAD_NAME
+                  value: {{.DeploymentName|quote}}
+                - name: ISTIO_META_OWNER
+                  value: "kubernetes://apis/apps/v1/namespaces/{{.Namespace}}/deployments/{{.DeploymentName}}"
+                {{- if .Values.global.meshID }}
+                - name: ISTIO_META_MESH_ID
+                  value: "{{ .Values.global.meshID }}"
+                {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+                - name: ISTIO_META_MESH_ID
+                  value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+                {{- end }}
+                {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+                - name: TRUST_DOMAIN
+                  value: "{{ . }}"
+                {{- end }}
+                {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+                - name: {{ $key }}
+                  value: "{{ $value }}"
+                {{- end }}
+                {{- with (index .Labels "topology.istio.io/network") }}
+                - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+                  value: {{.|quote}}
+                {{- end }}
+                startupProbe:
+                  failureThreshold: 30
+                  httpGet:
+                    path: /healthz/ready
+                    port: 15021
+                    scheme: HTTP
+                  initialDelaySeconds: 1
+                  periodSeconds: 1
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                readinessProbe:
+                  failureThreshold: 4
+                  httpGet:
+                    path: /healthz/ready
+                    port: 15021
+                    scheme: HTTP
+                  initialDelaySeconds: 0
+                  periodSeconds: 15
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                volumeMounts:
+                - name: workload-socket
+                  mountPath: /var/run/secrets/workload-spiffe-uds
+                - name: credential-socket
+                  mountPath: /var/run/secrets/credential-uds
+                {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+                - name: gke-workload-certificate
+                  mountPath: /var/run/secrets/workload-spiffe-credentials
+                  readOnly: true
+                {{- else }}
+                - name: workload-certs
+                  mountPath: /var/run/secrets/workload-spiffe-credentials
+                {{- end }}
+                {{- if eq .Values.global.pilotCertProvider "istiod" }}
+                - mountPath: /var/run/secrets/istio
+                  name: istiod-ca-cert
+                {{- end }}
+                - mountPath: /var/lib/istio/data
+                  name: istio-data
+                # SDS channel between istioagent and Envoy
+                - mountPath: /etc/istio/proxy
+                  name: istio-envoy
+                {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+                - mountPath: /var/run/secrets/tokens
+                  name: istio-token
+                {{- end }}
+                - name: istio-podinfo
+                  mountPath: /etc/istio/pod
+              volumes:
+              - emptyDir: {}
+                name: workload-socket
+              - emptyDir: {}
+                name: credential-socket
+              {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+              - name: gke-workload-certificate
+                csi:
+                  driver: workloadcertificates.security.cloud.google.com
+              {{- else}}
+              - emptyDir: {}
+                name: workload-certs
+              {{- end }}
+              # SDS channel between istioagent and Envoy
+              - emptyDir:
+                  medium: Memory
+                name: istio-envoy
+              - name: istio-data
+                emptyDir: {}
+              - name: istio-podinfo
+                downwardAPI:
+                  items:
+                    - path: "labels"
+                      fieldRef:
+                        fieldPath: metadata.labels
+                    - path: "annotations"
+                      fieldRef:
+                        fieldPath: metadata.annotations
+              {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+              - name: istio-token
+                projected:
+                  sources:
+                  - serviceAccountToken:
+                      path: istio-token
+                      expirationSeconds: 43200
+                      audience: {{ .Values.global.sds.token.aud }}
+              {{- end }}
+              {{- if eq .Values.global.pilotCertProvider "istiod" }}
+              - name: istiod-ca-cert
+                configMap:
+                  name: istio-ca-root-cert
+              {{- end }}
+              {{- if .Values.global.imagePullSecrets }}
+              imagePullSecrets:
+                {{- range .Values.global.imagePullSecrets }}
+                - name: {{ . }}
+                {{- end }}
+              {{- end }}
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{ toJsonMap .Labels | nindent 4}}
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          ownerReferences:
+          - apiVersion: gateway.networking.k8s.io/v1beta1
+            kind: Gateway
+            name: {{.Name}}
+            uid: {{.UID}}
+        spec:
+          ports:
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
+            protocol: TCP
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
+          selector:
+            istio.io/gateway-name: {{.Name}}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
+        ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 4,
+          "readinessInitialDelaySeconds": 0,
+          "readinessPeriodSeconds": 15,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "startupProbe": {
+            "enabled": true,
+            "failureThreshold": 600
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.20.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": false
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-- name: rev.namespace.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
   clientConfig:
     service:
       name: istiod
       namespace: istio-system
-      path: "/inject"
+      path: /inject
       port: 443
-    caBundle: ""
-  sideEffects: None
-  rules:
-  - operations: [ "CREATE" ]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  name: rev.namespace.sidecar-injector.istio.io
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
       operator: In
       values:
-      - "default"
+      - default
     - key: istio-injection
       operator: DoesNotExist
   objectSelector:
@@ -8005,22 +10748,28 @@ webhooks:
       operator: NotIn
       values:
       - "false"
-- name: rev.object.sidecar-injector.istio.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
   clientConfig:
     service:
       name: istiod
       namespace: istio-system
-      path: "/inject"
+      path: /inject
       port: 443
-    caBundle: ""
-  sideEffects: None
-  rules:
-  - operations: [ "CREATE" ]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  name: rev.object.sidecar-injector.istio.io
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
@@ -8036,23 +10785,29 @@ webhooks:
     - key: istio.io/rev
       operator: In
       values:
-      - "default"
-- name: namespace.sidecar-injector.istio.io
+      - default
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
   clientConfig:
     service:
       name: istiod
       namespace: istio-system
-      path: "/inject"
+      path: /inject
       port: 443
-    caBundle: ""
-  sideEffects: None
-  rules:
-  - operations: [ "CREATE" ]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  name: namespace.sidecar-injector.istio.io
   namespaceSelector:
     matchExpressions:
     - key: istio-injection
@@ -8065,22 +10820,28 @@ webhooks:
       operator: NotIn
       values:
       - "false"
-- name: object.sidecar-injector.istio.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
   clientConfig:
     service:
       name: istiod
       namespace: istio-system
-      path: "/inject"
+      path: /inject
       port: 443
-    caBundle: ""
-  sideEffects: None
-  rules:
-  - operations: [ "CREATE" ]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  name: object.sidecar-injector.istio.io
   namespaceSelector:
     matchExpressions:
     - key: istio-injection
@@ -8095,19 +10856,31 @@ webhooks:
       - "true"
     - key: istio.io/rev
       operator: DoesNotExist
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   selector:
     matchLabels:
@@ -8119,460 +10892,479 @@ spec:
       maxUnavailable: 25%
   template:
     metadata:
-      labels:
-        app: istio-ingressgateway
-        istio: ingressgateway
-        heritage: Tiller
-        release: istio
-        chart: gateways
-        service.istio.io/canonical-name: istio-ingressgateway
-        service.istio.io/canonical-revision: latest
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        operator.istio.io/component: "IngressGateways"
-        sidecar.istio.io/inject: "false"
       annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        prometheus.io/path: "/stats/prometheus"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istio-ingressgateway
+        chart: gateways
+        heritage: Tiller
+        install.operator.istio.io/owning-resource: unknown
+        istio: ingressgateway
+        istio.io/rev: default
+        operator.istio.io/component: IngressGateways
+        release: istio
+        service.istio.io/canonical-name: istio-ingressgateway
+        service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: istio-ingressgateway
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        - name: ISTIO_META_UNPRIVILEGED_POD
+          value: "true"
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: docker.io/istio/proxyv2:1.20.0
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          protocol: TCP
+        - containerPort: 8080
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio/config
+          name: config-volume
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/pod
+          name: podinfo
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          readOnly: true
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          readOnly: true
       securityContext:
-        runAsUser: 1337
         runAsGroup: 1337
         runAsNonRoot: true
-        fsGroup: 1337
+        runAsUser: 1337
       serviceAccountName: istio-ingressgateway-service-account
-      containers:
-        - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.10.1"
-          ports:
-            - containerPort: 15021
-              protocol: TCP
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 8443
-              protocol: TCP
-            - containerPort: 15090
-              protocol: TCP
-              name: http-envoy-prom
-          args:
-          - proxy
-          - router
-          - --domain
-          - $(POD_NAMESPACE).svc.cluster.local
-          - --proxyLogLevel=warning
-          - --proxyComponentLogLevel=misc:error
-          - --log_output_level=default:info
-          - --serviceCluster
-          - istio-ingressgateway
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15021
-              scheme: HTTP
-            initialDelaySeconds: 1
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          env:
-          - name: JWT_POLICY
-            value: third-party-jwt
-          - name: PILOT_CERT_PROVIDER
-            value: istiod
-          - name: CA_ADDR
-            value: istiod.istio-system.svc:15012
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: CANONICAL_SERVICE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-name']
-          - name: CANONICAL_REVISION
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-revision']
-          - name: ISTIO_META_WORKLOAD_NAME
-            value: istio-ingressgateway
-          - name: ISTIO_META_OWNER
-            value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
-          - name: ISTIO_META_MESH_ID
-            value: "cluster.local"
-          - name: TRUST_DOMAIN
-            value: "cluster.local"
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
-          - name: ISTIO_META_ROUTER_MODE
-            value: "standard"
-          - name: ISTIO_META_CLUSTER_ID
-            value: "Kubernetes"
-          volumeMounts:
-          - name: istio-envoy
-            mountPath: /etc/istio/proxy
-          - name: config-volume
-            mountPath: /etc/istio/config
-          - mountPath: /var/run/secrets/istio
-            name: istiod-ca-cert
-          - name: istio-token
-            mountPath: /var/run/secrets/tokens
-            readOnly: true
-          - mountPath: /var/lib/istio/data
-            name: istio-data
-          - name: podinfo
-            mountPath: /etc/istio/pod
-          - name: ingressgateway-certs
-            mountPath: "/etc/istio/ingressgateway-certs"
-            readOnly: true
-          - name: ingressgateway-ca-certs
-            mountPath: "/etc/istio/ingressgateway-ca-certs"
-            readOnly: true
       volumes:
-      - name: istiod-ca-cert
-        configMap:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - configMap:
           name: istio-ca-root-cert
-      - name: podinfo
-        downwardAPI:
+        name: istiod-ca-cert
+      - downwardAPI:
           items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
-            - path: "cpu-limit"
-              resourceFieldRef:
-                containerName: istio-proxy
-                resource: limits.cpu
-                divisor: 1m
-            - path: "cpu-request"
-              resourceFieldRef:
-                containerName: istio-proxy
-                resource: requests.cpu
-                divisor: 1m
-      - name: istio-envoy
-        emptyDir: {}
-      - name: istio-data
-        emptyDir: {}
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: podinfo
+      - emptyDir: {}
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
       - name: istio-token
         projected:
           sources:
           - serviceAccountToken:
-              path: istio-token
-              expirationSeconds: 43200
               audience: istio-ca
-      - name: config-volume
-        configMap:
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
           name: istio
           optional: true
+        name: config-volume
       - name: ingressgateway-certs
         secret:
-          secretName: "istio-ingressgateway-certs"
           optional: true
+          secretName: istio-ingressgateway-certs
       - name: ingressgateway-ca-certs
         secret:
-          secretName: "istio-ingressgateway-ca-certs"
           optional: true
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - "amd64"
-                  - "ppc64le"
-                  - "s390x"
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 2
-              preference:
-                matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - "amd64"
-            - weight: 2
-              preference:
-                matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - "ppc64le"
-            - weight: 2
-              preference:
-                matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - "s390x"
+          secretName: istio-ingressgateway-ca-certs
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: "Pilot"
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod-service-account
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: "docker.io/istio/pilot:1.10.1"
-          args:
-          - "discovery"
-          - --monitoringAddr=:15014
-          - --log_output_level=default:info
-          - --domain
-          - cluster.local
-          - --keepaliveMaxServerConnectionAge
-          - "30m"
-          ports:
-          - containerPort: 8080
-            protocol: TCP
-          - containerPort: 15010
-            protocol: TCP
-          - containerPort: 15017
-            protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
-          env:
-          - name: REVISION
-            value: "default"
-          - name: JWT_POLICY
-            value: third-party-jwt
-          - name: PILOT_CERT_PROVIDER
-            value: istiod
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.serviceAccountName
-          - name: KUBECONFIG
-            value: /var/run/secrets/remote/config
-          - name: PILOT_TRACE_SAMPLING
-            value: "1"
-          - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-            value: "true"
-          - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-            value: "true"
-          - name: ISTIOD_ADDR
-            value: istiod.istio-system.svc:15012
-          - name: PILOT_ENABLE_ANALYSIS
-            value: "false"
-          - name: CLUSTER_ID
-            value: "Kubernetes"
-          resources:
-            requests:
-              cpu: 500m
-              memory: 2048Mi
-          securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
-            capabilities:
-              drop:
-              - ALL
-          volumeMounts:
-          - name: istio-token
-            mountPath: /var/run/secrets/tokens
-            readOnly: true
-          - name: local-certs
-            mountPath: /var/run/secrets/istio-dns
-          - name: cacerts
-            mountPath: /etc/cacerts
-            readOnly: true
-          - name: istio-kubeconfig
-            mountPath: /var/run/secrets/remote
-            readOnly: true
+      - args:
+        - discovery
+        - --monitoringAddr=:15014
+        - --log_output_level=default:info
+        - --domain
+        - cluster.local
+        - --keepaliveMaxServerConnectionAge
+        - 30m
+        env:
+        - name: REVISION
+          value: default
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: KUBECONFIG
+          value: /var/run/secrets/remote/config
+        - name: PILOT_TRACE_SAMPLING
+          value: "1"
+        - name: PILOT_ENABLE_ANALYSIS
+          value: "false"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PLATFORM
+          value: ""
+        image: docker.io/istio/pilot:1.20.0
+        name: discovery
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        - containerPort: 15010
+          protocol: TCP
+        - containerPort: 15017
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 3
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2048Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
+        - mountPath: /var/run/secrets/istio-dns
+          name: local-certs
+        - mountPath: /etc/cacerts
+          name: cacerts
+          readOnly: true
+        - mountPath: /var/run/secrets/remote
+          name: istio-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/secrets/istiod/tls
+          name: istio-csr-dns-cert
+          readOnly: true
+        - mountPath: /var/run/secrets/istiod/ca
+          name: istio-csr-ca-configmap
+          readOnly: true
+      serviceAccountName: istiod
       volumes:
-      # Technically not needed on this pod - but it helps debugging/testing SDS
-      # Should be removed after everything works.
       - emptyDir:
           medium: Memory
         name: local-certs
       - name: istio-token
         projected:
           sources:
-            - serviceAccountToken:
-                audience: istio-ca
-                expirationSeconds: 43200
-                path: istio-token
-      # Optional: user-generated root
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
       - name: cacerts
         secret:
-          secretName: cacerts
           optional: true
+          secretName: cacerts
       - name: istio-kubeconfig
         secret:
-          secretName: istio-kubeconfig
           optional: true
+          secretName: istio-kubeconfig
+      - name: istio-csr-dns-cert
+        secret:
+          optional: true
+          secretName: istiod-tls
+      - configMap:
+          defaultMode: 420
+          name: istio-ca-root-cert
+          optional: true
+        name: istio-csr-ca-configmap
+
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
+
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    release: istio
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: istiod
       istio: pilot
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
-- apiGroups: ["networking.istio.io"]
-  verbs: ["create"]
-  resources: ["gateways"]
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - watch
+  - list
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+  - patch
+  - create
 
-- apiGroups: [""]
-  resources: ["secrets"]
-  # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
-  verbs: ["create", "get", "watch", "list", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8580,138 +11372,143 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: istio-ingressgateway-service-account
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istiod-istio-system
+  name: istiod
 subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
-    namespace: istio-system
+- kind: ServiceAccount
+  name: istiod
+  namespace: istio-system
+
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istio-ingressgateway
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
+
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 80
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: null
+  labels:
+    app: istio-ingressgateway
+    install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway
   namespace: istio-system
-  annotations:
-  labels:
-    app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "IngressGateways"
 spec:
-  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - name: http2
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-  ports:
-    -
-      name: status-port
-      port: 15021
-      protocol: TCP
-      targetPort: 15021
-    -
-      name: http2
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-    -
-      name: https
-      port: 443
-      protocol: TCP
-      targetPort: 8443
+  type: LoadBalancer
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds # plaintext
-      protocol: TCP
-    - port: 15012
-      name: https-dns # mTLS with k8s-signed cert
-      protocol: TCP
-    - port: 443
-      name: https-webhook # validation and injection
-      targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring # prometheus stats
-      protocol: TCP
+  - name: grpc-xds
+    port: 15010
+    protocol: TCP
+  - name: https-dns
+    port: 15012
+    protocol: TCP
+  - name: https-webhook
+    port: 443
+    protocol: TCP
+    targetPort: 15017
+  - name: http-monitoring
+    port: 15014
+    protocol: TCP
   selector:
     app: istiod
-    # Label used by the 'default' service. For versioned deployments we match with app and version.
-    # This avoids default deployment picking the canary
     istio: pilot
+
 ---


### PR DESCRIPTION
### Proposed changes
This pull request updates our CI Kubernetes cluster to version v1.28 and incorporates a new manifest for the TestIstio test. Note: GKE v1.24 EOL is slated for January 2024, so we should be updating our version soon anyway.

**Changes Made:**
- Upgraded the CI Kubernetes cluster to v1.28 for compatibility with the latest Kubernetes version.
- Updated the TestIstio test to use a new manifest obtained from the Istio installation instructions.
- Obtained manifests using the installation instructions from [Istio documentation](https://istio.io/latest/docs/setup/getting-started/#install).
- The provided commands were executed to fetch artifacts, including bookinfo samples and the istioctl binary. The istio installation manifest was generated using the istioctl binary.

**Commands run to update Istio:**
```bash
curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.20.0 TARGET_ARCH=x86_64 sh -
cd istio-1.20.0
bin/istioctl manifest generate > istio.yaml
# Manually add the istio-system namespace to the generated manifest.
```

### Related issues (optional)
This should also fix #2701 by bringing the APIServer version to match the installed kubectl version in CI.
