### PR TITLE
Ensure deplyoment await logic uses the latest deployment object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - ConfigFile V2 (https://github.com/pulumi/pulumi-kubernetes/pull/2862)
 - Bugfix for ambiguous kinds (https://github.com/pulumi/pulumi-kubernetes/pull/2889)
 - [yaml/v2] Support for resource ordering (https://github.com/pulumi/pulumi-kubernetes/pull/2894)
+- Bugfix for deployment await logic not referencing the correct deployment status (https://github.com/pulumi/pulumi-kubernetes/pull/2943)
 
 ### New Features
 

--- a/tests/sdk/nodejs/deployment-rollout/step4/index.ts
+++ b/tests/sdk/nodejs/deployment-rollout/step4/index.ts
@@ -1,0 +1,44 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+export const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+const appLabels = { app: "nginx" };
+new k8s.apps.v1.Deployment("nginx", {
+  metadata: {
+    namespace: namespace.metadata.name,
+    annotations: {
+      "pulumi.com/timeoutSeconds": "30",
+    },
+  },
+  spec: {
+    selector: { matchLabels: appLabels },
+    replicas: 1,
+    template: {
+      metadata: { labels: appLabels },
+      spec: {
+        containers: [
+          {
+            name: "nginx",
+            image: "nginx:fake", // Should trigger a failure on await.
+            ports: [{ containerPort: 80 }],
+          },
+        ],
+        schedulerName: "default-scheduler",
+      },
+    },
+  },
+});

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -669,6 +669,13 @@ func TestDeploymentRollout(t *testing.T) {
 					assert.Equal(t, image.(string), "nginx:stable")
 				},
 			},
+			{
+				// This is a deployment spec update that should cause a failure on await.
+				// https://github.com/pulumi/pulumi-kubernetes/issues/2941
+				Dir:           filepath.Join("deployment-rollout", "step4"),
+				Additive:      true,
+				ExpectFailure: true,
+			},
 		},
 	})
 	integration.ProgramTest(t, &test)


### PR DESCRIPTION
### Proposed changes

This PR ensures that we compare deployment revisions based on the old live object, and the most current deployment object. 

This PR does the following:

- Add a repro test that fails before the change is applied
- Only watch for deployment events until the deployment object has been reconciled by the deployment controller
- Update existing unit tests to account for blocking unbuffered channels, and faked objects that did not have `.status.observedGeneration`

### Related issues (optional)

Fixes: #2941
