### PR TITLE
[yaml/v2] Improved resource prefix

### DIFF
--- a/provider/pkg/provider/yaml/v2/configfile_test.go
+++ b/provider/pkg/provider/yaml/v2/configfile_test.go
@@ -92,10 +92,10 @@ var _ = Describe("ConfigFile.Construct", func() {
 				outputs := unmarshalProperties(GinkgoTB(), resp.State)
 				Expect(outputs).To(MatchProps(IgnoreExtras, Props{
 					"resources": MatchArrayValue(ConsistOf(
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::test-my-namespace", "test-my-namespace"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test-crontabs.stable.example.com", "test-crontabs.stable.example.com"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::test-my-namespace/my-map", "test-my-namespace/my-map"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::test-my-namespace/my-new-cron-object", "test-my-namespace/my-new-cron-object"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::test:my-namespace", "test:my-namespace"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test:crontabs.stable.example.com", "test:crontabs.stable.example.com"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::test:my-namespace/my-map", "test:my-namespace/my-map"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::test:my-namespace/my-new-cron-object", "test:my-namespace/my-new-cron-object"),
 					)),
 				}))
 			})
@@ -110,10 +110,10 @@ var _ = Describe("ConfigFile.Construct", func() {
 					outputs := unmarshalProperties(GinkgoTB(), resp.State)
 					Expect(outputs).To(MatchProps(IgnoreExtras, Props{
 						"resources": MatchArrayValue(ConsistOf(
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::prefixed-my-namespace", "prefixed-my-namespace"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed-crontabs.stable.example.com", "prefixed-crontabs.stable.example.com"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map", "prefixed-my-namespace/my-map"),
-							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object", "prefixed-my-namespace/my-new-cron-object"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:Namespace::prefixed:my-namespace", "prefixed:my-namespace"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed:crontabs.stable.example.com", "prefixed:crontabs.stable.example.com"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:core/v1:ConfigMap::prefixed:my-namespace/my-map", "prefixed:my-namespace/my-map"),
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigFile$kubernetes:stable.example.com/v1:CronTab::prefixed:my-namespace/my-new-cron-object", "prefixed:my-namespace/my-new-cron-object"),
 						)),
 					}))
 				})

--- a/provider/pkg/provider/yaml/v2/configgroup_test.go
+++ b/provider/pkg/provider/yaml/v2/configgroup_test.go
@@ -82,10 +82,10 @@ var _ = Describe("Construct", func() {
 			outputs := unmarshalProperties(GinkgoTB(), resp.State)
 			Expect(outputs).To(MatchProps(IgnoreExtras, Props{
 				"resources": MatchArrayValue(ConsistOf(
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::test-my-namespace", "test-my-namespace"),
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test-crontabs.stable.example.com", "test-crontabs.stable.example.com"),
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-my-namespace/my-map", "test-my-namespace/my-map"),
-					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::test-my-namespace/my-new-cron-object", "test-my-namespace/my-new-cron-object"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::test:my-namespace", "test:my-namespace"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::test:crontabs.stable.example.com", "test:crontabs.stable.example.com"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test:my-namespace/my-map", "test:my-namespace/my-map"),
+					MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::test:my-namespace/my-new-cron-object", "test:my-namespace/my-new-cron-object"),
 				)),
 			}))
 		})
@@ -168,9 +168,9 @@ var _ = Describe("Construct", func() {
 				outputs := unmarshalProperties(GinkgoTB(), resp.State)
 				Expect(outputs).To(MatchProps(IgnoreExtras, Props{
 					"resources": MatchArrayValue(HaveExactElements(
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-map-1", "test-map-1"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-map-2", "test-map-2"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test-map-3", "test-map-3"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test:map-1", "test:map-1"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test:map-2", "test:map-2"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::test:map-3", "test:map-3"),
 					)),
 				}))
 			})

--- a/provider/pkg/provider/yaml/v2/configgroup_test.go
+++ b/provider/pkg/provider/yaml/v2/configgroup_test.go
@@ -100,10 +100,10 @@ var _ = Describe("Construct", func() {
 				outputs := unmarshalProperties(GinkgoTB(), resp.State)
 				Expect(outputs).To(MatchProps(IgnoreExtras, Props{
 					"resources": MatchArrayValue(ConsistOf(
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::prefixed-my-namespace", "prefixed-my-namespace"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed-crontabs.stable.example.com", "prefixed-crontabs.stable.example.com"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map", "prefixed-my-namespace/my-map"),
-						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object", "prefixed-my-namespace/my-new-cron-object"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:Namespace::prefixed:my-namespace", "prefixed:my-namespace"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed:crontabs.stable.example.com", "prefixed:crontabs.stable.example.com"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::prefixed:my-namespace/my-map", "prefixed:my-namespace/my-map"),
+						MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:yaml/v2:ConfigGroup$kubernetes:stable.example.com/v1:CronTab::prefixed:my-namespace/my-new-cron-object", "prefixed:my-namespace/my-new-cron-object"),
 					)),
 				}))
 			})

--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -297,7 +297,7 @@ func register(
 		resourceName = fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 	}
 	if opts.ResourcePrefix != "" {
-		resourceName = fmt.Sprintf("%s#%s", opts.ResourcePrefix, resourceName)
+		resourceName = fmt.Sprintf("%s:%s", opts.ResourcePrefix, resourceName)
 	}
 
 	// Apply the skipAwait annotation if necessary.

--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -297,7 +297,7 @@ func register(
 		resourceName = fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 	}
 	if opts.ResourcePrefix != "" {
-		resourceName = fmt.Sprintf("%s-%s", opts.ResourcePrefix, resourceName)
+		resourceName = fmt.Sprintf("%s#%s", opts.ResourcePrefix, resourceName)
 	}
 
 	// Apply the skipAwait annotation if necessary.

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -189,28 +189,28 @@ var _ = Describe("Register", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(tc.monitor.Resources()).To(MatchAllKeys(Keys{
-					"urn:pulumi:stack::project::kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed-crontabs.stable.example.com": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition::prefixed:crontabs.stable.example.com": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("crontabs.stable.example.com"),
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:core/v1:Namespace::prefixed-my-namespace": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:core/v1:Namespace::prefixed:my-namespace": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("my-namespace"),
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::prefixed-my-namespace/my-map": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:core/v1:ConfigMap::prefixed:my-namespace/my-map": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("my-map"),
 							}),
 						}),
 					}),
-					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::prefixed-my-namespace/my-new-cron-object": MatchProps(IgnoreExtras, Props{
+					"urn:pulumi:stack::project::kubernetes:stable.example.com/v1:CronTab::prefixed:my-namespace/my-new-cron-object": MatchProps(IgnoreExtras, Props{
 						"state": MatchObject(IgnoreExtras, Props{
 							"metadata": MatchObject(IgnoreExtras, Props{
 								"name": MatchValue("my-new-cron-object"),


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
This PR changes the prefix character that is used, as per this discussion:
https://pulumi.slack.com/archives/C8R654Y6S/p1711035557620359

Tested with a few well-known manifests and seems to be a good improvement on readability.

```plain
     pulumi:pulumi:Stack                                                              issue-2881-cert-manager-dev                                            4 warn
     ├─ kubernetes:yaml/v2:ConfigGroup                                                install                                                                
 +   │  ├─ kubernetes:core/v1:Namespace                                               install:cert-manager                                        create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-cluster-view                           create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-certificates                create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-edit                                   create     
 +   │  ├─ kubernetes:core/v1:ServiceAccount                                          install:cert-manager/cert-manager-webhook                   create     
 +   │  ├─ kubernetes:core/v1:ServiceAccount                                          install:cert-manager/cert-manager                           create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-view                                   create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-issuers                     create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-clusterissuers              create     
 +   │  ├─ kubernetes:core/v1:ServiceAccount                                          install:cert-manager/cert-manager-cainjector                create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-ingress-shim                create     
 +   │  ├─ kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition                install:certificaterequests.cert-manager.io                 create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding                 install:cert-manager-controller-certificates                create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-cainjector                             create     
 +   │  ├─ kubernetes:core/v1:Service                                                 install:cert-manager/cert-manager                           create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:Role                               install:kube-system/cert-manager-cainjector:leaderelection  create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:RoleBinding                        install:cert-manager/cert-manager-webhook:dynamic-serving   create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:Role                               install:cert-manager/cert-manager-webhook:dynamic-serving   create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-certificatesigningrequests  create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding                 install:cert-manager-controller-certificatesigningrequests  create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:Role                               install:kube-system/cert-manager:leaderelection             create     
 +   │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRole                        install:cert-manager-controller-approve:cert-manager-io     create     
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
