### PR TITLE
yaml/v2: apply the namespace uniformly to the resource name

### DIFF
--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -167,7 +167,7 @@ func (dcs *DynamicClientSet) searchKindInGVResources(gvResources *v1.APIResource
 // For GVKs not in the table, attempt to look up the GVK from the API server. If the GVK cannot be found, a
 // NoNamespaceInfoErr is returned.
 func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInterface, objs ...unstructured.Unstructured) (bool, error) {
-	if gvk.Group == "core" {
+	if gvk.Group == "core" { // nolint:goconst
 		gvk.Group = ""
 	}
 

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -164,7 +164,8 @@ func (dcs *DynamicClientSet) searchKindInGVResources(gvResources *v1.APIResource
 }
 
 // IsNamespacedKind checks if a given GVK is namespace-scoped. Known GVKs are compared against a static lookup table.
-// For GVKs not in the table, attempt to look up the GVK from the API server. If the GVK cannot be found, a
+// For GVKs not in the table, look at the given objects for a matching CRD.
+// Finally, attempt to look up the GVK from the API server. If the GVK cannot be found, a
 // NoNamespaceInfoErr is returned.
 func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInterface, objs ...unstructured.Unstructured) (bool, error) {
 	if gvk.Group == "core" { // nolint:goconst

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -166,10 +166,9 @@ func (dcs *DynamicClientSet) searchKindInGVResources(gvResources *v1.APIResource
 // IsNamespacedKind checks if a given GVK is namespace-scoped. Known GVKs are compared against a static lookup table.
 // For GVKs not in the table, attempt to look up the GVK from the API server. If the GVK cannot be found, a
 // NoNamespaceInfoErr is returned.
-func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInterface) (bool, error) {
-	gv := gvk.GroupVersion().String()
-	if strings.Contains(gv, "core/v1") {
-		gv = "v1"
+func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInterface, objs ...unstructured.Unstructured) (bool, error) {
+	if gvk.Group == "core" {
+		gvk.Group = ""
 	}
 
 	if kinds.KnownGroupVersions.Has(gvk.GroupVersion().String()) {
@@ -179,12 +178,19 @@ func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInte
 		}
 	}
 
+	// check the provided objects for a matching CRD.
+	crd, _ := FindCRD(objs, gvk.GroupKind())
+	if crd != nil {
+		crdScope, _, err := unstructured.NestedString(crd.Object, "spec", "scope")
+		return crdScope == "Namespaced", err
+	}
+
 	// If the Kind is not known, attempt to look up from the API server. This applies to Kinds defined using a CRD.
 	// If the API server is not reachable, return an error.
 	if disco == nil {
 		return false, &NoNamespaceInfoErr{gvk}
 	}
-	resourceList, err := disco.ServerResourcesForGroupVersion(gv)
+	resourceList, err := disco.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
 		return false, &NoNamespaceInfoErr{gvk}
 	}
@@ -255,6 +261,25 @@ func NamespaceOrDefault(ns string) string {
 func IsCRD(obj *unstructured.Unstructured) bool {
 	return obj.GetKind() == string(kinds.CustomResourceDefinition) &&
 		strings.HasPrefix(obj.GetAPIVersion(), "apiextensions.k8s.io/")
+}
+
+// FindCRD finds the CRD for a given kind amongst a list of unstructured objects.
+func FindCRD(objs []unstructured.Unstructured, kind schema.GroupKind) (*unstructured.Unstructured, bool) {
+	for i := 0; i < len(objs); i++ {
+		obj := objs[i]
+		if IsCRD(&obj) {
+			crdGroup, _, err := unstructured.NestedString(obj.Object, "spec", "group")
+			if err != nil || crdGroup != kind.Group {
+				continue
+			}
+			crdKind, _, err := unstructured.NestedString(obj.Object, "spec", "names", "kind")
+			if err != nil || crdKind != kind.Kind {
+				continue
+			}
+			return &obj, true
+		}
+	}
+	return nil, false
 }
 
 func IsSecret(obj *unstructured.Unstructured) bool {

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -180,7 +180,7 @@ func IsNamespacedKind(gvk schema.GroupVersionKind, disco discovery.DiscoveryInte
 	}
 
 	// check the provided objects for a matching CRD.
-	crd, _ := FindCRD(objs, gvk.GroupKind())
+	crd := FindCRD(objs, gvk.GroupKind())
 	if crd != nil {
 		crdScope, _, err := unstructured.NestedString(crd.Object, "spec", "scope")
 		return crdScope == "Namespaced", err
@@ -265,7 +265,7 @@ func IsCRD(obj *unstructured.Unstructured) bool {
 }
 
 // FindCRD finds the CRD for a given kind amongst a list of unstructured objects.
-func FindCRD(objs []unstructured.Unstructured, kind schema.GroupKind) (*unstructured.Unstructured, bool) {
+func FindCRD(objs []unstructured.Unstructured, kind schema.GroupKind) *unstructured.Unstructured {
 	for i := 0; i < len(objs); i++ {
 		obj := objs[i]
 		if IsCRD(&obj) {
@@ -277,10 +277,10 @@ func FindCRD(objs []unstructured.Unstructured, kind schema.GroupKind) (*unstruct
 			if err != nil || crdKind != kind.Kind {
 				continue
 			}
-			return &obj, true
+			return &obj
 		}
 	}
-	return nil, false
+	return nil
 }
 
 func IsSecret(obj *unstructured.Unstructured) bool {

--- a/provider/pkg/clients/clients_test.go
+++ b/provider/pkg/clients/clients_test.go
@@ -73,7 +73,7 @@ var fakeCRDs = []unstructured.Unstructured{{Object: map[string]interface{}{
 
 var fakeResources = []*metav1.APIResourceList{
 	{
-		GroupVersion: "postgresql.sql.crossplane.io/v1alpha1",
+		GroupVersion: "postgresql.example.com/v1alpha1",
 		APIResources: []metav1.APIResource{
 			{Name: "roles", Namespaced: false, Kind: "Role"},
 		},
@@ -81,7 +81,7 @@ var fakeResources = []*metav1.APIResourceList{
 }
 
 func TestIsNamespacedKind(t *testing.T) {
-	// coverage: in-built kinds, kinds based on the supplied CRDs, and discoverable kinds.
+	// coverage: in-built kinds, discoverable kinds, and kinds based on the supplied CRDs.
 	tests := []struct {
 		gvk     schema.GroupVersionKind
 		want    bool
@@ -90,8 +90,8 @@ func TestIsNamespacedKind(t *testing.T) {
 		{schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, true, false},
 		{schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, true, false},
 		{schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"}, true, false},
-		{schema.GroupVersionKind{Group: "postgresql.sql.crossplane.io", Version: "v1alpha1", Kind: "Role"}, false, false},
-		{schema.GroupVersionKind{Group: "postgresql.sql.crossplane.io", Version: "v1alpha1", Kind: "Missing"}, false, true},
+		{schema.GroupVersionKind{Group: "postgresql.example.com", Version: "v1alpha1", Kind: "Role"}, false, false},
+		{schema.GroupVersionKind{Group: "postgresql.example.com", Version: "v1alpha1", Kind: "Missing"}, false, true},
 		{schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"}, true, false},
 		{schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "Missing"}, false, true},
 	}

--- a/provider/pkg/provider/provider_construct.go
+++ b/provider/pkg/provider/provider_construct.go
@@ -37,7 +37,8 @@ func (k *kubeProvider) getResourceProvider(typ string) (providerresource.Resourc
 		return nil, false
 	}
 	options := &providerresource.ResourceProviderOptions{
-		ClientSet: k.clientSet,
+		ClientSet:        k.clientSet,
+		DefaultNamespace: k.defaultNamespace,
 	}
 	return providerF(options), true
 }

--- a/provider/pkg/provider/resource/provider.go
+++ b/provider/pkg/provider/resource/provider.go
@@ -26,7 +26,8 @@ type ResourceProvider interface {
 }
 
 type ResourceProviderOptions struct {
-	ClientSet *clients.DynamicClientSet
+	ClientSet        *clients.DynamicClientSet
+	DefaultNamespace string
 }
 
 type ResourceProviderFactory func(*ResourceProviderOptions) ResourceProvider

--- a/provider/pkg/provider/yaml/v2/configfile_test.go
+++ b/provider/pkg/provider/yaml/v2/configfile_test.go
@@ -94,8 +94,8 @@ var _ = Describe("ConfigFile.Construct", func() {
 					"resources": MatchArrayValue(ConsistOf(
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::test-my-namespace", "test-my-namespace"),
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test-crontabs.stable.example.com", "test-crontabs.stable.example.com"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::test-my-map", "test-my-map"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::test-my-new-cron-object", "test-my-new-cron-object"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::test-my-namespace/my-map", "test-my-namespace/my-map"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::test-my-namespace/my-new-cron-object", "test-my-namespace/my-new-cron-object"),
 					)),
 				}))
 			})
@@ -112,8 +112,8 @@ var _ = Describe("ConfigFile.Construct", func() {
 						"resources": MatchArrayValue(ConsistOf(
 							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::prefixed-my-namespace", "prefixed-my-namespace"),
 							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed-crontabs.stable.example.com", "prefixed-crontabs.stable.example.com"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::prefixed-my-map", "prefixed-my-map"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::prefixed-my-new-cron-object", "prefixed-my-new-cron-object"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map", "prefixed-my-namespace/my-map"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object", "prefixed-my-namespace/my-new-cron-object"),
 						)),
 					}))
 				})
@@ -131,8 +131,8 @@ var _ = Describe("ConfigFile.Construct", func() {
 						"resources": MatchArrayValue(ConsistOf(
 							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::my-namespace", "my-namespace"),
 							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::crontabs.stable.example.com", "crontabs.stable.example.com"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::my-map", "my-map"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::my-new-cron-object", "my-new-cron-object"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::my-namespace/my-map", "my-namespace/my-map"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::my-namespace/my-new-cron-object", "my-namespace/my-new-cron-object"),
 						)),
 					}))
 				})

--- a/provider/pkg/provider/yaml/v2/configfile_test.go
+++ b/provider/pkg/provider/yaml/v2/configfile_test.go
@@ -39,7 +39,7 @@ var _ = Describe("ConfigFile.Construct", func() {
 
 	BeforeEach(func() {
 		tc = newTestContext(GinkgoTB())
-		
+
 		opts = &providerresource.ResourceProviderOptions{}
 		opts.ClientSet, _, _, _ = fake.NewSimpleDynamicClient()
 

--- a/provider/pkg/provider/yaml/v2/configfile_test.go
+++ b/provider/pkg/provider/yaml/v2/configfile_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 	providerresource "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/provider/resource"
 	. "github.com/pulumi/pulumi-kubernetes/tests/v4/gomega"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -38,7 +39,9 @@ var _ = Describe("ConfigFile.Construct", func() {
 
 	BeforeEach(func() {
 		tc = newTestContext(GinkgoTB())
+		
 		opts = &providerresource.ResourceProviderOptions{}
+		opts.ClientSet, _, _, _ = fake.NewSimpleDynamicClient()
 
 		// initialize the ConstructRequest to be customized in nested BeforeEach blocks
 		req = tc.NewConstructRequest()

--- a/provider/pkg/provider/yaml/v2/configgroup_test.go
+++ b/provider/pkg/provider/yaml/v2/configgroup_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 	providerresource "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/provider/resource"
 	. "github.com/pulumi/pulumi-kubernetes/tests/v4/gomega"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -38,7 +39,9 @@ var _ = Describe("Construct", func() {
 
 	BeforeEach(func() {
 		tc = newTestContext(GinkgoTB())
+
 		opts = &providerresource.ResourceProviderOptions{}
+		opts.ClientSet, _, _, _ = fake.NewSimpleDynamicClient()
 
 		// initialize the ConstructRequest to be customized in nested BeforeEach blocks
 		req = tc.NewConstructRequest()
@@ -138,7 +141,7 @@ var _ = Describe("Construct", func() {
 	Describe("objs", func() {
 		decodeObjects := func(manifest string) []resource.PropertyValue {
 			// decode the manifest to Unstructured objects, then convert to input properties
-			resources, err := yamlDecode(manifest, nil)
+			resources, err := yamlDecode(manifest)
 			Expect(err).ShouldNot(HaveOccurred())
 			var objs []resource.PropertyValue
 			for _, res := range resources {

--- a/provider/pkg/provider/yaml/v2/configgroup_test.go
+++ b/provider/pkg/provider/yaml/v2/configgroup_test.go
@@ -84,8 +84,8 @@ var _ = Describe("Construct", func() {
 				"resources": MatchArrayValue(ConsistOf(
 					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::test-my-namespace", "test-my-namespace"),
 					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test-crontabs.stable.example.com", "test-crontabs.stable.example.com"),
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-my-map", "test-my-map"),
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::test-my-new-cron-object", "test-my-new-cron-object"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-my-namespace/my-map", "test-my-namespace/my-map"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::test-my-namespace/my-new-cron-object", "test-my-namespace/my-new-cron-object"),
 				)),
 			}))
 		})
@@ -102,8 +102,8 @@ var _ = Describe("Construct", func() {
 					"resources": MatchArrayValue(ConsistOf(
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::prefixed-my-namespace", "prefixed-my-namespace"),
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed-crontabs.stable.example.com", "prefixed-crontabs.stable.example.com"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::prefixed-my-map", "prefixed-my-map"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::prefixed-my-new-cron-object", "prefixed-my-new-cron-object"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map", "prefixed-my-namespace/my-map"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object", "prefixed-my-namespace/my-new-cron-object"),
 					)),
 				}))
 			})
@@ -121,8 +121,8 @@ var _ = Describe("Construct", func() {
 					"resources": MatchArrayValue(ConsistOf(
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::my-namespace", "my-namespace"),
 						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::crontabs.stable.example.com", "crontabs.stable.example.com"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::my-map", "my-map"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::my-new-cron-object", "my-new-cron-object"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::my-namespace/my-map", "my-namespace/my-map"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::my-namespace/my-new-cron-object", "my-namespace/my-new-cron-object"),
 					)),
 				}))
 			})

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -331,37 +331,6 @@ var _ = Describe("Register", func() {
 	})
 
 	Describe("Kubernetes object specifics", func() {
-		Context("when the object has no kind", func() {
-			BeforeEach(func() {
-				registerOpts.Objects = []unstructured.Unstructured{{
-					Object: map[string]any{
-						"apiVersion": "v1",
-						"metadata":   map[string]any{},
-					},
-				}}
-			})
-			It("should fail", func(ctx context.Context) {
-				_, err := register(ctx)
-				Expect(err).Should(MatchError(ContainSubstring("Kubernetes resources require a kind and apiVersion")))
-			})
-		})
-
-		Context("when the object has no metadata.name", func() {
-			BeforeEach(func() {
-				registerOpts.Objects = []unstructured.Unstructured{{
-					Object: map[string]any{
-						"apiVersion": "v1",
-						"kind":       "Secret",
-						"metadata":   map[string]any{},
-					},
-				}}
-			})
-			It("should fail", func(ctx context.Context) {
-				_, err := register(ctx)
-				Expect(err).Should(MatchError(ContainSubstring("YAML object does not have a .metadata.name")))
-			})
-		})
-
 		Context("when the object is a Secret", func() {
 			BeforeEach(func() {
 				registerOpts.Objects = []unstructured.Unstructured{{
@@ -522,6 +491,39 @@ var _ = Describe("Normalize", func() {
 			},
 		}
 		disco.Resources = append(disco.Resources, fakeResources...)
+	})
+
+	Describe("validation", func() {
+		Context("when the object has no kind", func() {
+			BeforeEach(func() {
+				objs = []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"metadata":   map[string]any{},
+					},
+				}}
+			})
+			It("should fail", func(ctx context.Context) {
+				_, err := Normalize(objs, defaultNamespace, clientSet)
+				Expect(err).Should(MatchError(ContainSubstring("Kubernetes resources require a kind and apiVersion")))
+			})
+		})
+
+		Context("when the object has no metadata.name", func() {
+			BeforeEach(func() {
+				objs = []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]any{},
+					},
+				}}
+			})
+			It("should fail", func(ctx context.Context) {
+				_, err := Normalize(objs, defaultNamespace, clientSet)
+				Expect(err).Should(MatchError(ContainSubstring("Kubernetes resources require a .metadata.name")))
+			})
+		})
 	})
 
 	Describe("namespacing", func() {

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -76,6 +76,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-map
+  namespace: my-namespace
 data:
   altGreeting: "Good Morning!"
 ---
@@ -83,6 +84,7 @@ apiVersion: "stable.example.com/v1"
 kind: CronTab
 metadata:
   name: my-new-cron-object
+  namespace: my-namespace
 spec:
   cronSpec: "* * * * */5"
   image: my-awesome-cron-image
@@ -152,14 +154,14 @@ var _ = Describe("Register", func() {
 						}),
 					}),
 				}),
-				"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-map": MatchProps(IgnoreExtras, Props{
+				"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-namespace/my-map": MatchProps(IgnoreExtras, Props{
 					"state": MatchObject(IgnoreExtras, Props{
 						"metadata": MatchObject(IgnoreExtras, Props{
 							"name": MatchValue("my-map"),
 						}),
 					}),
 				}),
-				"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-new-cron-object": MatchProps(IgnoreExtras, Props{
+				"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-namespace/my-new-cron-object": MatchProps(IgnoreExtras, Props{
 					"state": MatchObject(IgnoreExtras, Props{
 						"metadata": MatchObject(IgnoreExtras, Props{
 							"name": MatchValue("my-new-cron-object"),
@@ -201,14 +203,14 @@ var _ = Describe("Register", func() {
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::prefixed-my-map": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("my-map"),
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::prefixed-my-new-cron-object": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("my-new-cron-object"),
@@ -246,7 +248,7 @@ var _ = Describe("Register", func() {
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-map": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-namespace/my-map": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"annotations": MatchObject(IgnoreExtras, Props{
@@ -255,7 +257,7 @@ var _ = Describe("Register", func() {
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-new-cron-object": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-namespace/my-new-cron-object": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"annotations": MatchObject(IgnoreExtras, Props{
@@ -285,14 +287,19 @@ var _ = Describe("Register", func() {
 								"Dependencies": BeEmpty(),
 							}),
 						}),
-						"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-map": MatchFields(IgnoreExtras, Fields{
+						"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::my-namespace/my-map": MatchFields(IgnoreExtras, Fields{
 							"Request": MatchFields(IgnoreExtras, Fields{
-								"Dependencies": BeEmpty(),
+								"Dependencies": ConsistOf(
+									"urn:pulumi:stack::project::kubernetes:core/v1:Namespace::my-namespace",
+								),
 							}),
 						}),
-						"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-new-cron-object": MatchFields(IgnoreExtras, Fields{
+						"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::my-namespace/my-new-cron-object": MatchFields(IgnoreExtras, Fields{
 							"Request": MatchFields(IgnoreExtras, Fields{
-								"Dependencies": ConsistOf("urn:pulumi:stack::project::kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::crontabs.stable.example.com"),
+								"Dependencies": ConsistOf(
+									"urn:pulumi:stack::project::kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::crontabs.stable.example.com",
+									"urn:pulumi:stack::project::kubernetes:core/v1:Namespace::my-namespace",
+								),
 							}),
 						}),
 					}))


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR strengthens the normalization of the parsed Kubernetes objects to better interoperate with #2881.
Specifically:
1. Applies the default namespace as necessary on each object, so that they may be reliably targeted by the `depends-on` resource.
2. Stabilizes the resource id (e.g. `default/my-map` versus `my-map`).
3. Validates that the objects are well-formed more eagerly than during `Register`.

For example, given the below manifest and assuming that the default namespace is `default`, we would expect a `DependsOn` option from `Certificate` to `Issuer`. Observe that `namespace` isn't explicitly set on the issuer.

```yaml
name: issue-2870-cert-manager
runtime: yaml
resources:
  example:
    type: kubernetes:yaml/v2:ConfigGroup
    properties:
      yaml: |
        apiVersion: cert-manager.io/v1
        kind: Issuer
        metadata:
          name: test-selfsigned
        spec:
          selfSigned: {}
        ---
        apiVersion: cert-manager.io/v1
        kind: Certificate
        metadata:
          name: selfsigned-cert
          annotations:
            config.kubernetes.io/depends-on: cert-manager.io/namespaces/default/Issuer/test-selfsigned
        spec:
          dnsNames:
            - example.com
          secretName: selfsigned-cert-tls
          issuerRef:
            name: test-selfsigned
```

To apply the default namespace correctly, one must know whether a given kind is namespace-scoped. The provider naturally uses the discovery client, and also looks for a matching CRD amongst the parsed objects (since they're not yet installed).

### Testing
New test cases were added for `Normalize`, and some test cases were moved from `Register` because the validation is performed more eagerly.

New sub-tests were added for `IsNamespacedKind` to cover the local CRD enhancement.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #2870 