### PR TITLE
Scope yamlv2 CRDs to fix test flake

### DIFF
--- a/tests/sdk/java/testdata/yamlv2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/yamlv2/Pulumi.yaml
@@ -26,22 +26,21 @@ resources:
     type: kubernetes:yaml/v2:ConfigGroup
     options:
       dependsOn:
-      - ${install}
+        - ${install}
       provider: ${provider}
     properties:
       objs:
-      - apiVersion: stable.example.com/v1
-        kind: CronTab
-        metadata:
-          name: foo
-        spec:
-          cronSpec: "* * * * */5"
-      - apiVersion: stable.example.com/v1
-        kind: CronTab
-        metadata:
-          name: bar
-          annotations:
-            config.kubernetes.io/depends-on: stable.example.com/namespaces/${ns.metadata.name}/CronTab/foo
-        spec:
-          cronSpec: "* * * * */5"
-
+        - apiVersion: yamlv2.pulumi.com/v1
+          kind: CronTab
+          metadata:
+            name: foo
+          spec:
+            cronSpec: "* * * * */5"
+        - apiVersion: yamlv2.pulumi.com/v1
+          kind: CronTab
+          metadata:
+            name: bar
+            annotations:
+              config.kubernetes.io/depends-on: yamlv2.pulumi.com/namespaces/${ns.metadata.name}/CronTab/foo
+          spec:
+            cronSpec: "* * * * */5"

--- a/tests/sdk/java/testdata/yamlv2/crds.yaml
+++ b/tests/sdk/java/testdata/yamlv2/crds.yaml
@@ -1,30 +1,30 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crontabs.stable.example.com
+  name: crontabs.yamlv2.pulumi.com
 spec:
-  group: stable.example.com
+  group: yamlv2.pulumi.com
   versions:
-  - name: v1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              cronSpec:
-                type: string
-              image:
-                type: string
-              replicas:
-                type: integer
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
   scope: Namespaced
   names:
     plural: crontabs
     singular: crontab
     kind: CronTab
     shortNames:
-    - ct
+      - ct


### PR DESCRIPTION
The yamlv2 test installs a `crontabs.stable.example.com` CRD but so do some other tests.

This renames the CRD to `crontabs.yamlv2.pulumi.com` to not conflict with other tests.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3005.