### PR TITLE
yaml/v2: Detect file patterns automatically

### DIFF
--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -70,10 +71,10 @@ func ParseDecodeYamlFiles(ctx *pulumi.Context, args *ParseArgs, glob bool, clien
 			}
 			yamls = append(yamls, string(yaml))
 		} else {
-			// Otherwise, assume this is a path to a file on disk. If globbing is enabled, we might have
-			// multiple files -- otherwise just read a singular file.
+			// Otherwise, assume this is a path to a file on disk. If globbing is enabled and a pattern is provided, we might have
+			// multiple files -- otherwise just read a singular file and fail if it doesn't exist.  
 			var files []string
-			if glob {
+			if glob && isPattern(file) {
 				files, err = filepath.Glob(file)
 				if err != nil {
 					return pulumi.ArrayOutput{}, errors.Wrapf(err, "expanding glob")
@@ -245,4 +246,12 @@ func printUnstructured(obj *unstructured.Unstructured) string {
 
 	bytes, _ := obj.MarshalJSON()
 	return truncate(strings.TrimSpace(string(bytes)), 100)
+}
+
+// patternRegexp is a regular expression that matches any of the special characters in a glob pattern.
+// see: https://pkg.go.dev/path/filepath#Match
+var patternRegexp = regexp.MustCompile(`(?:^|[^\\])[*?\[]`)
+
+func isPattern(pattern string) bool {
+	return patternRegexp.Match([]byte(pattern))
 }

--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -72,9 +72,9 @@ func ParseDecodeYamlFiles(ctx *pulumi.Context, args *ParseArgs, glob bool, clien
 			yamls = append(yamls, string(yaml))
 		} else {
 			// Otherwise, assume this is a path to a file on disk. If globbing is enabled and a pattern is provided, we might have
-			// multiple files -- otherwise just read a singular file and fail if it doesn't exist.  
+			// multiple files -- otherwise just read a singular file and fail if it doesn't exist.
 			var files []string
-			if glob && isPattern(file) {
+			if glob && isGlobPattern(file) {
 				files, err = filepath.Glob(file)
 				if err != nil {
 					return pulumi.ArrayOutput{}, errors.Wrapf(err, "expanding glob")
@@ -248,10 +248,10 @@ func printUnstructured(obj *unstructured.Unstructured) string {
 	return truncate(strings.TrimSpace(string(bytes)), 100)
 }
 
-// patternRegexp is a regular expression that matches any of the special characters in a glob pattern.
+// globPatternRegexp is a regular expression that matches any of the special characters in a glob pattern.
 // see: https://pkg.go.dev/path/filepath#Match
-var patternRegexp = regexp.MustCompile(`(?:^|[^\\])[*?\[]`)
+var globPatternRegexp = regexp.MustCompile(`(?:^|[^\\])[*?\[]`)
 
-func isPattern(pattern string) bool {
-	return patternRegexp.Match([]byte(pattern))
+func isGlobPattern(pattern string) bool {
+	return globPatternRegexp.Match([]byte(pattern))
 }

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -347,7 +347,7 @@ var _ = Describe("ParseDecodeYamlFiles", func() {
 	})
 })
 
-func TestIsPattern(t *testing.T) {
+func TestIsGlobPattern(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -357,6 +357,7 @@ func TestIsPattern(t *testing.T) {
 		{pattern: `manifest.yaml`, expected: false},
 		{pattern: `*.yaml`, expected: true},
 		{pattern: `*`, expected: true},
+		{pattern: `test-?.yaml`, expected: true},
 		{pattern: `ba[rz].yaml`, expected: true},
 		{pattern: `escaped-\*.yaml`, expected: false},
 		{pattern: `\*.yaml`, expected: false},
@@ -367,7 +368,7 @@ func TestIsPattern(t *testing.T) {
 		t.Run(tt.pattern, func(t *testing.T) {
 			t.Parallel()
 
-			isPattern := isPattern(tt.pattern)
+			isPattern := isGlobPattern(tt.pattern)
 			if tt.expected {
 				assert.Truef(t, isPattern, "expected %q to be a pattern", tt.pattern)
 			} else {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR teaches `ConfigGroup` to detect whether a given file path is a glob pattern, to make the handling of non-existent files be consistent w.r.t `ConfigFile`.  In other words, `*.yaml` MAY match a file whereas `manifest.yaml` MUST match a file.

The detection code looks for special characters '*',  '?', and '[' and respects the escape syntax.  Intended to be consistent with: [https://pkg.go.dev/path/filepath#Match](https://pkg.go.dev/path/filepath#Match)

An alternative to doing pattern detection would be:
1. to expose a `glob` property to toggle globbing, or 
2. a `patterns` property alongside the `files` property for patterns and non-patterns respectively

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes #2871 
