### PR TITLE
Fix a panic when diffing nil values against missing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 - Fix Release behavior to deep merge `valueYamlFiles` to match Helm. (https://github.com/pulumi/pulumi-kubernetes/pull/2963)
-- Add field manager's name to server-side apply conflict errors. (https://github.com/pulumi/pulumi-kubernetes/pull/2983)
 - Fix a panic that could occur when a missing field became `null`. (https://github.com/pulumi/pulumi-kubernetes/issues/1970)
+- Add field manager's name to server-side apply conflict errors. (https://github.com/pulumi/pulumi-kubernetes/pull/2983)
 
 ## 4.11.0 (April 17, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix Release behavior to deep merge `valueYamlFiles` to match Helm. (https://github.com/pulumi/pulumi-kubernetes/pull/2963)
 - Add field manager's name to server-side apply conflict errors. (https://github.com/pulumi/pulumi-kubernetes/pull/2983)
+- Fix a panic that could occur when a missing field became `null`. (https://github.com/pulumi/pulumi-kubernetes/issues/1970)
 
 ## 4.11.0 (April 17, 2024)
 

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 type (
-	object   map[string]any
-	list     []any
-	expected map[string]*pulumirpc.PropertyDiff
+	object   = map[string]any
+	list     = []any
+	expected = map[string]*pulumirpc.PropertyDiff
 )
 
 func TestPatchToDiff(t *testing.T) {

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 type (
-	object   = map[string]any
-	list     = []any
-	expected = map[string]*pulumirpc.PropertyDiff
+	object   map[string]any
+	list     []any
+	expected map[string]*pulumirpc.PropertyDiff
 )
 
 func TestPatchToDiff(t *testing.T) {

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -235,11 +235,22 @@ func TestPatchToDiff(t *testing.T) {
 			},
 		},
 		{
+			name:  `Removing array values results in correct diff`,
+			group: "core", version: "v1", kind: "Pod",
+			old:    object{"spec": object{"containers": list{object{"name": "nginx"}}}},
+			new:    object{"spec": object{"containers": list{}}},
+			inputs: object{"spec": object{"containers": list{}}},
+			expected: expected{
+				"spec.containers[0]": D,
+			},
+		},
+		{
 			name:  "Removing a field that was nil should not panic (#1970).",
 			group: "tekton.dev", version: "v1beta1", kind: "Pipeline",
 			old: object{"taskSpec": object{"spec": nil, "steps": list{object{"name": "something"}}}},
 			new: object{"taskSpec": object{"steps": list{object{"name": "something-else"}}}},
 			expected: expected{
+				"taskSpec.spec":          D,
 				"taskSpec.steps[0].name": U,
 			},
 		},

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -15,9 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type object = map[string]any
-type list = []any
-type expected = map[string]*pulumirpc.PropertyDiff
+type (
+	object   = map[string]any
+	list     = []any
+	expected = map[string]*pulumirpc.PropertyDiff
+)
 
 func TestPatchToDiff(t *testing.T) {
 	var (
@@ -230,6 +232,15 @@ func TestPatchToDiff(t *testing.T) {
 			inputs: object{"spec": object{"containers": list{resource.Computed{}}}},
 			expected: expected{
 				"spec.containers[0]": U,
+			},
+		},
+		{
+			name:  "Removing a field that was nil should not panic (#1970).",
+			group: "tekton.dev", version: "v1beta1", kind: "Pipeline",
+			old: object{"taskSpec": object{"spec": nil, "steps": list{object{"name": "something"}}}},
+			new: object{"taskSpec": object{"steps": list{object{"name": "something-else"}}}},
+			expected: expected{
+				"taskSpec.steps[0].name": U,
 			},
 		},
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -3015,18 +3015,26 @@ func equalNumbers(a, b any) bool {
 type patchConverter struct {
 	forceNew []string
 	diff     map[string]*pulumirpc.PropertyDiff
+
+	// missing is a placeholder used during diffing to distinguish between
+	// `nil` values and absent ones.
+	missing struct{}
 }
 
 // addPatchValueToDiff adds the given patched value to the detailed diff.
 //
+// Values for old, newInput, and oldInput should be `pc.missing` if they were
+// originally absent from a map . This differenciates between the case where
+// they were present in the map but had `nil` values.
+//
 // The particular difference that is recorded depends on the old and new values:
-// - If the patched value is nil, the property is recorded as deleted
-// - If the old value is nil, the property is recorded as added
-// - If the old and patched values are both nil, no diff is recorded.
-// - If the types of the old and new values differ, the property is recorded as updated
-// - If both values are maps, the maps are recursively compared on a per-property basis and added to the diff
-// - If both values are arrays, the arrays are recursively compared on a per-element basis and added to the diff
-// - If both values are primitives and the values differ, the property is recorded as updated
+// - If the patched value is nil, the property is recorded as deleted.
+// - If the old value is missing, the property is recorded as added.
+// - If the old and patched values are both nil or missing, no diff is recorded.
+// - If the types of the old and new values differ, the property is recorded as updated.
+// - If both values are maps, the maps are recursively compared on a per-property basis and added to the diff.
+// - If both values are arrays, the arrays are recursively compared on a per-element basis and added to the diff.
+// - If both values are primitives and the values differ, the property is recorded as updated.
 // - Otherwise, no diff is recorded.
 //
 // If a difference is present at the given path and the path matches one of the patterns in the database of
@@ -3035,14 +3043,14 @@ type patchConverter struct {
 func (pc *patchConverter) addPatchValueToDiff(
 	path []any, v, old, newInput, oldInput any, inArray bool,
 ) error {
-	if v == nil && old == nil && oldInput == nil && newInput == nil {
-		return nil
-	}
+	contract.Assertf(v != nil || old != nil || oldInput != nil || newInput != nil,
+		"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v  |  newInput: %+v",
+		path, v, old, oldInput, newInput)
 
 	// If there is no new input, then the only possible diff here is a delete. All other diffs must be diffs between
 	// old and new properties that are populated by the server. If there is also no old input, then there is no diff
 	// whatsoever.
-	if newInput == nil && (v != nil || oldInput == nil) {
+	if newInput == pc.missing && (v != nil || oldInput == pc.missing) {
 		return nil
 	}
 
@@ -3051,7 +3059,7 @@ func (pc *patchConverter) addPatchValueToDiff(
 	if v == nil {
 		// computed values are rendered as null in the patch; handle this special case.
 		if _, ok := newInput.(resource.Computed); ok {
-			if old == nil {
+			if old == pc.missing {
 				diffKind = pulumirpc.PropertyDiff_ADD
 			} else {
 				diffKind = pulumirpc.PropertyDiff_UPDATE
@@ -3059,7 +3067,7 @@ func (pc *patchConverter) addPatchValueToDiff(
 		} else {
 			diffKind, inputDiff = pulumirpc.PropertyDiff_DELETE, true
 		}
-	} else if old == nil {
+	} else if old == pc.missing {
 		diffKind = pulumirpc.PropertyDiff_ADD
 	} else {
 		switch v := v.(type) {
@@ -3130,6 +3138,15 @@ func (pc *patchConverter) addPatchValueToDiff(
 	return nil
 }
 
+// get will return the map's value for the given key, or the `missing`
+// placeholder if no such key exists in the map.
+func (pc *patchConverter) get(m map[string]any, k string) any {
+	if v, ok := m[k]; ok {
+		return v
+	}
+	return pc.missing
+}
+
 // addPatchMapToDiff adds the diffs in the given patched map to the detailed diff.
 //
 // If this map is contained within an array, we do a little bit more work to detect deletes, as they are not recorded
@@ -3137,7 +3154,6 @@ func (pc *patchConverter) addPatchValueToDiff(
 func (pc *patchConverter) addPatchMapToDiff(
 	path []any, m, old, newInput, oldInput map[string]any, inArray bool,
 ) error {
-
 	if newInput == nil {
 		newInput = map[string]any{}
 	}
@@ -3146,7 +3162,7 @@ func (pc *patchConverter) addPatchMapToDiff(
 	}
 
 	for k, v := range m {
-		if err := pc.addPatchValueToDiff(append(path, k), v, old[k], newInput[k], oldInput[k], inArray); err != nil {
+		if err := pc.addPatchValueToDiff(append(path, k), v, pc.get(old, k), pc.get(newInput, k), pc.get(oldInput, k), inArray); err != nil {
 			return err
 		}
 	}
@@ -3155,7 +3171,7 @@ func (pc *patchConverter) addPatchMapToDiff(
 			if _, ok := m[k]; ok {
 				continue
 			}
-			if err := pc.addPatchValueToDiff(append(path, k), nil, v, newInput[k], oldInput[k], inArray); err != nil {
+			if err := pc.addPatchValueToDiff(append(path, k), nil, v, pc.get(newInput, k), pc.get(oldInput, k), inArray); err != nil {
 				return err
 			}
 		}
@@ -3167,7 +3183,6 @@ func (pc *patchConverter) addPatchMapToDiff(
 func (pc *patchConverter) addPatchArrayToDiff(
 	path []any, a, old, newInput, oldInput []any, inArray bool,
 ) error {
-
 	at := func(arr []any, i int) any {
 		if i < len(arr) {
 			return arr[i]
@@ -3185,7 +3200,7 @@ func (pc *patchConverter) addPatchArrayToDiff(
 
 	if i < len(a) {
 		for ; i < len(a); i++ {
-			err := pc.addPatchValueToDiff(append(path, i), a[i], nil, at(newInput, i), at(oldInput, i), true)
+			err := pc.addPatchValueToDiff(append(path, i), a[i], pc.missing, at(newInput, i), at(oldInput, i), true)
 			if err != nil {
 				return err
 			}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2955,7 +2955,6 @@ var deleteResponse = &pulumirpc.ReadResponse{Id: "", Properties: nil}
 func convertPatchToDiff(
 	patch, oldLiveState, newInputs, oldInputs map[string]any, forceNewFields ...string,
 ) (map[string]*pulumirpc.PropertyDiff, error) {
-
 	contract.Requiref(len(patch) != 0, "patch", "expected len() != 0")
 	contract.Requiref(oldLiveState != nil, "oldLiveState", "expected != nil")
 
@@ -3154,13 +3153,6 @@ func (pc *patchConverter) get(m map[string]any, k string) any {
 func (pc *patchConverter) addPatchMapToDiff(
 	path []any, m, old, newInput, oldInput map[string]any, inArray bool,
 ) error {
-	if newInput == nil {
-		newInput = map[string]any{}
-	}
-	if oldInput == nil {
-		oldInput = map[string]any{}
-	}
-
 	for k, v := range m {
 		if err := pc.addPatchValueToDiff(append(path, k), v, pc.get(old, k), pc.get(newInput, k), pc.get(oldInput, k), inArray); err != nil {
 			return err

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -3017,12 +3017,12 @@ type patchConverter struct {
 	diff     map[string]*pulumirpc.PropertyDiff
 }
 
-// addPatchValueToDiff adds the given patched value to the detailed diff. Either the patched value or the old value
-// must not be nil.
+// addPatchValueToDiff adds the given patched value to the detailed diff.
 //
 // The particular difference that is recorded depends on the old and new values:
 // - If the patched value is nil, the property is recorded as deleted
 // - If the old value is nil, the property is recorded as added
+// - If the old and patched values are both nil, no diff is recorded.
 // - If the types of the old and new values differ, the property is recorded as updated
 // - If both values are maps, the maps are recursively compared on a per-property basis and added to the diff
 // - If both values are arrays, the arrays are recursively compared on a per-element basis and added to the diff
@@ -3035,9 +3035,9 @@ type patchConverter struct {
 func (pc *patchConverter) addPatchValueToDiff(
 	path []any, v, old, newInput, oldInput any, inArray bool,
 ) error {
-	contract.Assertf(v != nil || old != nil || oldInput != nil || newInput != nil,
-		"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v  |  newInput: %+v",
-		path, v, old, oldInput, newInput)
+	if v == nil && old == nil && oldInput == nil && newInput == nil {
+		return nil
+	}
 
 	// If there is no new input, then the only possible diff here is a delete. All other diffs must be diffs between
 	// old and new properties that are populated by the server. If there is also no old input, then there is no diff

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -3024,10 +3024,10 @@ type patchConverter struct {
 // addPatchValueToDiff adds the given patched value to the detailed diff.
 //
 // Values for old, newInput, and oldInput should be `pc.missing` if they were
-// originally absent from a map . This differenciates between the case where
+// originally absent from a map. This differenciates between the case where
 // they were present in the map but had `nil` values.
 //
-// The particular difference that is recorded depends on the old and new values:
+// The diff that is recorded depends on the old and new values:
 // - If the patched value is nil, the property is recorded as deleted.
 // - If the old value is missing, the property is recorded as added.
 // - If the old and patched values are both nil or missing, no diff is recorded.


### PR DESCRIPTION
Users can run into a panic because we invoke `addPatchValueToDiff` like so:

```go
pc.addPatchValueToDiff(append(path, k), v, old[k], newInput[k], oldInput[k], inArray)
```

These are `map[string]any` types and will return `nil` when the `[k]` lookup returns `nil` _or_ when the key `k` is missing.

Then in `addPatchValueToDiff` we assert:
```go
contract.Assertf(v != nil || old != nil || oldInput != nil || newInput != nil)
```

but we don't have enough information to distinguish the "all values were `nil`" case from the "one value was `nil` and the other was missing" case. The assertion is only valid if all keys were present, hence we panic when a key is removed when it previously had a value of `nil`.

The easiest fix is to relax the assertion (b886cfb8d) -- allow the all-`nil` case since it can be valid. The downside is a poorer user experience, because we don't have enough information to say whether the update is an add or a delete; we could call it an update (odd) or a no-op (lossy). The upside is it's a much smaller change with less risk.

Alternatively, we can have a better user experience by making `addPatchValueToDiff` aware of whether keys were missing. This PR does this by introducing a `missing` sentinel to distinguish from `nil` values. This is riskier, but fortunately our test coverage is comprehensive.

A failing unit test was added, along with another test to cover a small bit of logic we weren't testing.

I spent a bit of time trying to cook up an E2E repro but ran into some roadblocks so I put that on the back burner for now.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1970.