### PR TITLE
Fix spurious diffs for updates in renderYaml mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update to pulumi-java v0.12.0 (https://github.com/pulumi/pulumi-kubernetes/pull/3025)
 - Fixed a panic that occurs when diffing Job resources containing `replaceUnready` annotations and an unreachable cluster connection. (https://github.com/pulumi/pulumi-kubernetes/pull/3024)
 - CustomResource for Java SDK (https://github.com/pulumi/pulumi-kubernetes/pull/3020)
+- Fixed spurious diffing for updates when in renderYaml mode (https://github.com/pulumi/pulumi-kubernetes/pull/3030)
 
 ## 4.12.0 (May 21, 2024)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2362,7 +2362,7 @@ func (k *kubeProvider) Update(
 			return nil, err
 		}
 
-		obj := checkpointObject(newInputs, oldLive, newResInputs, initialAPIVersion, fieldManager)
+		obj := checkpointObject(newInputs, newInputs, newResInputs, initialAPIVersion, fieldManager)
 		inputsAndComputed, err := plugin.MarshalProperties(
 			obj, plugin.MarshalOptions{
 				Label:        fmt.Sprintf("%s.inputsAndComputed", label),

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -1140,7 +1140,7 @@ func TestReadonlyMetadata(t *testing.T) {
 
 func TestRenderYAML(t *testing.T) {
 	// Create a temporary directory to hold rendered YAML manifests.
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "render-yaml-test")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -1168,6 +1168,19 @@ func TestRenderYAML(t *testing.T) {
 			files, err = ioutil.ReadDir(filepath.Join(dir, "1-manifest"))
 			assert.NoError(t, err)
 			assert.Equal(t, len(files), 2)
+		},
+		EditDirs: []integration.EditDir{
+			{
+				// Change some fields.
+				Dir:      filepath.Join("render-yaml", "step2"),
+				Additive: true,
+			},
+			{
+				// Ensure updates do not cause a spurrious diff when re-running `pulumi up`.
+				Dir:             filepath.Join("render-yaml", "step2"),
+				Additive:        true,
+				ExpectNoChanges: true,
+			},
 		},
 	})
 

--- a/tests/sdk/nodejs/render-yaml/step2/index.ts
+++ b/tests/sdk/nodejs/render-yaml/step2/index.ts
@@ -1,0 +1,41 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+let config = new pulumi.Config();
+let renderDir: string = config.require("renderDir");
+
+const provider = new k8s.Provider("render-yaml", {
+    renderYamlToDirectory: renderDir,
+});
+
+const appLabels = {app: "nginx"};
+const deployment = new k8s.apps.v1.Deployment("nginx", {
+    spec: {
+        selector: {matchLabels: appLabels},
+        replicas: 1,
+        template: {
+            metadata: {labels: appLabels},
+            spec: {containers: [{name: "nginx-fake", image: "nginx-fake", ports: [{containerPort: 80}]}]}
+        }
+    }
+}, {provider});
+const service = new k8s.core.v1.Service("nginx", {
+    spec: {
+        ports: [{port: 8080, protocol: "TCP"}],
+        selector: deployment.metadata.labels,
+    }
+}, {provider});


### PR DESCRIPTION
### Proposed changes

Always store `newInputs` to avoid spurious diffs in renderYaml updates. Storing `oldLive` in state will result in the Pulumi state never updating after the initial create.

Testing: added a new step within the `TestRenderYAML` that exercises the update flow. This test fails without the changes in this PR.

### Related issues (optional)

Fixes: #3026
