### PR TITLE
Fix resource kind lookup using URN.Type instead of QualifiedType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix: Refine URN lookup by implementing suffix search for more accurate resource identification (https://github.com/pulumi/pulumi-kubernetes/issues/2719)
 
 ## 4.6.0 (December 13, 2023)
 - Fix: Helm OCI chart deployment fails in Windows (https://github.com/pulumi/pulumi-kubernetes/pull/2648)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
-- Fix: Refine URN lookup by implementing suffix search for more accurate resource identification (https://github.com/pulumi/pulumi-kubernetes/issues/2719)
+
+## 4.6.1 (December 14, 2023)
+- Fix: Refine URN lookup by using its core type for more accurate resource identification (https://github.com/pulumi/pulumi-kubernetes/issues/2719)
 
 ## 4.6.0 (December 13, 2023)
 - Fix: Helm OCI chart deployment fails in Windows (https://github.com/pulumi/pulumi-kubernetes/pull/2648)

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -618,7 +618,7 @@ func makeInterfaceSlice[T any](inputs []T) []interface{} {
 // fixCSAFieldManagers patches the field managers for an existing resource that was managed using client-side apply.
 // The new server-side apply field manager takes ownership of all these fields to avoid conflicts.
 func fixCSAFieldManagers(c *UpdateConfig, liveOldObj *unstructured.Unstructured, client dynamic.ResourceInterface) (*unstructured.Unstructured, error) {
-	if kinds.PatchQualifiedTypes.Has(c.URN.QualifiedType().String()) {
+	if kinds.IsPatchURN(c.URN) {
 		// When dealing with a patch resource, there's no need to patch the field managers.
 		// Doing so would inadvertently make us responsible for managing fields that are not relevant to us during updates,
 		// which occurs when reusing a patch resource. Patch resources do not need to worry about other fields
@@ -711,7 +711,7 @@ func Deletion(c DeleteConfig) error {
 		return nilIfGVKDeleted(err)
 	}
 
-	patchResource := kinds.PatchQualifiedTypes.Has(c.URN.QualifiedType().String())
+	patchResource := kinds.IsPatchURN(c.URN)
 	if c.ServerSideApply && patchResource {
 		err = ssa.Relinquish(c.Context, client, c.Inputs, c.FieldManager)
 		return err

--- a/provider/pkg/kinds/util.go
+++ b/provider/pkg/kinds/util.go
@@ -1,0 +1,45 @@
+package kinds
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func suffixSearch(urnS string, suffixes []string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(urnS, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPatchURN returns true if the URN is for a Patch resource.
+func IsPatchURN(urn resource.URN) bool {
+	urnS := urn.QualifiedType().String()
+
+	// Do a simple O(1) lookup in a set of known patch types.
+	if PatchQualifiedTypes.Has(urnS) {
+		return true
+	}
+
+	// Do a suffix search in case the resource is a component resource containing
+	// a patch resource. Eg. a component resource patch resource could have the following URN:
+	// my:component:Resource$kubernetes:apps/v1:DaemonSetPatch.
+	return suffixSearch(urnS, PatchQualifiedTypes.SortedValues())
+}
+
+// IsListURN returns true if the URN is for a List resource.
+func IsListURN(urn resource.URN) bool {
+	urnS := urn.QualifiedType().String()
+
+	// Do a simple O(1) lookup in a set of known list types.
+	if ListQualifiedTypes.Has(urnS) {
+		return true
+	}
+
+	// Do a suffix search in case the resource is a component resource containing
+	// a list resource.
+	return suffixSearch(urnS, ListQualifiedTypes.SortedValues())
+}

--- a/provider/pkg/kinds/util.go
+++ b/provider/pkg/kinds/util.go
@@ -1,45 +1,19 @@
 package kinds
 
 import (
-	"strings"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func suffixSearch(s string, suffixes []string) bool {
-	for _, suffix := range suffixes {
-		if strings.HasSuffix(s, suffix) {
-			return true
-		}
-	}
-	return false
-}
-
 // IsPatchURN returns true if the URN is for a Patch resource.
 func IsPatchURN(urn resource.URN) bool {
-	urnS := urn.QualifiedType().String()
+	urnS := urn.Type().String()
 
-	// Do a simple O(1) lookup in a set of known patch types.
-	if PatchQualifiedTypes.Has(urnS) {
-		return true
-	}
-
-	// Do a suffix search in case the resource is a component resource containing
-	// a patch resource. Eg. a component resource patch resource could have the following URN:
-	// my:component:Resource$kubernetes:apps/v1:DaemonSetPatch.
-	return suffixSearch(urnS, PatchQualifiedTypes.SortedValues())
+	return PatchQualifiedTypes.Has(urnS)
 }
 
 // IsListURN returns true if the URN is for a List resource.
 func IsListURN(urn resource.URN) bool {
-	urnS := urn.QualifiedType().String()
+	urnS := urn.Type().String()
 
-	// Do a simple O(1) lookup in a set of known list types.
-	if ListQualifiedTypes.Has(urnS) {
-		return true
-	}
-
-	// Do a suffix search in case the resource is a component resource containing
-	// a list resource.
-	return suffixSearch(urnS, ListQualifiedTypes.SortedValues())
+	return ListQualifiedTypes.Has(urnS)
 }

--- a/provider/pkg/kinds/util.go
+++ b/provider/pkg/kinds/util.go
@@ -6,9 +6,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func suffixSearch(urnS string, suffixes []string) bool {
+func suffixSearch(s string, suffixes []string) bool {
 	for _, suffix := range suffixes {
-		if strings.HasSuffix(urnS, suffix) {
+		if strings.HasSuffix(s, suffix) {
 			return true
 		}
 	}

--- a/provider/pkg/kinds/util_test.go
+++ b/provider/pkg/kinds/util_test.go
@@ -54,7 +54,7 @@ func TestIsListURN(t *testing.T) {
 			true,
 		},
 		{
-			"Non-Patch DaemonSet resource",
+			"Non-List DaemonSet resource",
 			resource.URN("urn:pulumi:dev::kubernetes-ts::kubernetes:apps/v1:DaemonSet::k8s-daemonset"),
 			false,
 		},

--- a/provider/pkg/kinds/util_test.go
+++ b/provider/pkg/kinds/util_test.go
@@ -1,0 +1,69 @@
+package kinds
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestIsPatchURN(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  resource.URN
+		want bool
+	}{
+		{
+			"Simple Patch resource - Happy Path",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::kubernetes:apps/v1:DaemonSetPatch::k8s-daemonset-patch"),
+			true,
+		},
+		{
+			"Patch resource within a Component Resource",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::my:component:Resource$kubernetes:apps/v1:DaemonSetPatch::k8s-daemonset-patch-child"),
+			true,
+		},
+		{
+			"Non-Patch DaemonSet resource",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::kubernetes:apps/v1:DaemonSet::k8s-daemonset"),
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPatchURN(tc.urn); got != tc.want {
+				t.Errorf("IsPatchURN() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsListURN(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  resource.URN
+		want bool
+	}{
+		{
+			"Simple List resource - Happy Path",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::kubernetes:apps/v1:DaemonSetList::k8s-daemonset-list"),
+			true,
+		},
+		{
+			"List resource within a Component Resource",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::my:component:Resource$kubernetes:apps/v1:DaemonSetList::k8s-daemonset-list-child"),
+			true,
+		},
+		{
+			"Non-Patch DaemonSet resource",
+			resource.URN("urn:pulumi:dev::kubernetes-ts::kubernetes:apps/v1:DaemonSet::k8s-daemonset"),
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsListURN(tc.urn); got != tc.want {
+				t.Errorf("IsListURN() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/kinds"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -187,7 +188,7 @@ func Test_isPatchURN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, isPatchURN(tt.args.urn), "isPatchURN(%v)", tt.args.urn)
+			assert.Equalf(t, tt.want, kinds.IsPatchURN(tt.args.urn), "isPatchURN(%v)", tt.args.urn)
 		})
 	}
 }
@@ -225,7 +226,7 @@ func Test_isListURN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, isListURN(tt.args.urn), "isListURN(%v)", tt.args.urn)
+			assert.Equalf(t, tt.want, kinds.IsListURN(tt.args.urn), "isListURN(%v)", tt.args.urn)
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

This pull request uses the URN `Type` method, rather than `QualifiedType` to search if resources are a patch or list resource.  Qualified types include the parent resource if there is one, so it would have failed the lookup.

Additionally, comprehensive unit tests have been included to validate this change.

### Related issues (optional)
Fixes: #2718 (manual validation was done to ensure this fix solves this CUJ)