### PR TITLE
Enhance SSA ignoreChanges by having better field manager path comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix SSA ignoreChanges by enhancing field manager path comparisons (https://github.com/pulumi/pulumi-kubernetes/pull/2828)
+
 ## 4.8.1 (February 22, 2024)
 
 - skip normalization in preview w/ computed fields (https://github.com/pulumi/pulumi-kubernetes/pull/2846)

--- a/tests/sdk/nodejs/field-manager-patch-resources/step1/index.ts
+++ b/tests/sdk/nodejs/field-manager-patch-resources/step1/index.ts
@@ -33,9 +33,6 @@ const depPatch = new k8s.apps.v1.DeploymentPatch(
     },
     spec: {
         template: {
-            metadata: {
-                labels: undefined,
-            },
             spec: {
                 containers: [
                     {
@@ -46,4 +43,4 @@ const depPatch = new k8s.apps.v1.DeploymentPatch(
             },
     }
   },
-}, { provider: provider, retainOnDelete: true });
+}, { provider: provider, retainOnDelete: true, ignoreChanges: ["spec.template.metadata", "spec.selector"]});

--- a/tests/sdk/nodejs/field-manager-patch-resources/step2/index.ts
+++ b/tests/sdk/nodejs/field-manager-patch-resources/step2/index.ts
@@ -33,9 +33,6 @@ const depPatch = new k8s.apps.v1.DeploymentPatch(
     },
     spec: {
         template: {
-            metadata: {
-                labels: undefined,
-            },
             spec: {
                 containers: [
                     {
@@ -46,4 +43,4 @@ const depPatch = new k8s.apps.v1.DeploymentPatch(
             },
     }
   },
-}, { provider: provider, retainOnDelete: true });
+}, { provider: provider, retainOnDelete: true, ignoreChanges: ["spec.template.metadata", "spec.selector"]});


### PR DESCRIPTION
### Proposed changes
This PR enhances the field manager checks to ensure we do not take control of fields manager by other owners during a Patch Resource update. Previously, our set of managed fields only contains that the child node of a path. We now add the parent fields into the set as well.

#### Example:

Previously:
Set containing currently managed path(s): `.spec.metadata.template.labels`
Path we want to check if present in set: `.spec.metadata.template`

Using `set.Has(path)` will return `false`. However, this is not wanted since adding `.spec.metadata.template` as an ignoreChanges path means we don't care about children fields as well.

Now:
`set.Has(path)` will now return `true`, which indicates to our provider that we need to ignore `spec.metadata.template`


### Related issues (optional)

Fixes: #2714
