### PR TITLE
Fix deployment await logic for accurate rollout detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix deployment await logic for accurate rollout detection
+
 ## 4.7.0 (January 17, 2024)
 - Fix JSON encoding of KubeVersion and Version on Chart resource (.NET SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2740)
 - Fix option propagation in component resources (Python SDK) (https://github.com/pulumi/pulumi-kubernetes/pull/2717)

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -685,23 +685,15 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 	}
 }
 
+// changeTriggeredRollout returns true if the current deployment has a different revision than the last deployment.
+// This is used to determine whether the deployment is rolling out a new revision, which in turn, creates/updates a
+// replica set.
 func (dia *deploymentInitAwaiter) changeTriggeredRollout() bool {
 	if dia.config.lastInputs == nil {
 		return true
 	}
 
-	fields, err := openapi.PropertiesChanged(
-		dia.config.lastInputs.Object, dia.config.currentInputs.Object,
-		[]string{
-			".spec.template.spec",
-		})
-	if err != nil {
-		logger.V(3).Infof("Failed to check whether Pod template for Deployment %q changed",
-			dia.config.currentInputs.GetName())
-		return false
-	}
-
-	return len(fields) > 0
+	return dia.deployment.GetAnnotations()[revision] != dia.config.lastOutputs.GetAnnotations()[revision]
 }
 
 func (dia *deploymentInitAwaiter) checkPersistentVolumeClaimStatus() {

--- a/tests/sdk/nodejs/deployment-rollout/step3/index.ts
+++ b/tests/sdk/nodejs/deployment-rollout/step3/index.ts
@@ -16,10 +16,6 @@ import * as k8s from "@pulumi/kubernetes";
 
 export const namespace = new k8s.core.v1.Namespace("test-namespace");
 
-//
-// Change the image to trigger an update.
-//
-
 const appLabels = { app: "nginx" };
 new k8s.apps.v1.Deployment("nginx", {
   metadata: { namespace: namespace.metadata.name },

--- a/tests/sdk/nodejs/deployment-rollout/step3/index.ts
+++ b/tests/sdk/nodejs/deployment-rollout/step3/index.ts
@@ -1,0 +1,43 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+export const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+//
+// Change the image to trigger an update.
+//
+
+const appLabels = { app: "nginx" };
+new k8s.apps.v1.Deployment("nginx", {
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    selector: { matchLabels: appLabels },
+    replicas: 1,
+    template: {
+      metadata: { labels: appLabels },
+      spec: {
+        containers: [
+          {
+            name: "nginx",
+            image: "nginx:stable",
+            ports: [{ containerPort: 80 }],
+          },
+        ],
+        schedulerName: "default-scheduler", // No-op update that doesn't result in a new replica set rollout.
+      },
+    },
+  },
+});


### PR DESCRIPTION
### Proposed changes

This pull request enhances the deployment await logic to accurately identify whether a deployment has triggered a rollout. In the previous implementation, the logic relied on flagging a rollout if the pod template spec had changed. However, this approach proved inaccurate, as instances arose where a pod template spec update did not necessarily result in a replicaset rollout. Specifically, when users explicitly defined a default field, the await logic would run until timeout, erroneously reporting that the deployment failed to complete. The revised logic now assesses whether the new deployment revision has been incremented compared to the previous deployment.

#### Changes made:

- Updated logic for determining Deployment rollout triggers
- Added unit tests
- Addressed data race conditions in existing unit tests
- Added additional step to existing e2e test case to validate CUJ is fixed (test fails on older provider version, but passes on new version)

### Related issues (optional)

Fixes: #2662
