### PR TITLE
Component option propagation (NodeJS SDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-- Fix option propagation in component resources (NodeJS SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2709)
+- Fix option propagation in component resources (NodeJS SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2713)
 - Fix option propagation in component resources (Go SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2709)
 
 ## 4.6.1 (December 14, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix option propagation in component resources (NodeJS SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2709)
 - Fix option propagation in component resources (Go SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2709)
 
 ## 4.6.1 (December 14, 2023)

--- a/provider/pkg/gen/nodejs-templates/kustomize/kustomize.ts
+++ b/provider/pkg/gen/nodejs-templates/kustomize/kustomize.ts
@@ -94,11 +94,10 @@ export class Directory extends yaml.CollectionComponentResource {
         }
         super("kubernetes:kustomize:Directory", name, config, opts);
 
-        const directory = config.directory
-
-        // Rather than using the default provider for the following invoke call, use the version specified
-        // in package.json.
-        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
+        const directory = config.directory;
+        
+        const childOpts = yaml.getChildOpts(this, opts);
+        const invokeOpts = yaml.getInvokeOpts(childOpts);
 
         const promise = pulumi.runtime.invoke("kubernetes:kustomize:directory", {directory}, invokeOpts);
         this.resources = pulumi.output(promise).apply<{[key: string]: pulumi.CustomResource}>(p => yaml.parse(
@@ -107,7 +106,7 @@ export class Directory extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: config.transformations || [],
             },
-            { parent: this, dependsOn: opts?.dependsOn }
+            childOpts
         ));
     }
 }

--- a/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
@@ -202,7 +202,8 @@ export class ConfigGroup extends CollectionComponentResource {
      */
     constructor(name: string, config: ConfigGroupOpts, opts?: pulumi.ComponentResourceOptions) {
         super("kubernetes:yaml:ConfigGroup", name, config, opts);
-        this.resources = parse(config, {...opts, parent: this});
+        const childOpts = getChildOpts(this, opts);
+        this.resources = parse(config, childOpts);
     }
 }
 
@@ -291,13 +292,14 @@ export class ConfigFile extends CollectionComponentResource {
             transformations.push(skipAwait);
         }
 
-       this.resources = pulumi.output(text.then(t => {
+        const childOpts = getChildOpts(this, opts);
+        this.resources = pulumi.output(text.then(t => {
             try {
                 const parsed = parseYamlDocument({
-                    objs: yamlLoadAll(t, opts),
+                    objs: yamlLoadAll(t, childOpts),
                     transformations,
                     resourcePrefix: config && config.resourcePrefix || undefined
-                }, {...opts, parent: this});
+                }, childOpts);
                 // If the provider is not fully initialized, the engine skips invoking on the provider and returns an
                 // empty result. This may change based on how https://github.com/pulumi/pulumi/issues/10209 is addressed.
                 parsed.apply(p => {
@@ -383,9 +385,26 @@ export interface ConfigOpts {
     resourcePrefix?: string;
 }
 
-/** @ignore */ function yamlLoadAll(text: string, opts?: pulumi.ComponentResourceOptions): Promise<any[]> {
-    let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
+/** @ignore */ export function getChildOpts(parent: pulumi.Resource, opts?: pulumi.ComponentResourceOptions): pulumi.CustomResourceOptions {
+    return {
+        parent: parent,
+        ...opts?.version && {version: opts.version},
+        ...opts?.pluginDownloadURL && {pluginDownloadURL: opts.pluginDownloadURL}
+    };
+}
 
+/** @ignore */ export function getInvokeOpts(opts?: pulumi.CustomResourceOptions): pulumi.InvokeOptions {
+    return {
+        parent: opts?.parent,
+        provider: opts?.provider,
+        version: opts?.version ?? getVersion(),
+        pluginDownloadURL: opts?.pluginDownloadURL,
+        async: true
+    };
+}
+
+/** @ignore */ function yamlLoadAll(text: string, opts?: pulumi.CustomResourceOptions): Promise<any[]> {
+    const invokeOpts = getInvokeOpts(opts);
     return pulumi.runtime.invoke("kubernetes:yaml:decode", {text}, invokeOpts)
         .then(p => p.result);
 }

--- a/sdk/nodejs/kustomize/kustomize.ts
+++ b/sdk/nodejs/kustomize/kustomize.ts
@@ -94,11 +94,10 @@ export class Directory extends yaml.CollectionComponentResource {
         }
         super("kubernetes:kustomize:Directory", name, config, opts);
 
-        const directory = config.directory
-
-        // Rather than using the default provider for the following invoke call, use the version specified
-        // in package.json.
-        let invokeOpts: pulumi.InvokeOptions = { async: true, version: getVersion(), provider: opts?.provider };
+        const directory = config.directory;
+        
+        const childOpts = yaml.getChildOpts(this, opts);
+        const invokeOpts = yaml.getInvokeOpts(childOpts);
 
         const promise = pulumi.runtime.invoke("kubernetes:kustomize:directory", {directory}, invokeOpts);
         this.resources = pulumi.output(promise).apply<{[key: string]: pulumi.CustomResource}>(p => yaml.parse(
@@ -107,7 +106,7 @@ export class Directory extends yaml.CollectionComponentResource {
                 objs: p.result,
                 transformations: config.transformations || [],
             },
-            { parent: this, dependsOn: opts?.dependsOn }
+            childOpts
         ));
     }
 }

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -29,13 +29,21 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/openapi"
 	"github.com/pulumi/pulumi-kubernetes/tests/v4"
+	. "github.com/pulumi/pulumi-kubernetes/tests/v4/gomega"
+	pulumirpctesting "github.com/pulumi/pulumi-kubernetes/tests/v4/pulumirpc"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,6 +55,9 @@ var baseOptions = &integration.ProgramTestOptions{
 	Verbose: true,
 	Dependencies: []string{
 		"@pulumi/kubernetes",
+	},
+	PostPrepareProject: func(p *engine.Projinfo) error {
+		return fsutil.CopyFile(filepath.Join(p.Root, "testdata"), filepath.Join("..", "..", "testdata"), nil)
 	},
 	Env: []string{
 		"PULUMI_K8S_CLIENT_BURST=200",
@@ -2124,4 +2135,448 @@ func TestFieldManagerPatchResources(t *testing.T) {
 	})
 
 	integration.ProgramTest(t, &test)
+}
+
+// TestOptionPropagation tests the handling of resource options by the various compoonent resources.
+// Component resources are responsible for implementing option propagation logic when creating
+// child resources.
+func TestOptionPropagation(t *testing.T) {
+	g := NewWithT(t)
+	format.MaxLength = 0
+	format.MaxDepth = 5
+	format.RegisterCustomFormatter(pulumirpctesting.FormatDebugInterceptorLog)
+
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	grpcLog, err := pulumirpctesting.NewDebugInterceptorLog(t)
+	require.NoError(t, err)
+
+	options := baseOptions.With(integration.ProgramTestOptions{
+		Dir:                  filepath.Join(cwd, "options"),
+		Env:                  []string{grpcLog.Env()},
+		Quick:                true,
+		ExpectRefreshChanges: false,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+
+			// lookup some resources for later use
+			providerA := tests.SearchResourcesByName(stackInfo, "", "pulumi:providers:kubernetes", "a")
+			require.NotNil(t, providerA)
+			providerB := tests.SearchResourcesByName(stackInfo, "", "pulumi:providers:kubernetes", "b")
+			require.NotNil(t, providerB)
+			providerNullOpts := tests.SearchResourcesByName(stackInfo, "", "pulumi:providers:kubernetes", "nullopts")
+			require.NotNil(t, providerNullOpts)
+			sleep := tests.SearchResourcesByName(stackInfo, "", "time:index/sleep:Sleep", "sleep")
+			require.NotNil(t, sleep)
+
+			// some helper functions for naming purposes
+			providerUrn := func(prov *apitype.ResourceV3) resource.URN {
+				return prov.URN + resource.URNNameDelimiter + resource.URN(prov.ID)
+			}
+			urn := func(parentType, baseType tokens.Type, name string) resource.URN {
+				return resource.NewURN(stackInfo.StackName, "options-test", parentType, baseType, name)
+			}
+
+			// read the GRPC log file to inspect the RegisterResource calls, since they provide
+			// the most detailed view of the resource's options as determined by the SDK.
+			logEntries, err := grpcLog.ReadAll()
+			require.NoError(t, err)
+			rr := logEntries.ListRegisterResource()
+			invokes := logEntries.Invokes()
+
+			// Verify that the invokes for provider A contain version info across-the-board.
+			// The Version and PluginDownloadURL options normally serve as hints when selecting
+			// a default provider, and should be propagated. For testing purposes, we set the provider explicitly to avoid
+			// any attempt to use the fake version/url.
+			g.Expect(invokes.ByProvider(providerUrn(providerA))).To(HaveEach(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Version": Equal("1.2.3"),
+						// bug: https://github.com/pulumi/pulumi/issues/14839
+						// "PluginDownloadURL": Equal("https://a.pulumi.test"),
+					}),
+				}),
+			))
+
+			// --- ConfigGroup ---
+
+			// ConfigGroup "cg-options" with most options
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigGroup", "cg-options")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("cg-options-old"), Alias("cg-options-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      HaveExactElements(string(sleep.URN)),
+						"Provider":          BeEmpty(),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerA)),
+						}),
+						"IgnoreChanges": HaveExactElements("ignored"),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:yaml:ConfigGroup", "cg-options"),
+				"kubernetes:core/v1:ConfigMap", "cg-options-cg-options-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("cg-options-cm-1-k8s-aliased"), Alias("cg-options-cg-options-cm-1-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEquivalentTo(providerUrn(providerA)),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers":         BeEmpty(),
+						"IgnoreChanges":     BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name":        Equal("cg-options-cm-1"),
+								"annotations": And(HaveKey("pulumi.com/skipAwait"), HaveKey("transformed")),
+							}),
+						}))),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:yaml:ConfigGroup", "cg-options"),
+				"kubernetes:yaml:ConfigFile", "cg-options-./testdata/options/configgroup/manifest.yaml")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("cg-options-./testdata/options/configgroup/manifest.yaml-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEmpty(),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"IgnoreChanges":     BeEmpty(),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("kubernetes:yaml:ConfigGroup", "kubernetes:yaml:ConfigFile", "cg-options-./testdata/options/configgroup/manifest.yaml"),
+				"kubernetes:core/v1:ConfigMap", "cg-options-configgroup-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("configgroup-cm-1-k8s-aliased"), Alias("cg-options-configgroup-cm-1-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEquivalentTo(providerUrn(providerA)),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers":         BeEmpty(),
+						"IgnoreChanges":     BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name":        Equal("configgroup-cm-1"),
+								"annotations": And(HaveKey("pulumi.com/skipAwait"), HaveKey("transformed")),
+							}),
+						}))),
+					}),
+				}),
+			))
+
+			// ConfigGroup "cg-provider" with "provider" option that should propagate to children.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigGroup", "cg-provider")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerB)),
+						}),
+					}),
+				}),
+			))
+
+			// ConfigGroup "cg-nullopts" with a stack transform to apply a "provider" option.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigGroup", "cg-nullopts")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerNullOpts)),
+						}),
+					}),
+				}),
+			))
+
+			// --- ConfigFile ---
+
+			// ConfigFile "cf-options" with most options
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigFile", "cf-options-cf-options")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("cf-options") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("cf-options-old"), Alias("cf-options-cf-options-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      HaveExactElements(string(sleep.URN)),
+						"Provider":          BeEmpty(),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerA)),
+						}),
+						"IgnoreChanges": HaveExactElements("ignored"),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:yaml:ConfigFile", "cf-options-cf-options"),
+				"kubernetes:core/v1:ConfigMap", "cf-options-configfile-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("configfile-cm-1-k8s-aliased"), Alias("cf-options-configfile-cm-1-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEquivalentTo(providerUrn(providerA)),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers":         BeEmpty(),
+						"IgnoreChanges":     BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name":        Equal("configfile-cm-1"),
+								"annotations": And(HaveKey("pulumi.com/skipAwait"), HaveKey("transformed")),
+							}),
+						}))),
+					}),
+				}),
+			))
+
+			// ConfigFile "cf-provider" with "provider" option that should propagate to children.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigFile", "cf-provider-cf-provider")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("cf-provider") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerB)),
+						}),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:yaml:ConfigFile", "cf-provider-cf-provider"),
+				"kubernetes:core/v1:ConfigMap", "cf-provider-configfile-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider":  BeEquivalentTo(providerUrn(providerB)),
+						"Version":   Not(BeEmpty()),
+						"Providers": BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name": Equal("configfile-cm-1"),
+							}),
+						}))),
+					}),
+				}),
+			))
+
+			// ConfigFile "cf-nullopts" with a stack transform to apply a "provider" option.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:yaml:ConfigFile", "cf-nullopts-cf-nullopts")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("cf-nullopts") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerNullOpts)),
+						}),
+					}),
+				}),
+			))
+
+			// --- Directory ---
+
+			// Directory "kustomize-options" with most options
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:kustomize:Directory", "kustomize-options-kustomize-options")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("kustomize-options") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("kustomize-options-old"), Alias("kustomize-options-kustomize-options-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      HaveExactElements(string(sleep.URN)),
+						"Provider":          BeEmpty(),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerA)),
+						}),
+						"IgnoreChanges": HaveExactElements("ignored"),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:kustomize:Directory", "kustomize-options-kustomize-options"),
+				"kubernetes:core/v1:ConfigMap", "kustomize-options-kustomize-cm-1-2kkk4bthmg")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("kustomize-cm-1-2kkk4bthmg-k8s-aliased"), Alias("kustomize-options-kustomize-cm-1-2kkk4bthmg-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEquivalentTo(providerUrn(providerA)),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers":         BeEmpty(),
+						"IgnoreChanges":     BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name":        Equal("kustomize-cm-1-2kkk4bthmg"),
+								"annotations": And(HaveKey("transformed")),
+							}),
+						}))),
+					}),
+				}),
+			))
+
+			// Directory "kustomize-provider" with "provider" option that should propagate to children.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:kustomize:Directory", "kustomize-provider-kustomize-provider")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("kustomize-provider") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerB)),
+						}),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:kustomize:Directory", "kustomize-provider-kustomize-provider"),
+				"kubernetes:core/v1:ConfigMap", "kustomize-provider-kustomize-cm-1-2kkk4bthmg")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider":  BeEquivalentTo(providerUrn(providerB)),
+						"Version":   Not(BeEmpty()),
+						"Providers": BeEmpty(),
+					}),
+				}),
+			))
+
+			// Directory "kustomize-nullopts" with a stack transform to apply a "provider" option.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:kustomize:Directory", "kustomize-nullopts-kustomize-nullopts")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("kustomize-nullopts") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerNullOpts)),
+						}),
+					}),
+				}),
+			))
+
+			// --- Chart ---
+
+			// Chart "chart-options"
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:helm.sh/v3:Chart", "chart-options-chart-options")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("chart-options") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(AliasByType("kubernetes:helm.sh/v2:Chart"), Alias("chart-options-old"), Alias("chart-options-chart-options-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      HaveExactElements(string(sleep.URN)),
+						"Provider":          BeEmpty(),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerA)),
+						}),
+						"IgnoreChanges": HaveExactElements("ignored"),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:helm.sh/v3:Chart", "chart-options-chart-options"),
+				"kubernetes:core/v1:ConfigMap", "chart-options-chart-options-chart-options-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Aliases":           HaveExactElements(Alias("chart-options-chart-options-cm-1-k8s-aliased"), Alias("chart-options-chart-options-chart-options-cm-1-aliased")),
+						"Protect":           BeTrue(),
+						"Dependencies":      BeEmpty(),
+						"Provider":          BeEquivalentTo(providerUrn(providerA)),
+						"Version":           Equal("1.2.3"),
+						"PluginDownloadURL": Equal("https://a.pulumi.test"),
+						"Providers":         BeEmpty(),
+						"IgnoreChanges":     BeEmpty(),
+						"Object": PointTo(ProtobufStruct(MatchKeys(IgnoreExtras, Keys{
+							"metadata": MatchKeys(IgnoreExtras, Keys{
+								"name":        Equal("chart-options-chart-options-cm-1"), // note: based on the Helm Release name
+								"annotations": And(HaveKey("pulumi.com/skipAwait")),
+							}),
+						}))),
+					}),
+				}),
+			))
+
+			// Chart "chart-provider" with "provider" option that should propagate to children.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:helm.sh/v3:Chart", "chart-provider-chart-provider")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("chart-provider") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerB)),
+						}),
+					}),
+				}),
+			))
+			g.Expect(rr.Named(urn("", "kubernetes:helm.sh/v3:Chart", "chart-provider-chart-provider"),
+				"kubernetes:core/v1:ConfigMap", "chart-provider-chart-provider-chart-provider-cm-1")).To(HaveExactElements(
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider":  BeEquivalentTo(providerUrn(providerB)),
+						"Version":   Not(BeEmpty()),
+						"Providers": BeEmpty(),
+					}),
+				}),
+			))
+
+			// Chart "chart-nullopts" with a stack transform to apply a "provider" option.
+			g.Expect(rr.Named(stackInfo.RootResource.URN,
+				"kubernetes:helm.sh/v3:Chart", "chart-nullopts-chart-nullopts")).To(HaveExactElements(
+				// quirk: NodeJS SDK applies resource_prefix ("chart-options") to the component itself.
+				MatchFields(IgnoreExtras, Fields{
+					"Request": MatchFields(IgnoreExtras, Fields{
+						"Provider": BeEmpty(),
+						"Version":  BeEmpty(),
+						"Providers": MatchAllKeys(Keys{
+							"kubernetes": BeEquivalentTo(providerUrn(providerNullOpts)),
+						}),
+					}),
+				}),
+			))
+		},
+	})
+
+	pt := integration.ProgramTestManualLifeCycle(t, &options)
+
+	err = pt.TestLifeCyclePrepare()
+	require.NoError(t, err)
+	t.Cleanup(pt.TestCleanUp)
+	err = pt.TestLifeCycleInitialize()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// to ensure cleanup, we need to unprotected all resources
+		err = pt.RunPulumiCommand("state", "unprotect", "--all", "-y")
+		contract.IgnoreError(err)
+
+		destroyErr := pt.TestLifeCycleDestroy()
+		contract.IgnoreError(destroyErr)
+	})
+
+	err = pt.TestPreviewUpdateAndEdits()
+	require.NoError(t, err)
 }

--- a/tests/sdk/nodejs/options/.gitignore
+++ b/tests/sdk/nodejs/options/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/tests/sdk/nodejs/options/Pulumi.yaml
+++ b/tests/sdk/nodejs/options/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: options-test
+runtime: nodejs
+description: Test options propagation with component resources.
+config:
+  pulumi:disable-default-providers: [kubernetes]

--- a/tests/sdk/nodejs/options/index.ts
+++ b/tests/sdk/nodejs/options/index.ts
@@ -1,0 +1,204 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+import * as time from "@pulumiverse/time";
+
+const config = new pulumi.Config();
+
+const bootstrapProvider = new k8s.Provider("bootstrap", {});
+
+// create a set of providers across namespaces, simply to facilitate the reuse of manifests in the below tests.
+const nulloptsNs = new k8s.core.v1.Namespace("nullopts", {}, { provider: bootstrapProvider });
+const aNs = new k8s.core.v1.Namespace("a", {}, { provider: bootstrapProvider });
+const bNs = new k8s.core.v1.Namespace("b", {}, { provider: bootstrapProvider });
+const nulloptsProvider = new k8s.Provider("nullopts", { namespace: nulloptsNs.metadata["name"] })
+const aProvider = new k8s.Provider("a", { namespace: aNs.metadata["name"] })
+const bProvider = new k8s.Provider("b", { namespace: bNs.metadata["name"] })
+
+// a sleep resource to exercise the "depends_on" component-level option
+const sleep = new time.Sleep("sleep", { createDuration: "1s" }, { dependsOn: [aProvider, bProvider] });
+
+// apply_default_opts is a stack transformation that applies default opts to any resource whose name ends with "-nullopts".
+// this is intended to be applied to component resources only.
+function applyDefaultOpts(args: pulumi.ResourceTransformationArgs): pulumi.ResourceTransformationResult | undefined {
+    if (args.name.endsWith("-nullopts")) {
+        return {
+            props: args.props,
+            opts: pulumi.mergeOptions(args.opts, {
+                provider: nulloptsProvider,
+            }),
+        };
+    }
+    return undefined;
+}
+pulumi.runtime.registerStackTransformation(applyDefaultOpts);
+
+// applyAlias is a Pulumi transformation that applies a unique alias to each resource.
+function applyAlias(args: pulumi.ResourceTransformationArgs): pulumi.ResourceTransformationResult | undefined {
+    return {
+        props: args.props,
+        opts: pulumi.mergeOptions(args.opts, {
+            aliases: [{ name: `${args.name}-aliased` }],
+        }),
+    };
+}
+
+// transform_k8s is a Kubernetes transformation that applies a unique alias and annotation to each resource.
+function transformK8s(obj: any, opts: pulumi.CustomResourceOptions) {
+    opts.aliases = [{ name: `${obj.metadata.name}-k8s-aliased` }, ...(opts.aliases ?? [])]
+    obj.metadata.annotations = { "transformed": "true" }
+}
+
+// --- ConfigGroup ---
+// options: providers, aliases, depends_on, ignore_changes, protect, transformations
+// args: skip_await, transformations
+new k8s.yaml.ConfigGroup("cg-options", {
+    resourcePrefix: "cg-options",
+    skipAwait: true,
+    transformations: [transformK8s],
+    files: ["./testdata/options/configgroup/*.yaml"],
+    yaml: [`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cg-options-cm-1
+`],
+},
+    {
+        providers: [aProvider],
+        aliases: [{ name: "cg-options-old" }],
+        ignoreChanges: ["ignored"],
+        protect: true,
+        dependsOn: [sleep],
+        transformations: [applyAlias],
+        version: "1.2.3",
+        pluginDownloadURL: "https://a.pulumi.test",
+    });
+
+// "providers" option
+new k8s.yaml.ConfigGroup("cg-providers", {
+    resourcePrefix: "cg-providers",
+    yaml: [`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cg-providers-cm-1
+`],
+}, { providers: [bProvider] });
+
+// "provider" option
+new k8s.yaml.ConfigGroup("cg-provider", {
+    resourcePrefix: "cg-provider",
+    yaml: [`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cg-provider-cm-1
+`],
+}, { provider: bProvider });
+
+// null opts
+new k8s.yaml.ConfigGroup("cg-nullopts", {
+    resourcePrefix: "cg-nullopts",
+    yaml: [`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cg-nullopts-cm-1
+`],
+});
+
+//  --- ConfigFile ---
+new k8s.yaml.ConfigFile("cf-options", {
+    resourcePrefix: "cf-options",
+    skipAwait: true,
+    transformations: [transformK8s],
+    file: "./testdata/options/configfile/manifest.yaml",
+}, {
+    providers: [aProvider],
+    aliases: [{ name: "cf-options-old" }],
+    ignoreChanges: ["ignored"],
+    protect: true,
+    dependsOn: [sleep],
+    transformations: [applyAlias],
+    version: "1.2.3",
+    pluginDownloadURL: "https://a.pulumi.test",
+});
+
+// "provider" option
+new k8s.yaml.ConfigFile("cf-provider", {
+    resourcePrefix: "cf-provider",
+    file: "./testdata/options/configfile/manifest.yaml",
+}, { provider: bProvider });
+
+// null opts
+new k8s.yaml.ConfigFile("cf-nullopts", {
+    resourcePrefix: "cf-nullopts",
+    file: "./testdata/options/configfile/manifest.yaml",
+});
+
+// empty manifest
+new k8s.yaml.ConfigFile("cf-empty", {
+    resourcePrefix: "cf-empty",
+    file: "./testdata/options/configfile/empty.yaml",
+}, { providers: [bProvider] });
+
+// --- Directory ---
+new k8s.kustomize.Directory("kustomize-options", {
+    directory: "./testdata/options/kustomize",
+    resourcePrefix: "kustomize-options",
+    transformations: [transformK8s],
+}, {
+    providers: [aProvider],
+    aliases: [{ name: "kustomize-options-old" }],
+    ignoreChanges: ["ignored"],
+    protect: true,
+    dependsOn: [sleep],
+    transformations: [applyAlias],
+    version: "1.2.3",
+    pluginDownloadURL: "https://a.pulumi.test",
+});
+
+// "provider" option
+new k8s.kustomize.Directory("kustomize-provider", {
+    directory: "./testdata/options/kustomize",
+    resourcePrefix: "kustomize-provider",
+}, { provider: bProvider });
+
+// null opts
+new k8s.kustomize.Directory("kustomize-nullopts", {
+    directory: "./testdata/options/kustomize",
+    resourcePrefix: "kustomize-nullopts",
+});
+
+// --- Chart ---
+// options: providers, aliases, depends_on, ignore_changes, protect, transformations
+// args: transformations
+new k8s.helm.v3.Chart("chart-options", {
+    path: "./testdata/options/chart",
+    resourcePrefix: "chart-options",
+    transformations: [transformK8s],
+    skipAwait: true,
+}, {
+    providers: [aProvider],
+    aliases: [{ name: "chart-options-old" }],
+    ignoreChanges: ["ignored"],
+    protect: true,
+    dependsOn: [sleep],
+    transformations: [applyAlias],
+    version: "1.2.3",
+    pluginDownloadURL: "https://a.pulumi.test",
+});
+
+// "provider" option
+new k8s.helm.v3.Chart("chart-provider", {
+    path: "./testdata/options/chart",
+    resourcePrefix: "chart-provider",
+}, { provider: bProvider });
+
+// null opts
+new k8s.helm.v3.Chart("chart-nullopts", {
+    path: "./testdata/options/chart",
+    resourcePrefix: "chart-nullopts",
+});
+
+

--- a/tests/sdk/nodejs/options/package.json
+++ b/tests/sdk/nodejs/options/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "options-test",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^16"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "^4.0.0",
+        "@pulumiverse/time": "^0.0.16"
+    }
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Epic: https://github.com/pulumi/pulumi-kubernetes/issues/2254
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/1938
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2049
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/812

This PR standardizes the option propagation logic for the component resources in the pulumi-kubernetes NodeJS SDK.  The general approach is:
1. In the component resource constructor, compute the child options to be propagated to any children.  The child options consist of the component as parent, and with `version` and `pluginDownloadURL` if specified.
2. Compute the invoke options by copying the child options.

### Specification
The component resource is responsible for computing sub-options for invokes and for child resource declarations. This table outlines the expected behavior for each [resource option](https://www.pulumi.com/docs/concepts/options/) when presented to a component resource.

|  | Propagated | Remarks |
|---|---|---|
| `additionalSecretOutputs` | no | "does not apply to component resources" |
| `aliases` | no | Inherited via parent-child relationship. |
| `customTimeouts` | no | "does not apply to component resources" |
| `deleteBeforeReplace` | no |  |
| `deletedWith` | no |  |
| `dependsOn` | no | The children implicitly wait for the dependency. |
| `ignoreChanges` | no | Nonsensical to apply directly to children (see [discussion](https://github.com/pulumi/pulumi/issues/8969)). |
| `import` | no |  |
| `parent` | **yes** | The component becomes the parent. |
| `protect` | no | Inherited. |
| `provider` | no | Combined into providers map, then inherited via parent-child relationship. |
| `providers` | no | Inherited. |
| `replaceOnChanges` | no | "does not apply to component resources" |
| `retainOnDelete` | no | "does not apply to component resources" |
| `transformations` | no | Inherited. |
| `version` | **yes** | Influences default provider selection logic during invokes.<br/>Should propagate when child resource is from the same provider type. |
| `pluginDownloadURL` | **yes** | Influences default provider selection logic during invokes.<br/>Should propagate when child resource is  from the same provider type. |

### Testing
A new test case is provided ([test case](https://github.com/pulumi/pulumi-kubernetes/blob/e1ad541a9c86e8eb207bd1d8a276822862425109/tests/sdk/nodejs/nodejs_test.go#L2107), [test program](https://github.com/pulumi/pulumi-kubernetes/blob/e1ad541a9c86e8eb207bd1d8a276822862425109/tests/sdk/nodejs/options/index.ts)) that exercises option propagation across the component resources:
- [kubernetes.helm.sh.v3.Chart](https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/chart/)
- [kubernetes.kustomize.Directory](https://www.pulumi.com/registry/packages/kubernetes/api-docs/kustomize/directory/)
- [kubernetes.yaml.ConfigGroup](https://www.pulumi.com/registry/packages/kubernetes/api-docs/yaml/configgroup/)
- [kubernetes.yaml.ConfigFile](https://www.pulumi.com/registry/packages/kubernetes/api-docs/yaml/configfile/)

Upgrade testing must be done manually, with an emphasis on avoiding replacement due to reparenting.

### Related issues (optional)

The p/p NodeJS SDK doesn't propagate the `pluginDownloadURL` option to the Invoke RPC.
https://github.com/pulumi/pulumi/issues/14839

