### PR TITLE
Increase daemonset await timeout in CI

### DIFF
--- a/tests/sdk/java/testdata/await/daemonset/Pulumi.yaml
+++ b/tests/sdk/java/testdata/await/daemonset/Pulumi.yaml
@@ -21,9 +21,9 @@ resources:
         minReadySeconds: 5
     options:
       customTimeouts:
-        create: 15s
-        update: 15s
-        delete: 15s
+        create: 60s
+        update: 60s
+        delete: 60s
 outputs:
   currentNumberScheduled: ${ds.status.currentNumberScheduled}
   desiredNumberScheduled: ${ds.status.desiredNumberScheduled}

--- a/tests/sdk/java/testdata/await/daemonset/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/await/daemonset/step2/Pulumi.yaml
@@ -21,9 +21,9 @@ resources:
         minReadySeconds: 5
     options:
       customTimeouts:
-        create: 15s
-        update: 15s
-        delete: 15s
+        create: 60s
+        update: 60s
+        delete: 60s
 outputs:
   currentNumberScheduled: ${ds.status.currentNumberScheduled}
   desiredNumberScheduled: ${ds.status.desiredNumberScheduled}

--- a/tests/sdk/java/testdata/await/daemonset/step3/Pulumi.yaml
+++ b/tests/sdk/java/testdata/await/daemonset/step3/Pulumi.yaml
@@ -21,9 +21,9 @@ resources:
         minReadySeconds: 5
     options:
       customTimeouts:
-        create: 15s
-        update: 15s
-        delete: 15s
+        create: 30s
+        update: 30s
+        delete: 30s
 outputs:
   currentNumberScheduled: ${ds.status.currentNumberScheduled}
   desiredNumberScheduled: ${ds.status.desiredNumberScheduled}


### PR DESCRIPTION
This PR increases the await timeout for the newly added DaemonSet tests. The tests were passing in presubmits within a KinD cluster, but the timeouts appears to be too low for GKE in our post-submits.

Validation: Reverted the acceptance tests temporarily to use GKE to ensure the timeouts are sufficient. See: https://github.com/pulumi/pulumi-kubernetes/actions/runs/9177413633/job/25235467222?pr=3018

Fixes: #3017