### PR TITLE
Upgrade postgres operator integration test to use v1.11.0

### DIFF
--- a/tests/sdk/nodejs/examples/helm-release-crd/step1/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-crd/step1/index.ts
@@ -3,7 +3,7 @@ import * as k8s from "@pulumi/kubernetes";
 const postgresOperator = new k8s.helm.v3.Release("postgres-operator", {
     name: "postgres-operator",
     chart: "postgres-operator",
-    version: "1.7.0",
+    version: "1.11.0",
     repositoryOpts: {
         repo: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator/",
     },

--- a/tests/sdk/nodejs/examples/helm-release-crd/step2/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-crd/step2/index.ts
@@ -3,7 +3,7 @@ import * as k8s from "@pulumi/kubernetes";
 const postgresOperator = new k8s.helm.v3.Release("postgres-operator", {
     name: "postgres-operator",
     chart: "postgres-operator",
-    version: "1.7.0",
+    version: "1.11.0",
     repositoryOpts: {
         repo: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator/",
     },


### PR DESCRIPTION
The v1.7.0 version of the Zolando Posgres Operator chart is no longer being hosted causing our CI tests to fail (eg. https://github.com/pulumi/pulumi-kubernetes/actions/runs/8300755190/job/22843283137). This PR bumps the chart version to a more recent 1.11.0. I've inspected the new version to ensure that the intent of the test isn't lost by upgrading to this version.

Fixes: #2892
Fixes: #2893