### PR TITLE
skip normalization in preview w/ computed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+#2846
+- skip normalization in preview w/ computed fields (https://github.com/pulumi/pulumi-kubernetes/pull/2846)
+
 ## 4.8.0 (February 22, 2024)
 
 - Fix DiffConfig issue when when provider's kubeconfig is set to file path (https://github.com/pulumi/pulumi-kubernetes/pull/2771)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2765,7 +2765,7 @@ func shouldNormalize(uns *unstructured.Unstructured) bool {
 // are set to the same output shape. This is important to avoid generating diffs for inputs that will produce the same
 // result on the cluster.
 func normalizeInputs(uns *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	if shouldNormalize(uns) {
+	if !hasComputedValue(uns) && shouldNormalize(uns) {
 		normalized, err := clients.Normalize(uns)
 		if err != nil {
 			return nil, err

--- a/tests/sdk/go/go_test.go
+++ b/tests/sdk/go/go_test.go
@@ -707,6 +707,14 @@ func TestGo(t *testing.T) {
 		integration.ProgramTest(t, &options)
 	})
 
+	t.Run("SecretsWithUnknowns", func(t *testing.T) {
+		options := baseOptions.With(integration.ProgramTestOptions{
+			Dir:   filepath.Join(cwd, "secrets-with-unknowns"),
+			Quick: false,
+		})
+		integration.ProgramTest(t, &options)
+	})
+
 	t.Run("ServerSideApply", func(t *testing.T) {
 		options := baseOptions.With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(cwd, "server-side-apply"),

--- a/tests/sdk/go/secrets-with-unknowns/Pulumi.yaml
+++ b/tests/sdk/go/secrets-with-unknowns/Pulumi.yaml
@@ -1,0 +1,17 @@
+name: go_secrets_with_unknowns
+runtime: yaml
+description: Unknown values in secrets
+variables: {}
+outputs:
+  password: ${prefix.id}
+resources:
+  prefix:
+    type: random:RandomPet
+  my-secret:
+    type: kubernetes:core/v1:Secret
+    properties:
+      data:
+        username: dXNlcm5hbWU= # base64 encoded "username"
+        password:
+          fn::toBase64: ${prefix.id}
+


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Skips the normalization step in the presence of computed inputs. 

Note: previously when `clients.Normalize` was called with a `Secret`, it would panic. If called with a non-secret, an internal error would be masked and the original object would be used. 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes #2845
