### PR TITLE
Fix unmarshalling of Helm values yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix for replacement having incorrect status messages (https://github.com/pulumi/pulumi-kubernetes/pull/2810)
 - Use output properties for await logic (https://github.com/pulumi/pulumi-kubernetes/pull/2790)
 - Support for metadata.generateName (CSA) (https://github.com/pulumi/pulumi-kubernetes/pull/2808)
+- Fix unmarshalling of Helm values yaml file (https://github.com/pulumi/pulumi-kubernetes/issues/2815)
  
 ## 4.7.1 (January 17, 2024)
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
 	helmchart "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -56,6 +55,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/yaml"
 )
 
 // Default timeout for awaited install and uninstall operations

--- a/tests/sdk/nodejs/examples/helm-release/step1/metrics.yml
+++ b/tests/sdk/nodejs/examples/helm-release/step1/metrics.yml
@@ -3,3 +3,8 @@ metrics:
   service:
     annotations:
       "prometheus.io/port": "9127"
+
+# fake-value contains a numeric/complex mapping key that require marshing into strings to be used with Helm.
+# An example of this in the wild is the ingress-nginx chart from https://kubernetes.github.io/ingress-nginx.
+fake-value:
+  2: "test-string"


### PR DESCRIPTION
### Proposed changes

Previously, we used `gopkg.in/yaml.v3` as our yaml library to unmarshal helm values. This library allows unmarshalling complex mapping key types, which would be unmarshalled into `map[any]any` types instead of `map[string]any`.

Upstream Kubernetes has mostly switched to using their yaml fork (`sigs.k8s.io/yaml`), which upstream Helm is also using. `sigs.k8s.io/yaml` does not handle complex mapping key types, and instead, will try to marshal these keys as strings instead. In short, they convert yaml to json before marshaling/unmarshaling into a struct. To maintain compatibility with upstream Helm, this PR switches our yaml library to the Kubernetes fork to ensure the unmarshalled result is comparable.

Example yaml:
```yaml
key1: value1
2: value2
```

With `gopkg.in/yaml.v3` unmarshaling:
```go
objType: map[any]any
```

With `sigs.k8s.io/yaml`:
```go
objType: map[string]any
```

Changes made:
 * Switched yaml package to `sigs.k8s.io/yaml`
 * Expanded integration test case to incorporate complex mapping types in the values file, ensuring resolution of panics

### Related issues (optional)

Fixes: #2814
Fixes #2684
