### PR TITLE
Prepare for v4.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.9.1 (March 13, 2024)
+
 - Use async invokes to avoid hangs/stalls in Python `helm`, `kustomize`, and `yaml` components (https://github.com/pulumi/pulumi-kubernetes/pull/2863)
 - ConfigGroup V2 (https://github.com/pulumi/pulumi-kubernetes/pull/2844)
 - ConfigFile V2 (https://github.com/pulumi/pulumi-kubernetes/pull/2862)


### PR DESCRIPTION
(cherry picked from commit b56dfbdc38213cb82c5ca3341e5a3e4e3533221e)

Cherry picking the changelog updates for the v4.9.1 release cut from a release branch.
