### PR TITLE
Use upstream's MergeValues with assets

### DIFF
--- a/provider/pkg/helm/tool.go
+++ b/provider/pkg/helm/tool.go
@@ -35,6 +35,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/registry"
@@ -98,7 +99,7 @@ type TemplateOrInstallCommand struct {
 	Chart string
 
 	// Values to be applied to the chart.
-	Values ValueOpts
+	Values values.Options
 
 	tool         *Tool
 	actionConfig *action.Configuration
@@ -130,15 +131,7 @@ func (cmd *TemplateOrInstallCommand) addInstallFlags() {
 	client.SubNotes = false
 	client.Labels = nil
 	client.EnableDNS = false
-	cmd.addValueOptionsFlags()
 	cmd.addChartPathOptionsFlags()
-}
-
-func (cmd *TemplateOrInstallCommand) addValueOptionsFlags() {
-	// https://github.com/helm/helm/blob/14d0c13e9eefff5b4a1b511cf50643529692ec94/cmd/helm/flags.go#L45-L51
-	v := cmd.Values
-	v.Values = map[string]any{}
-	v.ValuesFiles = []pulumi.Asset{}
 }
 
 func (cmd *TemplateOrInstallCommand) addChartPathOptionsFlags() {
@@ -180,7 +173,6 @@ func (t *Tool) Template() *TemplateCommand {
 			tool:         t,
 			actionConfig: actionConfig,
 			Install:      action.NewInstall(actionConfig),
-			Values:       ValueOpts{},
 		},
 	}
 
@@ -472,7 +464,6 @@ type cleanupF func() error
 
 // downloadAsset downloads an asset to the local filesystem.
 func downloadAsset(p getter.Providers, asset pulumi.AssetOrArchive) (string, cleanupF, error) {
-
 	a, isAsset := asset.(pulumi.Asset)
 	if !isAsset {
 		return "", nil, errors.New("expected an asset")

--- a/provider/pkg/provider/helm/v4/values_test.go
+++ b/provider/pkg/provider/helm/v4/values_test.go
@@ -147,6 +147,7 @@ image:
 			p := getter.All(cli.New())
 			opts, cleanup, err := readValues(p, tt.values, tt.valuesFiles)
 			defer cleanup()
+			require.NoError(t, err)
 
 			actual, err := opts.MergeValues(p)
 			require.NoError(t, err)


### PR DESCRIPTION
Followup to my comment [here](https://github.com/pulumi/pulumi-kubernetes/pull/2947#discussion_r1588192130), this removes our custom `ValueOpts` in favor of upstream's `value.Options` to handle merging.

Upstream expects to work with files on disk, so we fetch any assets in our provided values and then write them to disk temporarily.