### PR TITLE
Fix previews in SSA mode when there are replacements due to immutable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `Chart` v4 now handles an array of assets. (https://github.com/pulumi/pulumi-kubernetes/pull/3061)
+- Fix previews always failing when a resource is to be replaced (https://github.com/pulumi/pulumi-kubernetes/pull/3053)
 
 ## 4.13.0 (June 4, 2024)
 

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -225,7 +225,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 				if c.Preview &&
 					(apierrors.IsInvalid(err) && strings.Contains(err.Error(), apivalidation.FieldImmutableErrorMsg)) {
 					previewName := names.SimpleNameGenerator.GenerateName(c.Inputs.GetName())
-					c.Host.Log(c.Context, diag.Info, c.URN, fmt.Sprintf("Preview creation failed due to immutable fields; retrying with name %q", previewName))
+					_ = c.Host.Log(c.Context, diag.Info, c.URN, fmt.Sprintf("Preview creation failed due to immutable fields; retrying with name %q", previewName))
 					c.Inputs.SetName(previewName)
 
 					objYAML, errYaml := yaml.Marshal(c.Inputs.Object)

--- a/tests/sdk/java/preview_test.go
+++ b/tests/sdk/java/preview_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+)
+
+// TestPreviewReplacements ensures that replacements for immutable fields are correctly previewed.
+func TestPreviewReplacements(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/preview-replacements", opttest.SkipInstall())
+	t.Logf("into %s", test.Source())
+	t.Cleanup(func() {
+		test.Destroy()
+	})
+	test.Preview()
+	test.Up()
+
+	// Preview should not fail when there is a replacement due to immutable fields.
+	test.UpdateSource("testdata/preview-replacements", "step2")
+	test.Preview()
+}

--- a/tests/sdk/java/testdata/preview-replacements/Pulumi.yaml
+++ b/tests/sdk/java/testdata/preview-replacements/Pulumi.yaml
@@ -1,0 +1,32 @@
+name: job-unreachable
+runtime: yaml
+resources:
+  provider:
+    type: pulumi:providers:kubernetes
+  ns:
+    type: kubernetes:core/v1:Namespace
+    options:
+      provider: ${provider}
+  job:
+    type: kubernetes:batch/v1:Job
+    properties:
+      metadata:
+        name: test-job-previews
+        namespace: ${ns.metadata.name}
+        annotations:
+          pulumi.com/skipAwait: "true"
+      spec:
+        template:
+          metadata:
+            name: test-job-unreachable
+          spec:
+            containers:
+              - name: test-job-unreachable-container
+                image: busybox
+                command:
+                  - sh
+                  - -c
+                  - exit 0
+            restartPolicy: Never
+    options:
+      provider: ${provider}

--- a/tests/sdk/java/testdata/preview-replacements/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/preview-replacements/step2/Pulumi.yaml
@@ -1,0 +1,32 @@
+name: job-unreachable
+runtime: yaml
+resources:
+  provider:
+    type: pulumi:providers:kubernetes
+  ns:
+    type: kubernetes:core/v1:Namespace
+    options:
+      provider: ${provider}
+  job:
+    type: kubernetes:batch/v1:Job
+    properties:
+      metadata:
+        name: test-job-previews
+        namespace: ${ns.metadata.name}
+        annotations:
+          pulumi.com/skipAwait: "true"
+      spec:
+        template:
+          metadata:
+            name: test-job-unreachable
+          spec:
+            containers:
+              - name: test-job-unreachable-container-step2
+                image: busybox
+                command:
+                  - sh
+                  - -c
+                  - exit 0
+            restartPolicy: Never
+    options:
+      provider: ${provider}


### PR DESCRIPTION
### Proposed changes

This PR adds special handling for previews with SSA when we have a replacement (delete before create) operation. There is no easy way to tell the API server that the dry-run to be run is an object replacement. As such, a workaround that we can do is to send a different object name so the API server thinks we are creating a new object, so a already exists type error doesn't occur.

Note, because of how SSA creates work currently with upserts, we'll never face the `AlreadyExists` error, so we do not have to account for that in this PR.

As an aside, `kubectl` also supports delete before create replacements with the `replace` sub-command. A user would need to run `kubectl replace --force -f .` to recreate any resources that update an immutable field. `kubectl` does not support `-dry-run=server` with the `--force` flag and the follow error is shown `--dry-run can not be used when --force is set` since the API server does not support previewing this type of operation.

### Related issues (optional)

Fixes: #2575
