### PR TITLE
Component option propagation (Python SDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix option propagation in component resources (Python SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2717)
 - Fix option propagation in component resources (.NET SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2720)
 - Fix option propagation in component resources (NodeJS SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2713)
 - Fix option propagation in component resources (Go SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2709)

--- a/provider/pkg/gen/python-templates/helm/v3/helm.py
+++ b/provider/pkg/gen/python-templates/helm/v3/helm.py
@@ -19,7 +19,7 @@ import json
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import pulumi.runtime
-from pulumi_kubernetes.yaml.yaml import _parse_yaml_document, _skip_await
+from pulumi_kubernetes.yaml.yaml import _get_child_options, _get_invoke_options, _parse_yaml_document, _skip_await
 
 from ... import _utilities
 
@@ -189,7 +189,8 @@ class Chart(pulumi.ComponentResource):
 
         config.release_name = release_name
 
-        all_config = pulumi.Output.from_input((config, pulumi.ResourceOptions(parent=self)))
+        parseOpts = _get_child_options(self, opts)
+        all_config = pulumi.Output.from_input((config, parseOpts))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the
@@ -607,12 +608,8 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     json_opts = config.to_json()
 
-    # Rather than using the default provider for the following invoke call, use the version specified
-    # in package.json.
-    invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version() if not opts.version else opts.version,
-     parent=opts.parent if opts.parent else None,
-     provider=opts.provider if opts.provider else None)
-
+    invoke_opts = _get_invoke_options(opts)
+    
     transformations = config.transformations if config.transformations is not None else []
     if config.skip_await:
         transformations.append(_skip_await)

--- a/provider/pkg/gen/python-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/python-templates/yaml/yaml.tmpl
@@ -179,22 +179,18 @@ class ConfigGroup(pulumi.ComponentResource):
             else:
                 _files += [f for f in glob(file)]
 
-        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
+        child_opts = _get_child_options(self, opts)
 
         for file in _files:
             cf = ConfigFile(
-                file, file_id=file, transformations=transformations, resource_prefix=resource_prefix, opts=opts)
+                file, file_id=file, transformations=transformations, resource_prefix=resource_prefix, opts=child_opts)
             # Add any new ConfigFile resources to the ConfigGroup's resources
             self.resources = pulumi.Output.all(cf.resources, self.resources).apply(lambda x: {**x[0], **x[1]})
 
         for text in yaml:
-            # Rather than using the default provider for the following invoke call, use the version specified
-            # in package.json.
-            invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
-                                               provider=opts.provider if opts.provider else None)
-
+            invoke_opts = _get_invoke_options(child_opts)
             __ret__ = invoke_yaml_decode(text, invoke_opts)
-            resources = _parse_yaml_document(__ret__, opts, transformations, resource_prefix)
+            resources = _parse_yaml_document(__ret__, child_opts, transformations, resource_prefix)
             # Add any new YAML resources to the ConfigGroup's resources
             self.resources = pulumi.Output.all(resources, self.resources).apply(lambda x: {**x[0], **x[1]})
 
@@ -334,23 +330,19 @@ class ConfigFile(pulumi.ComponentResource):
         else:
             text = _read_file(file)
 
-        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
+        child_opts = _get_child_options(self, opts)
 
         transformations = transformations if transformations is not None else []
         if skip_await:
             transformations.append(_skip_await)
-
-        # Rather than using the default provider for the following invoke call, use the version specified
-        # in package.json.
-        invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
-                                           provider=opts.provider if opts.provider else None)
-
+ 
+        invoke_opts = _get_invoke_options(child_opts)
         __ret__ = invoke_yaml_decode(text, invoke_opts)
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the
         # resolution of all resources that this YAML document created.
-        self.resources = _parse_yaml_document(__ret__, opts, transformations, resource_prefix)
+        self.resources = _parse_yaml_document(__ret__, child_opts, transformations, resource_prefix)
         self.register_outputs({"resources": self.resources})
 
     def translate_output_property(self, prop: str) -> str:
@@ -410,7 +402,26 @@ def _read_file(path: str) -> str:
 def _build_resources_dict(objs: Sequence[pulumi.Output]) -> Mapping[pulumi.Output, pulumi.Output]:
     return {key: value for key, value in objs}
 
+def _get_child_options(parent: pulumi.Resource, opts: pulumi.ResourceOptions):
+    if not opts:
+        opts = pulumi.ResourceOptions()
+    child_opts = pulumi.ResourceOptions(parent=parent)
+    if opts.version is not None:
+        child_opts.version = opts.version
+    if opts.plugin_download_url is not None:
+        child_opts.plugin_download_url = opts.plugin_download_url
+    return child_opts
 
+def _get_invoke_options(opts: pulumi.ResourceOptions):
+    if not opts:
+        opts = pulumi.ResourceOptions()
+    return pulumi.InvokeOptions(
+        parent=opts.parent if opts.parent else None,
+        provider=opts.provider if opts.provider else None,
+        version=_utilities.get_version() if not opts.version else opts.version,
+        plugin_download_url=opts.plugin_download_url if opts.plugin_download_url else None
+     )
+     
 def _parse_yaml_document(
         objects, opts: Optional[pulumi.ResourceOptions] = None,
         transformations: Optional[Sequence[Callable]] = None,

--- a/sdk/python/pulumi_kubernetes/helm/v3/helm.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/helm.py
@@ -19,7 +19,7 @@ import json
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import pulumi.runtime
-from pulumi_kubernetes.yaml.yaml import _parse_yaml_document, _skip_await
+from pulumi_kubernetes.yaml.yaml import _get_child_options, _get_invoke_options, _parse_yaml_document, _skip_await
 
 from ... import _utilities
 
@@ -189,7 +189,8 @@ class Chart(pulumi.ComponentResource):
 
         config.release_name = release_name
 
-        all_config = pulumi.Output.from_input((config, pulumi.ResourceOptions(parent=self)))
+        parseOpts = _get_child_options(self, opts)
+        all_config = pulumi.Output.from_input((config, parseOpts))
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the
@@ -607,12 +608,8 @@ def _parse_chart(all_config: Tuple[Union[ChartOpts, LocalChartOpts], pulumi.Reso
 
     json_opts = config.to_json()
 
-    # Rather than using the default provider for the following invoke call, use the version specified
-    # in package.json.
-    invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version() if not opts.version else opts.version,
-     parent=opts.parent if opts.parent else None,
-     provider=opts.provider if opts.provider else None)
-
+    invoke_opts = _get_invoke_options(opts)
+    
     transformations = config.transformations if config.transformations is not None else []
     if config.skip_await:
         transformations.append(_skip_await)

--- a/sdk/python/pulumi_kubernetes/yaml/yaml.py
+++ b/sdk/python/pulumi_kubernetes/yaml/yaml.py
@@ -179,22 +179,18 @@ class ConfigGroup(pulumi.ComponentResource):
             else:
                 _files += [f for f in glob(file)]
 
-        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
+        child_opts = _get_child_options(self, opts)
 
         for file in _files:
             cf = ConfigFile(
-                file, file_id=file, transformations=transformations, resource_prefix=resource_prefix, opts=opts)
+                file, file_id=file, transformations=transformations, resource_prefix=resource_prefix, opts=child_opts)
             # Add any new ConfigFile resources to the ConfigGroup's resources
             self.resources = pulumi.Output.all(cf.resources, self.resources).apply(lambda x: {**x[0], **x[1]})
 
         for text in yaml:
-            # Rather than using the default provider for the following invoke call, use the version specified
-            # in package.json.
-            invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
-                                               provider=opts.provider if opts.provider else None)
-
+            invoke_opts = _get_invoke_options(child_opts)
             __ret__ = invoke_yaml_decode(text, invoke_opts)
-            resources = _parse_yaml_document(__ret__, opts, transformations, resource_prefix)
+            resources = _parse_yaml_document(__ret__, child_opts, transformations, resource_prefix)
             # Add any new YAML resources to the ConfigGroup's resources
             self.resources = pulumi.Output.all(resources, self.resources).apply(lambda x: {**x[0], **x[1]})
 
@@ -334,23 +330,19 @@ class ConfigFile(pulumi.ComponentResource):
         else:
             text = _read_file(file)
 
-        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(parent=self))
+        child_opts = _get_child_options(self, opts)
 
         transformations = transformations if transformations is not None else []
         if skip_await:
             transformations.append(_skip_await)
-
-        # Rather than using the default provider for the following invoke call, use the version specified
-        # in package.json.
-        invoke_opts = pulumi.InvokeOptions(version=_utilities.get_version(),
-                                           provider=opts.provider if opts.provider else None)
-
+ 
+        invoke_opts = _get_invoke_options(child_opts)
         __ret__ = invoke_yaml_decode(text, invoke_opts)
 
         # Note: Unlike NodeJS, Python requires that we "pull" on our futures in order to get them scheduled for
         # execution. In order to do this, we leverage the engine's RegisterResourceOutputs to wait for the
         # resolution of all resources that this YAML document created.
-        self.resources = _parse_yaml_document(__ret__, opts, transformations, resource_prefix)
+        self.resources = _parse_yaml_document(__ret__, child_opts, transformations, resource_prefix)
         self.register_outputs({"resources": self.resources})
 
     def translate_output_property(self, prop: str) -> str:
@@ -410,7 +402,26 @@ def _read_file(path: str) -> str:
 def _build_resources_dict(objs: Sequence[pulumi.Output]) -> Mapping[pulumi.Output, pulumi.Output]:
     return {key: value for key, value in objs}
 
+def _get_child_options(parent: pulumi.Resource, opts: pulumi.ResourceOptions):
+    if not opts:
+        opts = pulumi.ResourceOptions()
+    child_opts = pulumi.ResourceOptions(parent=parent)
+    if opts.version is not None:
+        child_opts.version = opts.version
+    if opts.plugin_download_url is not None:
+        child_opts.plugin_download_url = opts.plugin_download_url
+    return child_opts
 
+def _get_invoke_options(opts: pulumi.ResourceOptions):
+    if not opts:
+        opts = pulumi.ResourceOptions()
+    return pulumi.InvokeOptions(
+        parent=opts.parent if opts.parent else None,
+        provider=opts.provider if opts.provider else None,
+        version=_utilities.get_version() if not opts.version else opts.version,
+        plugin_download_url=opts.plugin_download_url if opts.plugin_download_url else None
+     )
+     
 def _parse_yaml_document(
         objects, opts: Optional[pulumi.ResourceOptions] = None,
         transformations: Optional[Sequence[Callable]] = None,

--- a/tests/sdk/python/options/Pulumi.yaml
+++ b/tests/sdk/python/options/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: options-test
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+description: Test options propagation with component resources.
+config:
+  pulumi:disable-default-providers: [kubernetes]

--- a/tests/sdk/python/options/__main__.py
+++ b/tests/sdk/python/options/__main__.py
@@ -1,0 +1,228 @@
+"""A Kubernetes Python Pulumi program"""
+
+import pulumi
+from pulumi import ResourceOptions, ResourceTransformationResult, ResourceTransformationArgs, Alias
+import pulumi_kubernetes as k8s
+import pulumiverse_time as time
+
+bootstrap_provider = k8s.Provider("bootstrap")
+
+# create a set of providers across namespaces, simply to facilitate the reuse of manifests in the below tests.
+nullopts_ns = k8s.core.v1.Namespace("nullopts", opts=pulumi.ResourceOptions(provider=bootstrap_provider))
+a_ns = k8s.core.v1.Namespace("a", opts=pulumi.ResourceOptions(provider=bootstrap_provider))
+b_ns = k8s.core.v1.Namespace("b", opts=pulumi.ResourceOptions(provider=bootstrap_provider))
+nullopts_provider = k8s.Provider("nullopts", namespace=nullopts_ns.metadata["name"])
+a_provider = k8s.Provider("a", namespace=a_ns.metadata["name"])
+b_provider = k8s.Provider("b", namespace=b_ns.metadata["name"])
+
+# a sleep resource to exercise the "depends_on" component-level option
+sleep = time.Sleep("sleep", create_duration="1s", opts=pulumi.ResourceOptions(depends_on=[a_provider, b_provider]))
+
+# apply_default_opts is a stack transformation that applies default opts to any resource whose name ends with "-nullopts".
+# this is intended to be applied to component resources only.
+def apply_default_opts(args):
+    if args.name.endswith("-nullopts"):
+        return ResourceTransformationResult(
+            props=args.props,
+            opts=ResourceOptions.merge(args.opts, ResourceOptions(
+                provider=nullopts_provider,
+            )))
+    return None
+pulumi.runtime.register_stack_transformation(apply_default_opts)
+
+# apply_alias is a Pulumi transformation that applies a unique alias to each resource.
+def apply_alias(args: ResourceTransformationArgs):
+    return ResourceTransformationResult(
+      props=args.props,
+      opts=ResourceOptions.merge(args.opts, ResourceOptions(
+        aliases=[Alias(name=f'{args.name}-aliased')],
+      )),
+    )
+
+# transform_k8s is a Kubernetes transformation that applies a unique alias and annotation to each resource.
+def transform_k8s(obj, opts):
+    opts.aliases = [Alias(f'{obj["metadata"]["name"]}-k8s-aliased')] + (opts.aliases if opts.aliases is not None else [])
+    obj["metadata"]["annotations"] = {"transformed": "true"}
+
+### --- ConfigGroup ---
+# options: providers, aliases, depends_on, ignore_changes, protect, transformations
+# args: skip_await, transformations
+k8s.yaml.ConfigGroup(
+    "cg-options",
+    resource_prefix="cg-options",
+    skip_await=True,
+    transformations=[transform_k8s],
+    files=["./testdata/options/configgroup/*.yaml"],
+    yaml=['''
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cg-options-cm-1
+    '''],
+    opts=ResourceOptions(
+        providers=[a_provider],
+        aliases=[Alias(name="cg-options-old")],
+        ignore_changes=["ignored"],
+        protect=True,
+        depends_on=[sleep],
+        transformations=[apply_alias],
+        version="1.2.3",
+        plugin_download_url="https://a.pulumi.test",
+    ),
+)
+
+# "provider" option
+k8s.yaml.ConfigGroup(
+    "cg-provider",
+    resource_prefix="cg-provider",
+    yaml=['''
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cg-provider-cm-1
+    '''],
+    opts=ResourceOptions(
+        provider=b_provider,
+    ),
+)
+
+# null opts
+k8s.yaml.ConfigGroup(
+    "cg-nullopts",
+    resource_prefix="cg-nullopts",
+    yaml=['''
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cg-nullopts-cm-1
+    '''],
+)
+
+### --- ConfigFile ---
+# options: providers, aliases, depends_on, ignore_changes, protect, transformations
+# args: skip_await, transformations
+k8s.yaml.ConfigFile(
+    "cf-options",
+    file="./testdata/options/configfile/manifest.yaml",
+    resource_prefix="cf-options",
+    skip_await=True,
+    transformations=[transform_k8s],
+    opts=ResourceOptions(
+        providers=[a_provider],
+        aliases=[Alias(name="cf-options-old")],
+        ignore_changes=["ignored"],
+        protect=True,
+        depends_on=[sleep],
+        transformations=[apply_alias],
+        version="1.2.3",
+        plugin_download_url="https://a.pulumi.test",
+    ),
+)
+
+# "provider" option
+k8s.yaml.ConfigFile(
+    "cf-provider",
+    resource_prefix="cf-provider",
+    file="./testdata/options/configfile/manifest.yaml",
+    opts=ResourceOptions(
+        provider=b_provider,
+    ),
+)
+
+# null opts
+k8s.yaml.ConfigFile(
+    "cf-nullopts",
+    resource_prefix="cf-nullopts",
+    file="./testdata/options/configfile/manifest.yaml",
+)
+
+# empty manifests
+k8s.yaml.ConfigFile(
+    "cf-empty",
+    resource_prefix="cf-empty",
+    file="./testdata/options/configfile/empty.yaml",
+    opts=ResourceOptions(
+        providers=[b_provider],
+    ),
+)
+
+### --- Directory ---
+# options: providers, aliases, depends_on, ignore_changes, protect, transformations
+# args: transformations
+k8s.kustomize.Directory(
+    "kustomize-options",
+    directory="./testdata/options/kustomize",
+    resource_prefix="kustomize-options",
+    transformations=[transform_k8s],
+    opts=ResourceOptions(
+        providers=[a_provider],
+        aliases=[Alias(name="kustomize-options-old")],
+        ignore_changes=["ignored"],
+        protect=True,
+        depends_on=[sleep],
+        transformations=[apply_alias],
+        version="1.2.3",
+        plugin_download_url="https://a.pulumi.test",
+    ),
+)
+
+# "provider" option
+k8s.kustomize.Directory(
+    "kustomize-provider",
+    directory="./testdata/options/kustomize",
+    resource_prefix="kustomize-provider",
+    opts=ResourceOptions(
+        provider=b_provider,
+    ),
+)
+
+# null opts
+k8s.kustomize.Directory(
+    "kustomize-nullopts",
+    directory="./testdata/options/kustomize",
+    resource_prefix="kustomize-nullopts",
+)
+
+### --- Chart ---
+# options: providers, aliases, depends_on, ignore_changes, protect, transformations
+# args: transformations
+k8s.helm.v3.Chart(
+    "chart-options",
+    k8s.helm.v3.LocalChartOpts(
+        path="./testdata/options/chart",
+        resource_prefix="chart-options",
+        transformations=[transform_k8s],
+        skip_await=True,
+    ),
+    opts=ResourceOptions(
+        providers=[a_provider],
+        aliases=[Alias(name="chart-options-old")],
+        ignore_changes=["ignored"],
+        protect=True,
+        depends_on=[sleep],
+        transformations=[apply_alias],
+        version="1.2.3",
+        plugin_download_url="https://a.pulumi.test",
+    ),
+)
+
+# "provider" option
+k8s.helm.v3.Chart(
+    "chart-provider",
+    k8s.helm.v3.LocalChartOpts(
+        path="./testdata/options/chart",
+        resource_prefix="chart-provider",
+    ),
+    opts=ResourceOptions(
+        provider=b_provider,
+    ),
+)
+
+# null opts
+k8s.helm.v3.Chart(
+    "chart-nullopts",
+    k8s.helm.v3.LocalChartOpts(
+        path="./testdata/options/chart",
+        resource_prefix="chart-nullopts",
+    )
+)

--- a/tests/sdk/python/options/requirements.txt
+++ b/tests/sdk/python/options/requirements.txt
@@ -1,0 +1,3 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-kubernetes>=4.0.0,<5.0.0
+pulumiverse_time>=v0.0.16

--- a/tests/sdk/python/python_test.go
+++ b/tests/sdk/python/python_test.go
@@ -970,7 +970,10 @@ func TestOptionPropagation(t *testing.T) {
 				// quirk: Python SDK applies resource_prefix ("chart-options") to the component itself.
 				MatchFields(IgnoreExtras, Fields{
 					"Request": MatchFields(IgnoreExtras, Fields{
-						"Aliases":           ConsistOf(Alias("chart-options-old"), Alias("chart-options-chart-options-aliased"), AliasByType("kubernetes:helm.sh/v2:Chart")),
+						"Aliases":           ConsistOf(
+							Alias("chart-options-old"), 
+							Alias("chart-options-chart-options-aliased"), 
+							Alias(tokens.Type("kubernetes:helm.sh/v2:Chart"))),
 						"Protect":           BeTrue(),
 						"Dependencies":      ConsistOf(string(sleep.URN)),
 						"Provider":          BeEmpty(),

--- a/tests/sdk/python/yaml-test/__main__.py
+++ b/tests/sdk/python/yaml-test/__main__.py
@@ -63,15 +63,6 @@ cf_url2 = ConfigFile(
     resource_prefix="dup",
     opts=ResourceOptions(provider=provider),
 )
-
-# Test provider variations
-cf_provider = ConfigFile(
-    "yaml-test",
-    "manifest.yaml",
-    transformations=[set_namespace(ns)],
-    opts=ResourceOptions(providers=[provider]),
-)
-
 cg = ConfigGroup(
     "deployment",
     files=["ns*.yaml"],
@@ -82,17 +73,4 @@ metadata:
   name: cg3
     """],
     opts=ResourceOptions(provider=provider)
-)
-
-## Test provider variations
-cg = ConfigGroup(
-    "deployment",
-    files=["ns*.yaml"],
-    yaml=["""
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cg3
-    """],
-    opts=ResourceOptions(providers=[provider])
 )

--- a/tests/sdk/python/yaml-test/__main__.py
+++ b/tests/sdk/python/yaml-test/__main__.py
@@ -63,6 +63,15 @@ cf_url2 = ConfigFile(
     resource_prefix="dup",
     opts=ResourceOptions(provider=provider),
 )
+
+# Test provider variations
+cf_provider = ConfigFile(
+    "yaml-test",
+    "manifest.yaml",
+    transformations=[set_namespace(ns)],
+    opts=ResourceOptions(providers=[provider]),
+)
+
 cg = ConfigGroup(
     "deployment",
     files=["ns*.yaml"],
@@ -73,4 +82,17 @@ metadata:
   name: cg3
     """],
     opts=ResourceOptions(provider=provider)
+)
+
+## Test provider variations
+cg = ConfigGroup(
+    "deployment",
+    files=["ns*.yaml"],
+    yaml=["""
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cg3
+    """],
+    opts=ResourceOptions(providers=[provider])
 )


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Epic: https://github.com/pulumi/pulumi-kubernetes/issues/2254
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2356

This PR standardizes the option propagation logic for the component resources in the pulumi-kubernetes Python SDK.  The general approach is:
1. In the component resource constructor, compute the child options to be propagated to any children.  The child options consist of the component as parent, and with `version` and `pluginDownloadURL` if specified.
2. Compute the invoke options by copying the child options.

### Specification
The component resource is responsible for computing sub-options for invokes and for child resource declarations. This table outlines the expected behavior for each [resource option](https://www.pulumi.com/docs/concepts/options/) when presented to a component resource.

|  | Propagated | Remarks |
|---|---|---|
| `additionalSecretOutputs` | no | "does not apply to component resources" |
| `aliases` | no | Inherited via parent-child relationship. |
| `customTimeouts` | no | "does not apply to component resources" |
| `deleteBeforeReplace` | no |  |
| `deletedWith` | no |  |
| `dependsOn` | no | The children implicitly wait for the dependency. |
| `ignoreChanges` | no | Nonsensical to apply directly to children (see [discussion](https://github.com/pulumi/pulumi/issues/8969)). |
| `import` | no |  |
| `parent` | **yes** | The component becomes the parent. |
| `protect` | no | Inherited. |
| `provider` | no | Combined into providers map, then inherited via parent-child relationship. |
| `providers` | no | Inherited. |
| `replaceOnChanges` | no | "does not apply to component resources" |
| `retainOnDelete` | no | "does not apply to component resources" |
| `transformations` | no | Inherited. |
| `version` | **yes** | Influences default provider selection logic during invokes.<br/>Should propagate when child resource is from the same provider type. |
| `pluginDownloadURL` | **yes** | Influences default provider selection logic during invokes.<br/>Should propagate when child resource is  from the same provider type. |

### Testing
A new test case is provided ([test case](https://github.com/pulumi/pulumi-kubernetes/blob/183db21e939ac960f3474859138c0b13985fc627/tests/sdk/python/python_test.go#L629), [test program](https://github.com/pulumi/pulumi-kubernetes/blob/183db21e939ac960f3474859138c0b13985fc627/tests/sdk/python/options/__main__.py)) that exercises option propagation across the component resources:
- [kubernetes.helm.sh.v3.Chart](https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/chart/)
- [kubernetes.kustomize.Directory](https://www.pulumi.com/registry/packages/kubernetes/api-docs/kustomize/directory/)
- [kubernetes.yaml.ConfigGroup](https://www.pulumi.com/registry/packages/kubernetes/api-docs/yaml/configgroup/)
- [kubernetes.yaml.ConfigFile](https://www.pulumi.com/registry/packages/kubernetes/api-docs/yaml/configfile/)

Upgrade testing must be done manually, with an emphasis on avoiding replacement due to reparenting.

### Related issues (optional)


