### PR TITLE
Provider Unit Tests (Provider Lifecycle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ sdk/java/gradlew
 sdk/java/gradlew.bat
 
 sdk/python/venv
+
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ sdk/java/gradlew.bat
 sdk/python/venv
 
 coverage/
+coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ sdk/python/venv
 
 coverage/
 coverage.txt
+ginkgo.report

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ JAVA_GEN		 := pulumi-java-gen
 JAVA_GEN_VERSION := v0.8.0
 
 WORKING_DIR     := $(shell pwd)
-TESTPARALLELISM := 4
 
 openapi_file::
 	@mkdir -p $(OPENAPI_DIR)
@@ -53,7 +52,7 @@ k8sprovider_debug::
 	(cd provider && CGO_ENABLED=0 go build -o $(WORKING_DIR)/bin/${PROVIDER} -gcflags="all=-N -l" -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 
 test_provider::
-	cd provider/pkg && go test -short -v -count=1 -coverprofile="coverage.txt" -coverpkg=./... -timeout 2h -parallel ${TESTPARALLELISM} ./...
+	cd provider/pkg && go test -short -v -coverprofile="coverage.txt" -coverpkg=./... -timeout 2h ./...
 
 dotnet_sdk:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 dotnet_sdk::
@@ -115,8 +114,8 @@ install_provider::
 
 install:: install_nodejs_sdk install_dotnet_sdk install_provider
 
-GO_TEST_FAST := go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
-GO_TEST		 := go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
+GO_TEST_FAST := go test -short -v -cover -timeout 2h
+GO_TEST		 := go test -v -cover -timeout 2h
 
 # Required for the codegen action that runs in pulumi/pulumi
 test:: test_all

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/onsi/ginkgo/v2 v2.13.0
+	github.com/onsi/gomega v1.29.0
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/cloud-ready-checks v1.1.0
 	github.com/pulumi/pulumi/pkg/v3 v3.101.1
@@ -254,6 +256,8 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-git/go-git/v5 v5.11.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.4 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/onsi/ginkgo/v2 v2.13.0
-	github.com/onsi/gomega v1.29.0
+	github.com/onsi/ginkgo/v2 v2.15.0
+	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/cloud-ready-checks v1.1.0
 	github.com/pulumi/pulumi/pkg/v3 v3.101.1
@@ -296,7 +296,7 @@ require (
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
+	golang.org/x/tools v0.16.1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1505,6 +1505,8 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1517,6 +1519,8 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
+github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2505,6 +2509,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
 golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
+golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
+golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1502,7 +1502,6 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1503,8 +1503,6 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
-github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1517,8 +1515,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
-github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
@@ -2507,8 +2503,6 @@ golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
-golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
 golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
 golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -159,7 +159,7 @@ var _ pulumirpc.ResourceProviderServer = (*kubeProvider)(nil)
 
 func makeKubeProvider(
 	host *provider.HostClient, name, version string, pulumiSchema, terraformMapping []byte,
-) (pulumirpc.ResourceProviderServer, error) {
+) (*kubeProvider, error) {
 	return &kubeProvider{
 		host:                        host,
 		canceler:                    makeCancellationContext(),

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -186,7 +186,7 @@ func makeClient(ctx context.Context, config *rest.Config) (*clients.DynamicClien
 	if err != nil {
 		return nil, nil, err
 	}
-	return cs, lc, err
+	return cs, lc, nil
 }
 
 func (k *kubeProvider) getResources() (k8sopenapi.Resources, error) {
@@ -779,9 +779,7 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 				config.Timeout = time.Duration(*kubeClientSettings.Timeout) * time.Second
 				logger.V(9).Infof("kube client timeout set to %v", config.Timeout)
 			}
-			warningConfig := rest.CopyConfig(config)
-			warningConfig.WarningHandler = rest.NoWarnings{}
-			config = warningConfig
+			config.WarningHandler = rest.NoWarnings{}
 		}
 	}
 

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -25,18 +25,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
-
-func MatchCheckFailure(prop string) gomegatypes.GomegaMatcher {
-	return WithTransform(func(failure *pulumirpc.CheckFailure) string {
-		return failure.GetProperty()
-	}, Equal(prop))
-}
 
 var _ = Describe("RPC:CheckConfig", func() {
 	var k *kubeProvider
@@ -90,7 +83,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because strict mode prohibits default provider", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("", Equal(`strict mode prohibits default provider`))))
 			})
 		})
 
@@ -101,7 +95,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because strict mode requires kubeconfig", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("kubeconfig")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("kubeconfig", Equal(`strict mode requires Provider "kubeconfig" argument`))))
 			})
 		})
 
@@ -112,7 +107,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because strict mode requires context", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("context")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("context", Equal(`strict mode requires Provider "context" argument`))))
 			})
 		})
 
@@ -137,7 +133,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because yaml mode disallows kubeconfig", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("kubeconfig")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("kubeconfig", Equal(`"kubeconfig" arg is not compatible with "renderYamlToDirectory" arg`))))
 			})
 		})
 
@@ -148,7 +145,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because yaml mode disallows context", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("context")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("context", Equal(`"context" arg is not compatible with "renderYamlToDirectory" arg`))))
 			})
 		})
 
@@ -159,7 +157,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 			It("should fail because yaml mode disallows cluster", func() {
 				resp, err := k.CheckConfig(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("cluster")))
+				Expect(resp.Failures).To(HaveExactElements(
+					CheckFailure("cluster", Equal(`"cluster" arg is not compatible with "renderYamlToDirectory" arg`))))
 			})
 		})
 

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -32,42 +32,6 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-// type CheckFailureMatcher struct {
-// 	Property string
-// 	Reason   string
-// }
-
-// var _ gomegatypes.GomegaMatcher = &CheckFailureMatcher{}
-
-// func (matcher *CheckFailureMatcher) Match(actual interface{}) (success bool, err error) {
-// 	if failure, ok := actual.(*pulumirpc.CheckFailure); ok {
-// 		if failure.GetProperty() != matcher.Property {
-// 			return false, nil
-// 		}
-// 		if failure.GetReason() != matcher.Reason {
-// 			return false, nil
-// 		}
-// 		return true, nil
-// 	}
-// 	return false, fmt.Errorf("CheckFailureMatcher matcher expects a *pulumirpc.CheckFailure")
-// }
-
-// func (matcher *CheckFailureMatcher) FailureMessage(actual interface{}) (message string) {
-// 	var msg strings.Builder
-// 	fmt.Fprintf(&msg, "Expected:\n\t%#v\nto have ", actual)
-// 	fmt.Fprintf(&msg, "property=%q", matcher.Property)
-// 	fmt.Fprintf(&msg, "reason=%q", matcher.Reason)
-// 	return msg.String()
-// }
-
-// func (matcher *CheckFailureMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-// 	var msg strings.Builder
-// 	fmt.Fprintf(&msg, "Expected:\n\t%#v\nto not have ", actual)
-// 	fmt.Fprintf(&msg, "property=%q", matcher.Property)
-// 	fmt.Fprintf(&msg, "reason=%q", matcher.Reason)
-// 	return msg.String()
-// }
-
 func MatchCheckFailure(prop string) gomegatypes.GomegaMatcher {
 	return WithTransform(func(failure *pulumirpc.CheckFailure) string {
 		return failure.GetProperty()

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -1,0 +1,209 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	_ "embed"
+	"os/user"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// type CheckFailureMatcher struct {
+// 	Property string
+// 	Reason   string
+// }
+
+// var _ gomegatypes.GomegaMatcher = &CheckFailureMatcher{}
+
+// func (matcher *CheckFailureMatcher) Match(actual interface{}) (success bool, err error) {
+// 	if failure, ok := actual.(*pulumirpc.CheckFailure); ok {
+// 		if failure.GetProperty() != matcher.Property {
+// 			return false, nil
+// 		}
+// 		if failure.GetReason() != matcher.Reason {
+// 			return false, nil
+// 		}
+// 		return true, nil
+// 	}
+// 	return false, fmt.Errorf("CheckFailureMatcher matcher expects a *pulumirpc.CheckFailure")
+// }
+
+// func (matcher *CheckFailureMatcher) FailureMessage(actual interface{}) (message string) {
+// 	var msg strings.Builder
+// 	fmt.Fprintf(&msg, "Expected:\n\t%#v\nto have ", actual)
+// 	fmt.Fprintf(&msg, "property=%q", matcher.Property)
+// 	fmt.Fprintf(&msg, "reason=%q", matcher.Reason)
+// 	return msg.String()
+// }
+
+// func (matcher *CheckFailureMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+// 	var msg strings.Builder
+// 	fmt.Fprintf(&msg, "Expected:\n\t%#v\nto not have ", actual)
+// 	fmt.Fprintf(&msg, "property=%q", matcher.Property)
+// 	fmt.Fprintf(&msg, "reason=%q", matcher.Reason)
+// 	return msg.String()
+// }
+
+func MatchCheckFailure(prop string) gomegatypes.GomegaMatcher {
+	return WithTransform(func(failure *pulumirpc.CheckFailure) string {
+		return failure.GetProperty()
+	}, Equal(prop))
+}
+
+var _ = Describe("RPC:CheckConfig", func() {
+	var k *kubeProvider
+	var req *pulumirpc.CheckRequest
+	var news resource.PropertyMap
+	var config *clientcmdapi.Config
+
+	BeforeEach(func() {
+		var err error
+		k, err = pctx.NewProvider()
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// load the ambient kubeconfig for test purposes
+		homeDir := func() string {
+			// Ignore errors. The filepath will be checked later, so we can handle failures there.
+			usr, _ := user.Current()
+			return usr.HomeDir
+		}
+		config, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
+		Expect(err).ToNot(HaveOccurred())
+
+		req = &pulumirpc.CheckRequest{
+			Urn: "urn:pulumi:test::test::pulumi:providers:kubernetes::k8s",
+		}
+		news = make(resource.PropertyMap)
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		// serialize the new values into the request
+		Expect(err).ShouldNot(HaveOccurred())
+		req.News, err = plugin.MarshalProperties(news, plugin.MarshalOptions{
+			Label: "news", KeepUnknowns: true, SkipNulls: true,
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	Describe("Strict Mode", func() {
+		BeforeEach(func() {
+			news["strictMode"] = resource.NewStringProperty("true")
+			news["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(config))
+			news["context"] = resource.NewStringProperty(config.CurrentContext)
+		})
+
+		Context("when enabled on the default provider", func() {
+			BeforeEach(func() {
+				req.Urn = "urn:pulumi:test::test::pulumi:providers:kubernetes::default"
+				Expect(providers.IsDefaultProvider(resource.URN(req.Urn))).To(BeTrue())
+			})
+			It("should fail because strict mode prohibits default provider", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("")))
+			})
+		})
+
+		Context("when kubeconfig is NOT specified", func() {
+			BeforeEach(func() {
+				delete(news, "kubeconfig")
+			})
+			It("should fail because strict mode requires kubeconfig", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("kubeconfig")))
+			})
+		})
+
+		Context("when context is NOT specified", func() {
+			BeforeEach(func() {
+				delete(news, "context")
+			})
+			It("should fail because strict mode requires context", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("context")))
+			})
+		})
+
+		Context("when properly configured", func() {
+			It("should succeed", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("Yaml Rendering Mode", func() {
+		BeforeEach(func() {
+			news["renderYamlToDirectory"] = resource.NewStringProperty("true")
+		})
+
+		Context("when kubeconfig is specified", func() {
+			BeforeEach(func() {
+				news["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(config))
+			})
+			It("should fail because yaml mode disallows kubeconfig", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("kubeconfig")))
+			})
+		})
+
+		Context("when context is specified", func() {
+			BeforeEach(func() {
+				news["context"] = resource.NewStringProperty(config.CurrentContext)
+			})
+			It("should fail because yaml mode disallows context", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("context")))
+			})
+		})
+
+		Context("when cluster is specified", func() {
+			BeforeEach(func() {
+				news["cluster"] = resource.NewStringProperty(config.Contexts[config.CurrentContext].Cluster)
+			})
+			It("should fail because yaml mode disallows cluster", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(HaveExactElements(MatchCheckFailure("cluster")))
+			})
+		})
+
+		Context("when properly configured", func() {
+			It("should succeed", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Failures).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -58,15 +58,16 @@ var _ = Describe("RPC:CheckConfig", func() {
 		config, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
 		Expect(err).ToNot(HaveOccurred())
 
+		// initialize the CheckRequest to be customized in nested BeforeEach blocks
 		req = &pulumirpc.CheckRequest{
 			Urn: "urn:pulumi:test::test::pulumi:providers:kubernetes::k8s",
 		}
+		// initialize the 'new' PropertyMap to be serialized into the request in JustBeforeEach
 		news = make(resource.PropertyMap)
 	})
 
 	JustBeforeEach(func() {
 		var err error
-		// serialize the new values into the request
 		Expect(err).ShouldNot(HaveOccurred())
 		req.News, err = plugin.MarshalProperties(news, plugin.MarshalOptions{
 			Label: "news", KeepUnknowns: true, SkipNulls: true,

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 var _ = Describe("RPC:CheckConfig", func() {
+	var opts []NewProviderOption
 	var k *kubeProvider
 	var req *pulumirpc.CheckRequest
 	var news resource.PropertyMap
@@ -39,8 +40,7 @@ var _ = Describe("RPC:CheckConfig", func() {
 
 	BeforeEach(func() {
 		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
+		opts = []NewProviderOption{}
 
 		// load the ambient kubeconfig for test purposes
 		homeDir := func() string {
@@ -61,7 +61,8 @@ var _ = Describe("RPC:CheckConfig", func() {
 
 	JustBeforeEach(func() {
 		var err error
-		Expect(err).ShouldNot(HaveOccurred())
+		k = pctx.NewProvider(opts...)
+
 		req.News, err = plugin.MarshalProperties(news, plugin.MarshalOptions{
 			Label: "news", KeepUnknowns: true, SkipNulls: true,
 		})

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -142,6 +142,7 @@ var _ = Describe("RPC:Configure", func() {
 		k, err = pctx.NewProvider()
 		Expect(err).ShouldNot(HaveOccurred())
 
+		// initialize the ConfigureRequest to be customized in nested BeforeEach blocks
 		req = &pulumirpc.ConfigureRequest{
 			AcceptSecrets: true,
 			Variables:     map[string]string{},

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -152,7 +152,7 @@ var _ = Describe("RPC:Configure", func() {
 	})
 
 	It("should return a response detailing the provider's capabilities", func() {
-		r, err := k.Configure(context.Background(), &pulumirpc.ConfigureRequest{})
+		r, err := k.Configure(context.Background(), req)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(r.AcceptSecrets).Should(BeTrue())
 		Expect(r.SupportsPreview).Should(BeTrue())

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -114,10 +114,6 @@ var _ = Describe("RPC:Configure", func() {
 				_, err := k.Configure(context.Background(), req)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				By("creating a client-go config")
-				Expect(k.config).ToNot(BeNil())
-				Expect(k.kubeconfig).ToNot(BeNil())
-
 				By("creating strongly-typed clients")
 				Expect(k.clientSet).ToNot(BeNil())
 				Expect(k.logClient).ToNot(BeNil())
@@ -155,8 +151,6 @@ var _ = Describe("RPC:Configure", func() {
 				_, err := k.Configure(context.Background(), req)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(k.clusterUnreachable).To(BeTrue())
-				Expect(k.config).To(BeNil())
-				Expect(k.kubeconfig).To(BeNil())
 				Expect(k.clientSet).To(BeNil())
 				Expect(k.logClient).To(BeNil())
 			})

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -197,8 +197,8 @@ var _ = Describe("RPC:Configure", func() {
 					DeferCleanup(func() {
 						os.Remove(f.Name())
 					})
-					f.WriteString("invalid")
-					f.Close()
+					_, _ = f.WriteString("invalid")
+					_ = f.Close()
 					req.Variables["kubernetes:config:kubeconfig"] = f.Name()
 				})
 				commonChecks()

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -118,7 +118,12 @@ var _ = Describe("RPC:Configure", func() {
 				Expect(k.clientSet).ToNot(BeNil())
 				Expect(k.logClient).ToNot(BeNil())
 
-				By("discovering the server version")
+			})
+
+			It("should check the server version", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+
 				Expect(k.k8sVersion).ToNot(BeNil())
 			})
 

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -1,0 +1,325 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	pbempty "github.com/golang/protobuf/ptypes/empty"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// A mock engine for test purposes.
+type mockEngine struct {
+	pulumirpc.UnsafeEngineServer
+	t            TestingTB
+	logger       *log.Logger
+	rootResource string
+}
+
+// Log logs a global message in the engine, including errors and warnings.
+func (m *mockEngine) Log(ctx context.Context, in *pulumirpc.LogRequest) (*pbempty.Empty, error) {
+	m.t.Logf("%s: %s", in.GetSeverity(), in.GetMessage())
+	if m.logger != nil {
+		m.logger.Printf("%s: %s", in.GetSeverity(), in.GetMessage())
+	}
+	return &pbempty.Empty{}, nil
+}
+
+// GetRootResource gets the URN of the root resource, the resource that should be the root of all
+// otherwise-unparented resources.
+func (m *mockEngine) GetRootResource(ctx context.Context, in *pulumirpc.GetRootResourceRequest) (*pulumirpc.GetRootResourceResponse, error) {
+	return &pulumirpc.GetRootResourceResponse{
+		Urn: m.rootResource,
+	}, nil
+}
+
+// SetRootResource sets the URN of the root resource.
+func (m *mockEngine) SetRootResource(ctx context.Context, in *pulumirpc.SetRootResourceRequest) (*pulumirpc.SetRootResourceResponse, error) {
+	m.rootResource = in.GetUrn()
+	return &pulumirpc.SetRootResourceResponse{}, nil
+}
+
+// newMockHost creates a mock host for test purposes and returns a client.
+// Dispatches Engine RPC calls to the given engine.
+func newMockHost(ctx context.Context, engine pulumirpc.EngineServer) *provider.HostClient {
+	cancel := make(chan bool)
+	go func() {
+		<-ctx.Done()
+		close(cancel)
+	}()
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterEngineServer(srv, engine)
+			return nil
+		},
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
+	if err != nil {
+		panic(fmt.Errorf("could not start host engine service: %v", err))
+	}
+
+	go func() {
+		err := <-handle.Done
+		if err != nil {
+			panic(fmt.Errorf("host engine service failed: %v", err))
+		}
+	}()
+
+	address := fmt.Sprintf("127.0.0.1:%v", handle.Port)
+	hostClient, err := provider.NewHostClient(address)
+	if err != nil {
+		panic(fmt.Errorf("could not connect to host engine service: %v", err))
+	}
+	return hostClient
+}
+
+type providerTestContext struct {
+	engine *mockEngine
+	host   *provider.HostClient
+}
+
+func (c *providerTestContext) NewProvider() (*kubeProvider, error) {
+	var pulumiSchema []byte
+	var terraformMapping []byte
+	return makeKubeProvider(c.host, "kubernetes", "v0.0.0", pulumiSchema, terraformMapping)
+}
+
+var pctx *providerTestContext
+
+var _ = BeforeSuite(func() {
+	var buff bytes.Buffer
+	engine := &mockEngine{
+		t:      GinkgoT(),
+		logger: log.New(&buff, "\t", 0),
+	}
+	// t.Cleanup(func() {
+	// 	log.Default().Printf("Engine Log:\n%s", buff.String())
+	// })
+	ctx, cancel := context.WithCancel(context.Background())
+	host := newMockHost(ctx, engine)
+	DeferCleanup(func() {
+		cancel()
+	})
+
+	pctx = &providerTestContext{
+		engine: engine,
+		host:   host,
+	}
+})
+
+var _ = Describe("RPC:Configure", func() {
+	var k *kubeProvider
+	var req *pulumirpc.ConfigureRequest
+
+	BeforeEach(func() {
+		var err error
+		k, err = pctx.NewProvider()
+		Expect(err).ShouldNot(HaveOccurred())
+
+		req = &pulumirpc.ConfigureRequest{
+			AcceptSecrets: true,
+			Variables:     map[string]string{},
+		}
+	})
+
+	It("should return a response detailing the provider's capabilities", func() {
+		r, err := k.Configure(context.Background(), &pulumirpc.ConfigureRequest{})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(r.AcceptSecrets).Should(BeTrue())
+		Expect(r.SupportsPreview).Should(BeTrue())
+		Expect(r.AcceptResources).Should(BeFalse())
+		Expect(r.AcceptOutputs).Should(BeFalse())
+	})
+
+	Describe("Secrets Support", func() {
+		Context("when configured to support secrets", func() {
+			BeforeEach(func() {
+				req.AcceptSecrets = true
+			})
+			It("should enable secrets support in subsequent RPC methods", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(k.enableSecrets).Should(BeTrue())
+			})
+		})
+
+		Context("when configured to NOT support secrets", func() {
+			BeforeEach(func() {
+				req.AcceptSecrets = false
+			})
+			It("should not enable secrets support in subsequent RPC methods", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(k.enableSecrets).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("Connectivity", func() {
+		var config *clientcmdapi.Config
+
+		BeforeEach(func() {
+			var err error
+			homeDir := func() string {
+				// Ignore errors. The filepath will be checked later, so we can handle failures there.
+				usr, _ := user.Current()
+				return usr.HomeDir
+			}
+			// load the ambient kubeconfig for test purposes
+			config, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		commonChecks := func() {
+			Context("when configured to use a particular namespace", func() {
+				JustBeforeEach(func() {
+					req.Variables["kubernetes:config:namespace"] = "testns"
+				})
+				It("should use the configured namespace as the default namespace", func() {
+					_, err := k.Configure(context.Background(), req)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(k.defaultNamespace).To(Equal("testns"))
+				})
+			})
+		}
+
+		clientChecks := func() {
+			It("should have an initialized client", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("creating a client-go config")
+				Expect(k.config).ToNot(BeNil())
+				Expect(k.kubeconfig).ToNot(BeNil())
+
+				By("creating strongly-typed clients")
+				Expect(k.clientSet).ToNot(BeNil())
+				Expect(k.logClient).ToNot(BeNil())
+
+				By("discovering the server version")
+				Expect(k.k8sVersion).ToNot(BeNil())
+			})
+
+			It("should provide a resource cache", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("discovering the server resources")
+				Expect(k.resources).ToNot(BeNil())
+
+				By("supporting invalidation")
+				k.invalidateResources()
+				Expect(k.resources).To(BeNil())
+				Expect(k.getResources()).ToNot(BeNil())
+			})
+
+			It("should use the context namespace as the default namespace", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				ns := config.Contexts[config.CurrentContext].Namespace
+				if ns == "" {
+					ns = "default"
+				}
+				Expect(k.defaultNamespace).To(Equal(ns))
+			})
+		}
+
+		clusterUnreachableChecks := func() {
+			It("should be in clusterUnreachable mode", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(k.clusterUnreachable).To(BeTrue())
+				Expect(k.config).To(BeNil())
+				Expect(k.kubeconfig).To(BeNil())
+				Expect(k.clientSet).To(BeNil())
+				Expect(k.logClient).To(BeNil())
+			})
+		}
+
+		Describe("ambient kubeconfig", func() {
+			commonChecks()
+			clientChecks()
+		})
+
+		Describe("kubeconfig literal", func() {
+			Context("with an invalid value", func() {
+				JustBeforeEach(func() {
+					req.Variables["kubernetes:config:kubeconfig"] = "invalid"
+				})
+				commonChecks()
+				clusterUnreachableChecks()
+			})
+
+			Context("with a valid kubeconfig as a literal value", func() {
+				JustBeforeEach(func() {
+					contents, err := clientcmd.Write(*config)
+					Expect(err).ToNot(HaveOccurred())
+					req.Variables["kubernetes:config:kubeconfig"] = string(contents)
+				})
+				commonChecks()
+				clientChecks()
+			})
+		})
+
+		Describe("kubeconfig path", func() {
+			Context("with a non-existent config file", func() {
+				BeforeEach(func() {
+					req.Variables["kubernetes:config:kubeconfig"] = "./nosuchfile"
+				})
+				commonChecks()
+				clusterUnreachableChecks()
+			})
+
+			Context("with an invalid config file", func() {
+				BeforeEach(func() {
+					f, _ := os.CreateTemp("", "kubeconfig-")
+					DeferCleanup(func() {
+						os.Remove(f.Name())
+					})
+					f.WriteString("invalid")
+					f.Close()
+					req.Variables["kubernetes:config:kubeconfig"] = f.Name()
+				})
+				commonChecks()
+				clusterUnreachableChecks()
+			})
+
+			Context("with a valid config file", func() {
+				BeforeEach(func() {
+					req.Variables["kubernetes:config:kubeconfig"] = "~/.kube/config"
+				})
+				commonChecks()
+				clientChecks()
+			})
+		})
+	})
+})

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -93,6 +93,9 @@ var _ = Describe("RPC:Configure", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		// Define some "shared behaviors" that will be used to test various use cases.
+		// pattern: https://onsi.github.io/ginkgo/#shared-behaviors
+
 		commonChecks := func() {
 			Context("when configured to use a particular namespace", func() {
 				JustBeforeEach(func() {
@@ -106,7 +109,7 @@ var _ = Describe("RPC:Configure", func() {
 			})
 		}
 
-		clientChecks := func() {
+		connectedChecks := func() {
 			It("should have an initialized client", func() {
 				_, err := k.Configure(context.Background(), req)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -159,12 +162,12 @@ var _ = Describe("RPC:Configure", func() {
 			})
 		}
 
-		Describe("ambient kubeconfig", func() {
+		Describe("use case: ambient kubeconfig", func() {
 			commonChecks()
-			clientChecks()
+			connectedChecks()
 		})
 
-		Describe("kubeconfig literal", func() {
+		Describe("use case: kubeconfig string", func() {
 			Context("with an invalid value", func() {
 				JustBeforeEach(func() {
 					req.Variables["kubernetes:config:kubeconfig"] = "invalid"
@@ -173,16 +176,16 @@ var _ = Describe("RPC:Configure", func() {
 				clusterUnreachableChecks()
 			})
 
-			Context("with a valid kubeconfig as a literal value", func() {
+			Context("with a valid kubeconfig as a string value", func() {
 				JustBeforeEach(func() {
 					req.Variables["kubernetes:config:kubeconfig"] = KubeconfigAsFile(config)
 				})
 				commonChecks()
-				clientChecks()
+				connectedChecks()
 			})
 		})
 
-		Describe("kubeconfig path", func() {
+		Describe("use case: kubeconfig file", func() {
 			Context("with a non-existent config file", func() {
 				BeforeEach(func() {
 					req.Variables["kubernetes:config:kubeconfig"] = "./nosuchfile"
@@ -210,7 +213,7 @@ var _ = Describe("RPC:Configure", func() {
 					req.Variables["kubernetes:config:kubeconfig"] = "~/.kube/config"
 				})
 				commonChecks()
-				clientChecks()
+				connectedChecks()
 			})
 		})
 	})

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,12 +174,15 @@ var _ = Describe("RPC:Configure", func() {
 
 			Context("with an invalid config file", func() {
 				BeforeEach(func() {
-					f, _ := os.CreateTemp("", "kubeconfig-")
+					f, err := os.CreateTemp("", "kubeconfig-")
+					Expect(err).ToNot(HaveOccurred())
 					DeferCleanup(func() {
 						os.Remove(f.Name())
 					})
-					_, _ = f.WriteString("invalid")
-					_ = f.Close()
+					_, err = f.WriteString("invalid")
+					Expect(err).ToNot(HaveOccurred())
+					err = f.Close()
+					Expect(err).ToNot(HaveOccurred())
 					req.Variables["kubernetes:config:kubeconfig"] = f.Name()
 				})
 				commonChecks()

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -121,9 +121,6 @@ var _ = BeforeSuite(func() {
 		t:      GinkgoT(),
 		logger: log.New(&buff, "\t", 0),
 	}
-	// t.Cleanup(func() {
-	// 	log.Default().Printf("Engine Log:\n%s", buff.String())
-	// })
 	ctx, cancel := context.WithCancel(context.Background())
 	host := newMockHost(ctx, engine)
 	DeferCleanup(func() {

--- a/provider/pkg/provider/provider_diffconfig_test.go
+++ b/provider/pkg/provider/provider_diffconfig_test.go
@@ -1,0 +1,165 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	_ "embed"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func KubeconfigAsString(config *clientcmdapi.Config) string {
+	contents, err := clientcmd.Write(*config)
+	Expect(err).ToNot(HaveOccurred())
+	return string(contents)
+}
+
+func KubeconfigAsFile(config *clientcmdapi.Config) string {
+	f, _ := os.CreateTemp("", "kubeconfig-")
+	f.Close()
+	DeferCleanup(func() {
+		os.Remove(f.Name())
+	})
+	err := clientcmd.WriteToFile(*config, f.Name())
+	Expect(err).ToNot(HaveOccurred())
+	return f.Name()
+}
+
+var _ = Describe("RPC:DiffConfig", func() {
+	var k *kubeProvider
+	var req *pulumirpc.DiffRequest
+	var olds, news resource.PropertyMap
+	var oldConfig, newConfig *clientcmdapi.Config
+
+	BeforeEach(func() {
+		var err error
+		k, err = pctx.NewProvider()
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// load the ambient kubeconfig for test purposes
+		homeDir := func() string {
+			// Ignore errors. The filepath will be checked later, so we can handle failures there.
+			usr, _ := user.Current()
+			return usr.HomeDir
+		}
+		oldConfig, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
+		Expect(err).ToNot(HaveOccurred())
+		newConfig, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
+		Expect(err).ToNot(HaveOccurred())
+
+		req = &pulumirpc.DiffRequest{
+			Urn: "urn:pulumi:test::test::pulumi:providers:kubernetes::k8s",
+		}
+		olds = make(resource.PropertyMap)
+		news = make(resource.PropertyMap)
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		// serialize the old/new values into the request
+		req.Olds, err = plugin.MarshalProperties(olds, plugin.MarshalOptions{
+			Label: "olds", KeepUnknowns: true, SkipNulls: true,
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		req.News, err = plugin.MarshalProperties(news, plugin.MarshalOptions{
+			Label: "news", KeepUnknowns: true, SkipNulls: true,
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	Describe("Kubeconfig Parsing", func() {
+		Context("when kubeconfig is a computed value", func() {
+			BeforeEach(func() {
+				olds["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(oldConfig))
+				news["kubeconfig"] = resource.MakeComputed(resource.NewStringProperty(""))
+			})
+
+			It("should suggest replacement since a detailed diff cannot be performed", func() {
+				resp, err := k.DiffConfig(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(resp.Changes).To(Equal(pulumirpc.DiffResponse_DIFF_SOME))
+				Expect(resp.Diffs).To(ContainElements("kubeconfig"))
+				Expect(resp.Replaces).To(ContainElements("kubeconfig"))
+			})
+		})
+
+		Context("when kubeconfig is a string value", func() {
+			BeforeEach(func() {
+				olds["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(oldConfig))
+				news["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(newConfig))
+			})
+
+			It("should return an empty diff", func() {
+				resp, err := k.DiffConfig(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(resp.Changes).To(Equal(pulumirpc.DiffResponse_DIFF_NONE))
+				Expect(resp.Diffs).To(BeEmpty())
+				Expect(resp.Replaces).To(BeEmpty())
+			})
+		})
+
+		Context("when kubeconfig is a file", func() {
+			BeforeEach(func() {
+				olds["kubeconfig"] = resource.NewStringProperty(KubeconfigAsFile(oldConfig))
+				news["kubeconfig"] = resource.NewStringProperty(KubeconfigAsFile(newConfig))
+			})
+
+			XIt("should return an empty diff", func() {
+				resp, err := k.DiffConfig(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(resp.Changes).To(Equal(pulumirpc.DiffResponse_DIFF_NONE))
+				Expect(resp.Diffs).To(BeEmpty())
+				Expect(resp.Replaces).To(BeEmpty())
+			})
+
+			It("should fail due to pulumi/pulumi-kubernetes#2663", func() {
+				_, err := k.DiffConfig(context.Background(), req)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Cluster Change Detection", func() {
+
+		Context("when the cluster info has changed", func() {
+			BeforeEach(func() {
+				clusterName := newConfig.Contexts[newConfig.CurrentContext].Cluster
+				newConfig.Clusters[clusterName].Server = "https://updated.invalid"
+
+				olds["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(oldConfig))
+				news["kubeconfig"] = resource.NewStringProperty(KubeconfigAsString(newConfig))
+			})
+
+			It("should suggest replacement since the cluster itself may have been replaced", func() {
+				resp, err := k.DiffConfig(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(resp.Changes).To(Equal(pulumirpc.DiffResponse_DIFF_SOME))
+				Expect(resp.Diffs).To(ContainElements("kubeconfig"))
+				Expect(resp.Replaces).To(ContainElements("kubeconfig"))
+			})
+		})
+	})
+})

--- a/provider/pkg/provider/provider_diffconfig_test.go
+++ b/provider/pkg/provider/provider_diffconfig_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 var _ = Describe("RPC:DiffConfig", func() {
+	var opts []NewProviderOption
 	var k *kubeProvider
 	var req *pulumirpc.DiffRequest
 	var olds, news resource.PropertyMap
@@ -38,8 +39,7 @@ var _ = Describe("RPC:DiffConfig", func() {
 
 	BeforeEach(func() {
 		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
+		opts = []NewProviderOption{}
 
 		// load the ambient kubeconfig for test purposes
 		homeDir := func() string {
@@ -63,6 +63,8 @@ var _ = Describe("RPC:DiffConfig", func() {
 
 	JustBeforeEach(func() {
 		var err error
+		k = pctx.NewProvider(opts...)
+
 		req.Olds, err = plugin.MarshalProperties(olds, plugin.MarshalOptions{
 			Label: "olds", KeepUnknowns: true, SkipNulls: true,
 		})

--- a/provider/pkg/provider/provider_diffconfig_test.go
+++ b/provider/pkg/provider/provider_diffconfig_test.go
@@ -17,7 +17,6 @@ package provider
 import (
 	"context"
 	_ "embed"
-	"os"
 	"os/user"
 	"path/filepath"
 
@@ -30,23 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
-
-func KubeconfigAsString(config *clientcmdapi.Config) string {
-	contents, err := clientcmd.Write(*config)
-	Expect(err).ToNot(HaveOccurred())
-	return string(contents)
-}
-
-func KubeconfigAsFile(config *clientcmdapi.Config) string {
-	f, _ := os.CreateTemp("", "kubeconfig-")
-	f.Close()
-	DeferCleanup(func() {
-		os.Remove(f.Name())
-	})
-	err := clientcmd.WriteToFile(*config, f.Name())
-	Expect(err).ToNot(HaveOccurred())
-	return f.Name()
-}
 
 var _ = Describe("RPC:DiffConfig", func() {
 	var k *kubeProvider

--- a/provider/pkg/provider/provider_diffconfig_test.go
+++ b/provider/pkg/provider/provider_diffconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/provider/pkg/provider/provider_diffconfig_test.go
+++ b/provider/pkg/provider/provider_diffconfig_test.go
@@ -70,16 +70,17 @@ var _ = Describe("RPC:DiffConfig", func() {
 		newConfig, err = clientcmd.LoadFromFile(filepath.Join(homeDir(), "/.kube/config"))
 		Expect(err).ToNot(HaveOccurred())
 
+		// initialize the DiffRequest to be customized in nested BeforeEach blocks
 		req = &pulumirpc.DiffRequest{
 			Urn: "urn:pulumi:test::test::pulumi:providers:kubernetes::k8s",
 		}
+		// initialize the 'old'/'new' PropertyMaps to be serialized into the request in JustBeforeEach
 		olds = make(resource.PropertyMap)
 		news = make(resource.PropertyMap)
 	})
 
 	JustBeforeEach(func() {
 		var err error
-		// serialize the old/new values into the request
 		req.Olds, err = plugin.MarshalProperties(olds, plugin.MarshalOptions{
 			Label: "olds", KeepUnknowns: true, SkipNulls: true,
 		})

--- a/provider/pkg/provider/provider_plugin_test.go
+++ b/provider/pkg/provider/provider_plugin_test.go
@@ -27,10 +27,8 @@ import (
 var _ = Describe("RPC:Cancel", func() {
 	var k *kubeProvider
 
-	BeforeEach(func() {
-		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
+	JustBeforeEach(func() {
+		k = pctx.NewProvider()
 	})
 
 	It("should cancel any future operations", func() {
@@ -43,10 +41,8 @@ var _ = Describe("RPC:Cancel", func() {
 var _ = Describe("RPC:GetPluginInfo", func() {
 	var k *kubeProvider
 
-	BeforeEach(func() {
-		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
+	JustBeforeEach(func() {
+		k = pctx.NewProvider()
 	})
 
 	It("should return plugin info", func() {
@@ -59,13 +55,14 @@ var _ = Describe("RPC:GetPluginInfo", func() {
 var _ = Describe("RPC:GetSchema", func() {
 	var k *kubeProvider
 	var req *pulumirpc.GetSchemaRequest
-	BeforeEach(func() {
-		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
 
+	BeforeEach(func() {
 		// initialize the GetSchemaRequest to be customized in nested BeforeEach blocks
 		req = &pulumirpc.GetSchemaRequest{}
+	})
+
+	JustBeforeEach(func() {
+		k = pctx.NewProvider()
 	})
 
 	Context("when the requested version is 0", func() {
@@ -95,13 +92,14 @@ var _ = Describe("RPC:GetSchema", func() {
 var _ = Describe("RPC:GetMapping", func() {
 	var k *kubeProvider
 	var req *pulumirpc.GetMappingRequest
-	BeforeEach(func() {
-		var err error
-		k, err = pctx.NewProvider()
-		Expect(err).ShouldNot(HaveOccurred())
 
+	BeforeEach(func() {
 		// initialize the GetMappingRequest to be customized in nested BeforeEach blocks
 		req = &pulumirpc.GetMappingRequest{}
+	})
+
+	JustBeforeEach(func() {
+		k = pctx.NewProvider()
 	})
 
 	Context("when the requested mapping is for terraform", func() {

--- a/provider/pkg/provider/provider_plugin_test.go
+++ b/provider/pkg/provider/provider_plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/provider/pkg/provider/provider_plugin_test.go
+++ b/provider/pkg/provider/provider_plugin_test.go
@@ -1,0 +1,40 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	_ "embed"
+
+	pbempty "github.com/golang/protobuf/ptypes/empty"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RPC:Cancel", func() {
+	var k *kubeProvider
+
+	BeforeEach(func() {
+		var err error
+		k, err = pctx.NewProvider()
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should cancel any future operations", func() {
+		_, err := k.Cancel(context.Background(), &pbempty.Empty{})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(k.canceler.context.Done()).Should(BeClosed())
+	})
+})

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -15,28 +15,12 @@
 package provider
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	"fmt"
-	"log"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
-	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/kinds"
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 var (
@@ -245,100 +229,4 @@ func Test_isListURN(t *testing.T) {
 			assert.Equalf(t, tt.want, kinds.IsListURN(tt.args.urn), "isListURN(%v)", tt.args.urn)
 		})
 	}
-}
-
-// CheckFailure matches a CheckFailure by property and reason.
-func CheckFailure(prop string, reason types.GomegaMatcher) gomegatypes.GomegaMatcher {
-	return And(
-		WithTransform(func(failure *pulumirpc.CheckFailure) string {
-			return failure.GetProperty()
-		}, Equal(prop)),
-		WithTransform(func(failure *pulumirpc.CheckFailure) string {
-			return failure.GetReason()
-		}, reason))
-}
-
-// KubeconfigAsString converts a Kubernetes configuration to a string.
-func KubeconfigAsString(config *clientcmdapi.Config) string {
-	contents, err := clientcmd.Write(*config)
-	Expect(err).ToNot(HaveOccurred())
-	return string(contents)
-}
-
-// KubeconfigAsFile converts a Kubernetes configuration to a string.
-func KubeconfigAsFile(config *clientcmdapi.Config) string {
-	f, _ := os.CreateTemp("", "kubeconfig-")
-	f.Close()
-	DeferCleanup(func() {
-		os.Remove(f.Name())
-	})
-	err := clientcmd.WriteToFile(*config, f.Name())
-	Expect(err).ToNot(HaveOccurred())
-	return f.Name()
-}
-
-// A mock engine for test purposes.
-type mockEngine struct {
-	pulumirpc.UnsafeEngineServer
-	t            TestingTB
-	logger       *log.Logger
-	rootResource string
-}
-
-// Log logs a global message in the engine, including errors and warnings.
-func (m *mockEngine) Log(ctx context.Context, in *pulumirpc.LogRequest) (*pbempty.Empty, error) {
-	m.t.Logf("%s: %s", in.GetSeverity(), in.GetMessage())
-	if m.logger != nil {
-		m.logger.Printf("%s: %s", in.GetSeverity(), in.GetMessage())
-	}
-	return &pbempty.Empty{}, nil
-}
-
-// GetRootResource gets the URN of the root resource, the resource that should be the root of all
-// otherwise-unparented resources.
-func (m *mockEngine) GetRootResource(ctx context.Context, in *pulumirpc.GetRootResourceRequest) (*pulumirpc.GetRootResourceResponse, error) {
-	return &pulumirpc.GetRootResourceResponse{
-		Urn: m.rootResource,
-	}, nil
-}
-
-// SetRootResource sets the URN of the root resource.
-func (m *mockEngine) SetRootResource(ctx context.Context, in *pulumirpc.SetRootResourceRequest) (*pulumirpc.SetRootResourceResponse, error) {
-	m.rootResource = in.GetUrn()
-	return &pulumirpc.SetRootResourceResponse{}, nil
-}
-
-// newMockHost creates a mock host for test purposes and returns a client.
-// Dispatches Engine RPC calls to the given engine.
-func newMockHost(ctx context.Context, engine pulumirpc.EngineServer) *provider.HostClient {
-	cancel := make(chan bool)
-	go func() {
-		<-ctx.Done()
-		close(cancel)
-	}()
-	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
-		Cancel: cancel,
-		Init: func(srv *grpc.Server) error {
-			pulumirpc.RegisterEngineServer(srv, engine)
-			return nil
-		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
-	})
-	if err != nil {
-		panic(fmt.Errorf("could not start host engine service: %v", err))
-	}
-
-	go func() {
-		err := <-handle.Done
-		if err != nil {
-			panic(fmt.Errorf("host engine service failed: %v", err))
-		}
-	}()
-
-	address := fmt.Sprintf("127.0.0.1:%v", handle.Port)
-	hostClient, err := provider.NewHostClient(address)
-	if err != nil {
-		panic(fmt.Errorf("could not connect to host engine service: %v", err))
-	}
-	return hostClient
 }

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package provider
 
 import (
@@ -62,12 +76,14 @@ func WriteKubeconfigToString(config *clientcmdapi.Config) string {
 
 // WriteKubeconfigToFile converts a clientcmdapi.Config to a temporary file.
 func WriteKubeconfigToFile(config *clientcmdapi.Config) string {
-	f, _ := os.CreateTemp("", "kubeconfig-")
+	f, err := os.CreateTemp("", "kubeconfig-")
+	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(func() {
 		os.Remove(f.Name())
 	})
-	_ = f.Close()
-	err := clientcmd.WriteToFile(*config, f.Name())
+	err = f.Close()
+	Expect(err).ToNot(HaveOccurred())
+	err = clientcmd.WriteToFile(*config, f.Name())
 	Expect(err).ToNot(HaveOccurred())
 	return f.Name()
 }
@@ -191,7 +207,8 @@ func (c *providerTestContext) NewConfig(opts ...NewConfigOption) *clientcmdapi.C
 	}
 
 	config := &clientcmdapi.Config{
-		Kind: "Config",
+		APIVersion: "v1",
+		Kind:       "Config",
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"cluster1": {
 				Server: "https://cluster1.test",

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "provider/pkg/provider")
+}
+
+// TestingTB is an interface that describes the implementation of the testing object.
+// Using an interface that describes testing.TB instead of the actual implementation
+// makes testutil usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
+type TestingTB interface {
+	Cleanup(func())
+	Failed() bool
+	Logf(format string, args ...interface{})
+	Name() string
+}

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -291,15 +291,15 @@ func (c *providerTestContext) NewProvider(opts ...NewProviderOption) *kubeProvid
 	return k
 }
 
-// getDiscoveryClient returns the fake discovery client that the provider is using.
+// GetDiscoveryClient returns the fake discovery client that the provider is using.
 // use the Resources field to populate the server resources.
-func getDiscoveryClient(k *kubeProvider) *discoveryfake.FakeDiscovery {
+func GetDiscoveryClient(k *kubeProvider) *discoveryfake.FakeDiscovery {
 	return k.clientSet.DiscoveryClientCached.(*mockCachedDiscoveryClient).DiscoveryInterface.(*discoveryfake.FakeDiscovery)
 }
 
-// getDynamicClient returns the fake dynamic client that the provider is using.
-// Use the Tracker() method to inject fake objects.
-func getDynamicClient(k *kubeProvider) *dynamicfake.FakeDynamicClient {
+// GetDynamicClient returns the fake dynamic client that the provider is using.
+// Use the Tracker() accessor to inject fake objects.
+func GetDynamicClient(k *kubeProvider) *dynamicfake.FakeDynamicClient {
 	return k.clientSet.GenericClient.(*dynamicfake.FakeDynamicClient)
 }
 

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -20,6 +20,12 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+const (
+	testPluginVersion    = "v0.0.0"
+	testPulumiSchema     = "{}"
+	testTerraformMapping = "{}"
+)
+
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "provider/pkg/provider")
@@ -137,9 +143,7 @@ type providerTestContext struct {
 }
 
 func (c *providerTestContext) NewProvider() (*kubeProvider, error) {
-	var pulumiSchema []byte
-	var terraformMapping []byte
-	return makeKubeProvider(c.host, "kubernetes", "v0.0.0", pulumiSchema, terraformMapping)
+	return makeKubeProvider(c.host, "kubernetes", testPluginVersion, []byte(testPulumiSchema), []byte(testTerraformMapping))
 }
 
 var pctx *providerTestContext

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -3,12 +3,21 @@ package provider
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
+	"os"
 	"testing"
 
+	pbempty "github.com/golang/protobuf/ptypes/empty"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestSuite(t *testing.T) {
@@ -24,6 +33,102 @@ type TestingTB interface {
 	Failed() bool
 	Logf(format string, args ...interface{})
 	Name() string
+}
+
+// CheckFailure matches a CheckFailure by property and reason.
+func CheckFailure(prop string, reason gomegatypes.GomegaMatcher) gomegatypes.GomegaMatcher {
+	return And(
+		WithTransform(func(failure *pulumirpc.CheckFailure) string {
+			return failure.GetProperty()
+		}, Equal(prop)),
+		WithTransform(func(failure *pulumirpc.CheckFailure) string {
+			return failure.GetReason()
+		}, reason))
+}
+
+// KubeconfigAsString converts a Kubernetes configuration to a string.
+func KubeconfigAsString(config *clientcmdapi.Config) string {
+	contents, err := clientcmd.Write(*config)
+	Expect(err).ToNot(HaveOccurred())
+	return string(contents)
+}
+
+// KubeconfigAsFile converts a Kubernetes configuration to a string.
+func KubeconfigAsFile(config *clientcmdapi.Config) string {
+	f, _ := os.CreateTemp("", "kubeconfig-")
+	DeferCleanup(func() {
+		os.Remove(f.Name())
+	})
+	_ = f.Close()
+	err := clientcmd.WriteToFile(*config, f.Name())
+	Expect(err).ToNot(HaveOccurred())
+	return f.Name()
+}
+
+// A mock engine for test purposes.
+type mockEngine struct {
+	pulumirpc.UnsafeEngineServer
+	t            TestingTB
+	logger       *log.Logger
+	rootResource string
+}
+
+// Log logs a global message in the engine, including errors and warnings.
+func (m *mockEngine) Log(ctx context.Context, in *pulumirpc.LogRequest) (*pbempty.Empty, error) {
+	m.t.Logf("%s: %s", in.GetSeverity(), in.GetMessage())
+	if m.logger != nil {
+		m.logger.Printf("%s: %s", in.GetSeverity(), in.GetMessage())
+	}
+	return &pbempty.Empty{}, nil
+}
+
+// GetRootResource gets the URN of the root resource, the resource that should be the root of all
+// otherwise-unparented resources.
+func (m *mockEngine) GetRootResource(ctx context.Context, in *pulumirpc.GetRootResourceRequest) (*pulumirpc.GetRootResourceResponse, error) {
+	return &pulumirpc.GetRootResourceResponse{
+		Urn: m.rootResource,
+	}, nil
+}
+
+// SetRootResource sets the URN of the root resource.
+func (m *mockEngine) SetRootResource(ctx context.Context, in *pulumirpc.SetRootResourceRequest) (*pulumirpc.SetRootResourceResponse, error) {
+	m.rootResource = in.GetUrn()
+	return &pulumirpc.SetRootResourceResponse{}, nil
+}
+
+// newMockHost creates a mock host for test purposes and returns a client.
+// Dispatches Engine RPC calls to the given engine.
+func newMockHost(ctx context.Context, engine pulumirpc.EngineServer) *provider.HostClient {
+	cancel := make(chan bool)
+	go func() {
+		<-ctx.Done()
+		close(cancel)
+	}()
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterEngineServer(srv, engine)
+			return nil
+		},
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
+	if err != nil {
+		panic(fmt.Errorf("could not start host engine service: %v", err))
+	}
+
+	go func() {
+		err := <-handle.Done
+		if err != nil {
+			panic(fmt.Errorf("host engine service failed: %v", err))
+		}
+	}()
+
+	address := fmt.Sprintf("127.0.0.1:%v", handle.Port)
+	hostClient, err := provider.NewHostClient(address)
+	if err != nil {
+		panic(fmt.Errorf("could not connect to host engine service: %v", err))
+	}
+	return hostClient
 }
 
 type providerTestContext struct {

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -12,18 +12,34 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubectl/pkg/scheme"
 )
 
 const (
 	testPluginVersion    = "v0.0.0"
 	testPulumiSchema     = "{}"
 	testTerraformMapping = "{}"
+)
+
+var (
+	testServerVersion = kubeversion.Info{Major: "1", Minor: "29"}
 )
 
 // TestingTB is an interface that describes the implementation of the testing object.
@@ -132,13 +148,70 @@ func newMockHost(ctx context.Context, engine pulumirpc.EngineServer) *provider.H
 	return hostClient
 }
 
+type mockCachedDiscoveryClient struct {
+	discovery.DiscoveryInterface
+}
+
+var _ discovery.CachedDiscoveryInterface = &mockCachedDiscoveryClient{}
+
+func (*mockCachedDiscoveryClient) Fresh() bool {
+	return true
+}
+
+func (*mockCachedDiscoveryClient) Invalidate() {}
+
+type mockRestMapper struct {
+	meta.RESTMapper
+}
+
+var _ meta.ResettableRESTMapper = &mockRestMapper{}
+
+func (m *mockRestMapper) Reset() {}
+
 type providerTestContext struct {
 	engine *mockEngine
 	host   *provider.HostClient
 }
 
-func (c *providerTestContext) NewProvider() (*kubeProvider, error) {
-	return makeKubeProvider(c.host, "kubernetes", testPluginVersion, []byte(testPulumiSchema), []byte(testTerraformMapping))
+func (c *providerTestContext) NewProvider(objects ...runtime.Object) (*kubeProvider, error) {
+	k, err := makeKubeProvider(c.host, "kubernetes", testPluginVersion, []byte(testPulumiSchema), []byte(testTerraformMapping))
+	if err != nil {
+		return nil, err
+	}
+	k.makeClient = func(ctx context.Context, config *rest.Config) (*clients.DynamicClientSet, *clients.LogClient, error) {
+		// make a fake clientset for testing purposes, backed by an testing.ObjectTracker with pre-populated objects.
+		// see also: https://github.com/kubernetes/client-go/blob/kubernetes-1.29.0/examples/fake-client/main_test.go
+		disco := &discoveryfake.FakeDiscovery{
+			Fake:               &kubetesting.Fake{},
+			FakedServerVersion: &testServerVersion,
+		}
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+		client := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+		cs := &clients.DynamicClientSet{
+			GenericClient:         client,
+			DiscoveryClientCached: &mockCachedDiscoveryClient{DiscoveryInterface: disco},
+			RESTMapper:            &mockRestMapper{RESTMapper: mapper},
+		}
+
+		// make a fake log client for testing purposes.
+		clientset := fake.NewSimpleClientset(objects...)
+		lc := clients.NewLogClient(ctx, clientset.CoreV1())
+
+		return cs, lc, nil
+	}
+	return k, nil
+}
+
+// getDiscoveryClient returns the fake discovery client that the provider is using.
+// use the Resources field to populate the server resources.
+func getDiscoveryClient(k *kubeProvider) *discoveryfake.FakeDiscovery {
+	return k.clientSet.DiscoveryClientCached.(*mockCachedDiscoveryClient).DiscoveryInterface.(*discoveryfake.FakeDiscovery)
+}
+
+// getDynamicClient returns the fake dynamic client that the provider is using.
+// Use the Tracker() method to inject fake objects.
+func getDynamicClient(k *kubeProvider) *dynamicfake.FakeDynamicClient {
+	return k.clientSet.GenericClient.(*dynamicfake.FakeDynamicClient)
 }
 
 var pctx *providerTestContext

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -1,10 +1,14 @@
 package provider
 
 import (
+	"bytes"
+	"context"
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 )
 
 func TestSuite(t *testing.T) {
@@ -21,3 +25,37 @@ type TestingTB interface {
 	Logf(format string, args ...interface{})
 	Name() string
 }
+
+type providerTestContext struct {
+	engine *mockEngine
+	host   *provider.HostClient
+}
+
+func (c *providerTestContext) NewProvider() (*kubeProvider, error) {
+	var pulumiSchema []byte
+	var terraformMapping []byte
+	return makeKubeProvider(c.host, "kubernetes", "v0.0.0", pulumiSchema, terraformMapping)
+}
+
+var pctx *providerTestContext
+
+var _ = BeforeSuite(func() {
+	// mock engine
+	var buff bytes.Buffer
+	engine := &mockEngine{
+		t:      GinkgoT(),
+		logger: log.New(&buff, "\t", 0),
+	}
+
+	// mock host
+	ctx, cancel := context.WithCancel(context.Background())
+	host := newMockHost(ctx, engine)
+	DeferCleanup(func() {
+		cancel()
+	})
+
+	pctx = &providerTestContext{
+		engine: engine,
+		host:   host,
+	}
+})

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -42,16 +42,6 @@ var (
 	testServerVersion = kubeversion.Info{Major: "1", Minor: "29"}
 )
 
-// TestingTB is an interface that describes the implementation of the testing object.
-// Using an interface that describes testing.TB instead of the actual implementation
-// makes testutil usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
-type TestingTB interface {
-	Cleanup(func())
-	Failed() bool
-	Logf(format string, args ...interface{})
-	Name() string
-}
-
 // CheckFailure matches a CheckFailure by property and reason.
 func CheckFailure(prop string, reason gomegatypes.GomegaMatcher) gomegatypes.GomegaMatcher {
 	return And(
@@ -85,7 +75,7 @@ func WriteKubeconfigToFile(config *clientcmdapi.Config) string {
 // A mock engine for test purposes.
 type mockEngine struct {
 	pulumirpc.UnsafeEngineServer
-	t            TestingTB
+	t            testing.TB
 	logger       *log.Logger
 	rootResource string
 }
@@ -214,7 +204,9 @@ func (c *providerTestContext) NewConfig(opts ...NewConfigOption) *clientcmdapi.C
 			"user1": {
 				Token: "secret",
 			},
-			"user2": {},
+			"user2": {
+				Token: "secret",
+			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
 			"context1": {
@@ -309,7 +301,7 @@ var _ = BeforeSuite(func() {
 	// make a mock engine that simply buffers the log messages.
 	var buff bytes.Buffer
 	engine := &mockEngine{
-		t:      GinkgoT(),
+		t:      GinkgoTB(),
 		logger: log.New(&buff, "\t", 0),
 	}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/onsi/gomega v1.29.0
+	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.0.0
@@ -270,7 +270,7 @@ require (
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
+	golang.org/x/tools v0.16.1 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.128.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1496,8 +1496,8 @@ github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1ls
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
-github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1508,8 +1508,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
-github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
+github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2492,8 +2492,8 @@ golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
-golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
+golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
+golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR implements a suite of unit tests for the provider implementation code in `provider/pkg/provider/provider.go`.  Unlike the test suites in `tests/`, this suite uses a mock Kubernetes client and executes the provider code directly.

This PR focuses on the provider lifecycle (e.g. plugin info and provider configuration):
- [x] Suite
- [x] RPC:CheckConfig
  - [x] Strict Mode
  - [x] Yaml Rendering Mode
- [x] RPC:DiffConfig
  - [x] Kubeconfig Parsing
  - [x] Cluster Change Detection 
- [x] RPC:Configure
  - [x] Secrets Support
  - [x] Connectivity
- [x] RPC:GetPluginInfo
- [x] RPC:GetSchema
- [x] RPC:GetMapping
- [x] RPC:Cancel

In follow-up PR(s), tests will be developed for the resource lifecycle (eg. `Check`, `Diff`, `Read`, `Create`, `Update`, `Delete`), and for invokes (`Invoke`, `StreamInvoke`).

### Changes to Implementation Code
Some minor refactoring was necessary to make it possible to substitute fake Kubernetes clients.
- the type of the `RESTMapper` field of `DynamicClientSet` was changed to an interface.
- the type of the `client` field of `LogClient` was changed to an interface.
- the low-level logic for making a Kubernetes client from a kubeconfig was moved into a function called `makeClient`.
- add a `makeClient` field to `kubeProvider` as an indirection for test purposes.

### Running the Tests
The tests are written as a Ginkgo suite and is integrated with gotest via an ordinary test function called `TestSuite` in `suite_test.go`.  Here's how `go test` behaves:

```
 $ make test_provider
=== RUN   Test_Watcher_Interface_Cancel
--- PASS: Test_Watcher_Interface_Cancel (0.00s)
=== RUN   TestSuite
Running Suite: provider/pkg/provider - /Users/eronwright/Pulumi/pulumi-kubernetes/provider/pkg/provider
===============================================================================
Random Seed: 1706123566

Will run 39 of 40 specs
••••••••
------------------------------
P [PENDING]
RPC:DiffConfig Kubeconfig Parsing when kubeconfig is a file should return an empty diff
/Users/eronwright/Pulumi/pulumi-kubernetes/provider/pkg/provider/provider_diffconfig_test.go:113
------------------------------
•••••••••••••••••••••••••••••••

Ran 39 of 40 Specs in 0.590 seconds
SUCCESS! -- 39 Passed | 0 Failed | 1 Pending | 0 Skipped
--- PASS: TestSuite (0.59s)
=== RUN   TestHasComputedValue
--- PASS: TestHasComputedValue (0.00s)
...
```

Here's a [full example](https://github.com/pulumi/pulumi-kubernetes/actions/runs/7645156279/job/20831066857?pr=2768#step:20:621) in a CI context.

One may also use the `ginkgo` CLI as a drop-in replacement with some niceties.
There's a minor limitation of using `go test`, it is that the `--parallel` flag doesn't work and causes Ginkgo to quit. The overall test pass is fast enough without parallelization and so I removed the flag for now.  We could switch to using the `ginkgo` CLI (which runs the standard tests too) as an alternative solution.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #2767 