### PR TITLE
Add metadata fields for resource lookup in GoTest/ServerSideApply

### DIFF
--- a/tests/sdk/go/server-side-apply/step2/main.go
+++ b/tests/sdk/go/server-side-apply/step2/main.go
@@ -111,6 +111,7 @@ func main() {
 					pulumi.ID(fmt.Sprintf("%s/%s", *namespace, *name)), &apiextensions.CustomResourceState{
 						ApiVersion: cr.ApiVersion,
 						Kind:       cr.Kind,
+						Metadata:   cr.Metadata,
 					},
 					pulumi.Provider(provider))
 				if err != nil {


### PR DESCRIPTION
### Proposed changes

Newer versions of the Pulumi engine now requires the CR's metadata fields to be passed into the input props object to give a successful search within state.

### Related issues (optional)

Fixes: #2728
