### PR TITLE
[yaml/v2] implement the default ordering strategy

### DIFF
--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -77,6 +78,7 @@ func Parse(ctx context.Context, clientSet *clients.DynamicClientSet, opts ParseO
 				if err != nil {
 					return nil, errors.Wrapf(err, "expanding glob")
 				}
+				sort.Strings(files)
 			} else {
 				files = []string{file}
 			}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR stabilizes the order in which the objects are registered.  Specifically:
1.  sorts the glob results, so that `001-crds.yaml` would be processed before `002-deployments.yaml`.
2. applies the files, then the yamls, then the objects.

Some new tests were added for the ordering aspect.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Related: #2880 
