### PR TITLE
Ensure nodejs path globs prepend all relative path strings with ./

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+## 4.9.0 (March 4, 2024)
+
 - Fix SSA ignoreChanges by enhancing field manager path comparisons (https://github.com/pulumi/pulumi-kubernetes/pull/2828)
+- Update nodejs SDK dependencies (https://github.com/pulumi/pulumi-kubernetes/pull/2858, https://github.com/pulumi/pulumi-kubernetes/pull/2861)
 
 ## 4.8.1 (February 22, 2024)
 

--- a/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
+++ b/provider/pkg/gen/nodejs-templates/yaml/yaml.tmpl
@@ -433,14 +433,14 @@ export interface ConfigOpts {
             if (isUrl(config.files)) {
                 files = [config.files];
             } else {
-                files = glob.sync(config.files);
+                files = glob.sync(config.files, {dotRelative: true});
             }
         } else {
             for (const file of config.files) {
                 if (isUrl(file)) {
                     files.push(file);
                 } else {
-                    files.push(...glob.sync(file));
+                    files.push(...glob.sync(file, {dotRelative: true}));
                 }
             }
         }

--- a/sdk/nodejs/yaml/yaml.ts
+++ b/sdk/nodejs/yaml/yaml.ts
@@ -3268,14 +3268,14 @@ export interface ConfigOpts {
             if (isUrl(config.files)) {
                 files = [config.files];
             } else {
-                files = glob.sync(config.files);
+                files = glob.sync(config.files, {dotRelative: true});
             }
         } else {
             for (const file of config.files) {
                 if (isUrl(file)) {
                     files.push(file);
                 } else {
-                    files.push(...glob.sync(file));
+                    files.push(...glob.sync(file, {dotRelative: true}));
                 }
             }
         }


### PR DESCRIPTION
### Proposed changes

The latest version of the NodeJS `glob` package introduced in #2858 has slightly different behaviour than in the previously used version. This PR sets the options for these glob functions to maintain backwards compatibility and ensure our resource urns do not change.

### Related issues (optional)

Fixes: #2860