### PR TITLE
Fix: Chart v4 fails on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - CustomResource for Java SDK (https://github.com/pulumi/pulumi-kubernetes/pull/3020)
 - Fixed spurious diffing for updates when in renderYaml mode (https://github.com/pulumi/pulumi-kubernetes/pull/3030)
 - Kustomize Directory v2 resource (https://github.com/pulumi/pulumi-kubernetes/pull/3036) 
+- Fix: Chart v4 fails on update (https://github.com/pulumi/pulumi-kubernetes/pull/3046)
 
 ## 4.12.0 (May 21, 2024)
 

--- a/provider/pkg/clients/fake/clients.go
+++ b/provider/pkg/clients/fake/clients.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	DefaultServerVersion = kubeversion.Info{Major: "1", Minor: "29"}
+	DefaultServerVersion = kubeversion.Info{Major: "1", Minor: "29", GitVersion: "v1.29.2"}
 )
 
 type NewDynamicClientOption func(*newDynamicClientOptions)

--- a/provider/pkg/provider/helm/v4/chart_test.go
+++ b/provider/pkg/provider/helm/v4/chart_test.go
@@ -128,7 +128,26 @@ var _ = Describe("Construct", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(executor.Action().DryRun).To(BeTrue())
 			Expect(executor.Action().DryRunOption).To(Equal("server"))
-			Expect(executor.Action().ClientOnly).To(BeFalse())
+			Expect(executor.Action().ClientOnly).To(BeTrue())
+		})
+		Describe("Capabilities", func() {
+			BeforeEach(func() {
+				inputs["values"] = resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
+					"versionCheck": ">=1.21-0",
+				}))
+			})
+			It("should have the correct kubeversion", func(ctx context.Context) {
+				_, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+				Expect(err).ShouldNot(HaveOccurred())
+				v := fake.DefaultServerVersion
+				Expect(executor.Action().KubeVersion).To(PointTo(Equal(
+					chartutil.KubeVersion{Version: v.GitVersion, Major: v.Major, Minor: v.Minor})))
+			})
+			It("should have the correct apiversions", func(ctx context.Context) {
+				_, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(executor.Action().APIVersions).To(Not(BeEmpty()))
+			})
 		})
 	})
 

--- a/provider/pkg/provider/helm/v4/testdata/reference/templates/versioncheck.yaml
+++ b/provider/pkg/provider/helm/v4/testdata/reference/templates/versioncheck.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.versionCheck -}}
-{{- if semverCompare .Values.versionCheck .Capabilities.KubeVersion.GitVersion -}}
+{{- if not (semverCompare .Values.versionCheck .Capabilities.KubeVersion.GitVersion) -}}
 {{ fail "Version check failed" }}
 {{- end }}
 {{- end }}

--- a/provider/pkg/provider/helm/v4/testdata/reference/values.yaml
+++ b/provider/pkg/provider/helm/v4/testdata/reference/values.yaml
@@ -23,4 +23,4 @@ serviceAccount:
   # annotations:
   #   helm.sh/resource-policy: keep
 
-# versionCheck: "<1.21-0"
+# versionCheck: ">=1.21-0"

--- a/tests/sdk/java/chartv4_test.go
+++ b/tests/sdk/java/chartv4_test.go
@@ -1,0 +1,20 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
+)
+
+// TestChartV4 deploys a complex stack using chart/v4 package.
+func TestChartv4(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/chartv4")
+	t.Logf("into %s", test.Source())
+	t.Cleanup(func() {
+		test.Destroy()
+	})
+	test.Preview()
+	test.Up()
+	test.Up(optup.ExpectNoChanges())
+}

--- a/tests/sdk/java/testdata/chartv4/Pulumi.yaml
+++ b/tests/sdk/java/testdata/chartv4/Pulumi.yaml
@@ -1,0 +1,18 @@
+name: chartv4
+runtime: yaml
+description: |
+  Installs cert-manager using Helm Chart v4 resource.
+  Features used:
+  - Chart resource
+variables: {}
+outputs:
+  resources: ${install.resources}
+resources:
+  ns:
+    type: kubernetes:core/v1:Namespace
+  install:
+    type: kubernetes:helm.sh/v4:Chart
+    properties:
+      namespace: ${ns.metadata.name}
+      chart: oci://registry-1.docker.io/bitnamicharts/cert-manager
+      version: "1.3.1"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR fixes a problem with how Chart v4 uses the Helm library. The design goal is to allow for connectivity during template rendering, to support the lookup function (see https://github.com/helm/helm/pull/9426) and to provide an accurate [Capabilities object](https://helm.sh/docs/chart_template_guide/builtin_objects/). Unfortunately we were slightly too aggressive and caused some of Helm's "non-template" code to execute.

This fix works by turning off the `helm template --validation` flag, so that the internal `ClientOnly` flag is true thus avoiding [this block of code](https://github.com/helm/helm/blob/6f32a8f9d338bacc3c6a1c0c3610012b01edb3d1/pkg/action/install.go#L345-L350) that causes the unexpected error. A side-effect of `ClientOnly` being true is that the capabilities aren't automatically set, and so we set them using the provider's kube client (akin to using `--kube-version`).

Detailed changes:
- (chart.go) use ClientOnly mode, set KubeVersion and APIVersions
- (tool.go) remove redundant KubeVersion and ExtraAPIs 
- (testdata/reference) add a version check
- (chart_test.go) unit tests for `.Capabilities`
- integration test to install cert-manager

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes #3045