### PR TITLE
Enable respectSchemaVersion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -218,7 +218,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -134,7 +134,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -239,7 +239,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/Makefile
+++ b/Makefile
@@ -65,27 +65,25 @@ test_provider::
 
 dotnet_sdk:: DOTNET_VERSION := $(shell pulumictl convert-version --language dotnet -v "$(VERSION_GENERIC)")
 dotnet_sdk::
-	$(WORKING_DIR)/bin/$(CODEGEN) -version=${DOTNET_VERSION} dotnet $(SCHEMA_FILE) $(CURDIR)
+	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION_GENERIC} dotnet $(SCHEMA_FILE) $(CURDIR)
 	rm -rf sdk/dotnet/bin/Debug
 	cd ${PACKDIR}/dotnet/&& \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
-		echo "${DOTNET_VERSION}" >version.txt && \
-		dotnet build /p:Version=${DOTNET_VERSION}
+		dotnet build
 
 go_sdk::
 	# Delete generated SDK before regenerating.
 	rm -rf sdk/go/kubernetes
-	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION} go $(SCHEMA_FILE) $(CURDIR)
+	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION_GENERIC} go $(SCHEMA_FILE) $(CURDIR)
 
 nodejs_sdk:: NODE_VERSION := $(shell pulumictl convert-version --language javascript -v "$(VERSION_GENERIC)")
 nodejs_sdk::
-	$(WORKING_DIR)/bin/$(CODEGEN) -version=${NODE_VERSION} nodejs $(SCHEMA_FILE) $(CURDIR)
+	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION_GENERIC} nodejs $(SCHEMA_FILE) $(CURDIR)
 	cd ${PACKDIR}/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		yarn install && \
 		yarn run tsc
 	cp README.md LICENSE ${PACKDIR}/nodejs/package.json ${PACKDIR}/nodejs/yarn.lock ${PACKDIR}/nodejs/bin/
-	sed -i.bak 's/$${VERSION}/$(NODE_VERSION)/g' ${PACKDIR}/nodejs/bin/package.json
 
 python_sdk:: PYPI_VERSION := $(shell pulumictl convert-version --language python -v "$(VERSION_GENERIC)")
 python_sdk::
@@ -93,7 +91,7 @@ python_sdk::
 	rm -rf sdk/python/pulumi_kubernetes/*/ sdk/python/pulumi_kubernetes/__init__.py
 	# Delete files not tracked in Git
 	cd ${PACKDIR}/python/ && git clean -fxd
-	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION} python $(SCHEMA_FILE) $(CURDIR)
+	$(WORKING_DIR)/bin/$(CODEGEN) -version=${VERSION_GENERIC} python $(SCHEMA_FILE) $(CURDIR)
 	cp README.md ${PACKDIR}/python/
 	PYPI_VERSION=$(PYPI_VERSION) ./scripts/build_python_sdk.sh
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -469,6 +469,7 @@ additional information about using Server-Side Apply to manage Kubernetes resour
 	const kubernetes20 = "kubernetes20"
 
 	pkg.Language["csharp"] = rawMessage(map[string]any{
+		"respectSchemaVersion": true,
 		"packageReferences": map[string]string{
 			"Glob":   "1.1.5",
 			"Pulumi": "3.*",
@@ -483,6 +484,7 @@ additional information about using Server-Side Apply to manage Kubernetes resour
 	})
 
 	pkg.Language["go"] = rawMessage(map[string]any{
+		"respectSchemaVersion":           true,
 		"importBasePath":                 goImportPath,
 		"moduleToPackage":                modToPkg,
 		"packageImportAliases":           pkgImportAliases,
@@ -491,7 +493,8 @@ additional information about using Server-Side Apply to manage Kubernetes resour
 		"internalModuleName":             "utilities",
 	})
 	pkg.Language["nodejs"] = rawMessage(map[string]any{
-		"compatibility": kubernetes20,
+		"respectSchemaVersion": true,
+		"compatibility":        kubernetes20,
 		"dependencies": map[string]string{
 			"@pulumi/pulumi":    "^3.25.0",
 			"shell-quote":       "^1.6.1",
@@ -524,6 +527,7 @@ Use the navigation below to see detailed documentation for each of the supported
 `,
 	})
 	pkg.Language["python"] = rawMessage(map[string]any{
+		"respectSchemaVersion": true,
 		"requires": map[string]string{
 			"pulumi":   ">=3.109.0,<4.0.0",
 			"requests": ">=2.21,<3.0",

--- a/sdk/dotnet/Pulumi.Kubernetes.csproj
+++ b/sdk/dotnet/Pulumi.Kubernetes.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-kubernetes</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>4.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kubernetes"
+  "name": "kubernetes",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/go/kubernetes/pulumi-plugin.json
+++ b/sdk/go/kubernetes/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kubernetes"
+  "name": "kubernetes",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/go/kubernetes/utilities/pulumiUtilities.go
+++ b/sdk/go/kubernetes/utilities/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "${VERSION}",
+    "version": "4.0.0-alpha.0+dev",
     "keywords": [
         "pulumi",
         "kubernetes",
@@ -31,6 +31,7 @@
     },
     "pulumi": {
         "resource": true,
-        "name": "kubernetes"
+        "name": "kubernetes",
+        "version": "4.0.0-alpha.0+dev"
     }
 }

--- a/sdk/python/pulumi_kubernetes/pulumi-plugin.json
+++ b/sdk/python/pulumi_kubernetes/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kubernetes"
+  "name": "kubernetes",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["pulumi", "kubernetes", "category/cloud", "kind/native"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "0.0.0"
+  version = "4.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Embed provider version in all SDKs. Part of https://github.com/pulumi/ci-mgmt/issues/915, follow up to: https://github.com/pulumi/pulumi-kubernetes/pull/3008

1. Enable `respectSchemaVersion` for each language so codegen includes the version number.
2. Pass the _provider_ version into codegen rather than a language-specific version - as codegen will do the conversion for us.

### Related issues (optional)

- https://github.com/pulumi/pulumi-kubernetes/pull/3008
- https://github.com/pulumi/ci-mgmt/issues/915