### PR TITLE
Fix normalization of base64 encoded secrets.data values to strip whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix Helm Chart resource lookup key handling for objects in default namespace (https://github.com/pulumi/pulumi-kubernetes/pull/2655)
 - Update Kubernetes schemas and libraries to v1.29.0 (https://github.com/pulumi/pulumi-kubernetes/pull/2690)
 - Fix panic when using `PULUMI_KUBERNETES_MANAGED_BY_LABEL` env var with SSA created objects (https://github.com/pulumi/pulumi-kubernetes/pull/2711)
+- Fix normalization of base64 encoded secrets.data values to strip whitespace (https://github.com/pulumi/pulumi-kubernetes/issues/2715)
 
 ## 4.5.5 (November 28, 2023)
 - Fix: Make the invoke calls for Helm charts and YAML config resilient to the value being None or an empty dict (https://github.com/pulumi/pulumi-kubernetes/pull/2665)

--- a/provider/pkg/clients/unstructured_test.go
+++ b/provider/pkg/clients/unstructured_test.go
@@ -284,6 +284,31 @@ var (
 			},
 		},
 	}
+
+	secretNewLineUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name": "foo"},
+			"data": map[string]any{
+				"foo": "dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n",
+			},
+		},
+	}
+
+	secretNewLineNormalizedUnstructured = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name": "foo",
+			},
+			"data": map[string]any{
+				"foo": "dGhpcyBpcyBhIHRlc3Qgc3RyaW5n",
+			},
+		},
+	}
 )
 
 func TestFromUnstructured(t *testing.T) {
@@ -329,6 +354,7 @@ func TestNormalize(t *testing.T) {
 		{"CRD with status", args{uns: crdStatusUnstructured}, crdUnstructured, false},
 		{"Secret with stringData input", args{uns: secretUnstructured}, secretNormalizedUnstructured, false},
 		{"Secret with data input", args{uns: secretNormalizedUnstructured}, secretNormalizedUnstructured, false},
+		{"Secret with data containing trailing new line", args{uns: secretNewLineUnstructured}, secretNewLineNormalizedUnstructured, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/sdk/nodejs/secrets-new-line/Pulumi.yaml
+++ b/tests/sdk/nodejs/secrets-new-line/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: secrets-new-line
+description: Tests secrets support with newline at end of data
+runtime: nodejs

--- a/tests/sdk/nodejs/secrets-new-line/index.ts
+++ b/tests/sdk/nodejs/secrets-new-line/index.ts
@@ -21,7 +21,7 @@ const provider = new k8s.Provider("k8s");
 
 const newlineSecret = new k8s.core.v1.Secret("newline", {
     data: {
-        password: " \n dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n\n\n", // "decoded base64 value: 'this is a test string'"
+        password: "dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n\n\n", // "decoded base64 value: 'this is a test string'"
     }
 }, {provider});
 

--- a/tests/sdk/nodejs/secrets-new-line/index.ts
+++ b/tests/sdk/nodejs/secrets-new-line/index.ts
@@ -21,7 +21,7 @@ const provider = new k8s.Provider("k8s");
 
 const newlineSecret = new k8s.core.v1.Secret("newline", {
     data: {
-        password: "dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n", // "this is a test string"
+        password: " \n dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n\n\n", // "decoded base64 value: 'this is a test string'"
     }
 }, {provider});
 

--- a/tests/sdk/nodejs/secrets-new-line/index.ts
+++ b/tests/sdk/nodejs/secrets-new-line/index.ts
@@ -1,0 +1,30 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const config = new pulumi.Config();
+
+const provider = new k8s.Provider("k8s");
+
+const newlineSecret = new k8s.core.v1.Secret("newline", {
+    data: {
+        password: "dGhpcyBpcyBhIHRlc3Qgc3RyaW5n\n", // "this is a test string"
+    }
+}, {provider});
+
+
+export const stringData = newlineSecret.stringData;
+export const data = newlineSecret.data;

--- a/tests/sdk/nodejs/secrets-new-line/package.json
+++ b/tests/sdk/nodejs/secrets-new-line/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "secrets",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/secrets-new-line/tsconfig.json
+++ b/tests/sdk/nodejs/secrets-new-line/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
### Proposed changes

This pull request introduces a normalization mechanism for `secret.data` base64 encoded values, specifically stripping whitespace to prevent unintended spurious diffs.

**Changes Made:**
- Created comprehensive integration and unit tests to verify and highlight the broken behavior associated with `secret.data` values containing whitespaces.
- Updated the provider to incorporate the normalization process, ensuring that all related tests pass seamlessly.

### Related issues (optional)

Fixes: #2681