### PR TITLE
Fix panic when PULUMI_KUBERNETES_MANAGED_BY_LABEL is used on resources without the managed by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: Fix: Helm Release fails with "the server could not find the requested resource" (https://github.com/pulumi/pulumi-kubernetes/pull/2677)
 - Fix Helm Chart resource lookup key handling for objects in default namespace (https://github.com/pulumi/pulumi-kubernetes/pull/2655)
 - Update Kubernetes schemas and libraries to v1.29.0 (https://github.com/pulumi/pulumi-kubernetes/pull/2690)
+- Fix panic when using `PULUMI_KUBERNETES_MANAGED_BY_LABEL` env var with SSA created objects (https://github.com/pulumi/pulumi-kubernetes/pull/2711)
 
 ## 4.5.5 (November 28, 2023)
 - Fix: Make the invoke calls for Helm charts and YAML config resilient to the value being None or an empty dict (https://github.com/pulumi/pulumi-kubernetes/pull/2665)

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -106,12 +106,18 @@ func HasManagedByLabel(obj *unstructured.Unstructured) bool {
 	if isComputedValue(val) {
 		return true
 	}
-	// now we should check to see if the user has specified a label via EnvVar
-	// we should also check to see if that value is the same as what is in the metadata
+
+	// Check if the value is a string/exists.
+	valStr, ok := val.(string)
+	if !ok {
+		return false
+	}
+
+	// Compare the obtained value with the value of `PULUMI_KUBERNETES_MANAGED_BY_LABEL` EnvVar if it exists.
 	labelVal, exists := os.LookupEnv("PULUMI_KUBERNETES_MANAGED_BY_LABEL")
 	if exists {
-		return labelVal == val.(string)
+		return labelVal == valStr
 	}
-	str, ok := val.(string)
-	return ok && str == "pulumi"
+
+	return valStr == "pulumi"
 }

--- a/provider/pkg/metadata/labels.go
+++ b/provider/pkg/metadata/labels.go
@@ -107,17 +107,12 @@ func HasManagedByLabel(obj *unstructured.Unstructured) bool {
 		return true
 	}
 
-	// Check if the value is a string/exists.
+	labelVal := "pulumi"
+	if env, exists := os.LookupEnv("PULUMI_KUBERNETES_MANAGED_BY_LABEL"); exists {
+		labelVal = env
+	}
+
 	valStr, ok := val.(string)
-	if !ok {
-		return false
-	}
 
-	// Compare the obtained value with the value of `PULUMI_KUBERNETES_MANAGED_BY_LABEL` EnvVar if it exists.
-	labelVal, exists := os.LookupEnv("PULUMI_KUBERNETES_MANAGED_BY_LABEL")
-	if exists {
-		return labelVal == valStr
-	}
-
-	return valStr == "pulumi"
+	return ok && valStr == labelVal
 }


### PR DESCRIPTION
### Proposed changes

This pull request addresses a panic scenario that occurs when attempting to assert a nil object as a string. The issue arises specifically when the `app.kubernetes.io/managed-by` label is absent from the Kubernetes object. This is the case when the object is created using SSA mode. The fix ensures proper handling of this situation to prevent the panic.

In addition to the fix, a new unit test has been introduced to  confirm the resolution of this panic scenario.

### Related issues (optional)

Fixes: #2708