### PR TITLE
Fix CRD cache for fake clients

### DIFF
--- a/provider/pkg/clients/cache.go
+++ b/provider/pkg/clients/cache.go
@@ -27,28 +27,20 @@ import (
 // For example, it allows the yaml/v2 package to lookup a CRD during preview that would be installed by
 // a "CustomResourceDefinition" resource. The user is expected to use DependsOn to ensure that
 // the CRD is created first.
-type CRDCache interface {
-	GetCRD(kind schema.GroupKind) *unstructured.Unstructured
-	AddCRD(crd *unstructured.Unstructured) error
-	RemoveCRD(crd *unstructured.Unstructured) error
-}
-
-type crdCache struct {
+type CRDCache struct {
 	mu   sync.Mutex
 	crds map[schema.GroupKind]*unstructured.Unstructured
 }
 
-var _ CRDCache = &crdCache{}
-
 // GetCRD returns the CRD for the given kind, if it exists in the cache.
-func (c *crdCache) GetCRD(kind schema.GroupKind) *unstructured.Unstructured {
+func (c *CRDCache) GetCRD(kind schema.GroupKind) *unstructured.Unstructured {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.crds[kind]
 }
 
 // AddCRD adds a CRD to the cache.
-func (c *crdCache) AddCRD(crd *unstructured.Unstructured) error {
+func (c *CRDCache) AddCRD(crd *unstructured.Unstructured) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	kind, err := groupKindFromCRD(crd)
@@ -63,7 +55,7 @@ func (c *crdCache) AddCRD(crd *unstructured.Unstructured) error {
 }
 
 // RemoveCRD removes a CRD from the cache.
-func (c *crdCache) RemoveCRD(crd *unstructured.Unstructured) error {
+func (c *CRDCache) RemoveCRD(crd *unstructured.Unstructured) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	kind, err := groupKindFromCRD(crd)

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -64,7 +64,6 @@ func NewDynamicClientSet(clientConfig *rest.Config) (*DynamicClientSet, error) {
 			GenericClient:         nil,
 			DiscoveryClientCached: nil,
 			RESTMapper:            nil,
-			CRDCache:              &crdCache{},
 		}, nil
 	}
 
@@ -88,7 +87,6 @@ func NewDynamicClientSet(clientConfig *rest.Config) (*DynamicClientSet, error) {
 		GenericClient:         client,
 		DiscoveryClientCached: discoCacheClient,
 		RESTMapper:            mapper,
-		CRDCache:              &crdCache{},
 	}, nil
 }
 

--- a/provider/pkg/clients/clients_test.go
+++ b/provider/pkg/clients/clients_test.go
@@ -111,7 +111,6 @@ func TestIsNamespacedKind(t *testing.T) {
 						FakedServerVersion: &version,
 					},
 				},
-				CRDCache: &crdCache{},
 			}
 			for _, crd := range tt.cached {
 				crd := crd


### PR DESCRIPTION
The fake DynamicClientSet will currently panic in situations that require the CRD cache because we weren't initializing a cache in the fake's constructor.

The cache already works well as a zero value, and we don't currently need any alternative implementations, so we can remove the exported interface in favor of the concrete struct.

This fixes the fake client because we now no longer need to initialize a cache -- every `DynamicClientSet` comes with a usable zero-value `CRDCache{}`.