### PR TITLE
new annotation: `deletionPropagationPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix a panic that could occur when a missing field became `null`. (https://github.com/pulumi/pulumi-kubernetes/issues/1970)
 - Add field manager's name to server-side apply conflict errors. (https://github.com/pulumi/pulumi-kubernetes/pull/2983)
 - Helm Chart V4 (https://github.com/pulumi/pulumi-kubernetes/pull/2947)
+- New annotation: deletionPropagationPolicy (https://github.com/pulumi/pulumi-kubernetes/pull/3011)
 
 ## 4.11.0 (April 17, 2024)
 

--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -35,7 +35,7 @@ const (
 	AnnotationPatchForce        = AnnotationPrefix + "patchForce"
 	AnnotationPatchFieldManager = AnnotationPrefix + "patchFieldManager"
 
-	AnnotationDeletionPropagation = AnnotationPrefix + "deletionPropagation"
+	AnnotationDeletionPropagation = AnnotationPrefix + "deletionPropagationPolicy"
 
 	AnnotationHelmHook = "helm.sh/hook"
 )

--- a/provider/pkg/metadata/annotations.go
+++ b/provider/pkg/metadata/annotations.go
@@ -35,6 +35,8 @@ const (
 	AnnotationPatchForce        = AnnotationPrefix + "patchForce"
 	AnnotationPatchFieldManager = AnnotationPrefix + "patchFieldManager"
 
+	AnnotationDeletionPropagation = AnnotationPrefix + "deletionPropagation"
+
 	AnnotationHelmHook = "helm.sh/hook"
 )
 

--- a/provider/pkg/metadata/overrides.go
+++ b/provider/pkg/metadata/overrides.go
@@ -16,8 +16,10 @@ package metadata
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -48,4 +50,17 @@ func TimeoutDuration(resourceTimeoutSeconds float64, obj *unstructured.Unstructu
 	}
 
 	return nil
+}
+
+// DeletionPropagation returns the delete propagation policy, Foreground by default.
+func DeletionPropagation(obj *unstructured.Unstructured) metav1.DeletionPropagation {
+	policy := GetAnnotationValue(obj, AnnotationDeletionPropagation)
+	switch strings.ToLower(policy) {
+	case "orphan":
+		return metav1.DeletePropagationOrphan
+	case "background":
+		return metav1.DeletePropagationBackground
+	default:
+		return metav1.DeletePropagationForeground
+	}
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Introduces a new Pulumi annotation to set the [deletion propagation policy](https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/), e.g. to support non-cascading delete on `StatefulSet` to preserve pods during replacement (see [walkthrough](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#non-cascading-delete)). 

Note that the policy annotation must be set on the old resource before deleting or replacing it; setting it on the replacement or on the live object is ineffective.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #1831 

### Example

This example serves to show how the 'orphan' propagation policy allows for non-disruptive replacement of
a StatefulSet, e.g. by touching the `volumeClaimTemplates`.

```yaml
name: issue-1831
runtime: yaml
description: A StatefulSet to demonstrate the `pulumi.com/deletionPropagationPolicy` annotation.
config:
  # disable SSA for this demonstration
  kubernetes:enableServerSideApply: false
resources:
  nginx:
    type: kubernetes:apps/v1:StatefulSet
    properties:
      metadata:
        name: nginx
        annotations:
          pulumi.com/deletionPropagationPolicy: "orphan"
      spec:
        replicas: 1
        selector:
          matchLabels:
            app: nginx
        serviceName: nginx
        template:
          metadata:
            labels:
              app: nginx
          spec:
            containers:
            - image: nginx:1.19.9
              name: nginx
              ports:
              - containerPort: 80
                name: web
        volumeClaimTemplates:
        - metadata:
            name: nginx
          spec:
            accessModes:
            - ReadWriteOnce
            resources:
              requests:
                storage: 1Gi
```

Following the initial deployment, we have these objects:
```
❯ kubectl get statefulset,pod,pvc -ocustom-columns='KIND:.kind,NAME:.metadata.name,UID:.metadata.uid'
KIND                    NAME            UID
StatefulSet             nginx           b1aa144d-3f16-448e-8e15-02d2c2d4b61a
Pod                     nginx-0         c00d97cc-39d7-4a95-b839-0910f911dbca
PersistentVolumeClaim   nginx-nginx-0   2c624ff9-e856-4d2d-bfaf-527c6b770bc7
```

To provoke a replacement, we change the PVC template:
```
              requests:
-                storage: 1Gi
+                storage: 2Gi
```
Let's also increase the replicas:
```
      spec:
-        replicas: 1
+        replicas: 2
```

And deploy:
```
❯ pulumi up -f
Updating (dev)

     Type                               Name            Status            Info
     pulumi:pulumi:Stack                issue-1831-dev                    4 warnings; 2 messages
 +-  └─ kubernetes:apps/v1:StatefulSet  nginx           replaced (2s)     [diff: ~spec]

Resources:
    +-1 replaced
    1 unchanged
```

Looking again at the objects:
```
❯ kubectl get statefulset,pod,pvc -ocustom-columns='KIND:.kind,NAME:.metadata.name,UID:.metadata.uid'
KIND                    NAME            UID
StatefulSet             nginx           135d9142-460c-4f64-82a6-8ce23427f52b
Pod                     nginx-0         c00d97cc-39d7-4a95-b839-0910f911dbca
Pod                     nginx-1         8c80932f-7051-4fc7-baeb-00dae4b07b64
PersistentVolumeClaim   nginx-nginx-0   2c624ff9-e856-4d2d-bfaf-527c6b770bc7
PersistentVolumeClaim   nginx-nginx-1   e4b4fd18-28b2-454b-8c6b-9fa06435d3d6
```

We see the expected result: the StatefulSet was replaced, the existing pod was adopted, and a new pod was added w/ a PVC. 

In more detail, the StatefulSet controller uses the selector to identify existing pods, then chooses to delete or adopt based on suitability.  Note the updated owner reference on `nginx-0`:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx-0
  uid: c00d97cc-39d7-4a95-b839-0910f911dbca
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: StatefulSet
    name: nginx
    uid: 135d9142-460c-4f64-82a6-8ce23427f52b
```

To demonstrate how the StatefulSet controller might choose to delete the existing pod rather than adopting it, let's change the image rather than the replicas:
```
            containers:
-            - image: nginx:1.19.9
+            - image: nginx:1.19.10
 
              requests:
-                storage: 2Gi
+                storage: 3Gi
```

We deploy again and see that all pods were replaced.
```
KIND                    NAME            UID
StatefulSet             nginx           ead53943-abc9-47c8-9393-326f845c7f42
Pod                     nginx-0         74752b8c-3979-478b-9be4-ff3ca1b0aa6f
Pod                     nginx-1         b6c2f0f6-f5ff-4e04-a1da-66966b8d697c
PersistentVolumeClaim   nginx-nginx-0   2c624ff9-e856-4d2d-bfaf-527c6b770bc7
PersistentVolumeClaim   nginx-nginx-1   e4b4fd18-28b2-454b-8c6b-9fa06435d3d6
```

Note that PVC `nginx-nginx-0` was not replaced and still has `storage: 1Gi`.
