### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -603,7 +603,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -594,7 +594,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -623,7 +623,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -463,7 +463,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -85,7 +85,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Provider with Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter