### PR TITLE
tests: add SkipInstall option for pulumitest tests

### DIFF
--- a/tests/sdk/java/chartv4_test.go
+++ b/tests/sdk/java/chartv4_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 )
 
 // TestChartV4 deploys a complex stack using chart/v4 package.
 func TestChartv4(t *testing.T) {
-	test := pulumitest.NewPulumiTest(t, "testdata/chartv4")
+	test := pulumitest.NewPulumiTest(t, "testdata/chartv4", opttest.SkipInstall())
 	t.Logf("into %s", test.Source())
 	t.Cleanup(func() {
 		test.Destroy()

--- a/tests/sdk/java/kustomizev2_test.go
+++ b/tests/sdk/java/kustomizev2_test.go
@@ -20,6 +20,7 @@ func TestKustomizeV2(t *testing.T) {
 	pluginHome, _ := filepath.Abs("testdata/kustomizev2/pluginExample/plugin")
 	test := pulumitest.NewPulumiTest(t, "testdata/kustomizev2",
 		opttest.Env("KUSTOMIZE_PLUGIN_HOME", pluginHome),
+		opttest.SkipInstall(),
 	)
 	t.Logf("into %s", test.Source())
 	t.Cleanup(func() {

--- a/tests/sdk/java/yamlv2_test.go
+++ b/tests/sdk/java/yamlv2_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +15,7 @@ import (
 // - installs and uses CRDs across components
 // - uses implicit and explicit dependencies
 func TestYamlV2(t *testing.T) {
-	test := pulumitest.NewPulumiTest(t, "testdata/yamlv2")
+	test := pulumitest.NewPulumiTest(t, "testdata/yamlv2", opttest.SkipInstall())
 	t.Logf("into %s", test.Source())
 	t.Cleanup(func() {
 		test.Destroy()
@@ -26,7 +27,7 @@ func TestYamlV2(t *testing.T) {
 // TestJobUnreachable ensures that a panic does not occur when diffing Job resources against an unreachable API server.
 // https://github.com/pulumi/pulumi-kubernetes/issues/3022
 func TestJobUnreachable(t *testing.T) {
-	test := pulumitest.NewPulumiTest(t, "testdata/job-unreachable")
+	test := pulumitest.NewPulumiTest(t, "testdata/job-unreachable", opttest.SkipInstall())
 	t.Logf("into %s", test.Source())
 	t.Cleanup(func() {
 		test.Destroy()


### PR DESCRIPTION
### Proposed changes
 
This PR explicitly sets the `opttest.SkipInstall()` option for our yaml tests. It is observed that the test framework/automation API is unable successfully run `pulumi install` prior to the other pulumi operations. This error was hit in the presubmit for https://github.com/pulumi/pulumi-kubernetes/pull/3046, but went unnoticed in the past due to the `TestTerraformConvert` installing the right plugins before the other tests hit the installation step.

Manual validation:

- Deleted the local `~/.pulumi/plugin` folder
- Run the tests without the changes and notice the test errors
- Run the tests with the changes here and they pass

### Related issues (optional)

Fixes: #3048