### PR TITLE
Resource undergoing replacement has incorrect status messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix DiffConfig issue when when provider's kubeconfig is set to file path (https://github.com/pulumi/pulumi-kubernetes/pull/2771)
+- Fix for replacement having incorrect status messages (https://github.com/pulumi/pulumi-kubernetes/pull/2810)
 
 ## 4.7.1 (January 17, 2024)
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -276,6 +276,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				if waitErr != nil {
 					return nil, waitErr
 				}
+				_ = clearStatus(c.Context, c.Host, c.URN)
 			}
 		}
 	} else {
@@ -333,12 +334,13 @@ func Read(c ReadConfig) (*unstructured.Unstructured, error) {
 				if waitErr != nil {
 					return nil, waitErr
 				}
+				_ = clearStatus(c.Context, c.Host, c.URN)
 			}
 		}
+	} else {
+		logger.V(1).Infof(
+			"No read logic found for object of type %q; falling back to retrieving object", id)
 	}
-
-	logger.V(1).Infof(
-		"No read logic found for object of type %q; falling back to retrieving object", id)
 
 	// If the client fails to get the live object for some reason, DO NOT return the error. This
 	// will leak the fact that the object was successfully created. Instead, fall back to the
@@ -415,6 +417,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 				if waitErr != nil {
 					return nil, waitErr
 				}
+				_ = clearStatus(c.Context, c.Host, c.URN)
 			}
 		}
 	} else {
@@ -773,6 +776,10 @@ func Deletion(c DeleteConfig) error {
 				},
 				clientForResource: client,
 			})
+			if waitErr != nil {
+				return waitErr
+			}
+			_ = clearStatus(c.Context, c.Host, c.URN)
 		}
 	} else {
 		for {
@@ -824,7 +831,7 @@ func Deletion(c DeleteConfig) error {
 		}
 	}
 
-	return waitErr
+	return nil
 }
 
 // deleteResource deletes the specified resource using foreground cascading delete.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR clears the resource status after the awaiter completes, to ensure that the status pertaining to a replacement resource (which would have the same URN) isn't stale.

In this example, the status message is obsolete once the flow hits "created replacement".  Before:
```
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata];
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be scheduled
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be initialized
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
@ updating....
 ++ kubernetes:core/v1:Pod autonaming-test created replacement (1s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
 +- kubernetes:core/v1:Pod autonaming-test replacing (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
 +- kubernetes:core/v1:Pod autonaming-test replaced (0.00s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
 -- kubernetes:core/v1:Pod autonaming-test deleting original (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
@ updating.....
 -- kubernetes:core/v1:Pod autonaming-test deleted original (1s) [diff: ~metadata]; Waiting for Pod "test-namespace-4d5e71b3/autonaming-test" to be ready
```

After:
```
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata];
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-c74027dd/autonaming-test" to be scheduled
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-c74027dd/autonaming-test" to be initialized
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (0s) [diff: ~metadata]; Waiting for Pod "test-namespace-c74027dd/autonaming-test" to be ready
@ updating....
 ++ kubernetes:core/v1:Pod autonaming-test creating replacement (1s) [diff: ~metadata];
 ++ kubernetes:core/v1:Pod autonaming-test created replacement (1s) [diff: ~metadata];
 +- kubernetes:core/v1:Pod autonaming-test replacing (0s) [diff: ~metadata];
 +- kubernetes:core/v1:Pod autonaming-test replaced (0.00s) [diff: ~metadata];
 -- kubernetes:core/v1:Pod autonaming-test deleting original (0s) [diff: ~metadata];
@ updating.....
 -- kubernetes:core/v1:Pod autonaming-test deleting original (1s) [diff: ~metadata];
 -- kubernetes:core/v1:Pod autonaming-test deleted original (1s) [diff: ~metadata];
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes #2761 